### PR TITLE
Fix Binance futures market order average prices

### DIFF
--- a/crates/adapters/binance/src/futures/http/models.rs
+++ b/crates/adapters/binance/src/futures/http/models.rs
@@ -1118,6 +1118,17 @@ impl BinanceFuturesOrder {
                 )
             }
         };
+        let avg_px = if filled_qty > Decimal::ZERO {
+            self.avg_price
+                .as_deref()
+                .filter(|price| !price.is_empty())
+                .map(|price| parse_positive_price_at_precision(price, price_precision, "avg_price"))
+                .transpose()?
+                .flatten()
+                .map(|price| price.as_decimal())
+        } else {
+            None
+        };
 
         let mut report = OrderStatusReport::new(
             account_id,
@@ -1141,6 +1152,8 @@ impl BinanceFuturesOrder {
         if let Some(price) = price {
             report = report.with_price(price);
         }
+
+        report.avg_px = avg_px;
 
         Ok(report)
     }
@@ -2125,6 +2138,58 @@ mod tests {
             .unwrap();
 
         assert_eq!(report.price, None);
+    }
+
+    #[rstest]
+    fn test_order_to_report_sets_avg_px_for_filled_market_order() {
+        let mut order = order_with_price("0");
+        order.status = BinanceOrderStatus::Filled;
+        order.executed_qty = "0.001".to_string();
+        order.cum_quote = "50.00".to_string();
+        order.avg_price = Some("50000.00".to_string());
+        let account_id = AccountId::from("BINANCE-FUTURES-001");
+        let instrument_id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+        let ts_init = UnixNanos::from(1_000_000_000u64);
+
+        let report = order
+            .to_order_status_report(account_id, instrument_id, 2, 3, false, ts_init)
+            .unwrap();
+
+        assert_eq!(report.price, None);
+        assert_eq!(
+            report.avg_px,
+            Some(Decimal::from_str_exact("50000.00").unwrap())
+        );
+    }
+
+    #[rstest]
+    fn test_order_to_report_omits_avg_px_without_fills() {
+        let mut order = order_with_price("0");
+        order.avg_price = Some("50000.00".to_string());
+        let account_id = AccountId::from("BINANCE-FUTURES-001");
+        let instrument_id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+        let ts_init = UnixNanos::from(1_000_000_000u64);
+
+        let report = order
+            .to_order_status_report(account_id, instrument_id, 2, 3, false, ts_init)
+            .unwrap();
+
+        assert_eq!(report.avg_px, None);
+    }
+
+    #[rstest]
+    fn test_order_to_report_rejects_invalid_avg_px_for_filled_order() {
+        let mut order = order_with_price("0");
+        order.executed_qty = "0.001".to_string();
+        order.avg_price = Some("not-a-number".to_string());
+        let account_id = AccountId::from("BINANCE-FUTURES-001");
+        let instrument_id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+        let ts_init = UnixNanos::from(1_000_000_000u64);
+
+        let result = order.to_order_status_report(account_id, instrument_id, 2, 3, false, ts_init);
+
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("avg_price"));
     }
 
     #[rstest]


### PR DESCRIPTION
<!-- Suggested title: Fix Binance Futures market order average prices -->

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Binance Futures REST order reports now populate `OrderStatusReport.avg_px` from a positive `avgPrice` when the order has a non-zero filled quantity. This allows reconciliation to infer fills for filled MARKET orders whose Binance `price` is zero, while leaving the original limit `price` semantics unchanged.

The conversion validates the average price at the instrument price precision and ignores it for unfilled orders. Regression tests cover the filled MARKET case, the unfilled guard, and malformed average prices.

## Related Issues/PRs

- Closes #4440.
- Related but distinct: #3499 covered Binance Spot and the older Python adapter path.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

None.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

No user-facing documentation changes are required.

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

- `rustup run 1.97.0 cargo test -q -p nautilus-binance --lib` — 722 passed.
- `rustup run 1.97.0 cargo clippy -q -p nautilus-binance --lib -- -D warnings` — passed.
- `rustup run 1.97.0 cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- Manual Binance USD-M live diagnostic using an application with local path dependencies to this branch:
  - `query_order` discovered a historical filled MARKET order with `price=None`.
  - Reconciliation generated the inferred fill from Binance `avgPrice` and emitted `OrderFilled` with the expected MARKET type, filled quantity, and average execution price.
  - The previous `Cannot create inferred fill: no avg_px or price available` warning did not occur.
