### PR TITLE
Fix cash settlement for options on index underlyings

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -58,6 +58,7 @@ releases as feedback arrives, before the final `2.0.0` release.
 - Changed v2 order-event serialization to carry `activation_price` on `OrderInitialized`/`OrderSnapshot` and `info` on `OrderFilled`; catalog data written before this change cannot be read
 - Changed v2 `TrailingStopMarketOrder`/`TrailingStopLimitOrder`, `OrderInitialized`, and `OrderFilled` Python and PyO3 constructors to accept `activation_price`/`info` parameters
 - Changed v2 `OrderPendingUpdate` and `OrderPendingCancel` `account_id` to optional (`AccountId | None`), matching v1
+- Changed option settlement for an index underlying to read the index price (`IndexPriceUpdate`) rather than `PriceType::Last`; feed the index level via `IndexPriceUpdate` (an index does not trade) instead of a `TradeTick` (#4430)
 
 ### Fixes
 - Fixed v2 composite bar aggregation (`@` source) to deliver aggregated bars to subscribed actors and strategies

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -2462,12 +2462,9 @@ impl OrderMatchingEngine {
         };
         let underlying_id = InstrumentId::from(format!("{underlying}.{}", self.venue).as_str());
 
-        let (underlying_instrument, underlying_price) = {
+        let underlying_instrument = {
             let cache = self.cache.borrow();
-            (
-                cache.instrument(&underlying_id).cloned(),
-                cache.price(&underlying_id, PriceType::Last),
-            )
+            cache.instrument(&underlying_id).cloned()
         };
 
         let underlying_instrument = match underlying_instrument {
@@ -2475,6 +2472,19 @@ impl OrderMatchingEngine {
             None => {
                 log::error!("No underlying instrument for option {instrument_id}");
                 return;
+            }
+        };
+
+        // Resolve the underlying price by the underlying's instrument type. An index
+        // is disseminated via `IndexPriceUpdate` (it does not trade), so its level is
+        // held in the cache's index-price store rather than the trade/quote `price(...)`
+        // store; a tradeable underlying (e.g. an equity) keeps the `Last` trade lookup.
+        let underlying_price = {
+            let cache = self.cache.borrow();
+            if matches!(underlying_instrument, InstrumentAny::IndexInstrument(_)) {
+                cache.index_price(&underlying_id).map(|ip| ip.value)
+            } else {
+                cache.price(&underlying_id, PriceType::Last)
             }
         };
 

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -38,8 +38,8 @@ use nautilus_execution::{
 };
 use nautilus_model::{
     data::{
-        Bar, BarType, BookOrder, InstrumentClose, OptionGreeks, QuoteTick, TradeTick,
-        stubs::OrderBookDeltaTestBuilder,
+        Bar, BarType, BookOrder, IndexPriceUpdate, InstrumentClose, OptionGreeks, QuoteTick,
+        TradeTick, stubs::OrderBookDeltaTestBuilder,
     },
     enums::{
         AccountType, AggressorSide, AssetClass, BookAction, BookType, ContingencyType,
@@ -12564,12 +12564,12 @@ fn option_contract(
     kind: OptionKind,
 ) -> OptionContract {
     let symbol = match kind {
-        OptionKind::Call => "AAPL211217C00150000",
-        OptionKind::Put => "AAPL211217P00150000",
+        OptionKind::Call => format!("{underlying}211217C00150000"),
+        OptionKind::Put => format!("{underlying}211217P00150000"),
     };
     OptionContract::new(
         InstrumentId::from(format!("{symbol}.{venue}").as_str()),
-        Symbol::from(symbol),
+        Symbol::from(symbol.as_str()),
         AssetClass::Equity,
         Some(Ustr::from(venue)),
         Ustr::from(underlying),
@@ -12634,8 +12634,8 @@ fn crypto_option_call_btc(venue: &str, expiration_ns: UnixNanos, strike: Price) 
 
 fn underlying_index(venue: &str) -> IndexInstrument {
     IndexInstrument::new(
-        InstrumentId::from(format!("AAPL.{venue}").as_str()),
-        Symbol::from("AAPL"),
+        InstrumentId::from(format!("SPX.{venue}").as_str()),
+        Symbol::from("SPX"),
         Currency::USD(),
         2,
         0,
@@ -12732,7 +12732,7 @@ fn test_option_cash_settlement_at_intrinsic_value(account_id: AccountId) {
     let venue = "OPRA";
     let expiration_ns = UnixNanos::from(2_000_000_000_000_000_000u64);
     let option = InstrumentAny::OptionContract(option_contract(
-        "AAPL",
+        "SPX",
         venue,
         expiration_ns,
         OptionKind::Call,
@@ -12748,12 +12748,9 @@ fn test_option_cash_settlement_at_intrinsic_value(account_id: AccountId) {
     // ITM call: spot 160 > strike 149 -> cash payout 11.00
     cache
         .borrow_mut()
-        .add_trade(TradeTick::new(
+        .add_index_price(IndexPriceUpdate::new(
             underlying.id(),
             Price::from("160.00"),
-            Quantity::from(1),
-            AggressorSide::NoAggressor,
-            TradeId::from("U-1"),
             UnixNanos::from(1),
             UnixNanos::from(1),
         ))
@@ -13159,7 +13156,7 @@ fn test_option_cash_settlement_put_pays_strike_minus_spot(account_id: AccountId)
     let venue = "OPRA";
     let expiration_ns = UnixNanos::from(2_000_000_000_000_000_000u64);
     let option = InstrumentAny::OptionContract(option_contract(
-        "AAPL",
+        "SPX",
         venue,
         expiration_ns,
         OptionKind::Put,
@@ -13175,12 +13172,9 @@ fn test_option_cash_settlement_put_pays_strike_minus_spot(account_id: AccountId)
     // ITM put: spot 140 < strike 149 -> cash payout 9.00
     cache
         .borrow_mut()
-        .add_trade(TradeTick::new(
+        .add_index_price(IndexPriceUpdate::new(
             underlying.id(),
             Price::from("140.00"),
-            Quantity::from(1),
-            AggressorSide::NoAggressor,
-            TradeId::from("U-1"),
             UnixNanos::from(1),
             UnixNanos::from(1),
         ))
@@ -13636,7 +13630,7 @@ fn test_check_instrument_expiration_idempotent_after_processed(account_id: Accou
     let venue = "OPRA";
     let expiration_ns = UnixNanos::from(2_000_000_000_000_000_000u64);
     let option = InstrumentAny::OptionContract(option_contract(
-        "AAPL",
+        "SPX",
         venue,
         expiration_ns,
         OptionKind::Call,
@@ -13650,12 +13644,9 @@ fn test_check_instrument_expiration_idempotent_after_processed(account_id: Accou
         .unwrap();
     cache
         .borrow_mut()
-        .add_trade(TradeTick::new(
+        .add_index_price(IndexPriceUpdate::new(
             underlying.id(),
             Price::from("160.00"),
-            Quantity::from(1),
-            AggressorSide::NoAggressor,
-            TradeId::from("U-1"),
             UnixNanos::from(1),
             UnixNanos::from(1),
         ))
@@ -14089,12 +14080,9 @@ fn test_crypto_option_cash_settlement(account_id: AccountId) {
     // ITM call: spot 51000 > strike 50000 -> cash payout 1000.00
     cache
         .borrow_mut()
-        .add_trade(TradeTick::new(
+        .add_index_price(IndexPriceUpdate::new(
             underlying.id(),
             Price::from("51000.00"),
-            Quantity::from(1),
-            AggressorSide::NoAggressor,
-            TradeId::from("U-1"),
             UnixNanos::from(1),
             UnixNanos::from(1),
         ))
@@ -14317,7 +14305,7 @@ fn test_option_cash_settlement_with_custom_settlement_price(account_id: AccountI
     let venue = "OPRA";
     let expiration_ns = UnixNanos::from(2_000_000_000_000_000_000u64);
     let option = InstrumentAny::OptionContract(option_contract(
-        "AAPL",
+        "SPX",
         venue,
         expiration_ns,
         OptionKind::Call,
@@ -14332,12 +14320,9 @@ fn test_option_cash_settlement_with_custom_settlement_price(account_id: AccountI
 
     cache
         .borrow_mut()
-        .add_trade(TradeTick::new(
+        .add_index_price(IndexPriceUpdate::new(
             underlying.id(),
             Price::from("160.00"),
-            Quantity::from(1),
-            AggressorSide::NoAggressor,
-            TradeId::from("U-1"),
             UnixNanos::from(1),
             UnixNanos::from(1),
         ))


### PR DESCRIPTION
**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`OrderMatchingEngine::process_option_expiry` resolved the underlying price with `cache.price(underlying, PriceType::Last)` only. An index is disseminated via `IndexPriceUpdate` (it does not trade), so its level is held in the cache's index-price store rather than the trade/quote `price(...)` store — so a cash-settled option on an **index** underlying never settled at expiry: the position stayed open, its intrinsic value was never booked, and the only signal was a single `No underlying price for option ...` ERROR log. This resolves the underlying price by the underlying's instrument type: `cache.index_price(...)` for an `IndexInstrument`, and the existing `Last` trade-price lookup for tradeable underlyings (e.g. equities).

## Related Issues/PRs

Closes #4430.

## Type of change

- [x] Breaking change (impacts existing behavior)

## Breaking change details (if applicable)

Settlement for an option on an **index** underlying now reads the index price (`cache.index_price()`, i.e. an `IndexPriceUpdate`) instead of `PriceType::Last`.

**Migration:** feed the index underlying's level via `IndexPriceUpdate` (the canonical data type for an index, which by definition does not trade). Before this change the only way to settle an index option was to feed the index a `TradeTick` (populating `PriceType::Last`); that path no longer settles an index option. Tradeable underlyings (equities, etc.) are unchanged — they keep the `Last` trade-price lookup.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`) — n/a, no documentation change

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (under Breaking Changes)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] I added/updated tests to cover new or changed logic

The option cash-settlement tests in `crates/execution/tests/matching_engine.rs` — `test_option_cash_settlement_at_intrinsic_value`, `test_option_cash_settlement_put_pays_strike_minus_spot`, `test_crypto_option_cash_settlement`, `test_option_cash_settlement_with_custom_settlement_price`, and `test_check_instrument_expiration_idempotent_after_processed` — previously fed the index underlying a fabricated `TradeTick`. They now feed `IndexPriceUpdate`, which exercises the fixed resolution path and would not settle under the previous `PriceType::Last`-only lookup. These tests also modelled the index underlying as `AAPL` (a stock); they now use `SPX` so the fixture reflects an actual cash-settled index option — the shared `option_contract` fixture derives its symbol from the underlying, so the equity tests that pass `AAPL` are byte-identical. Physical-settlement and missing-underlying-price tests (tradeable underlyings) are unchanged. The full Rust suite runs in CI.
