### PR TITLE
Fix consolidation data loss with single-file period windows

### DIFF
--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -973,7 +973,7 @@ class ParquetDataCatalog(BaseDataCatalog):
             for file in globbed_files
             if (interval := _parse_filename_timestamps(file)) is not None
         }
-        interval_components = []
+        interval_components: list[tuple[int, int, list[str]]] = []
         for file, interval in sorted(file_intervals.items(), key=lambda item: item[1]):
             if interval_components and interval[0] <= interval_components[-1][1]:
                 component_start, component_end, component_files = interval_components[-1]
@@ -1016,6 +1016,7 @@ class ParquetDataCatalog(BaseDataCatalog):
                 and component_end >= query_info["query_start"]
                 for component_start, component_end in protected_components
             )
+
             if query_is_protected:
                 # Skipping a query means none of its input files were rewritten. Protect every
                 # component intersecting that query, and let extended components propagate the
@@ -1040,6 +1041,7 @@ class ParquetDataCatalog(BaseDataCatalog):
                         query_info["query_end"],
                     ),
                 )
+
                 if self.fs.exists(target_filename):
                     exclude_existing_target(target_filename)
                     continue
@@ -1104,9 +1106,13 @@ class ParquetDataCatalog(BaseDataCatalog):
             for file in list(existing_files):
                 interval = file_intervals.get(file)
 
-                if file not in protected_files and interval and (
-                    interval[1] <= query_info["query_end"]
-                    and interval[0] >= queries_to_execute[0]["query_start"]
+                if (
+                    file not in protected_files
+                    and interval
+                    and (
+                        interval[1] <= query_info["query_end"]
+                        and interval[0] >= queries_to_execute[0]["query_start"]
+                    )
                 ):
                     existing_files.pop(file)
                     self.fs.rm(file)

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -962,22 +962,95 @@ class ParquetDataCatalog(BaseDataCatalog):
 
         # Get directory for file operations
         directory = self._make_path(data_cls, identifier)
-        existing_files = sorted(self.fs.glob(os.path.join(directory, "*.parquet")))
+        globbed_files = sorted(self.fs.glob(os.path.join(directory, "*.parquet")))
 
-        # Track files to remove and maintain existing_files list
-        existing_files = list(existing_files)  # Make it mutable
+        # Dict insertion order preserves glob order while allowing skipped targets to be removed
+        # without rescanning every remaining file.
+        existing_files = dict.fromkeys(globbed_files)
+        canonical_files = {self.fs._strip_protocol(file): file for file in globbed_files}
+        file_intervals = {
+            file: interval
+            for file in globbed_files
+            if (interval := _parse_filename_timestamps(file)) is not None
+        }
+        interval_components = []
+        for file, interval in sorted(file_intervals.items(), key=lambda item: item[1]):
+            if interval_components and interval[0] <= interval_components[-1][1]:
+                component_start, component_end, component_files = interval_components[-1]
+                component_files.append(file)
+                interval_components[-1] = (
+                    component_start,
+                    max(component_end, interval[1]),
+                    component_files,
+                )
+            else:
+                interval_components.append((interval[0], interval[1], [file]))
+
+        # Overlapping intervals can be left behind by an interrupted consolidation. Treat each
+        # connected overlap component as read-only for this pass so discovering an existing
+        # target cannot happen after an earlier period has already been rewritten.
+        protected_components = [
+            (component_start, component_end)
+            for component_start, component_end, component_files in interval_components
+            if len(component_files) > 1
+        ]
+        protected_files = {
+            file
+            for _, _, component_files in interval_components
+            if len(component_files) > 1
+            for file in component_files
+        }
+
+        def exclude_existing_target(target_filename: str) -> None:
+            canonical_target = self.fs._strip_protocol(target_filename)
+            target_file = canonical_files.get(canonical_target)
+            if target_file is not None:
+                existing_files.pop(target_file, None)
 
         # Phase 2: Execute queries, write, and delete
         file_start_ns = None  # Track contiguity across periods
 
         for query_info in queries_to_execute:
+            query_is_protected = any(
+                component_start <= query_info["query_end"]
+                and component_end >= query_info["query_start"]
+                for component_start, component_end in protected_components
+            )
+            if query_is_protected:
+                # Skipping a query means none of its input files were rewritten. Protect every
+                # component intersecting that query, and let extended components propagate the
+                # read-only range to later queries.
+                for component_start, component_end, component_files in interval_components:
+                    if component_start > query_info["query_end"]:
+                        break
+                    if component_end >= query_info["query_start"]:
+                        component_range = (component_start, component_end)
+                        if component_range not in protected_components:
+                            protected_components.append(component_range)
+                        protected_files.update(component_files)
+                continue
+
+            # Boundary target names are known before loading data. Check them here so every
+            # existing target is protected without repeatedly querying the remaining files.
+            if query_info["use_period_boundaries"]:
+                target_filename = os.path.join(
+                    directory,
+                    _timestamps_to_filename(
+                        query_info["query_start"],
+                        query_info["query_end"],
+                    ),
+                )
+                if self.fs.exists(target_filename):
+                    exclude_existing_target(target_filename)
+                    continue
+
             # Query data for this period using existing files
             period_data = self.query(
                 data_cls=data_cls,
                 identifiers=[identifier] if identifier is not None else None,
                 start=query_info["query_start"],
                 end=query_info["query_end"],
-                files=existing_files,
+                files=list(existing_files),
                 optimize_file_loading=False,
             )
 
@@ -1009,7 +1082,10 @@ class ParquetDataCatalog(BaseDataCatalog):
             )
 
             if self.fs.exists(target_filename):
-                # Skip if target file already exists
+                # Keep a skipped target out of later cleanup sweeps. Filesystems may return a
+                # protocol-stripped path from glob.
+                exclude_existing_target(target_filename)
+                del period_data
                 continue
 
             # Write consolidated data for this period
@@ -1025,14 +1101,14 @@ class ParquetDataCatalog(BaseDataCatalog):
             del period_data
 
             # Identify files that are completely covered by this period
-            for file in existing_files[:]:  # Use slice copy to avoid modification during iteration
-                interval = _parse_filename_timestamps(file)
+            for file in list(existing_files):
+                interval = file_intervals.get(file)
 
-                if interval and (
+                if file not in protected_files and interval and (
                     interval[1] <= query_info["query_end"]
                     and interval[0] >= queries_to_execute[0]["query_start"]
                 ):
-                    existing_files.remove(file)
+                    existing_files.pop(file)
                     self.fs.rm(file)
 
     def _prepare_consolidation_queries(  # noqa: C901
@@ -1054,7 +1130,7 @@ class ParquetDataCatalog(BaseDataCatalog):
         2. Groups intervals into contiguous groups
         3. Identifies and creates split operations for data preservation
         4. Generates period-based consolidation queries
-        5. Checks for existing target files
+        5. Leaves existing-target checks to execution so skipped files can be protected
 
         Parameters
         ----------
@@ -1154,8 +1230,6 @@ class ParquetDataCatalog(BaseDataCatalog):
                     },
                 )
 
-        directory = self._make_path(data_cls, identifier)
-
         # Generate period-based consolidation queries for each contiguous group
         for group in contiguous_groups:
             # Get overall time range for this contiguous group
@@ -1193,18 +1267,6 @@ class ParquetDataCatalog(BaseDataCatalog):
                 # Adjust end to not exceed the group end timestamp
                 if current_end_ns > group_end_ts:
                     current_end_ns = group_end_ts
-
-                # Create target filename to check if it already exists (only for period boundaries)
-                if ensure_contiguous_files:
-                    target_filename = os.path.join(
-                        directory,
-                        _timestamps_to_filename(current_start_ns, current_end_ns),
-                    )
-
-                    # Skip if target file already exists
-                    if self.fs.exists(target_filename):
-                        current_start_ns += period_in_ns
-                        continue
 
                 # Add query to execution list
                 queries_to_execute.append(

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -1731,6 +1731,215 @@ class TestConsolidateDataByPeriod:
         assert len(self.catalog.get_intervals(Bar, bar_type_str)) == files_after_first
         assert len(self.catalog.bars(bar_types=[bar_type_str])) == bars_after_first
 
+    def test_consolidate_data_by_period_retains_skipped_target(self):
+        # Arrange - one file is alone in its window, followed by two files in a later window
+        start_ns = pd.Timestamp("2024-01-01", tz="UTC").value
+        day_ns = pd.Timedelta(days=1).value
+        minute_ns = pd.Timedelta(minutes=1).value
+        timestamp_batches = [
+            [start_ns + i * minute_ns for i in range(3)],
+            [start_ns + 5 * day_ns + i * minute_ns for i in range(3)],
+            [start_ns + 5 * day_ns + (10 + i) * minute_ns for i in range(3)],
+        ]
+
+        for timestamps in timestamp_batches:
+            self.catalog.write_data(self._create_test_bars(timestamps))
+
+        bar_type_str = self._get_bar_type_identifier()
+        expected_timestamps = sorted(ts for batch in timestamp_batches for ts in batch)
+
+        # Act
+        self.catalog.consolidate_data_by_period(
+            Bar,
+            bar_type_str,
+            period=pd.Timedelta(days=1),
+            ensure_contiguous_files=False,
+        )
+
+        # Assert - the skipped single-file target survives the later cleanup sweep
+        actual_timestamps = sorted(
+            bar.ts_init for bar in self.catalog.bars(bar_types=[bar_type_str])
+        )
+        assert actual_timestamps == expected_timestamps
+
+    def test_consolidate_data_by_period_retains_existing_boundary_target(self):
+        # Arrange - fragments surround an already-consolidated middle period
+        start_ns = pd.Timestamp("2024-01-01", tz="UTC").value
+        source_intervals = [(0, 4), (5, 9), (10, 19), (20, 24), (25, 29)]
+        for start_offset, end_offset in source_intervals:
+            timestamps = [start_ns + start_offset, start_ns + end_offset]
+            self.catalog.write_data(
+                self._create_test_bars(timestamps),
+                start=timestamps[0],
+                end=timestamps[-1],
+            )
+
+        bar_type_str = self._get_bar_type_identifier()
+        expected_timestamps = sorted(
+            start_ns + offset for interval in source_intervals for offset in interval
+        )
+
+        # Act
+        self.catalog.consolidate_data_by_period(
+            Bar,
+            bar_type_str,
+            period=pd.Timedelta(nanoseconds=10),
+            ensure_contiguous_files=True,
+        )
+
+        # Assert - cleanup around the existing 10..19 target keeps all rows
+        actual_timestamps = sorted(
+            bar.ts_init for bar in self.catalog.bars(bar_types=[bar_type_str])
+        )
+        assert actual_timestamps == expected_timestamps
+
+    def test_consolidate_data_by_period_retains_sources_overlapping_skipped_target(self):
+        # Arrange - the existing target overlaps a source with one additional row
+        start_ns = pd.Timestamp("2024-01-01", tz="UTC").value
+        day_ns = pd.Timedelta(days=1).value
+        minute_ns = pd.Timedelta(minutes=1).value
+        target_timestamps = [start_ns, start_ns + 10 * minute_ns]
+        supplemental_timestamp = start_ns + 5 * minute_ns
+
+        self.catalog.write_data(self._create_test_bars(target_timestamps))
+        self.catalog.write_data(
+            self._create_test_bars([supplemental_timestamp]),
+            start=start_ns,
+            end=supplemental_timestamp,
+            skip_disjoint_check=True,
+        )
+
+        spanning_timestamps = [start_ns + 8 * minute_ns, start_ns + 3 * day_ns]
+        self.catalog.write_data(
+            self._create_test_bars(spanning_timestamps),
+            skip_disjoint_check=True,
+        )
+        nested_timestamp = start_ns + 2 * day_ns + 5 * minute_ns
+        self.catalog.write_data(
+            self._create_test_bars([nested_timestamp]),
+            start=start_ns + 2 * day_ns,
+            end=nested_timestamp,
+            skip_disjoint_check=True,
+        )
+
+        later_batches = [
+            [start_ns + 5 * day_ns + i * minute_ns for i in range(3)],
+            [start_ns + 5 * day_ns + (10 + i) * minute_ns for i in range(3)],
+        ]
+        for timestamps in later_batches:
+            self.catalog.write_data(
+                self._create_test_bars(timestamps),
+                skip_disjoint_check=True,
+            )
+
+        bar_type_str = self._get_bar_type_identifier()
+        expected_timestamps = sorted(
+            [
+                *target_timestamps,
+                supplemental_timestamp,
+                *spanning_timestamps,
+                nested_timestamp,
+            ]
+            + [timestamp for batch in later_batches for timestamp in batch]
+        )
+
+        # Act
+        self.catalog.consolidate_data_by_period(
+            Bar,
+            bar_type_str,
+            period=pd.Timedelta(days=1),
+            ensure_contiguous_files=False,
+        )
+
+        # Assert - later cleanup must not remove data from the overlapping source
+        actual_timestamps = sorted(
+            bar.ts_init for bar in self.catalog.bars(bar_types=[bar_type_str])
+        )
+        assert actual_timestamps == expected_timestamps
+
+    def test_consolidate_data_by_period_does_not_write_before_overlapping_target(self):
+        # Arrange - an interrupted run left a middle-period target inside a spanning source
+        start_ns = pd.Timestamp("2024-01-01", tz="UTC").value
+        day_ns = pd.Timedelta(days=1).value
+        minute_ns = pd.Timedelta(minutes=1).value
+        spanning_timestamps = [start_ns + 5 * minute_ns, start_ns + 3 * day_ns + 5 * minute_ns]
+        target_timestamps = [start_ns + day_ns, start_ns + day_ns + 10 * minute_ns]
+
+        self.catalog.write_data(self._create_test_bars(spanning_timestamps))
+        self.catalog.write_data(
+            self._create_test_bars(target_timestamps),
+            skip_disjoint_check=True,
+        )
+
+        later_batches = [
+            [start_ns + 5 * day_ns + i * minute_ns for i in range(3)],
+            [start_ns + 5 * day_ns + (10 + i) * minute_ns for i in range(3)],
+        ]
+        for timestamps in later_batches:
+            self.catalog.write_data(
+                self._create_test_bars(timestamps),
+                skip_disjoint_check=True,
+            )
+
+        bar_type_str = self._get_bar_type_identifier()
+        expected_timestamps = sorted(
+            [*spanning_timestamps, *target_timestamps]
+            + [timestamp for batch in later_batches for timestamp in batch]
+        )
+
+        # Act
+        self.catalog.consolidate_data_by_period(
+            Bar,
+            bar_type_str,
+            period=pd.Timedelta(days=1),
+            ensure_contiguous_files=False,
+        )
+
+        # Assert - the interrupted component is unchanged while the later group is consolidated
+        actual_timestamps = sorted(
+            bar.ts_init for bar in self.catalog.bars(bar_types=[bar_type_str])
+        )
+        assert actual_timestamps == expected_timestamps
+        assert len(self.catalog.get_intervals(Bar, bar_type_str)) == 3
+
+    def test_consolidate_data_by_period_protects_all_files_in_skipped_query(self):
+        # Arrange - one query contains an overlap component and a separate source file
+        start_ns = pd.Timestamp("2024-01-01", tz="UTC").value
+        day_ns = pd.Timedelta(days=1).value
+        minute_ns = pd.Timedelta(minutes=1).value
+        timestamp_batches = [
+            [start_ns, start_ns + 10 * minute_ns],
+            [start_ns + 5 * minute_ns],
+            [start_ns + 20 * minute_ns, start_ns + 25 * minute_ns],
+            [start_ns + 3 * day_ns + i * minute_ns for i in range(3)],
+            [start_ns + 3 * day_ns + (10 + i) * minute_ns for i in range(3)],
+        ]
+
+        for timestamps in timestamp_batches:
+            self.catalog.write_data(
+                self._create_test_bars(timestamps),
+                skip_disjoint_check=True,
+            )
+
+        bar_type_str = self._get_bar_type_identifier()
+        expected_timestamps = sorted(
+            timestamp for batch in timestamp_batches for timestamp in batch
+        )
+
+        # Act
+        self.catalog.consolidate_data_by_period(
+            Bar,
+            bar_type_str,
+            period=pd.Timedelta(days=1),
+            ensure_contiguous_files=False,
+        )
+
+        # Assert - later cleanup cannot delete the separate file from the skipped window
+        actual_timestamps = sorted(
+            bar.ts_init for bar in self.catalog.bars(bar_types=[bar_type_str])
+        )
+        assert actual_timestamps == expected_timestamps
+
     def test_consolidate_predicate_exact_boundary_cases(self):
         """
         Validates deletion predicate handles exact boundary timestamps correctly. Each

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -1826,6 +1826,7 @@ class TestConsolidateDataByPeriod:
             [start_ns + 5 * day_ns + i * minute_ns for i in range(3)],
             [start_ns + 5 * day_ns + (10 + i) * minute_ns for i in range(3)],
         ]
+
         for timestamps in later_batches:
             self.catalog.write_data(
                 self._create_test_bars(timestamps),
@@ -1840,7 +1841,7 @@ class TestConsolidateDataByPeriod:
                 *spanning_timestamps,
                 nested_timestamp,
             ]
-            + [timestamp for batch in later_batches for timestamp in batch]
+            + [timestamp for batch in later_batches for timestamp in batch],
         )
 
         # Act
@@ -1875,6 +1876,7 @@ class TestConsolidateDataByPeriod:
             [start_ns + 5 * day_ns + i * minute_ns for i in range(3)],
             [start_ns + 5 * day_ns + (10 + i) * minute_ns for i in range(3)],
         ]
+
         for timestamps in later_batches:
             self.catalog.write_data(
                 self._create_test_bars(timestamps),
@@ -1884,7 +1886,7 @@ class TestConsolidateDataByPeriod:
         bar_type_str = self._get_bar_type_identifier()
         expected_timestamps = sorted(
             [*spanning_timestamps, *target_timestamps]
-            + [timestamp for batch in later_batches for timestamp in batch]
+            + [timestamp for batch in later_batches for timestamp in batch],
         )
 
         # Act


### PR DESCRIPTION
## Summary

Fixed consolidate_data_by_period(ensure_contiguous_files=False) silently dropping every row when a period window's data comes from exactly one source file. The skip-then-sweep algorithm was deleting source files before confirming their data was written.

Added three-layer protection: overlap detection groups files with overlapping intervals into connected components, query-level protection skips queries intersecting protected components and propagates protection to single-file members, and individual file protection prevents deletion of any file in a protected component.

## Related Issues/PRs

Closes #4435.

## Type of change

- [x] Bug fix (non-breaking)

## Testing

Affected code paths were verified through static analysis of the overlap-detection, query-protection, and file-protection layers against the single-file-per-window scenario, empty windows, multi-file windows, boundary conditions with start/end parameters, and timezone-aware timestamps.