### PR TITLE
Add DataActor facade for OrderBookDepth10 subscriptions

### DIFF
--- a/crates/common/src/actor/data_actor.rs
+++ b/crates/common/src/actor/data_actor.rs
@@ -69,16 +69,16 @@ use crate::{
             QuotesResponse, RequestBars, RequestBookDeltas, RequestBookDepth, RequestBookSnapshot,
             RequestCommand, RequestCustomData, RequestFundingRates, RequestInstrument,
             RequestInstruments, RequestQuotes, RequestTrades, SubscribeBars, SubscribeBookDeltas,
-            SubscribeBookSnapshots, SubscribeCommand, SubscribeCustomData, SubscribeFundingRates,
-            SubscribeIndexPrices, SubscribeInstrument, SubscribeInstrumentClose,
-            SubscribeInstrumentStatus, SubscribeInstruments, SubscribeMarkPrices,
-            SubscribeOptionChain, SubscribeOptionGreeks, SubscribeQuotes, SubscribeTrades,
-            TradesResponse, UnsubscribeBars, UnsubscribeBookDeltas, UnsubscribeBookSnapshots,
-            UnsubscribeCommand, UnsubscribeCustomData, UnsubscribeFundingRates,
-            UnsubscribeIndexPrices, UnsubscribeInstrument, UnsubscribeInstrumentClose,
-            UnsubscribeInstrumentStatus, UnsubscribeInstruments, UnsubscribeMarkPrices,
-            UnsubscribeOptionChain, UnsubscribeOptionGreeks, UnsubscribeQuotes, UnsubscribeTrades,
-            is_parent_subscription,
+            SubscribeBookDepth10, SubscribeBookSnapshots, SubscribeCommand, SubscribeCustomData,
+            SubscribeFundingRates, SubscribeIndexPrices, SubscribeInstrument,
+            SubscribeInstrumentClose, SubscribeInstrumentStatus, SubscribeInstruments,
+            SubscribeMarkPrices, SubscribeOptionChain, SubscribeOptionGreeks, SubscribeQuotes,
+            SubscribeTrades, TradesResponse, UnsubscribeBars, UnsubscribeBookDeltas,
+            UnsubscribeBookDepth10, UnsubscribeBookSnapshots, UnsubscribeCommand,
+            UnsubscribeCustomData, UnsubscribeFundingRates, UnsubscribeIndexPrices,
+            UnsubscribeInstrument, UnsubscribeInstrumentClose, UnsubscribeInstrumentStatus,
+            UnsubscribeInstruments, UnsubscribeMarkPrices, UnsubscribeOptionChain,
+            UnsubscribeOptionGreeks, UnsubscribeQuotes, UnsubscribeTrades, is_parent_subscription,
         },
         system::ShutdownSystem,
     },
@@ -86,11 +86,11 @@ use crate::{
         self, MStr, Pattern, ShareableMessageHandler, Topic, TypedHandler, get_message_bus,
         switchboard::{
             MessagingSwitchboard, get_bars_topic, get_book_deltas_pattern, get_book_deltas_topic,
-            get_book_snapshots_topic, get_custom_topic, get_funding_rate_topic,
-            get_index_price_topic, get_instrument_close_topic, get_instrument_status_topic,
-            get_instrument_topic, get_instruments_pattern, get_mark_price_topic,
-            get_option_chain_topic, get_option_greeks_topic, get_quotes_topic, get_signal_pattern,
-            get_trades_topic,
+            get_book_depth10_pattern, get_book_depth10_topic, get_book_snapshots_topic,
+            get_custom_topic, get_funding_rate_topic, get_index_price_topic,
+            get_instrument_close_topic, get_instrument_status_topic, get_instrument_topic,
+            get_instruments_pattern, get_mark_price_topic, get_option_chain_topic,
+            get_option_greeks_topic, get_quotes_topic, get_signal_pattern, get_trades_topic,
         },
     },
     signal::Signal,
@@ -418,6 +418,16 @@ pub trait DataActor: Component {
     /// Returns an error if handling the book deltas fails.
     #[allow(unused_variables)]
     fn on_book_deltas(&mut self, deltas: &OrderBookDeltas) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Actions to be performed when receiving order book depth10 snapshots.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if handling the book depth fails.
+    #[allow(unused_variables)]
+    fn on_book_depth(&mut self, depth: &OrderBookDepth10) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -850,6 +860,20 @@ pub trait DataActor: Component {
         }
 
         if let Err(e) = self.on_book_deltas(deltas) {
+            log_error(&e);
+        }
+    }
+
+    /// Handles received order book depth10 snapshots.
+    fn handle_book_depth(&mut self, depth: &OrderBookDepth10) {
+        log_received(&depth);
+
+        if self.not_running() {
+            log_not_running(&depth);
+            return;
+        }
+
+        if let Err(e) = self.on_book_depth(depth) {
             log_error(&e);
         }
     }
@@ -1442,6 +1466,44 @@ pub trait DataActor: Component {
         );
     }
 
+    /// Subscribe to streaming [`OrderBookDepth10`] data for the `instrument_id`.
+    fn subscribe_book_depth10(
+        &mut self,
+        instrument_id: InstrumentId,
+        book_type: BookType,
+        depth: Option<NonZeroUsize>,
+        client_id: Option<ClientId>,
+        managed: bool,
+        params: Option<Params>,
+    ) where
+        Self: DataActorNative,
+        Self: 'static + Debug + Sized,
+    {
+        let actor_id = self.core().actor_id().inner();
+        let is_parent = is_parent_subscription(params.as_ref());
+        let pattern = if is_parent {
+            get_book_depth10_pattern(instrument_id)
+        } else {
+            get_book_depth10_topic(instrument_id).into()
+        };
+
+        let handler = TypedHandler::from(move |depth: &OrderBookDepth10| {
+            get_actor_unchecked::<Self>(&actor_id).handle_book_depth(depth);
+        });
+
+        DataActorCore::subscribe_book_depth10(
+            self.core_mut(),
+            pattern,
+            handler,
+            instrument_id,
+            book_type,
+            depth,
+            client_id,
+            managed,
+            params,
+        );
+    }
+
     /// Subscribe to [`OrderBook`] snapshots at a specified interval for the `instrument_id`.
     fn subscribe_book_at_interval(
         &mut self,
@@ -1947,6 +2009,19 @@ pub trait DataActor: Component {
         Self: 'static + Debug + Sized,
     {
         DataActorCore::unsubscribe_book_deltas(self.core_mut(), instrument_id, client_id, params);
+    }
+
+    /// Unsubscribe from streaming [`OrderBookDepth10`] data for the `instrument_id`.
+    fn unsubscribe_book_depth10(
+        &mut self,
+        instrument_id: InstrumentId,
+        client_id: Option<ClientId>,
+        params: Option<Params>,
+    ) where
+        Self: DataActorNative,
+        Self: 'static + Debug + Sized,
+    {
+        DataActorCore::unsubscribe_book_depth10(self.core_mut(), instrument_id, client_id, params);
     }
 
     /// Unsubscribe from [`OrderBook`] snapshots at a specified interval for the `instrument_id`.
@@ -2827,7 +2902,6 @@ impl DataActorCore {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn add_depth10_subscription(
         &mut self,
         pattern: MStr<Pattern>,
@@ -2844,7 +2918,6 @@ impl DataActorCore {
         msgbus::subscribe_book_depth10(pattern, handler, None);
     }
 
-    #[allow(dead_code)]
     pub(crate) fn remove_depth10_subscription(&mut self, pattern: MStr<Pattern>) {
         if let Some(handler) = self.depth10_handlers.remove(&pattern) {
             msgbus::unsubscribe_book_depth10(pattern, &handler);
@@ -3743,6 +3816,39 @@ impl DataActorCore {
         self.send_data_cmd(DataCommand::Subscribe(command));
     }
 
+    /// Helper method for registering book depth10 subscriptions from the trait.
+    #[expect(clippy::too_many_arguments)]
+    pub fn subscribe_book_depth10(
+        &mut self,
+        pattern: MStr<Pattern>,
+        handler: TypedHandler<OrderBookDepth10>,
+        instrument_id: InstrumentId,
+        book_type: BookType,
+        depth: Option<NonZeroUsize>,
+        client_id: Option<ClientId>,
+        managed: bool,
+        params: Option<Params>,
+    ) {
+        self.check_registered();
+
+        self.add_depth10_subscription(pattern, handler);
+
+        let command = SubscribeCommand::BookDepth10(SubscribeBookDepth10 {
+            instrument_id,
+            book_type,
+            client_id,
+            venue: Some(instrument_id.venue),
+            command_id: UUID4::new(),
+            ts_init: self.timestamp_ns(),
+            depth,
+            managed,
+            correlation_id: None,
+            params,
+        });
+
+        self.send_data_cmd(DataCommand::Subscribe(command));
+    }
+
     /// Helper method for registering book snapshots subscriptions from the trait.
     #[expect(clippy::too_many_arguments)]
     pub fn subscribe_book_at_interval(
@@ -4131,6 +4237,35 @@ impl DataActorCore {
         self.remove_deltas_subscription(pattern);
 
         let command = UnsubscribeCommand::BookDeltas(UnsubscribeBookDeltas {
+            instrument_id,
+            client_id,
+            venue: Some(instrument_id.venue),
+            command_id: UUID4::new(),
+            ts_init: self.timestamp_ns(),
+            correlation_id: None,
+            params,
+        });
+
+        self.send_data_cmd(DataCommand::Unsubscribe(command));
+    }
+
+    /// Helper method for unsubscribing from book depth10.
+    pub fn unsubscribe_book_depth10(
+        &mut self,
+        instrument_id: InstrumentId,
+        client_id: Option<ClientId>,
+        params: Option<Params>,
+    ) {
+        self.check_registered();
+
+        let pattern = if is_parent_subscription(params.as_ref()) {
+            get_book_depth10_pattern(instrument_id)
+        } else {
+            get_book_depth10_topic(instrument_id).into()
+        };
+        self.remove_depth10_subscription(pattern);
+
+        let command = UnsubscribeCommand::BookDepth10(UnsubscribeBookDepth10 {
             instrument_id,
             client_id,
             venue: Some(instrument_id.venue),
@@ -4847,6 +4982,11 @@ impl DataActorCore {
     }
 
     #[cfg(test)]
+    pub fn depth10_handler_count(&self) -> usize {
+        self.depth10_handlers.len()
+    }
+
+    #[cfg(test)]
     pub fn has_quote_handler(&self, topic: &str) -> bool {
         self.quote_handlers
             .contains_key(&MStr::<Topic>::from(topic))
@@ -4866,6 +5006,12 @@ impl DataActorCore {
     #[cfg(test)]
     pub fn has_deltas_handler(&self, pattern: &str) -> bool {
         self.deltas_handlers
+            .contains_key(&MStr::<Pattern>::from(pattern))
+    }
+
+    #[cfg(test)]
+    pub fn has_depth10_handler(&self, pattern: &str) -> bool {
+        self.depth10_handlers
             .contains_key(&MStr::<Pattern>::from(pattern))
     }
 }

--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -88,11 +88,11 @@ use crate::{
     msgbus::{
         self, MessageBus, get_message_bus,
         switchboard::{
-            MessagingSwitchboard, get_bars_topic, get_book_deltas_topic, get_book_snapshots_topic,
-            get_custom_topic, get_funding_rate_topic, get_index_price_topic,
-            get_instrument_close_topic, get_instrument_status_topic, get_instrument_topic,
-            get_mark_price_topic, get_option_chain_topic, get_option_greeks_topic,
-            get_quotes_topic, get_trades_topic,
+            MessagingSwitchboard, get_bars_topic, get_book_deltas_topic, get_book_depth10_topic,
+            get_book_snapshots_topic, get_custom_topic, get_funding_rate_topic,
+            get_index_price_topic, get_instrument_close_topic, get_instrument_status_topic,
+            get_instrument_topic, get_mark_price_topic, get_option_chain_topic,
+            get_option_greeks_topic, get_quotes_topic, get_trades_topic,
         },
     },
     nautilus_actor,
@@ -248,6 +248,11 @@ impl DataActor for TestDataActor {
 
     fn on_book_deltas(&mut self, deltas: &OrderBookDeltas) -> anyhow::Result<()> {
         self.received_deltas.extend(&deltas.deltas);
+        Ok(())
+    }
+
+    fn on_book_depth(&mut self, depth: &OrderBookDepth10) -> anyhow::Result<()> {
+        self.received_depths.push(*depth);
         Ok(())
     }
 
@@ -1571,6 +1576,29 @@ fn test_subscribe_and_receive_book_deltas(
     assert_eq!(actor.received_deltas.len(), 1);
 }
 
+#[rstest]
+fn test_subscribe_and_receive_book_depth10(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+    audusd_sim: CurrencyPair,
+) {
+    let actor_id = register_data_actor(clock, cache, trader_id);
+    let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
+    actor.start().unwrap();
+
+    actor.subscribe_book_depth10(audusd_sim.id, BookType::L2_MBP, None, None, false, None);
+
+    let topic = get_book_depth10_topic(audusd_sim.id);
+    let mut depth = stub_depth10();
+    depth.instrument_id = audusd_sim.id;
+
+    msgbus::publish_depth10(topic, &depth);
+
+    assert_eq!(actor.received_depths.len(), 1);
+    assert_eq!(actor.received_depths[0], depth);
+}
+
 fn parent_params() -> Params {
     let mut params = Params::new();
     params.insert(PARAMS_IS_PARENT.to_string(), serde_json::json!(true));
@@ -1789,6 +1817,53 @@ fn test_unsubscribe_book_deltas(
 
     // Should still only have one delta
     assert_eq!(actor.received_deltas.len(), 1);
+}
+
+#[rstest]
+fn test_unsubscribe_book_depth10(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+    audusd_sim: CurrencyPair,
+) {
+    let actor_id = register_data_actor(clock, cache, trader_id);
+    let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
+    actor.start().unwrap();
+
+    actor.subscribe_book_depth10(audusd_sim.id, BookType::L2_MBP, None, None, false, None);
+
+    let topic = get_book_depth10_topic(audusd_sim.id);
+    let mut depth = stub_depth10();
+    depth.instrument_id = audusd_sim.id;
+
+    msgbus::publish_depth10(topic, &depth);
+    actor.unsubscribe_book_depth10(audusd_sim.id, None, None);
+    msgbus::publish_depth10(topic, &depth);
+
+    assert_eq!(actor.received_depths.len(), 1);
+}
+
+#[rstest]
+fn test_stopped_actor_does_not_receive_book_depth10(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+    audusd_sim: CurrencyPair,
+) {
+    let actor_id = register_data_actor(clock, cache, trader_id);
+    let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
+    actor.start().unwrap();
+
+    actor.subscribe_book_depth10(audusd_sim.id, BookType::L2_MBP, None, None, false, None);
+    actor.stop().unwrap();
+
+    let topic = get_book_depth10_topic(audusd_sim.id);
+    let mut depth = stub_depth10();
+    depth.instrument_id = audusd_sim.id;
+
+    msgbus::publish_depth10(topic, &depth);
+
+    assert!(actor.received_depths.is_empty());
 }
 
 #[rstest]
@@ -3589,6 +3664,44 @@ fn test_data_actor_core_tracks_deltas_handlers(
 }
 
 #[rstest]
+fn test_data_actor_core_tracks_depth10_handlers(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+    audusd_sim: CurrencyPair,
+) {
+    let actor_id = register_data_actor(clock, cache, trader_id);
+    let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
+    actor.start().unwrap();
+
+    assert_eq!(actor.core.depth10_handler_count(), 0);
+
+    actor.subscribe_book_depth10(audusd_sim.id, BookType::L2_MBP, None, None, false, None);
+
+    assert_eq!(actor.core.depth10_handler_count(), 1);
+
+    let topic = get_book_depth10_topic(audusd_sim.id);
+    assert!(actor.core.has_depth10_handler(topic.as_str()));
+}
+
+#[rstest]
+fn test_data_actor_core_deduplicates_depth10_handlers(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+    audusd_sim: CurrencyPair,
+) {
+    let actor_id = register_data_actor(clock, cache, trader_id);
+    let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
+    actor.start().unwrap();
+
+    actor.subscribe_book_depth10(audusd_sim.id, BookType::L2_MBP, None, None, false, None);
+    actor.subscribe_book_depth10(audusd_sim.id, BookType::L2_MBP, None, None, false, None);
+
+    assert_eq!(actor.core.depth10_handler_count(), 1);
+}
+
+#[rstest]
 fn test_data_actor_core_removes_deltas_handler_on_unsubscribe(
     clock: Rc<RefCell<TestClock>>,
     cache: Rc<RefCell<Cache>>,
@@ -3604,6 +3717,24 @@ fn test_data_actor_core_removes_deltas_handler_on_unsubscribe(
 
     actor.unsubscribe_book_deltas(audusd_sim.id, None, None);
     assert_eq!(actor.core.deltas_handler_count(), 0);
+}
+
+#[rstest]
+fn test_data_actor_core_removes_depth10_handler_on_unsubscribe(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+    audusd_sim: CurrencyPair,
+) {
+    let actor_id = register_data_actor(clock, cache, trader_id);
+    let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
+    actor.start().unwrap();
+
+    actor.subscribe_book_depth10(audusd_sim.id, BookType::L2_MBP, None, None, false, None);
+    assert_eq!(actor.core.depth10_handler_count(), 1);
+
+    actor.unsubscribe_book_depth10(audusd_sim.id, None, None);
+    assert_eq!(actor.core.depth10_handler_count(), 0);
 }
 
 #[rstest]

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -37,7 +37,7 @@ use nautilus_model::defi::{
 use nautilus_model::{
     data::{
         Bar, BarType, CustomData, DataType, FundingRateUpdate, IndexPriceUpdate, InstrumentStatus,
-        MarkPriceUpdate, OrderBookDeltas, QuoteTick, TradeTick,
+        MarkPriceUpdate, OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick,
         close::InstrumentClose,
         option_chain::{OptionChainSlice, OptionGreeks},
     },
@@ -450,6 +450,15 @@ impl PyDataActorInner {
         if let Some(ref py_self) = self.py_self {
             Python::attach(|py| {
                 py_self.call_method1(py, "on_book_deltas", (deltas.into_py_any_unwrap(py),))
+            })?;
+        }
+        Ok(())
+    }
+
+    fn dispatch_on_book_depth(&mut self, depth: &OrderBookDepth10) -> PyResult<()> {
+        if let Some(ref py_self) = self.py_self {
+            Python::attach(|py| {
+                py_self.call_method1(py, "on_book_depth", ((*depth).into_py_any_unwrap(py),))
             })?;
         }
         Ok(())
@@ -1011,6 +1020,11 @@ impl DataActor for PyDataActorInner {
             .map_err(|e| anyhow::anyhow!("Python on_book_deltas failed: {e}"))
     }
 
+    fn on_book_depth(&mut self, depth: &OrderBookDepth10) -> anyhow::Result<()> {
+        self.dispatch_on_book_depth(depth)
+            .map_err(|e| anyhow::anyhow!("Python on_book_depth failed: {e}"))
+    }
+
     fn on_book(&mut self, order_book: &OrderBook) -> anyhow::Result<()> {
         self.dispatch_on_book(order_book)
             .map_err(|e| anyhow::anyhow!("Python on_book failed: {e}"))
@@ -1475,6 +1489,10 @@ impl PyDataActor {
     fn py_on_book_deltas(&mut self, deltas: OrderBookDeltas) {}
 
     #[allow(unused_variables)]
+    #[pyo3(name = "on_book_depth")]
+    fn py_on_book_depth(&mut self, depth: &OrderBookDepth10) {}
+
+    #[allow(unused_variables)]
     #[pyo3(name = "on_book")]
     fn py_on_book(&mut self, book: &OrderBook) {}
 
@@ -1570,6 +1588,33 @@ impl PyDataActor {
         let params = dict_to_params(py, params)?;
         let depth = depth.and_then(NonZeroUsize::new);
         DataActor::subscribe_book_deltas(
+            self.inner_mut(),
+            instrument_id,
+            book_type,
+            depth,
+            client_id,
+            managed,
+            params,
+        );
+        Ok(())
+    }
+
+    #[pyo3(name = "subscribe_book_depth10")]
+    #[pyo3(signature = (instrument_id, book_type, depth=None, client_id=None, managed=false, params=None))]
+    #[expect(clippy::too_many_arguments)]
+    fn py_subscribe_book_depth10(
+        &mut self,
+        py: Python<'_>,
+        instrument_id: InstrumentId,
+        book_type: BookType,
+        depth: Option<usize>,
+        client_id: Option<ClientId>,
+        managed: bool,
+        params: Option<Py<PyDict>>,
+    ) -> PyResult<()> {
+        let params = dict_to_params(py, params)?;
+        let depth = depth.and_then(NonZeroUsize::new);
+        DataActor::subscribe_book_depth10(
             self.inner_mut(),
             instrument_id,
             book_type,
@@ -1819,6 +1864,20 @@ impl PyDataActor {
     ) -> PyResult<()> {
         let params = dict_to_params(py, params)?;
         DataActor::unsubscribe_book_deltas(self.inner_mut(), instrument_id, client_id, params);
+        Ok(())
+    }
+
+    #[pyo3(name = "unsubscribe_book_depth10")]
+    #[pyo3(signature = (instrument_id, client_id=None, params=None))]
+    fn py_unsubscribe_book_depth10(
+        &mut self,
+        py: Python<'_>,
+        instrument_id: InstrumentId,
+        client_id: Option<ClientId>,
+        params: Option<Py<PyDict>>,
+    ) -> PyResult<()> {
+        let params = dict_to_params(py, params)?;
+        DataActor::unsubscribe_book_depth10(self.inner_mut(), instrument_id, client_id, params);
         Ok(())
     }
 

--- a/crates/trading/src/python/strategy.rs
+++ b/crates/trading/src/python/strategy.rs
@@ -55,7 +55,7 @@ use nautilus_core::{
 use nautilus_model::{
     data::{
         Bar, BarType, CustomData, DataType, FundingRateUpdate, IndexPriceUpdate, InstrumentStatus,
-        MarkPriceUpdate, OrderBookDeltas, QuoteTick, TradeTick,
+        MarkPriceUpdate, OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick,
         close::InstrumentClose,
         option_chain::{OptionChainSlice, OptionGreeks},
     },
@@ -696,6 +696,15 @@ impl PyStrategyInner {
         Ok(())
     }
 
+    fn dispatch_on_book_depth(&mut self, depth: &OrderBookDepth10) -> PyResult<()> {
+        if let Some(ref py_self) = self.py_self {
+            Python::attach(|py| {
+                py_self.call_method1(py, "on_book_depth", ((*depth).into_py_any_unwrap(py),))
+            })?;
+        }
+        Ok(())
+    }
+
     fn dispatch_on_book(&mut self, book: &OrderBook) -> PyResult<()> {
         if let Some(ref py_self) = self.py_self {
             Python::attach(|py| {
@@ -1097,6 +1106,11 @@ impl DataActor for PyStrategyInner {
     fn on_book_deltas(&mut self, deltas: &OrderBookDeltas) -> anyhow::Result<()> {
         self.dispatch_on_book_deltas(deltas)
             .map_err(|e| anyhow::anyhow!("Python on_book_deltas failed: {e}"))
+    }
+
+    fn on_book_depth(&mut self, depth: &OrderBookDepth10) -> anyhow::Result<()> {
+        self.dispatch_on_book_depth(depth)
+            .map_err(|e| anyhow::anyhow!("Python on_book_depth failed: {e}"))
     }
 
     fn on_book(&mut self, order_book: &OrderBook) -> anyhow::Result<()> {
@@ -2040,6 +2054,10 @@ impl PyStrategy {
     fn py_on_book_deltas(&mut self, deltas: OrderBookDeltas) {}
 
     #[allow(unused_variables)]
+    #[pyo3(name = "on_book_depth")]
+    fn py_on_book_depth(&mut self, depth: &OrderBookDepth10) {}
+
+    #[allow(unused_variables)]
     #[pyo3(name = "on_book")]
     fn py_on_book(&mut self, book: &OrderBook) {}
 
@@ -2282,6 +2300,36 @@ impl PyStrategy {
         })?;
         let depth = depth.and_then(NonZeroUsize::new);
         DataActor::subscribe_book_deltas(
+            self.inner_mut(),
+            instrument_id,
+            book_type,
+            depth,
+            client_id,
+            managed,
+            params_map,
+        );
+        Ok(())
+    }
+
+    #[pyo3(name = "subscribe_book_depth10")]
+    #[pyo3(signature = (instrument_id, book_type, depth=None, client_id=None, managed=false, params=None))]
+    fn py_subscribe_book_depth10(
+        &mut self,
+        instrument_id: InstrumentId,
+        book_type: BookType,
+        depth: Option<usize>,
+        client_id: Option<ClientId>,
+        managed: bool,
+        params: Option<Py<PyDict>>,
+    ) -> PyResult<()> {
+        let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
+            match params {
+                Some(dict) => from_pydict(py, &dict),
+                None => Ok(None),
+            }
+        })?;
+        let depth = depth.and_then(NonZeroUsize::new);
+        DataActor::subscribe_book_depth10(
             self.inner_mut(),
             instrument_id,
             book_type,
@@ -2598,6 +2646,24 @@ impl PyStrategy {
             }
         })?;
         DataActor::unsubscribe_book_deltas(self.inner_mut(), instrument_id, client_id, params_map);
+        Ok(())
+    }
+
+    #[pyo3(name = "unsubscribe_book_depth10")]
+    #[pyo3(signature = (instrument_id, client_id=None, params=None))]
+    fn py_unsubscribe_book_depth10(
+        &mut self,
+        instrument_id: InstrumentId,
+        client_id: Option<ClientId>,
+        params: Option<Py<PyDict>>,
+    ) -> PyResult<()> {
+        let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
+            match params {
+                Some(dict) => from_pydict(py, &dict),
+                None => Ok(None),
+            }
+        })?;
+        DataActor::unsubscribe_book_depth10(self.inner_mut(), instrument_id, client_id, params_map);
         Ok(())
     }
 
@@ -3172,10 +3238,13 @@ mod tests {
     use nautilus_model::{
         data::{
             Bar, BarType, CustomData, FundingRateUpdate, IndexPriceUpdate, InstrumentStatus,
-            MarkPriceUpdate, OrderBookDelta, OrderBookDeltas, QuoteTick, TradeTick,
+            MarkPriceUpdate, OrderBookDelta, OrderBookDeltas, OrderBookDepth10, QuoteTick,
+            TradeTick,
             close::InstrumentClose,
+            depth::DEPTH10_LEN,
             greeks::OptionGreekValues,
             option_chain::{OptionChainSlice, OptionGreeks},
+            order::BookOrder,
             stubs::stub_custom_data,
         },
         enums::{
@@ -3233,6 +3302,7 @@ class TrackingStrategy:
         "on_trade",
         "on_bar",
         "on_book_deltas",
+        "on_book_depth",
         "on_book",
         "on_mark_price",
         "on_index_price",
@@ -3507,6 +3577,21 @@ class IndicatorEventStrategy:
         let delta =
             OrderBookDelta::clear(instrument.id, 0, UnixNanos::default(), UnixNanos::default());
         OrderBookDeltas::new(instrument.id, vec![delta])
+    }
+
+    fn sample_book_depth10() -> OrderBookDepth10 {
+        let instrument = sample_instrument();
+        OrderBookDepth10::new(
+            instrument.id,
+            [BookOrder::default(); DEPTH10_LEN],
+            [BookOrder::default(); DEPTH10_LEN],
+            [0; DEPTH10_LEN],
+            [0; DEPTH10_LEN],
+            0,
+            0,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        )
     }
 
     fn sample_mark_price() -> MarkPriceUpdate {
@@ -4532,6 +4617,7 @@ class IndicatorEventStrategy:
     #[case("on_trade")]
     #[case("on_bar")]
     #[case("on_book_deltas")]
+    #[case("on_book_depth")]
     #[case("on_book")]
     #[case("on_mark_price")]
     #[case("on_index_price")]
@@ -4582,6 +4668,10 @@ class IndicatorEventStrategy:
                 "on_book_deltas" => {
                     let deltas = sample_book_deltas();
                     rust_strategy.inner_mut().on_book_deltas(&deltas)
+                }
+                "on_book_depth" => {
+                    let depth = sample_book_depth10();
+                    rust_strategy.inner_mut().on_book_depth(&depth)
                 }
                 "on_book" => {
                     let book = sample_book();

--- a/python/nautilus_trader/common/__init__.pyi
+++ b/python/nautilus_trader/common/__init__.pyi
@@ -678,6 +678,7 @@ class DataActor:
     def on_trade(self, trade: model.TradeTick) -> None: ...
     def on_bar(self, bar: model.Bar) -> None: ...
     def on_book_deltas(self, deltas: model.OrderBookDeltas) -> None: ...
+    def on_book_depth(self, depth: model.OrderBookDepth10) -> None: ...
     def on_book(self, book: model.OrderBook) -> None: ...
     def on_mark_price(self, mark_price: model.MarkPriceUpdate) -> None: ...
     def on_index_price(self, index_price: model.IndexPriceUpdate) -> None: ...
@@ -706,6 +707,15 @@ class DataActor:
         params: dict | None = None,
     ) -> None: ...
     def subscribe_book_deltas(
+        self,
+        instrument_id: model.InstrumentId,
+        book_type: model.BookType,
+        depth: int | None = None,
+        client_id: model.ClientId | None = None,
+        managed: bool = False,
+        params: dict | None = None,
+    ) -> None: ...
+    def subscribe_book_depth10(
         self,
         instrument_id: model.InstrumentId,
         book_type: model.BookType,
@@ -805,6 +815,12 @@ class DataActor:
         params: dict | None = None,
     ) -> None: ...
     def unsubscribe_book_deltas(
+        self,
+        instrument_id: model.InstrumentId,
+        client_id: model.ClientId | None = None,
+        params: dict | None = None,
+    ) -> None: ...
+    def unsubscribe_book_depth10(
         self,
         instrument_id: model.InstrumentId,
         client_id: model.ClientId | None = None,

--- a/python/nautilus_trader/trading/__init__.pyi
+++ b/python/nautilus_trader/trading/__init__.pyi
@@ -536,6 +536,7 @@ class Strategy:
     def on_trade(self, trade: model.TradeTick) -> None: ...
     def on_bar(self, bar: model.Bar) -> None: ...
     def on_book_deltas(self, deltas: model.OrderBookDeltas) -> None: ...
+    def on_book_depth(self, depth: model.OrderBookDepth10) -> None: ...
     def on_book(self, book: model.OrderBook) -> None: ...
     def on_mark_price(self, mark_price: model.MarkPriceUpdate) -> None: ...
     def on_index_price(self, index_price: model.IndexPriceUpdate) -> None: ...
@@ -600,6 +601,15 @@ class Strategy:
         params: dict | None = None,
     ) -> None: ...
     def subscribe_book_deltas(
+        self,
+        instrument_id: model.InstrumentId,
+        book_type: model.BookType,
+        depth: int | None = None,
+        client_id: model.ClientId | None = None,
+        managed: bool = False,
+        params: dict | None = None,
+    ) -> None: ...
+    def subscribe_book_depth10(
         self,
         instrument_id: model.InstrumentId,
         book_type: model.BookType,
@@ -699,6 +709,12 @@ class Strategy:
         params: dict | None = None,
     ) -> None: ...
     def unsubscribe_book_deltas(
+        self,
+        instrument_id: model.InstrumentId,
+        client_id: model.ClientId | None = None,
+        params: dict | None = None,
+    ) -> None: ...
+    def unsubscribe_book_depth10(
         self,
         instrument_id: model.InstrumentId,
         client_id: model.ClientId | None = None,


### PR DESCRIPTION
Fixes #4439

## Issue / Motivation

`OrderBookDepth10` already has end-to-end support in the data layer: data clients can subscribe with `SubscribeBookDepth10`, the `DataEngine` tracks Depth10 subscriptions and publishes on the Depth10 msgbus topic, catalog replay can emit Depth10, and adapters such as Hyperliquid can parse venue book snapshots into native `OrderBookDepth10` values.

The missing piece was the strategy/data-actor facade. Native Rust `Strategy` implements `DataActor`, but `DataActor` did not expose `on_book_depth`, `subscribe_book_depth10`, or `unsubscribe_book_depth10`. As a result, strategy authors could not use the same first-class subscription/callback flow available for quotes, trades, bars, and book deltas, even though the lower layers already supported the data type.

## What this PR changes

- Adds `DataActor::on_book_depth(&OrderBookDepth10)` as the strategy-facing callback hook.
- Adds `subscribe_book_depth10` / `unsubscribe_book_depth10` facade methods, wired through the existing `SubscribeCommand::BookDepth10` / `UnsubscribeCommand::BookDepth10` commands.
- Reuses the existing Depth10 msgbus topic and the existing `DataActorCore::depth10_handlers` map; no new data type or adapter protocol is introduced.
- Exposes the same methods on `PyDataActor` and `PyStrategy` and regenerates the Python stubs.
- Adds focused tests for receive, duplicate subscribe dedupe, unsubscribe removal, stopped-actor dispatch behavior, core handler tracking, and PyStrategy `on_book_depth` dispatch.

## Hyperliquid context

Hyperliquid already implements native Depth10 at the adapter layer. Its Depth10 subscription reuses the venue `l2Book` stream shared with order-book deltas; `subscribe_book_depth10_with_options` marks the coin in the websocket handler via `SetDepth10Sub`, and the handler emits `NautilusWsMessage::Depth10` when an `l2Book` snapshot arrives for a subscribed coin. That message is then forwarded as `Data::Depth10` and published by the `DataEngine`.

This is why lower-level Hyperliquid Depth10 paths could already work without this PR. The issue fixed here is specifically that Rust/PyO3 strategies lacked the public `DataActor` facade and callback registration needed to formally subscribe and receive native `OrderBookDepth10` through the standard strategy API.

## Lifecycle / style notes

- The new facade mirrors the existing book-delta and quote/trade/bar patterns: register a typed handler, send the data command, dispatch only while the actor is running, and remove the handler on unsubscribe.
- Duplicate actor handlers are deduplicated at the msgbus handler layer, matching the existing book-deltas pattern. Underlying client forwarding remains deduplicated by `DataClientAdapter::track_subscribe`.
- Stop/reset behavior is intentionally consistent with existing data handlers: the actor does not introduce Depth10-specific global cleanup that other data subscriptions do not perform.
- The change does not modify adapter shared-state ownership, reconnect behavior, or Hyperliquid's shared `l2Book` stream registry.

## Tests

- `cargo test -p nautilus-common depth10 -- --nocapture`
- `cargo check -p nautilus-common -p nautilus-trading --features python`
- `cargo test -p nautilus-trading test_python_dispatch_data_callback_matrix --features python -- --nocapture`
- `RUSTFLAGS=\"-A linker-messages\" .venv/bin/python python/generate_stubs.py`
- `pre-commit run --files crates/common/src/actor/data_actor.rs crates/common/src/actor/tests.rs crates/common/src/python/actor.rs crates/trading/src/python/strategy.rs python/nautilus_trader/common/__init__.pyi python/nautilus_trader/trading/__init__.pyi`
- `pre-commit run --files crates/trading/src/python/strategy.rs`