### PR TITLE
Improve IB data farm recovery in the Rust adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "ibapi"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab7f26e4336d0cb94be12bc6c0779cced423c3aceda01f5fd23cbcb0446a43e"
+checksum = "61cfb4b8eefd8dda23e2e327187a6ae837018c15d7ca6a79199c6cd475e5f169"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,7 +338,7 @@ dydx-proto = "0.4.0"
 fallible-streaming-iterator = "0.1.9"
 flate2 = "1.1.9"
 hypersync-client = { version = "1.4.0" }
-ibapi = "=3.0.1"
+ibapi = "=3.2.0"
 itoa = "1.0.18"
 ryu = "1.0.23"
 serde_repr = "0.1.20"

--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -32,6 +32,8 @@ use anyhow::Context;
 use ibapi::{
     contracts::{Contract, Currency as IBCurrency, Exchange as IBExchange, SecurityType, Symbol},
     market_data::{IgnoreSize, historical::ToDuration},
+    prelude::StreamExt,
+    subscriptions::SubscriptionItem,
 };
 use nautilus_common::{
     clients::DataClient,
@@ -61,10 +63,10 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use self::streams::{
-    handle_historical_bars_subscription, handle_index_price_subscription,
+    DataFarmConnectionState, handle_historical_bars_subscription, handle_index_price_subscription,
     handle_market_depth_subscription, handle_option_greeks_subscription, handle_quote_subscription,
     handle_realtime_bars_subscription, handle_tick_by_tick_quote_subscription,
-    handle_trade_subscription,
+    handle_trade_subscription, monitor_data_farm_notices,
 };
 use super::{
     cache::{OptionGreeksCache, QuoteCache},
@@ -126,6 +128,8 @@ pub struct InteractiveBrokersDataClient {
     last_bars: Arc<tokio::sync::Mutex<AHashMap<String, ibapi::market_data::realtime::Bar>>>,
     /// Active timeout tasks for bar completion.
     bar_timeout_tasks: Arc<tokio::sync::Mutex<AHashMap<String, tokio::task::JoinHandle<()>>>>,
+    /// Shared data-farm state used to resubscribe data feeds without tearing down the IB socket.
+    data_farm_state: Arc<DataFarmConnectionState>,
 }
 
 /// Information about an active subscription.
@@ -307,6 +311,7 @@ impl InteractiveBrokersDataClient {
             ib_client: None,
             last_bars: Arc::new(tokio::sync::Mutex::new(AHashMap::new())),
             bar_timeout_tasks: Arc::new(tokio::sync::Mutex::new(AHashMap::new())),
+            data_farm_state: Arc::new(DataFarmConnectionState::default()),
         })
     }
 
@@ -663,8 +668,22 @@ impl DataClient for InteractiveBrokersDataClient {
             tracing::info!("Set market data type to {:?}", self.config.market_data_type);
         }
 
+        let notice_client = Arc::clone(client);
         self.ib_client = Some(handle);
         self.is_connected.store(true, Ordering::Relaxed);
+
+        let data_farm_state = Arc::clone(&self.data_farm_state);
+        let cancellation_token = self.cancellation_token.child_token();
+        let clock = self.clock;
+
+        self.tasks.push(get_runtime().spawn(async move {
+            if let Err(e) =
+                monitor_data_farm_notices(notice_client, data_farm_state, clock, cancellation_token)
+                    .await
+            {
+                tracing::warn!("IB data farm notice monitor stopped: {e:?}");
+            }
+        }));
 
         // Initialize provider and load instruments from cache/config if configured
         tracing::debug!("Initializing IB data instrument provider");
@@ -775,6 +794,7 @@ impl DataClient for InteractiveBrokersDataClient {
         let client_clone = client.as_arc().clone();
         let subscription_token_clone = subscription_token.clone();
         let ignore_size_updates = self.config.ignore_quote_tick_size_updates;
+        let data_farm_state = Arc::clone(&self.data_farm_state);
 
         let task = get_runtime().spawn(async move {
             if use_market_data {
@@ -797,6 +817,7 @@ impl DataClient for InteractiveBrokersDataClient {
                     clock,
                     subscription_token_clone,
                     ignore_size_updates,
+                    Arc::clone(&data_farm_state),
                 )
                 .await
                 {
@@ -820,6 +841,7 @@ impl DataClient for InteractiveBrokersDataClient {
                     clock,
                     subscription_token_clone.clone(),
                     price_magnifier,
+                    Arc::clone(&data_farm_state),
                 )
                 .await
                 {
@@ -844,6 +866,7 @@ impl DataClient for InteractiveBrokersDataClient {
                             clock,
                             subscription_token_clone,
                             ignore_size_updates,
+                            Arc::clone(&data_farm_state),
                         )
                         .await
                         {
@@ -933,6 +956,7 @@ impl DataClient for InteractiveBrokersDataClient {
 
         let client_clone = client.as_arc().clone();
         let subscription_token_clone = subscription_token.clone();
+        let data_farm_state = Arc::clone(&self.data_farm_state);
 
         let task = get_runtime().spawn(async move {
             if let Err(e) = handle_index_price_subscription(
@@ -944,6 +968,7 @@ impl DataClient for InteractiveBrokersDataClient {
                 data_sender,
                 clock,
                 subscription_token_clone,
+                data_farm_state,
             )
             .await
             {
@@ -1020,6 +1045,7 @@ impl DataClient for InteractiveBrokersDataClient {
         let subscription_token = self.cancellation_token.child_token();
         let subscription_token_clone = subscription_token.clone();
         let client_clone = client.as_arc().clone();
+        let data_farm_state = Arc::clone(&self.data_farm_state);
 
         let task = get_runtime().spawn(async move {
             if let Err(e) = handle_option_greeks_subscription(
@@ -1030,6 +1056,7 @@ impl DataClient for InteractiveBrokersDataClient {
                 option_greeks_cache,
                 clock,
                 subscription_token_clone,
+                data_farm_state,
             )
             .await
             {
@@ -1169,6 +1196,7 @@ impl DataClient for InteractiveBrokersDataClient {
         // Spawn subscription task
         let client_clone = client.as_arc().clone();
         let subscription_token_clone = subscription_token.clone();
+        let data_farm_state = Arc::clone(&self.data_farm_state);
 
         let task = get_runtime().spawn(async move {
             if let Err(e) = handle_trade_subscription(
@@ -1180,6 +1208,7 @@ impl DataClient for InteractiveBrokersDataClient {
                 data_sender,
                 clock,
                 subscription_token_clone,
+                data_farm_state,
             )
             .await
             {
@@ -1267,6 +1296,7 @@ impl DataClient for InteractiveBrokersDataClient {
         // Spawn subscription task
         let client_clone = client.as_arc().clone();
         let subscription_token_clone = subscription_token.clone();
+        let data_farm_state = Arc::clone(&self.data_farm_state);
 
         let task = get_runtime().spawn(async move {
             let result = if bar_type.spec().timedelta().num_seconds() == 5 {
@@ -1285,6 +1315,7 @@ impl DataClient for InteractiveBrokersDataClient {
                     handle_revised_bars,
                     use_rth,
                     subscription_token_clone,
+                    Arc::clone(&data_farm_state),
                 )
                 .await
             } else {
@@ -1301,6 +1332,7 @@ impl DataClient for InteractiveBrokersDataClient {
                     handle_revised_bars,
                     clock,
                     subscription_token_clone,
+                    Arc::clone(&data_farm_state),
                 )
                 .await
             };
@@ -1402,6 +1434,7 @@ impl DataClient for InteractiveBrokersDataClient {
         // Spawn subscription task
         let client_clone = client.as_arc().clone();
         let subscription_token_clone = subscription_token.clone();
+        let data_farm_state = Arc::clone(&self.data_farm_state);
 
         let task = get_runtime().spawn(async move {
             if let Err(e) = handle_market_depth_subscription(
@@ -1415,6 +1448,7 @@ impl DataClient for InteractiveBrokersDataClient {
                 data_sender,
                 clock,
                 subscription_token_clone,
+                data_farm_state,
             )
             .await
             {
@@ -1856,7 +1890,22 @@ impl DataClient for InteractiveBrokersDataClient {
                     Ok(mut subscription) => {
                         let mut batch_quotes = Vec::new();
 
-                        while let Some(tick) = subscription.next().await {
+                        while let Some(tick_result) = subscription.next().await {
+                            let tick = match tick_result {
+                                Ok(SubscriptionItem::Data(tick)) => tick,
+                                Ok(SubscriptionItem::Notice(notice)) => {
+                                    tracing::debug!(
+                                        "IB historical quote tick notice: {} - {}",
+                                        notice.code,
+                                        notice.message
+                                    );
+                                    continue;
+                                }
+                                Err(e) => {
+                                    tracing::warn!("Historical quote tick stream failed: {e:?}");
+                                    break;
+                                }
+                            };
                             let ts_event =
                                 super::convert::ib_timestamp_to_unix_nanos(&tick.timestamp);
                             let ts_init = clock.get_time_ns();
@@ -2037,7 +2086,22 @@ impl DataClient for InteractiveBrokersDataClient {
                     Ok(mut subscription) => {
                         let mut batch_trades = Vec::new();
 
-                        while let Some(tick) = subscription.next().await {
+                        while let Some(tick_result) = subscription.next().await {
+                            let tick = match tick_result {
+                                Ok(SubscriptionItem::Data(tick)) => tick,
+                                Ok(SubscriptionItem::Notice(notice)) => {
+                                    tracing::debug!(
+                                        "IB historical trade tick notice: {} - {}",
+                                        notice.code,
+                                        notice.message
+                                    );
+                                    continue;
+                                }
+                                Err(e) => {
+                                    tracing::warn!("Historical trade tick stream failed: {e:?}");
+                                    break;
+                                }
+                            };
                             let ts_event =
                                 super::convert::ib_timestamp_to_unix_nanos(&tick.timestamp);
                             let ts_init = clock.get_time_ns();

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -7,11 +7,19 @@
 //  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
 // -------------------------------------------------------------------------------------------------
 
-use std::{fmt::Debug, sync::Arc, time::Duration};
+use std::{
+    fmt::Debug,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use ahash::AHashMap;
 use anyhow::Context;
 use ibapi::{
+    ConnectivityStatus, Error, Notice,
     contracts::tick_types::TickType,
     market_data::{
         IgnoreSize, SmartDepth, TradingHours,
@@ -49,6 +57,7 @@ use crate::data::{
 enum StreamAction {
     Continue,
     Stop,
+    Resubscribe,
 }
 
 trait IntoSubscriptionTick {
@@ -67,9 +76,129 @@ impl IntoSubscriptionTick for SubscriptionItem<TickTypes> {
     }
 }
 
+const SUBSCRIPTION_DISCONNECTED_CODE: i32 = 10182;
 const HISTORICAL_BAR_MIN_COUNT: i64 = 300;
 const HISTORICAL_BAR_RETRY_DELAY: Duration = Duration::from_secs(1);
 const IB_GENERIC_TICK_OPTION_OPEN_INTEREST: &str = "101";
+
+#[derive(Debug, Default)]
+pub(super) struct DataFarmConnectionState {
+    degraded_since_ns: Mutex<Option<UnixNanos>>,
+    last_recovery: Mutex<Option<(u64, UnixNanos)>>,
+    recovery_generation: AtomicU64,
+    recovery_notify: tokio::sync::Notify,
+}
+
+impl DataFarmConnectionState {
+    pub(super) fn handle_notice(&self, notice: &Notice, clock: &'static AtomicTime) {
+        if is_data_farm_broken_code(notice.code) {
+            self.mark_degraded(clock.get_time_ns());
+            tracing::debug!(
+                "IB data farm degraded by notice {} - {}; waiting for farm OK before resubscribe",
+                notice.code,
+                notice.message
+            );
+        } else if is_data_farm_ok_code(notice.code) && self.mark_ok() {
+            tracing::info!(
+                "IB data farm recovered by notice {} - {}; resubscribing data feeds",
+                notice.code,
+                notice.message
+            );
+        }
+    }
+
+    pub(super) fn mark_degraded(&self, degraded_since_ns: UnixNanos) {
+        let mut guard = self
+            .degraded_since_ns
+            .lock()
+            .expect("data farm state mutex poisoned");
+
+        if guard.is_none() {
+            *guard = Some(degraded_since_ns);
+        }
+    }
+
+    fn mark_ok(&self) -> bool {
+        let Some(degraded_since_ns) = self
+            .degraded_since_ns
+            .lock()
+            .expect("data farm state mutex poisoned")
+            .take()
+        else {
+            return false;
+        };
+
+        let generation = self.recovery_generation.fetch_add(1, Ordering::Relaxed) + 1;
+        *self
+            .last_recovery
+            .lock()
+            .expect("data farm recovery mutex poisoned") = Some((generation, degraded_since_ns));
+        self.recovery_notify.notify_waiters();
+        true
+    }
+
+    fn recovery_generation(&self) -> u64 {
+        self.recovery_generation.load(Ordering::Relaxed)
+    }
+
+    fn last_recovery_since_ns(&self, generation: u64) -> Option<UnixNanos> {
+        self.last_recovery
+            .lock()
+            .expect("data farm recovery mutex poisoned")
+            .and_then(|(recovery_generation, degraded_since_ns)| {
+                (recovery_generation == generation).then_some(degraded_since_ns)
+            })
+    }
+
+    async fn wait_for_recovery_after(&self, generation: u64) {
+        loop {
+            let notified = self.recovery_notify.notified();
+
+            if self.recovery_generation() != generation {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+fn is_data_farm_broken_code(code: i32) -> bool {
+    matches!(
+        ConnectivityStatus::from_code(code),
+        Some(ConnectivityStatus::Broken)
+    )
+}
+
+fn is_data_farm_ok_code(code: i32) -> bool {
+    matches!(
+        ConnectivityStatus::from_code(code),
+        Some(ConnectivityStatus::Ok)
+    )
+}
+
+fn is_subscription_disconnected_error(error: &Error) -> bool {
+    matches!(error, Error::Notice(notice) if notice.code == SUBSCRIPTION_DISCONNECTED_CODE)
+}
+
+fn earliest_data_loss_ns(first: Option<UnixNanos>, second: Option<UnixNanos>) -> Option<UnixNanos> {
+    match (first, second) {
+        (Some(first), Some(second)) => Some(first.min(second)),
+        (Some(first), None) => Some(first),
+        (None, Some(second)) => Some(second),
+        (None, None) => None,
+    }
+}
+
+async fn wait_for_data_farm_recovery_or_cancel(
+    data_farm_state: &DataFarmConnectionState,
+    generation: u64,
+    cancellation_token: &CancellationToken,
+) -> bool {
+    tokio::select! {
+        () = data_farm_state.wait_for_recovery_after(generation) => true,
+        () = cancellation_token.cancelled() => false,
+    }
+}
 
 pub(super) fn resolve_historical_bar_start_ns(
     start_ns: Option<UnixNanos>,
@@ -116,6 +245,29 @@ fn should_emit_historical_bar(bar: &Bar, start_ns: UnixNanos) -> bool {
     bar.ts_init >= start_ns
 }
 
+pub(super) async fn monitor_data_farm_notices(
+    client: Arc<ibapi::Client>,
+    data_farm_state: Arc<DataFarmConnectionState>,
+    clock: &'static AtomicTime,
+    cancellation_token: CancellationToken,
+) -> anyhow::Result<()> {
+    let mut notices = client
+        .notice_stream()
+        .context("Failed to subscribe to IB notice stream")?;
+
+    loop {
+        tokio::select! {
+            () = cancellation_token.cancelled() => return Ok(()),
+            notice = notices.next() => {
+                let Some(notice) = notice else {
+                    return Ok(());
+                };
+                data_farm_state.handle_notice(&notice, clock);
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_historical_bars_subscription(
     client: Arc<ibapi::Client>,
@@ -130,11 +282,13 @@ pub(super) async fn handle_historical_bars_subscription(
     handle_revised_bars: bool,
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
+    data_farm_state: Arc<DataFarmConnectionState>,
 ) -> anyhow::Result<()> {
     tracing::debug!("Starting historical bars subscription for {}", bar_type);
 
     let first_start_ns = resolve_historical_bar_start_ns(start_ns, clock.get_time_ns());
     let mut last_disconnection_ns = None;
+    let mut farm_generation = data_farm_state.recovery_generation();
     // Only stamp last_disconnection_ns after receiving real data, mirroring the Python
     // adapter's _had_ib_connection guard. historical_data_streaming() returns Ok after
     // sending the request; server-side errors arrive later via subscription.next(). A
@@ -240,6 +394,7 @@ pub(super) async fn handle_historical_bars_subscription(
                         }
                         Some(Ok(SubscriptionItem::Data(HistoricalBarUpdate::End { .. }))) => {}
                         Some(Ok(SubscriptionItem::Notice(notice))) => {
+                            data_farm_state.handle_notice(&notice, clock);
                             tracing::debug!(
                                 "IB historical bars notice for {}: {} - {}",
                                 bar_type,
@@ -248,6 +403,33 @@ pub(super) async fn handle_historical_bars_subscription(
                             );
                         }
                         Some(Err(e)) => {
+                            if is_subscription_disconnected_error(&e) {
+                                data_farm_state.mark_degraded(clock.get_time_ns());
+                                tracing::warn!(
+                                    "Historical bars subscription disconnected for {}; waiting for data farm recovery: {:?}",
+                                    bar_type,
+                                    e
+                                );
+
+                                if !wait_for_data_farm_recovery_or_cancel(
+                                    &data_farm_state,
+                                    farm_generation,
+                                    &cancellation_token,
+                                )
+                                .await
+                                {
+                                    subscription.cancel().await;
+                                    return Ok(());
+                                }
+                                let recovered_generation = data_farm_state.recovery_generation();
+                                last_disconnection_ns = earliest_data_loss_ns(
+                                    last_disconnection_ns,
+                                    data_farm_state.last_recovery_since_ns(recovered_generation),
+                                );
+                                farm_generation = recovered_generation;
+                                break;
+                            }
+
                             tracing::warn!(
                                 "Historical bars subscription ended for {}: {:?}",
                                 bar_type,
@@ -278,6 +460,16 @@ pub(super) async fn handle_historical_bars_subscription(
                         }
                     }
                 }
+                () = data_farm_state.wait_for_recovery_after(farm_generation) => {
+                    let recovered_generation = data_farm_state.recovery_generation();
+                    last_disconnection_ns = earliest_data_loss_ns(
+                        last_disconnection_ns,
+                        data_farm_state.last_recovery_since_ns(recovered_generation),
+                    );
+                    farm_generation = recovered_generation;
+                    subscription.cancel().await;
+                    break;
+                }
             }
         }
 
@@ -304,31 +496,71 @@ pub(super) async fn handle_quote_subscription(
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
     ignore_size_updates: bool,
+    data_farm_state: Arc<DataFarmConnectionState>,
 ) -> anyhow::Result<()> {
     tracing::debug!("Starting quote subscription for {}", instrument_id);
 
-    let mut subscription = client
-        .market_data(&contract)
-        .streaming()
-        .subscribe()
-        .await
-        .context("Failed to create market data subscription")?;
+    let mut farm_generation = data_farm_state.recovery_generation();
 
     loop {
-        tokio::select! {
-            () = cancellation_token.cancelled() => {
-                tracing::debug!("Quote subscription cancelled for {}", instrument_id);
-                subscription.cancel().await;
-                break;
-            }
-            tick_result = subscription.next() => {
-                let Some(tick_result) = tick_result else {
-                    tracing::debug!("Quote subscription stream ended for {}", instrument_id);
-                    break;
-                };
+        if cancellation_token.is_cancelled() {
+            break;
+        }
 
-                if matches!(
-                    process_quote_tick_result(
+        let mut subscription = client
+            .market_data(&contract)
+            .streaming()
+            .subscribe()
+            .await
+            .context("Failed to create market data subscription")?;
+
+        loop {
+            tokio::select! {
+                () = cancellation_token.cancelled() => {
+                    tracing::debug!("Quote subscription cancelled for {}", instrument_id);
+                    subscription.cancel().await;
+                    return Ok(());
+                }
+                () = data_farm_state.wait_for_recovery_after(farm_generation) => {
+                    farm_generation = data_farm_state.recovery_generation();
+                    subscription.cancel().await;
+                    break;
+                }
+                tick_result = subscription.next() => {
+                    let Some(tick_result) = tick_result else {
+                        tracing::debug!("Quote subscription stream ended for {}", instrument_id);
+                        break;
+                    };
+
+                    if let Err(e) = &tick_result
+                        && is_subscription_disconnected_error(e)
+                    {
+                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        tracing::warn!(
+                            "Quote subscription disconnected for {}; waiting for data farm recovery: {:?}",
+                            instrument_id,
+                            e
+                        );
+
+                        if !wait_for_data_farm_recovery_or_cancel(
+                            &data_farm_state,
+                            farm_generation,
+                            &cancellation_token,
+                        )
+                        .await
+                        {
+                            subscription.cancel().await;
+                            return Ok(());
+                        }
+                        farm_generation = data_farm_state.recovery_generation();
+                        break;
+                    }
+
+                    if let Ok(SubscriptionItem::Notice(notice)) = &tick_result {
+                        data_farm_state.handle_notice(notice, clock);
+                    }
+
+                    let action = process_quote_tick_result(
                         tick_result,
                         instrument_id,
                         price_precision,
@@ -338,10 +570,17 @@ pub(super) async fn handle_quote_subscription(
                         clock,
                         ignore_size_updates,
                     )
-                    .await?,
-                    StreamAction::Stop
-                ) {
-                    break;
+                    .await?;
+
+                    match action {
+                        StreamAction::Continue => {}
+                        StreamAction::Stop => return Ok(()),
+                        StreamAction::Resubscribe => {
+                            farm_generation = data_farm_state.recovery_generation();
+                            subscription.cancel().await;
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -359,42 +598,89 @@ pub(super) async fn handle_option_greeks_subscription(
     option_greeks_cache: Arc<tokio::sync::Mutex<OptionGreeksCache>>,
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
+    data_farm_state: Arc<DataFarmConnectionState>,
 ) -> anyhow::Result<()> {
     tracing::debug!("Starting option greeks subscription for {}", instrument_id);
 
-    let mut subscription = client
-        .market_data(&contract)
-        .generic_ticks(&[IB_GENERIC_TICK_OPTION_OPEN_INTEREST])
-        .streaming()
-        .subscribe()
-        .await
-        .context("Failed to create option greeks market data subscription")?;
+    let mut farm_generation = data_farm_state.recovery_generation();
 
     loop {
-        tokio::select! {
-            () = cancellation_token.cancelled() => {
-                tracing::debug!("Option greeks subscription cancelled for {}", instrument_id);
-                subscription.cancel().await;
-                break;
-            }
-            tick_result = subscription.next() => {
-                let Some(tick_result) = tick_result else {
-                    tracing::debug!("Option greeks subscription stream ended for {}", instrument_id);
-                    break;
-                };
+        if cancellation_token.is_cancelled() {
+            break;
+        }
 
-                if matches!(
-                    process_option_greeks_tick_result(
+        let mut subscription = client
+            .market_data(&contract)
+            .generic_ticks(&[IB_GENERIC_TICK_OPTION_OPEN_INTEREST])
+            .streaming()
+            .subscribe()
+            .await
+            .context("Failed to create option greeks market data subscription")?;
+
+        loop {
+            tokio::select! {
+                () = cancellation_token.cancelled() => {
+                    tracing::debug!("Option greeks subscription cancelled for {}", instrument_id);
+                    subscription.cancel().await;
+                    return Ok(());
+                }
+                () = data_farm_state.wait_for_recovery_after(farm_generation) => {
+                    farm_generation = data_farm_state.recovery_generation();
+                    subscription.cancel().await;
+                    break;
+                }
+                tick_result = subscription.next() => {
+                    let Some(tick_result) = tick_result else {
+                        tracing::debug!("Option greeks subscription stream ended for {}", instrument_id);
+                        break;
+                    };
+
+                    if let Err(e) = &tick_result
+                        && is_subscription_disconnected_error(e)
+                    {
+                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        tracing::warn!(
+                            "Option greeks subscription disconnected for {}; waiting for data farm recovery: {:?}",
+                            instrument_id,
+                            e
+                        );
+
+                        if !wait_for_data_farm_recovery_or_cancel(
+                            &data_farm_state,
+                            farm_generation,
+                            &cancellation_token,
+                        )
+                        .await
+                        {
+                            subscription.cancel().await;
+                            return Ok(());
+                        }
+                        farm_generation = data_farm_state.recovery_generation();
+                        break;
+                    }
+
+                    if let Ok(SubscriptionItem::Notice(notice)) = &tick_result {
+                        data_farm_state.handle_notice(notice, clock);
+                    }
+
+                    let action = process_option_greeks_tick_result(
                         tick_result,
                         instrument_id,
                         &data_sender,
                         &option_greeks_cache,
                         clock,
                     )
-                    .await?,
-                    StreamAction::Stop
-                ) {
-                    break;
+                    .await?;
+
+                    match action {
+                        StreamAction::Continue => {}
+                        StreamAction::Stop => return Ok(()),
+                        StreamAction::Resubscribe => {
+                            farm_generation = data_farm_state.recovery_generation();
+                            subscription.cancel().await;
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -414,31 +700,71 @@ pub(super) async fn handle_index_price_subscription(
     data_sender: tokio::sync::mpsc::UnboundedSender<DataEvent>,
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
+    data_farm_state: Arc<DataFarmConnectionState>,
 ) -> anyhow::Result<()> {
     tracing::debug!("Starting index price subscription for {}", instrument_id);
 
-    let mut subscription = client
-        .market_data(&contract)
-        .streaming()
-        .subscribe()
-        .await
-        .context("Failed to create index market data subscription")?;
+    let mut farm_generation = data_farm_state.recovery_generation();
 
     loop {
-        tokio::select! {
-            () = cancellation_token.cancelled() => {
-                tracing::debug!("Index price subscription cancelled for {}", instrument_id);
-                subscription.cancel().await;
-                break;
-            }
-            tick_result = subscription.next() => {
-                let Some(tick_result) = tick_result else {
-                    tracing::debug!("Index price subscription stream ended for {}", instrument_id);
-                    break;
-                };
+        if cancellation_token.is_cancelled() {
+            break;
+        }
 
-                if matches!(
-                    process_index_price_tick_result(
+        let mut subscription = client
+            .market_data(&contract)
+            .streaming()
+            .subscribe()
+            .await
+            .context("Failed to create index market data subscription")?;
+
+        loop {
+            tokio::select! {
+                () = cancellation_token.cancelled() => {
+                    tracing::debug!("Index price subscription cancelled for {}", instrument_id);
+                    subscription.cancel().await;
+                    return Ok(());
+                }
+                () = data_farm_state.wait_for_recovery_after(farm_generation) => {
+                    farm_generation = data_farm_state.recovery_generation();
+                    subscription.cancel().await;
+                    break;
+                }
+                tick_result = subscription.next() => {
+                    let Some(tick_result) = tick_result else {
+                        tracing::debug!("Index price subscription stream ended for {}", instrument_id);
+                        break;
+                    };
+
+                    if let Err(e) = &tick_result
+                        && is_subscription_disconnected_error(e)
+                    {
+                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        tracing::warn!(
+                            "Index price subscription disconnected for {}; waiting for data farm recovery: {:?}",
+                            instrument_id,
+                            e
+                        );
+
+                        if !wait_for_data_farm_recovery_or_cancel(
+                            &data_farm_state,
+                            farm_generation,
+                            &cancellation_token,
+                        )
+                        .await
+                        {
+                            subscription.cancel().await;
+                            return Ok(());
+                        }
+                        farm_generation = data_farm_state.recovery_generation();
+                        break;
+                    }
+
+                    if let Ok(SubscriptionItem::Notice(notice)) = &tick_result {
+                        data_farm_state.handle_notice(notice, clock);
+                    }
+
+                    let action = process_index_price_tick_result(
                         tick_result,
                         instrument_id,
                         price_precision,
@@ -446,10 +772,17 @@ pub(super) async fn handle_index_price_subscription(
                         &data_sender,
                         clock,
                     )
-                    .await?,
-                    StreamAction::Stop
-                ) {
-                    break;
+                    .await?;
+
+                    match action {
+                        StreamAction::Continue => {}
+                        StreamAction::Stop => return Ok(()),
+                        StreamAction::Resubscribe => {
+                            farm_generation = data_farm_state.recovery_generation();
+                            subscription.cancel().await;
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -469,69 +802,105 @@ pub(super) async fn handle_tick_by_tick_quote_subscription(
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
     price_magnifier: f64,
+    data_farm_state: Arc<DataFarmConnectionState>,
 ) -> anyhow::Result<()> {
     tracing::debug!(
         "Starting tick-by-tick quote subscription for {}",
         instrument_id
     );
 
-    let mut subscription = client
-        .tick_by_tick(&contract, 0)
-        .bid_ask(IgnoreSize::No)
-        .await
-        .context("Failed to create tick-by-tick bid/ask subscription")?;
+    let mut farm_generation = data_farm_state.recovery_generation();
 
     loop {
-        tokio::select! {
-            () = cancellation_token.cancelled() => {
-                tracing::debug!("Tick-by-tick quote subscription cancelled for {}", instrument_id);
-                subscription.cancel().await;
-                break;
-            }
-            tick_result = subscription.next() => {
-                match tick_result {
-                    Some(Ok(SubscriptionItem::Data(bid_ask))) => {
-                        let ts_event = ib_timestamp_to_unix_nanos(&bid_ask.time);
-                        let ts_init = clock.get_time_ns();
+        if cancellation_token.is_cancelled() {
+            break;
+        }
 
-                        let bid_price = bid_ask.bid_price * price_magnifier;
-                        let ask_price = bid_ask.ask_price * price_magnifier;
+        let mut subscription = client
+            .tick_by_tick(&contract, 0)
+            .bid_ask(IgnoreSize::No)
+            .await
+            .context("Failed to create tick-by-tick bid/ask subscription")?;
 
-                        match parse_quote_tick(
-                            instrument_id,
-                            Some(bid_price),
-                            Some(ask_price),
-                            Some(bid_ask.bid_size),
-                            Some(bid_ask.ask_size),
-                            price_precision,
-                            size_precision,
-                            ts_event,
-                            ts_init,
-                        ) {
-                            Ok(quote_tick) => {
-                                if data_sender
-                                    .send(DataEvent::Data(Data::Quote(quote_tick)))
-                                    .is_err()
-                                {
-                                    break;
+        loop {
+            tokio::select! {
+                () = cancellation_token.cancelled() => {
+                    tracing::debug!("Tick-by-tick quote subscription cancelled for {}", instrument_id);
+                    subscription.cancel().await;
+                    return Ok(());
+                }
+                () = data_farm_state.wait_for_recovery_after(farm_generation) => {
+                    farm_generation = data_farm_state.recovery_generation();
+                    subscription.cancel().await;
+                    break;
+                }
+                tick_result = subscription.next() => {
+                    match tick_result {
+                        Some(Ok(SubscriptionItem::Data(bid_ask))) => {
+                            let ts_event = ib_timestamp_to_unix_nanos(&bid_ask.time);
+                            let ts_init = clock.get_time_ns();
+
+                            let bid_price = bid_ask.bid_price * price_magnifier;
+                            let ask_price = bid_ask.ask_price * price_magnifier;
+
+                            match parse_quote_tick(
+                                instrument_id,
+                                Some(bid_price),
+                                Some(ask_price),
+                                Some(bid_ask.bid_size),
+                                Some(bid_ask.ask_size),
+                                price_precision,
+                                size_precision,
+                                ts_event,
+                                ts_init,
+                            ) {
+                                Ok(quote_tick) => {
+                                    if data_sender
+                                        .send(DataEvent::Data(Data::Quote(quote_tick)))
+                                        .is_err()
+                                    {
+                                        return Ok(());
+                                    }
                                 }
+                                Err(e) => tracing::warn!("Failed to parse quote tick: {:?}", e),
                             }
-                            Err(e) => tracing::warn!("Failed to parse quote tick: {:?}", e),
                         }
+                        Some(Ok(SubscriptionItem::Notice(notice))) => {
+                            data_farm_state.handle_notice(&notice, clock);
+                            tracing::debug!(
+                                "IB tick-by-tick quote notice for {}: {} - {}",
+                                instrument_id,
+                                notice.code,
+                                notice.message
+                            );
+                        }
+                        Some(Err(e)) if is_subscription_disconnected_error(&e) => {
+                            data_farm_state.mark_degraded(clock.get_time_ns());
+                            tracing::warn!(
+                                "Tick-by-tick quote subscription disconnected for {}; waiting for data farm recovery: {:?}",
+                                instrument_id,
+                                e
+                            );
+
+                            if !wait_for_data_farm_recovery_or_cancel(
+                                &data_farm_state,
+                                farm_generation,
+                                &cancellation_token,
+                            )
+                            .await
+                            {
+                                subscription.cancel().await;
+                                return Ok(());
+                            }
+                            farm_generation = data_farm_state.recovery_generation();
+                            break;
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!("Subscription error for {}: {:?}", instrument_id, e);
+                            anyhow::bail!("Subscription error: {e:?}");
+                        }
+                        None => break,
                     }
-                    Some(Ok(SubscriptionItem::Notice(notice))) => {
-                        tracing::debug!(
-                            "IB tick-by-tick quote notice for {}: {} - {}",
-                            instrument_id,
-                            notice.code,
-                            notice.message
-                        );
-                    }
-                    Some(Err(e)) => {
-                        tracing::error!("Subscription error for {}: {:?}", instrument_id, e);
-                        anyhow::bail!("Subscription error: {e:?}");
-                    }
-                    None => break,
                 }
             }
         }
@@ -550,25 +919,41 @@ pub(super) async fn handle_trade_subscription(
     data_sender: tokio::sync::mpsc::UnboundedSender<DataEvent>,
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
+    data_farm_state: Arc<DataFarmConnectionState>,
 ) -> anyhow::Result<()> {
     tracing::debug!("Starting trade subscription for {}", instrument_id);
 
-    let mut subscription = client
-        .tick_by_tick(&contract, 0)
-        .all_last()
-        .await
-        .context("Failed to create tick-by-tick trade subscription")?;
+    let mut farm_generation = data_farm_state.recovery_generation();
 
-    process_trade_stream(
-        &mut subscription,
-        instrument_id,
-        price_precision,
-        size_precision,
-        &data_sender,
-        clock,
-        &cancellation_token,
-    )
-    .await?;
+    loop {
+        if cancellation_token.is_cancelled() {
+            break;
+        }
+
+        let mut subscription = client
+            .tick_by_tick(&contract, 0)
+            .all_last()
+            .await
+            .context("Failed to create tick-by-tick trade subscription")?;
+
+        let action = process_trade_stream(
+            &mut subscription,
+            instrument_id,
+            price_precision,
+            size_precision,
+            &data_sender,
+            clock,
+            &cancellation_token,
+            &data_farm_state,
+            farm_generation,
+        )
+        .await?;
+
+        match action {
+            StreamAction::Continue | StreamAction::Stop => break,
+            StreamAction::Resubscribe => farm_generation = data_farm_state.recovery_generation(),
+        }
+    }
 
     Ok(())
 }
@@ -583,12 +968,13 @@ pub(super) async fn handle_realtime_bars_subscription(
     price_precision: u8,
     size_precision: u8,
     data_sender: tokio::sync::mpsc::UnboundedSender<DataEvent>,
-    _clock: &'static AtomicTime,
+    clock: &'static AtomicTime,
     last_bars: Arc<tokio::sync::Mutex<AHashMap<String, RealtimeBar>>>,
     bar_timeout_tasks: Arc<tokio::sync::Mutex<AHashMap<String, tokio::task::JoinHandle<()>>>>,
     handle_revised_bars: bool,
     use_rth: bool,
     cancellation_token: CancellationToken,
+    data_farm_state: Arc<DataFarmConnectionState>,
 ) -> anyhow::Result<()> {
     tracing::debug!("Starting bars subscription for {}", bar_type);
     let trading_hours = if use_rth {
@@ -597,27 +983,43 @@ pub(super) async fn handle_realtime_bars_subscription(
         TradingHours::Extended
     };
 
-    let mut subscription = client
-        .realtime_bars(&contract)
-        .what_to_show(RealtimeWhatToShow::Trades)
-        .trading_hours(trading_hours)
-        .subscribe()
-        .await
-        .context("Failed to create realtime bars subscription")?;
+    let mut farm_generation = data_farm_state.recovery_generation();
 
-    process_realtime_bar_stream(
-        &mut subscription,
-        bar_type,
-        &bar_type_str,
-        price_precision,
-        size_precision,
-        &data_sender,
-        &last_bars,
-        &bar_timeout_tasks,
-        handle_revised_bars,
-        &cancellation_token,
-    )
-    .await?;
+    loop {
+        if cancellation_token.is_cancelled() {
+            break;
+        }
+
+        let mut subscription = client
+            .realtime_bars(&contract)
+            .what_to_show(RealtimeWhatToShow::Trades)
+            .trading_hours(trading_hours)
+            .subscribe()
+            .await
+            .context("Failed to create realtime bars subscription")?;
+
+        let action = process_realtime_bar_stream(
+            &mut subscription,
+            bar_type,
+            &bar_type_str,
+            price_precision,
+            size_precision,
+            &data_sender,
+            &last_bars,
+            &bar_timeout_tasks,
+            handle_revised_bars,
+            &cancellation_token,
+            &data_farm_state,
+            farm_generation,
+            clock,
+        )
+        .await?;
+
+        match action {
+            StreamAction::Continue | StreamAction::Stop => break,
+            StreamAction::Resubscribe => farm_generation = data_farm_state.recovery_generation(),
+        }
+    }
 
     Ok(())
 }
@@ -644,13 +1046,19 @@ async fn process_trade_stream(
     data_sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
     clock: &'static AtomicTime,
     cancellation_token: &CancellationToken,
-) -> anyhow::Result<()> {
+    data_farm_state: &DataFarmConnectionState,
+    farm_generation: u64,
+) -> anyhow::Result<StreamAction> {
     loop {
         tokio::select! {
             () = cancellation_token.cancelled() => {
                 tracing::debug!("Trade subscription cancelled for {}", instrument_id);
                 subscription.cancel().await;
-                break;
+                return Ok(StreamAction::Stop);
+            }
+            () = data_farm_state.wait_for_recovery_after(farm_generation) => {
+                subscription.cancel().await;
+                return Ok(StreamAction::Resubscribe);
             }
             tick_result = subscription.next() => {
                 match tick_result {
@@ -670,13 +1078,14 @@ async fn process_trade_stream(
                         ) {
                             Ok(trade_tick) => {
                                 if data_sender.send(DataEvent::Data(Data::Trade(trade_tick))).is_err() {
-                                    break;
+                                    return Ok(StreamAction::Stop);
                                 }
                             }
                             Err(e) => tracing::warn!("Failed to parse trade tick: {:?}", e),
                         }
                     }
                     Some(Ok(SubscriptionItem::Notice(notice))) => {
+                        data_farm_state.handle_notice(&notice, clock);
                         tracing::debug!(
                             "IB trade notice for {}: {} - {}",
                             instrument_id,
@@ -684,17 +1093,35 @@ async fn process_trade_stream(
                             notice.message
                         );
                     }
+                    Some(Err(e)) if is_subscription_disconnected_error(&e) => {
+                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        tracing::warn!(
+                            "Trade subscription disconnected for {}; waiting for data farm recovery: {:?}",
+                            instrument_id,
+                            e
+                        );
+
+                        if !wait_for_data_farm_recovery_or_cancel(
+                            data_farm_state,
+                            farm_generation,
+                            cancellation_token,
+                        )
+                        .await
+                        {
+                            subscription.cancel().await;
+                            return Ok(StreamAction::Stop);
+                        }
+                        return Ok(StreamAction::Resubscribe);
+                    }
                     Some(Err(e)) => {
                         tracing::error!("Trade subscription error for {}: {:?}", instrument_id, e);
                         anyhow::bail!("Subscription error: {e:?}");
                     }
-                    None => break,
+                    None => return Ok(StreamAction::Stop),
                 }
             }
         }
     }
-
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -709,13 +1136,20 @@ async fn process_realtime_bar_stream(
     bar_timeout_tasks: &Arc<tokio::sync::Mutex<AHashMap<String, tokio::task::JoinHandle<()>>>>,
     handle_revised_bars: bool,
     cancellation_token: &CancellationToken,
-) -> anyhow::Result<()> {
+    data_farm_state: &DataFarmConnectionState,
+    farm_generation: u64,
+    clock: &'static AtomicTime,
+) -> anyhow::Result<StreamAction> {
     loop {
         tokio::select! {
             () = cancellation_token.cancelled() => {
                 tracing::debug!("Bars subscription cancelled for {}", bar_type);
                 subscription.cancel().await;
-                break;
+                return Ok(StreamAction::Stop);
+            }
+            () = data_farm_state.wait_for_recovery_after(farm_generation) => {
+                subscription.cancel().await;
+                return Ok(StreamAction::Resubscribe);
             }
             bar_result = subscription.next() => {
                 match bar_result {
@@ -737,7 +1171,7 @@ async fn process_realtime_bar_stream(
                         )?;
 
                         if data_sender.send(DataEvent::Data(Data::Bar(parsed_bar))).is_err() {
-                            break;
+                            return Ok(StreamAction::Stop);
                         }
 
                         if handle_revised_bars {
@@ -751,6 +1185,7 @@ async fn process_realtime_bar_stream(
                         }
                     }
                     Some(Ok(SubscriptionItem::Notice(notice))) => {
+                        data_farm_state.handle_notice(&notice, clock);
                         tracing::debug!(
                             "IB realtime bar notice for {}: {} - {}",
                             bar_type,
@@ -758,17 +1193,35 @@ async fn process_realtime_bar_stream(
                             notice.message
                         );
                     }
+                    Some(Err(e)) if is_subscription_disconnected_error(&e) => {
+                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        tracing::warn!(
+                            "Realtime bar subscription disconnected for {}; waiting for data farm recovery: {:?}",
+                            bar_type,
+                            e
+                        );
+
+                        if !wait_for_data_farm_recovery_or_cancel(
+                            data_farm_state,
+                            farm_generation,
+                            cancellation_token,
+                        )
+                        .await
+                        {
+                            subscription.cancel().await;
+                            return Ok(StreamAction::Stop);
+                        }
+                        return Ok(StreamAction::Resubscribe);
+                    }
                     Some(Err(e)) => {
                         tracing::error!("Bars subscription error for {}: {:?}", bar_type, e);
                         anyhow::bail!("Subscription error: {e:?}");
                     }
-                    None => break,
+                    None => return Ok(StreamAction::Stop),
                 }
             }
         }
     }
-
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -780,14 +1233,20 @@ async fn process_market_depth_stream(
     data_sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
     clock: &'static AtomicTime,
     cancellation_token: &CancellationToken,
-) -> anyhow::Result<()> {
+    data_farm_state: &DataFarmConnectionState,
+    farm_generation: u64,
+) -> anyhow::Result<StreamAction> {
     let mut sequence: u64 = 0;
 
     loop {
         tokio::select! {
             () = cancellation_token.cancelled() => {
                 subscription.cancel().await;
-                break;
+                return Ok(StreamAction::Stop);
+            }
+            () = data_farm_state.wait_for_recovery_after(farm_generation) => {
+                subscription.cancel().await;
+                return Ok(StreamAction::Resubscribe);
             }
             depth_result = subscription.next() => {
                 match depth_result {
@@ -812,7 +1271,7 @@ async fn process_market_depth_stream(
                         );
 
                         if data_sender.send(DataEvent::Data(Data::Delta(delta))).is_err() {
-                            break;
+                            return Ok(StreamAction::Stop);
                         }
                     }
                     Some(Ok(SubscriptionItem::Data(MarketDepths::MarketDepthL2(depth)))) => {
@@ -844,10 +1303,11 @@ async fn process_market_depth_stream(
                         );
 
                         if data_sender.send(DataEvent::Data(Data::Delta(delta))).is_err() {
-                            break;
+                            return Ok(StreamAction::Stop);
                         }
                     }
                     Some(Ok(SubscriptionItem::Notice(notice))) => {
+                        data_farm_state.handle_notice(&notice, clock);
                         tracing::debug!(
                             "IB market depth notice for {}: {} - {}",
                             instrument_id,
@@ -855,14 +1315,32 @@ async fn process_market_depth_stream(
                             notice.message
                         );
                     }
+                    Some(Err(e)) if is_subscription_disconnected_error(&e) => {
+                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        tracing::warn!(
+                            "Market depth subscription disconnected for {}; waiting for data farm recovery: {:?}",
+                            instrument_id,
+                            e
+                        );
+
+                        if !wait_for_data_farm_recovery_or_cancel(
+                            data_farm_state,
+                            farm_generation,
+                            cancellation_token,
+                        )
+                        .await
+                        {
+                            subscription.cancel().await;
+                            return Ok(StreamAction::Stop);
+                        }
+                        return Ok(StreamAction::Resubscribe);
+                    }
                     Some(Err(e)) => anyhow::bail!("Subscription error: {e:?}"),
-                    None => break,
+                    None => return Ok(StreamAction::Stop),
                 }
             }
         }
     }
-
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -877,28 +1355,44 @@ pub(super) async fn handle_market_depth_subscription(
     data_sender: tokio::sync::mpsc::UnboundedSender<DataEvent>,
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
+    data_farm_state: Arc<DataFarmConnectionState>,
 ) -> anyhow::Result<()> {
-    let mut subscription = client
-        .market_depth(&contract, depth_rows)
-        .smart_depth(if is_smart_depth {
-            SmartDepth::Yes
-        } else {
-            SmartDepth::No
-        })
-        .subscribe()
-        .await
-        .context("Failed to create market depth subscription")?;
+    let mut farm_generation = data_farm_state.recovery_generation();
 
-    process_market_depth_stream(
-        &mut subscription,
-        instrument_id,
-        price_precision,
-        size_precision,
-        &data_sender,
-        clock,
-        &cancellation_token,
-    )
-    .await?;
+    loop {
+        if cancellation_token.is_cancelled() {
+            break;
+        }
+
+        let mut subscription = client
+            .market_depth(&contract, depth_rows)
+            .smart_depth(if is_smart_depth {
+                SmartDepth::Yes
+            } else {
+                SmartDepth::No
+            })
+            .subscribe()
+            .await
+            .context("Failed to create market depth subscription")?;
+
+        let action = process_market_depth_stream(
+            &mut subscription,
+            instrument_id,
+            price_precision,
+            size_precision,
+            &data_sender,
+            clock,
+            &cancellation_token,
+            &data_farm_state,
+            farm_generation,
+        )
+        .await?;
+
+        match action {
+            StreamAction::Continue | StreamAction::Stop => break,
+            StreamAction::Resubscribe => farm_generation = data_farm_state.recovery_generation(),
+        }
+    }
 
     Ok(())
 }
@@ -1136,7 +1630,8 @@ where
             }
             Ok(StreamAction::Continue)
         }
-        Ok(SubscriptionItem::Data(_) | SubscriptionItem::Notice(_)) => Ok(StreamAction::Continue),
+        Ok(SubscriptionItem::Notice(_)) => Ok(StreamAction::Continue),
+        Ok(SubscriptionItem::Data(_)) => Ok(StreamAction::Continue),
         Err(e) => {
             tracing::error!(
                 "Index price subscription stream error for {}: {:?}",
@@ -1337,7 +1832,7 @@ mod tests {
 
     use ahash::AHashMap;
     use ibapi::{
-        Notice,
+        Error, Notice,
         contracts::{OptionComputation, tick_types::TickType},
         market_data::realtime::{
             Bar as RealtimeBar, MarketDepth, MarketDepthL2, MarketDepths, TickAttribute,
@@ -1355,10 +1850,11 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::{
-        OptionGreeksCache, QuoteCache, StreamAction, process_index_price_tick_result,
-        process_market_depth_stream, process_option_greeks_tick_result, process_quote_tick_result,
-        process_realtime_bar_stream, process_trade_stream, send_quote_tick,
-        update_quote_from_price_tick, update_revised_bar_tracking,
+        DataFarmConnectionState, OptionGreeksCache, QuoteCache, StreamAction,
+        process_index_price_tick_result, process_market_depth_stream,
+        process_option_greeks_tick_result, process_quote_tick_result, process_realtime_bar_stream,
+        process_trade_stream, send_quote_tick, update_quote_from_price_tick,
+        update_revised_bar_tracking,
     };
 
     fn instrument_id() -> InstrumentId {
@@ -1367,6 +1863,15 @@ mod tests {
 
     fn minute_bar_type() -> BarType {
         BarType::from("SPX.CBOE-1-MINUTE-LAST-EXTERNAL")
+    }
+
+    fn notice(code: i32, message: &str) -> Notice {
+        Notice {
+            code,
+            message: message.to_string(),
+            error_time: None,
+            advanced_order_reject_json: String::new(),
+        }
     }
 
     #[rstest]
@@ -1425,6 +1930,28 @@ mod tests {
         );
 
         assert_eq!(duration, 18_000.seconds());
+    }
+
+    #[rstest]
+    fn test_data_farm_state_records_recovery_generation() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
+
+        data_farm_state.handle_notice(
+            &notice(2103, "Market data farm connection is broken:usfarm"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:usfarm"),
+            clock,
+        );
+
+        assert_eq!(data_farm_state.recovery_generation(), 1);
+        assert!(
+            data_farm_state
+                .last_recovery_since_ns(data_farm_state.recovery_generation())
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -1872,6 +2399,7 @@ mod tests {
         let mut subscription = Subscription::new(trade_receiver);
         let cancellation_token = CancellationToken::new();
         let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
 
         trade_sender
             .send(Ok(Trade {
@@ -1897,6 +2425,8 @@ mod tests {
             &sender,
             clock,
             &cancellation_token,
+            &data_farm_state,
+            data_farm_state.recovery_generation(),
         )
         .await
         .unwrap();
@@ -1911,6 +2441,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_process_trade_stream_10182_waits_for_farm_ok_and_resubscribes() {
+        let instrument_id = instrument_id();
+        let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+        let (trade_sender, trade_receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut subscription = Subscription::new(trade_receiver);
+        let cancellation_token = CancellationToken::new();
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = Arc::new(DataFarmConnectionState::default());
+        let farm_generation = data_farm_state.recovery_generation();
+
+        trade_sender
+            .send(Err(Error::Notice(notice(
+                10182,
+                "Failed to request live updates (disconnected).",
+            ))))
+            .unwrap();
+
+        let state_for_recovery = Arc::clone(&data_farm_state);
+
+        let recovery_task = tokio::spawn(async move {
+            loop {
+                if state_for_recovery
+                    .degraded_since_ns
+                    .lock()
+                    .expect("data farm state mutex poisoned")
+                    .is_some()
+                {
+                    state_for_recovery.handle_notice(
+                        &notice(2104, "Market data farm connection is OK:usfarm"),
+                        clock,
+                    );
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        });
+
+        let action = process_trade_stream(
+            &mut subscription,
+            instrument_id,
+            2,
+            0,
+            &sender,
+            clock,
+            &cancellation_token,
+            &data_farm_state,
+            farm_generation,
+        )
+        .await
+        .unwrap();
+        recovery_task.await.unwrap();
+
+        assert!(matches!(action, StreamAction::Resubscribe));
+        assert_eq!(data_farm_state.recovery_generation(), 1);
+    }
+
+    #[tokio::test]
     async fn test_process_realtime_bar_stream_emits_bar_and_tracks_revision() {
         let bar_type = BarType::from("SPX.CBOE-5-SECOND-LAST-EXTERNAL");
         let bar_type_str = bar_type.to_string();
@@ -1920,6 +2507,8 @@ mod tests {
         let cancellation_token = CancellationToken::new();
         let last_bars = Arc::new(tokio::sync::Mutex::new(AHashMap::new()));
         let timeout_tasks = Arc::new(tokio::sync::Mutex::new(AHashMap::new()));
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
 
         bar_sender
             .send(Ok(RealtimeBar {
@@ -1946,6 +2535,9 @@ mod tests {
             &timeout_tasks,
             true,
             &cancellation_token,
+            &data_farm_state,
+            data_farm_state.recovery_generation(),
+            clock,
         )
         .await
         .unwrap();
@@ -1968,6 +2560,7 @@ mod tests {
         let mut subscription = Subscription::new(depth_receiver);
         let cancellation_token = CancellationToken::new();
         let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
 
         depth_sender
             .send(Ok(MarketDepths::MarketDepth(MarketDepth {
@@ -1999,6 +2592,8 @@ mod tests {
             &sender,
             clock,
             &cancellation_token,
+            &data_farm_state,
+            data_farm_state.recovery_generation(),
         )
         .await
         .unwrap();

--- a/crates/adapters/interactive_brokers/src/historical/client.rs
+++ b/crates/adapters/interactive_brokers/src/historical/client.rs
@@ -23,6 +23,8 @@ use ibapi::{
     client::Client,
     contracts::Contract,
     market_data::{IgnoreSize, TradingHours, historical},
+    prelude::StreamExt,
+    subscriptions::SubscriptionItem,
 };
 use nautilus_core::UnixNanos;
 use nautilus_model::{
@@ -581,7 +583,21 @@ impl HistoricalInteractiveBrokersClient {
 
                         let mut batch_ticks = Vec::new();
 
-                        while let Some(tick) = subscription.next().await {
+                        while let Some(tick_result) = subscription.next().await {
+                            let tick = match tick_result {
+                                Ok(SubscriptionItem::Data(tick)) => tick,
+                                Ok(SubscriptionItem::Notice(notice)) => {
+                                    tracing::debug!(
+                                        "IB historical trade tick notice: {} - {}",
+                                        notice.code,
+                                        notice.message
+                                    );
+                                    continue;
+                                }
+                                Err(e) => {
+                                    return Err(e).context("Historical trade tick stream failed");
+                                }
+                            };
                             let ts_event = ib_timestamp_to_unix_nanos(&tick.timestamp);
 
                             if ts_event < start_date_time_ns || ts_event > end_date_time_ns {
@@ -682,7 +698,21 @@ impl HistoricalInteractiveBrokersClient {
 
                         let mut batch_ticks = Vec::new();
 
-                        while let Some(tick) = subscription.next().await {
+                        while let Some(tick_result) = subscription.next().await {
+                            let tick = match tick_result {
+                                Ok(SubscriptionItem::Data(tick)) => tick,
+                                Ok(SubscriptionItem::Notice(notice)) => {
+                                    tracing::debug!(
+                                        "IB historical bid/ask tick notice: {} - {}",
+                                        notice.code,
+                                        notice.message
+                                    );
+                                    continue;
+                                }
+                                Err(e) => {
+                                    return Err(e).context("Historical bid/ask tick stream failed");
+                                }
+                            };
                             let ts_event = ib_timestamp_to_unix_nanos(&tick.timestamp);
 
                             if ts_event < start_date_time_ns || ts_event > end_date_time_ns {


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Reproduces the data farm recovery behavior from upstream PR #4412 for the Rust Interactive Brokers adapter.
- Bumps `ibapi` from `3.0.1` to `3.2.0` so the adapter can use upstream notice stream and connectivity status support.
- Keeps socket connectivity separate from IB market data farm health: data farm 2103/2105 notices degrade data feeds without tearing down the client, and 2104/2106 notices trigger subscription recovery.
- Treats IB 10182 subscription disconnects as recoverable data farm interruptions when a farm outage is active, then resubscribes after farm recovery.
- Replays historical bar subscriptions from the earliest recorded data-loss timestamp after recovery so missed bars are backfilled.

### Design decisions
- Kept the policy in Nautilus rather than changing `rust-ibapi`, because `rust-ibapi` already exposes `ConnectivityStatus`, `Notice`, and `Client::notice_stream()` in version `3.2.0`. Subscription restart, backfill, and cancellation behavior are adapter lifecycle concerns.
- Added a shared `DataFarmConnectionState` to the data client so the global notice monitor and individual subscription tasks can coordinate farm degradation and recovery generations.
- Used recovery generations instead of a boolean flag so each subscription can detect only recoveries that happened after it was started.
- Left IB 10182 as a subscription-level error and handled it at the adapter boundary, where the affected subscription and Nautilus data type are known.
- Updated historical tick stream handling for the `ibapi 3.2.0` `SubscriptionItem` envelope while preserving existing pagination behavior.

### Data farm recovery flow
```mermaid
sequenceDiagram
    participant IB as Interactive Brokers
    participant Notice as Notice monitor
    participant State as DataFarmConnectionState
    participant Sub as Data subscription task
    participant Bus as Nautilus data bus

    IB->>Notice: 2103 or 2105 farm broken notice
    Notice->>State: mark degraded at current timestamp
    Sub->>Sub: keep socket task alive
    IB->>Sub: 10182 subscription disconnected
    Sub->>State: mark degraded if needed
    Sub->>State: wait for next recovery generation
    IB->>Notice: 2104 or 2106 farm OK notice
    Notice->>State: record recovery and notify waiters
    State-->>Sub: recovery generation changed
    Sub->>IB: cancel stale stream and resubscribe
    Sub->>Bus: publish fresh data
```

### Historical bar backfill flow
```mermaid
flowchart TD
    A[Historical bar stream starts] --> B[Track first requested start timestamp]
    B --> C{Farm interruption?}
    C -- No --> D[Continue streaming bars]
    C -- Yes --> E[Record earliest data-loss timestamp]
    E --> F[Wait for farm OK recovery generation]
    F --> G[Resolve replay start]
    G --> H{Data loss before requested start?}
    H -- Yes --> I[Replay from first requested start]
    H -- No --> J[Replay from data-loss timestamp]
    I --> K[Open replacement historical bar stream]
    J --> K
    K --> D
```

### Relevant files
- `Cargo.toml` and `Cargo.lock`: pin `ibapi` to `3.2.0`.
- `crates/adapters/interactive_brokers/src/data/core.rs`: owns shared data farm state and starts the notice monitor when the data client connects.
- `crates/adapters/interactive_brokers/src/data/core_streams.rs`: handles farm degradation, recovery waits, resubscription, and historical bar replay.
- `crates/adapters/interactive_brokers/src/historical/client.rs`: adapts historical tick collection to the `ibapi 3.2.0` stream envelope.

### Verification
- `cargo test -p nautilus-interactive-brokers --lib`
- `make build-debug`
- `make cargo-test-core-local`
- `make format`
- `mermaid-lint /Users/ata/Developer/nautilus/PR_Summaries/20260708T081342Z_ib_data_farm_recovery.md`
- `make pre-commit`


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

#4412

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
