### PR TITLE
fix(indicators): use typical price (HLC/3) in VWAP Python binding

### DIFF
--- a/crates/indicators/src/python/average/vwap.rs
+++ b/crates/indicators/src/python/average/vwap.rs
@@ -58,13 +58,8 @@ impl VolumeWeightedAveragePrice {
 
     #[pyo3(name = "handle_bar")]
     fn py_handle_bar(&mut self, bar: &Bar) {
-        let typical_price =
-            (bar.close.as_f64() + bar.high.as_f64() + bar.low.as_f64()) / 3.0;
-        self.py_update_raw(
-            typical_price,
-            (&bar.volume).into(),
-            bar.ts_init.as_f64(),
-        );
+        let typical_price = (bar.close.as_f64() + bar.high.as_f64() + bar.low.as_f64()) / 3.0;
+        self.py_update_raw(typical_price, (&bar.volume).into(), bar.ts_init.as_f64());
     }
 
     #[pyo3(name = "reset")]
@@ -77,4 +72,3 @@ impl VolumeWeightedAveragePrice {
         self.update_raw(value, volume, ts);
     }
 }
-

--- a/crates/indicators/src/python/average/vwap.rs
+++ b/crates/indicators/src/python/average/vwap.rs
@@ -58,8 +58,10 @@ impl VolumeWeightedAveragePrice {
 
     #[pyo3(name = "handle_bar")]
     fn py_handle_bar(&mut self, bar: &Bar) {
+        let typical_price =
+            (bar.close.as_f64() + bar.high.as_f64() + bar.low.as_f64()) / 3.0;
         self.py_update_raw(
-            (&bar.close).into(),
+            typical_price,
             (&bar.volume).into(),
             bar.ts_init.as_f64(),
         );
@@ -75,3 +77,4 @@ impl VolumeWeightedAveragePrice {
         self.update_raw(value, volume, ts);
     }
 }
+


### PR DESCRIPTION
The `py_handle_bar` method in the VWAP Python (PyO3) binding was passing 
only `bar.close` to `update_raw`, while the Rust core `handle_bar` 
correctly computes typical price as `(close + high + low) / 3.0`. This 
caused different VWAP values between the Rust and Python paths, breaking 
research-to-live parity for any strategy using VWAP from Python.

Fixed by computing `typical_price = (close + high + low) / 3.0` in 
`py_handle_bar` before passing it to `py_update_raw`, mirroring the 
existing Rust core implementation exactly.

Closes #4421

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
