### PR TITLE
Fix Binance futures historical algo query

### DIFF
--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -39,7 +39,7 @@ use nautilus_common::{
     },
 };
 use nautilus_core::{
-    AtomicSet, MUTEX_POISONED, UUID4, UnixNanos,
+    AtomicSet, MUTEX_POISONED, Params, UUID4, UnixNanos,
     datetime::{NANOSECONDS_IN_MILLISECOND, mins_to_nanos},
     time::{AtomicTime, get_atomic_clock_realtime},
 };
@@ -67,7 +67,10 @@ use tokio_util::sync::CancellationToken;
 use super::{
     http::{
         BinanceFuturesHttpError,
-        client::{BinanceFuturesHttpClient, BinanceFuturesInstrument, is_algo_order_type},
+        client::{
+            BinanceFuturesAlgoOrderQueryResult, BinanceFuturesHttpClient, BinanceFuturesInstrument,
+            is_algo_order_type,
+        },
         models::{BatchOrderResult, BinancePositionRisk},
         query::{
             BatchCancelItem, BinanceAllOrdersParamsBuilder, BinanceOpenOrdersParamsBuilder,
@@ -126,6 +129,55 @@ const LISTEN_KEY_KEEPALIVE_SECS: u64 = 30 * 60;
 
 /// Consecutive keepalive failures before a listenKey rotation is triggered.
 const MAX_KEEPALIVE_FAILURES: u32 = 1;
+
+/// Query parameter declaring that the command's venue order ID is a Binance Algo Service
+/// `algoId`, rather than a regular matching-engine `orderId` or triggered `actualOrderId`.
+pub const BINANCE_VENUE_ORDER_ID_IS_ALGO_ID_PARAM: &str = "venue_order_id_is_algo_id";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BinanceFuturesAlgoLookup {
+    Skip,
+    AlgoId,
+    ClientAlgoId,
+}
+
+fn create_algo_order_status_report(
+    result: &BinanceFuturesAlgoOrderQueryResult,
+    account_id: AccountId,
+    instrument_id: InstrumentId,
+    price_precision: u8,
+    size_precision: u8,
+    treat_expired_as_canceled: bool,
+    ts_init: UnixNanos,
+) -> anyhow::Result<OrderStatusReport> {
+    if let Some(actual) = result.actual.as_ref() {
+        match result.algo.to_order_status_report_with_actual(
+            actual,
+            account_id,
+            instrument_id,
+            price_precision,
+            size_precision,
+            treat_expired_as_canceled,
+            ts_init,
+        ) {
+            Ok(report) => return Ok(report),
+            Err(e) => {
+                log::warn!(
+                    "Failed to convert matching-engine enrichment for algo order {}: {e}; falling back to Algo Service report",
+                    result.algo.algo_id
+                );
+            }
+        }
+    }
+
+    result.algo.to_order_status_report(
+        account_id,
+        instrument_id,
+        price_precision,
+        size_precision,
+        ts_init,
+    )
+}
 
 /// Live execution client for Binance Futures trading.
 ///
@@ -262,6 +314,27 @@ impl BinanceFuturesExecutionClient {
     #[must_use]
     pub fn is_hedge_mode(&self) -> bool {
         self.is_hedge_mode.load(Ordering::Acquire)
+    }
+
+    fn resolve_algo_lookup(
+        &self,
+        client_order_id: Option<ClientOrderId>,
+        params: Option<&Params>,
+    ) -> BinanceFuturesAlgoLookup {
+        if params.and_then(|p| p.get_bool(BINANCE_VENUE_ORDER_ID_IS_ALGO_ID_PARAM)) == Some(true) {
+            return BinanceFuturesAlgoLookup::AlgoId;
+        }
+
+        let Some(client_order_id) = client_order_id else {
+            return BinanceFuturesAlgoLookup::ClientAlgoId;
+        };
+        let cache = self.core.cache();
+        match cache.order(&client_order_id) {
+            Some(order) if !is_algo_order_type(order.order_type()) => {
+                BinanceFuturesAlgoLookup::Skip
+            }
+            _ => BinanceFuturesAlgoLookup::ClientAlgoId,
+        }
     }
 
     /// Returns a clone of the HTTP client's instruments cache Arc.
@@ -1501,6 +1574,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
 
         let (price_precision, size_precision) = self.get_instrument_precision(instrument_id);
         let ts_init = self.clock.get_time_ns();
+        let algo_lookup = self.resolve_algo_lookup(cmd.client_order_id, cmd.params.as_ref());
 
         match self.http_client.query_order(&params).await {
             Ok(order) => {
@@ -1515,24 +1589,41 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                 Ok(Some(report))
             }
             Err(BinanceFuturesHttpError::BinanceError { code: -2013, .. }) => {
-                // Order not found in regular API, try algo order API
-                let Some(client_order_id) = cmd.client_order_id else {
+                if algo_lookup == BinanceFuturesAlgoLookup::Skip {
+                    log::debug!("Skipping Algo Service fallback for known regular order");
                     return Ok(None);
-                };
+                }
 
-                match self.http_client.query_algo_order(client_order_id).await {
-                    Ok(algo_order) => {
-                        let report = algo_order.to_order_status_report(
-                            self.core.account_id,
-                            instrument_id,
-                            price_precision,
-                            size_precision,
-                            ts_init,
-                        )?;
-                        Ok(Some(report))
-                    }
-                    Err(e) => {
-                        log::debug!("Algo order query also failed: {e}");
+                // A conditional order may expose its Algo Service `algoId` before triggering and
+                // its matching-engine `actualOrderId` afterwards. Only an explicit ID-kind hint
+                // makes a venue ID safe for Algo Service lookup; cached conditional orders retain
+                // their existing clientAlgoId fallback.
+                let algo_venue_order_id = if algo_lookup == BinanceFuturesAlgoLookup::AlgoId {
+                    cmd.venue_order_id
+                } else {
+                    None
+                };
+                let algo_order = self
+                    .http_client
+                    .query_algo_order_with_history(
+                        instrument_id,
+                        cmd.client_order_id,
+                        algo_venue_order_id,
+                    )
+                    .await?;
+
+                match algo_order {
+                    Some(result) => Ok(Some(create_algo_order_status_report(
+                        &result,
+                        self.core.account_id,
+                        instrument_id,
+                        price_precision,
+                        size_precision,
+                        self.config.treat_expired_as_canceled,
+                        ts_init,
+                    )?)),
+                    None => {
+                        log::debug!("Algo order query returned no matching order");
                         Ok(None)
                     }
                 }
@@ -1835,6 +1926,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
     fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
         log::debug!("query_order: client_order_id={}", cmd.client_order_id);
 
+        let algo_lookup = self.resolve_algo_lookup(Some(cmd.client_order_id), cmd.params.as_ref());
         let http_client = self.http_client.clone();
         let command = cmd;
         let emitter = self.emitter.clone();
@@ -1890,25 +1982,44 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                     emitter.send_order_status_report(report);
                 }
                 Err(BinanceFuturesHttpError::BinanceError { code: -2013, .. }) => {
+                    if algo_lookup == BinanceFuturesAlgoLookup::Skip {
+                        log::debug!("Skipping Algo Service fallback for known regular order");
+                        return Ok(());
+                    }
+
                     // Untriggered algo orders (STOP_MARKET, STOP_LIMIT, MIT, LIT,
                     // TRAILING_STOP_MARKET) live in the Binance Futures Algo Service
                     // and return -2013 on the regular order endpoint. Mirror the
                     // reconciliation path (`generate_order_status_report`) so live
                     // inflight checks resolve them instead of exhausting retries into
                     // `OrderRejected(reason='INFLIGHT_TIMEOUT')`.
-                    match http_client.query_algo_order(command.client_order_id).await {
-                        Ok(algo_order) => {
-                            let ts_init = clock.get_time_ns();
-                            let report = algo_order.to_order_status_report(
+                    let algo_venue_order_id = if algo_lookup == BinanceFuturesAlgoLookup::AlgoId {
+                        command.venue_order_id
+                    } else {
+                        None
+                    };
+
+                    match http_client
+                        .query_algo_order_with_history(
+                            command.instrument_id,
+                            Some(command.client_order_id),
+                            algo_venue_order_id,
+                        )
+                        .await
+                    {
+                        Ok(Some(result)) => {
+                            let report = create_algo_order_status_report(
+                                &result,
                                 account_id,
                                 command.instrument_id,
                                 price_precision,
                                 size_precision,
-                                ts_init,
+                                treat_expired_as_canceled,
+                                clock.get_time_ns(),
                             )?;
-
                             emitter.send_order_status_report(report);
                         }
+                        Ok(None) => log::warn!("Algo order query returned no matching order"),
                         Err(e) => log::warn!("Algo order query also failed: {e}"),
                     }
                 }

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -1576,6 +1576,33 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         let ts_init = self.clock.get_time_ns();
         let algo_lookup = self.resolve_algo_lookup(cmd.client_order_id, cmd.params.as_ref());
 
+        if algo_lookup == BinanceFuturesAlgoLookup::AlgoId {
+            let algo_order = self
+                .http_client
+                .query_algo_order_with_history(
+                    instrument_id,
+                    cmd.client_order_id,
+                    cmd.venue_order_id,
+                )
+                .await?;
+
+            return match algo_order {
+                Some(result) => Ok(Some(create_algo_order_status_report(
+                    &result,
+                    self.core.account_id,
+                    instrument_id,
+                    price_precision,
+                    size_precision,
+                    self.config.treat_expired_as_canceled,
+                    ts_init,
+                )?)),
+                None => {
+                    log::debug!("Algo order query returned no matching order");
+                    Ok(None)
+                }
+            };
+        }
+
         match self.http_client.query_order(&params).await {
             Ok(order) => {
                 let report = order.to_order_status_report(
@@ -1951,6 +1978,34 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         let treat_expired_as_canceled = self.config.treat_expired_as_canceled;
 
         self.spawn_task("query_order", async move {
+            if algo_lookup == BinanceFuturesAlgoLookup::AlgoId {
+                match http_client
+                    .query_algo_order_with_history(
+                        command.instrument_id,
+                        Some(command.client_order_id),
+                        command.venue_order_id,
+                    )
+                    .await
+                {
+                    Ok(Some(result)) => {
+                        let report = create_algo_order_status_report(
+                            &result,
+                            account_id,
+                            command.instrument_id,
+                            price_precision,
+                            size_precision,
+                            treat_expired_as_canceled,
+                            clock.get_time_ns(),
+                        )?;
+                        emitter.send_order_status_report(report);
+                    }
+                    Ok(None) => log::warn!("Algo order query returned no matching order"),
+                    Err(e) => log::warn!("Failed to query algo order status: {e}"),
+                }
+
+                return Ok(());
+            }
+
             let mut builder = BinanceOrderQueryParamsBuilder::default();
             builder.symbol(symbol.clone());
 

--- a/crates/adapters/binance/src/futures/http/client.rs
+++ b/crates/adapters/binance/src/futures/http/client.rs
@@ -95,6 +95,15 @@ use crate::{
 const BINANCE_GLOBAL_RATE_KEY: &str = "binance:global";
 const BINANCE_ORDERS_RATE_KEY: &str = "binance:orders";
 
+/// A Binance Futures Algo Service order with optional matching-engine details.
+#[derive(Debug)]
+pub struct BinanceFuturesAlgoOrderQueryResult {
+    /// The original conditional order from the Algo Service.
+    pub algo: BinanceFuturesAlgoOrder,
+    /// The matching-engine order created after the condition triggered, when enrichment succeeds.
+    pub actual: Option<BinanceFuturesOrder>,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct BatchCancelParams {
@@ -2192,6 +2201,141 @@ impl BinanceFuturesHttpClient {
         };
 
         self.inner.query_algo_order(&params).await
+    }
+
+    /// Queries a single algo order by venue order ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the venue order ID is not numeric or the request fails.
+    pub async fn query_algo_order_by_venue_order_id(
+        &self,
+        venue_order_id: VenueOrderId,
+    ) -> BinanceFuturesHttpResult<BinanceFuturesAlgoOrder> {
+        let algo_id = venue_order_id
+            .inner()
+            .parse::<i64>()
+            .map_err(|e| BinanceFuturesHttpError::ValidationError(e.to_string()))?;
+        let params = BinanceAlgoOrderQueryParams {
+            algo_id: Some(algo_id),
+            client_algo_id: None,
+            recv_window: None,
+        };
+
+        self.inner.query_algo_order(&params).await
+    }
+
+    async fn query_historical_algo_order_by_venue_order_id(
+        &self,
+        instrument_id: InstrumentId,
+        venue_order_id: VenueOrderId,
+    ) -> BinanceFuturesHttpResult<Option<BinanceFuturesAlgoOrder>> {
+        let algo_id = venue_order_id
+            .inner()
+            .parse::<i64>()
+            .map_err(|e| BinanceFuturesHttpError::ValidationError(e.to_string()))?;
+        let symbol = format_binance_symbol(&instrument_id);
+        let params = BinanceAllAlgoOrdersParams {
+            symbol,
+            algo_id: Some(algo_id),
+            start_time: None,
+            end_time: None,
+            page: None,
+            limit: Some(1),
+            recv_window: None,
+        };
+        let order = self
+            .inner
+            .query_all_algo_orders(&params)
+            .await?
+            .into_iter()
+            .next()
+            .filter(|order| order.algo_id == algo_id);
+
+        Ok(order)
+    }
+
+    /// Queries an algo order by venue ID, falling back to recent history when needed.
+    ///
+    /// Uses the client order ID only when no venue order ID is available.
+    /// Matching-engine details are best-effort; remote enrichment failures fall back to the
+    /// Algo Service execution fields.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an ID is invalid, the Algo Service request fails, or matching-engine
+    /// enrichment fails because of a local configuration or validation error.
+    pub async fn query_algo_order_with_history(
+        &self,
+        instrument_id: InstrumentId,
+        client_order_id: Option<ClientOrderId>,
+        algo_venue_order_id: Option<VenueOrderId>,
+    ) -> BinanceFuturesHttpResult<Option<BinanceFuturesAlgoOrderQueryResult>> {
+        let order = if let Some(venue_order_id) = algo_venue_order_id {
+            match self
+                .query_algo_order_by_venue_order_id(venue_order_id)
+                .await
+            {
+                Ok(order) => Some(order),
+                Err(BinanceFuturesHttpError::BinanceError { code: -2013, .. }) => {
+                    self.query_historical_algo_order_by_venue_order_id(
+                        instrument_id,
+                        venue_order_id,
+                    )
+                    .await?
+                }
+                Err(e) => return Err(e),
+            }
+        } else {
+            let Some(client_order_id) = client_order_id else {
+                return Ok(None);
+            };
+            match self.query_algo_order(client_order_id).await {
+                Ok(order) => Some(order),
+                Err(BinanceFuturesHttpError::BinanceError { code: -2013, .. }) => None,
+                Err(e) => return Err(e),
+            }
+        };
+
+        let Some(order) = order else {
+            return Ok(None);
+        };
+        let actual = if let Some(actual_order_id) = order
+            .actual_order_id
+            .as_deref()
+            .filter(|id| !id.is_empty())
+            .map(str::parse::<i64>)
+            .transpose()
+            .map_err(|e| BinanceFuturesHttpError::ValidationError(e.to_string()))?
+        {
+            let params = BinanceOrderQueryParams {
+                symbol: format_binance_symbol(&instrument_id),
+                order_id: Some(actual_order_id),
+                orig_client_order_id: None,
+                recv_window: None,
+            };
+            match self.inner.query_order(&params).await {
+                Ok(actual) => Some(actual),
+                Err(
+                    e @ (BinanceFuturesHttpError::MissingCredentials
+                    | BinanceFuturesHttpError::ValidationError(_)),
+                ) => return Err(e),
+                Err(e) => {
+                    log::warn!(
+                        "Failed to enrich algo order with matching-engine order \
+                         {actual_order_id}: {e}; falling back to Algo Service execution fields"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(Some(BinanceFuturesAlgoOrderQueryResult {
+            algo: order,
+            actual,
+        }))
     }
 
     /// Returns the size precision for an instrument from the cache.

--- a/crates/adapters/binance/src/futures/http/client.rs
+++ b/crates/adapters/binance/src/futures/http/client.rs
@@ -2290,6 +2290,7 @@ impl BinanceFuturesHttpClient {
             let Some(client_order_id) = client_order_id else {
                 return Ok(None);
             };
+
             match self.query_algo_order(client_order_id).await {
                 Ok(order) => Some(order),
                 Err(BinanceFuturesHttpError::BinanceError { code: -2013, .. }) => None,
@@ -2314,6 +2315,7 @@ impl BinanceFuturesHttpClient {
                 orig_client_order_id: None,
                 recv_window: None,
             };
+
             match self.inner.query_order(&params).await {
                 Ok(actual) => Some(actual),
                 Err(

--- a/crates/adapters/binance/src/futures/http/models.rs
+++ b/crates/adapters/binance/src/futures/http/models.rs
@@ -1523,8 +1523,8 @@ impl BinanceFuturesAlgoOrder {
     /// Converts this algo order to a report enriched with matching-engine execution details.
     ///
     /// The algo order remains the source of client identity and conditional-order metadata.
-    /// The matching-engine order is authoritative for status, fills, average price, venue order
-    /// identity, and the last update time.
+    /// The matching-engine order is authoritative for status, quantity, fills, average price,
+    /// venue order identity, and the last update time.
     ///
     /// # Errors
     ///
@@ -1587,6 +1587,7 @@ impl BinanceFuturesAlgoOrder {
         )?;
         report.venue_order_id = actual_report.venue_order_id;
         report.order_status = actual_report.order_status;
+        report.quantity = actual_report.quantity;
         report.filled_qty = actual_report.filled_qty;
         report.avg_px = actual_report.avg_px.or(report.avg_px);
         report.ts_last = actual_report.ts_last;
@@ -2287,10 +2288,11 @@ mod tests {
     }
 
     #[rstest]
-    fn test_algo_order_report_with_actual_preserves_algo_metadata_and_execution_state() {
+    fn test_close_all_algo_report_with_actual_uses_matching_engine_quantity() {
         let mut algo = algo_order_with_price(None);
         algo.order_type = BinanceFuturesOrderType::StopMarket;
-        algo.quantity = Some("0.002".to_string());
+        algo.quantity = None;
+        algo.close_position = Some(true);
         algo.algo_status = Some(BinanceAlgoStatus::Finished);
         algo.actual_order_id = Some("987654321".to_string());
         algo.executed_qty = Some("0.002".to_string());

--- a/crates/adapters/binance/src/futures/http/models.rs
+++ b/crates/adapters/binance/src/futures/http/models.rs
@@ -1509,6 +1509,88 @@ impl BinanceFuturesAlgoOrder {
             report = report.with_activation_price(activation_price);
         }
 
+        if let Some(reduce_only) = self.reduce_only {
+            report = report.with_reduce_only(reduce_only);
+        }
+
+        if let Some(trigger_time) = self.trigger_time {
+            report = report.with_ts_triggered(UnixNanos::from_millis(trigger_time as u64));
+        }
+
+        Ok(report)
+    }
+
+    /// Converts this algo order to a report enriched with matching-engine execution details.
+    ///
+    /// The algo order remains the source of client identity and conditional-order metadata.
+    /// The matching-engine order is authoritative for status, fills, average price, venue order
+    /// identity, and the last update time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the matching-engine order does not match this algo order or either
+    /// response contains invalid report data.
+    #[expect(clippy::too_many_arguments)]
+    pub fn to_order_status_report_with_actual(
+        &self,
+        actual: &BinanceFuturesOrder,
+        account_id: AccountId,
+        instrument_id: InstrumentId,
+        price_precision: u8,
+        size_precision: u8,
+        treat_expired_as_canceled: bool,
+        ts_init: UnixNanos,
+    ) -> anyhow::Result<OrderStatusReport> {
+        let expected_actual_order_id = self
+            .actual_order_id
+            .as_deref()
+            .filter(|id| !id.is_empty())
+            .context("algo order has no actual_order_id")?;
+
+        if expected_actual_order_id != actual.order_id.to_string() {
+            anyhow::bail!(
+                "actual order ID mismatch: expected {expected_actual_order_id}, was {}",
+                actual.order_id
+            );
+        }
+
+        if self.symbol != actual.symbol {
+            anyhow::bail!(
+                "actual order symbol mismatch: expected {}, was {}",
+                self.symbol,
+                actual.symbol
+            );
+        }
+
+        if self.side != actual.side {
+            anyhow::bail!(
+                "actual order side mismatch: expected {:?}, was {:?}",
+                self.side,
+                actual.side
+            );
+        }
+
+        let mut report = self.to_order_status_report(
+            account_id,
+            instrument_id,
+            price_precision,
+            size_precision,
+            ts_init,
+        )?;
+        let actual_report = actual.to_order_status_report(
+            account_id,
+            instrument_id,
+            price_precision,
+            size_precision,
+            treat_expired_as_canceled,
+            ts_init,
+        )?;
+        report.venue_order_id = actual_report.venue_order_id;
+        report.order_status = actual_report.order_status;
+        report.filled_qty = actual_report.filled_qty;
+        report.avg_px = actual_report.avg_px.or(report.avg_px);
+        report.ts_last = actual_report.ts_last;
+
         Ok(report)
     }
 
@@ -1555,16 +1637,27 @@ impl BinanceFuturesAlgoOrder {
         match self.algo_status {
             Some(BinanceAlgoStatus::New) => OrderStatus::Accepted,
             Some(BinanceAlgoStatus::Triggering) => OrderStatus::Accepted,
-            Some(BinanceAlgoStatus::Triggered) => OrderStatus::Accepted,
+            Some(BinanceAlgoStatus::Triggered) => self
+                .executed_qty
+                .as_deref()
+                .and_then(|qty| qty.parse::<Decimal>().ok())
+                .filter(|qty| *qty > Decimal::ZERO)
+                .map_or(OrderStatus::Accepted, |_| OrderStatus::PartiallyFilled),
             Some(BinanceAlgoStatus::Finished) => {
-                // Check executed_qty to determine if filled or canceled
-                if let Some(qty) = &self.executed_qty
-                    && let Ok(dec) = qty.parse::<Decimal>()
-                    && !dec.is_zero()
-                {
-                    return OrderStatus::Filled;
+                let executed_qty = self
+                    .executed_qty
+                    .as_deref()
+                    .and_then(|qty| qty.parse::<Decimal>().ok());
+                let quantity = self
+                    .quantity
+                    .as_deref()
+                    .and_then(|qty| qty.parse::<Decimal>().ok());
+                match (executed_qty, quantity) {
+                    (Some(actual), Some(total)) if total > Decimal::ZERO && actual >= total => {
+                        OrderStatus::Filled
+                    }
+                    _ => OrderStatus::Canceled,
                 }
-                OrderStatus::Canceled
             }
             Some(BinanceAlgoStatus::Canceled) => OrderStatus::Canceled,
             Some(BinanceAlgoStatus::Expired) => OrderStatus::Expired,
@@ -2194,6 +2287,84 @@ mod tests {
     }
 
     #[rstest]
+    fn test_algo_order_report_with_actual_preserves_algo_metadata_and_execution_state() {
+        let mut algo = algo_order_with_price(None);
+        algo.order_type = BinanceFuturesOrderType::StopMarket;
+        algo.quantity = Some("0.002".to_string());
+        algo.algo_status = Some(BinanceAlgoStatus::Finished);
+        algo.actual_order_id = Some("987654321".to_string());
+        algo.executed_qty = Some("0.002".to_string());
+        algo.avg_price = Some("49000.00".to_string());
+        algo.reduce_only = Some(true);
+        algo.trigger_time = Some(1_625_474_305_000);
+
+        let mut actual = order_with_price("0");
+        actual.order_id = 987654321;
+        actual.orig_qty = "0.002".to_string();
+        actual.executed_qty = "0.001".to_string();
+        actual.avg_price = Some("50000.00".to_string());
+        actual.status = BinanceOrderStatus::PartiallyFilled;
+        actual.order_type = BinanceFuturesOrderType::Market;
+        actual.side = BinanceSide::Sell;
+        actual.update_time = Some(1_625_474_306_000);
+
+        let account_id = AccountId::from("BINANCE-FUTURES-001");
+        let instrument_id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+        let ts_init = UnixNanos::from(1_000_000_000u64);
+        let report = algo
+            .to_order_status_report_with_actual(
+                &actual,
+                account_id,
+                instrument_id,
+                2,
+                3,
+                false,
+                ts_init,
+            )
+            .unwrap();
+
+        assert_eq!(
+            report.client_order_id,
+            Some(ClientOrderId::from("my-algo-order-1"))
+        );
+        assert_eq!(report.venue_order_id, VenueOrderId::from("987654321"));
+        assert_eq!(report.order_type, OrderType::StopMarket);
+        assert_eq!(report.order_status, OrderStatus::PartiallyFilled);
+        assert_eq!(report.quantity, Quantity::from("0.002"));
+        assert_eq!(report.filled_qty, Quantity::from("0.001"));
+        assert_eq!(report.avg_px, Some(Decimal::from(50000)));
+        assert_eq!(report.trigger_price, Some(Price::from("45000.00")));
+        assert_eq!(report.trigger_type, Some(TriggerType::MarkPrice));
+        assert!(report.reduce_only);
+        assert_eq!(
+            report.ts_triggered,
+            Some(UnixNanos::from_millis(1_625_474_305_000))
+        );
+        assert_eq!(report.ts_last, UnixNanos::from_millis(1_625_474_306_000));
+    }
+
+    #[rstest]
+    #[case(BinanceAlgoStatus::Finished, Some("0.001"), OrderStatus::Filled)]
+    #[case(BinanceAlgoStatus::Finished, Some("0.0005"), OrderStatus::Canceled)]
+    #[case(
+        BinanceAlgoStatus::Triggered,
+        Some("0.0005"),
+        OrderStatus::PartiallyFilled
+    )]
+    #[case(BinanceAlgoStatus::Triggered, None, OrderStatus::Accepted)]
+    fn test_algo_order_status_uses_actual_quantity_conservatively(
+        #[case] algo_status: BinanceAlgoStatus,
+        #[case] executed_qty: Option<&str>,
+        #[case] expected: OrderStatus,
+    ) {
+        let mut order = algo_order_with_price(None);
+        order.algo_status = Some(algo_status);
+        order.executed_qty = executed_qty.map(str::to_string);
+
+        assert_eq!(order.parse_order_status(), expected);
+    }
+
+    #[rstest]
     fn test_algo_order_to_report_sets_price() {
         let order = algo_order_with_price(Some("50000.00"));
         let account_id = AccountId::from("BINANCE-FUTURES-001");
@@ -2226,7 +2397,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_algo_order_to_report_omits_actual_price_without_fills() {
+    fn test_algo_order_to_report_omits_avg_price_without_fills() {
         let mut order = algo_order_with_price(None);
         order.executed_qty = Some("0".to_string());
         order.avg_price = Some("not-a-number".to_string());

--- a/crates/adapters/binance/src/futures/http/query.rs
+++ b/crates/adapters/binance/src/futures/http/query.rs
@@ -685,6 +685,10 @@ pub struct BinanceOpenAlgoOrdersParams {
 pub struct BinanceAllAlgoOrdersParams {
     /// Trading symbol (required).
     pub symbol: String,
+    /// Return orders with an algo order ID greater than or equal to this value.
+    #[serde(rename = "algoId", skip_serializing_if = "Option::is_none")]
+    #[builder(default)]
+    pub algo_id: Option<i64>,
     /// Start time in milliseconds.
     #[serde(rename = "startTime", skip_serializing_if = "Option::is_none")]
     #[builder(default)]
@@ -697,7 +701,7 @@ pub struct BinanceAllAlgoOrdersParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub page: Option<u32>,
-    /// Number of results per page (default 100, max 100).
+    /// Number of results (default 500, max 1000).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub limit: Option<u32>,

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -49,7 +49,8 @@ use nautilus_binance::{
     },
     config::BinanceExecClientConfig,
     futures::{
-        execution::BinanceFuturesExecutionClient, http::models::BinanceFuturesUsdExchangeInfo,
+        execution::{BINANCE_VENUE_ORDER_ID_IS_ALGO_ID_PARAM, BinanceFuturesExecutionClient},
+        http::models::BinanceFuturesUsdExchangeInfo,
     },
 };
 use nautilus_common::{
@@ -59,7 +60,7 @@ use nautilus_common::{
     messages::{
         ExecutionEvent,
         execution::{
-            BatchCancelOrders, CancelAllOrders, CancelOrder, GenerateFillReports,
+            BatchCancelOrders, CancelAllOrders, CancelOrder, ExecutionReport, GenerateFillReports,
             GenerateOrderStatusReport, GenerateOrderStatusReports, GeneratePositionStatusReports,
             ModifyOrder, QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList,
         },
@@ -71,10 +72,10 @@ use nautilus_live::ExecutionClientCore;
 use nautilus_model::{
     accounts::{AccountAny, MarginAccount},
     enums::{
-        AccountType, ContingencyType, OmsType, OrderSide, TimeInForce, TrailingOffsetType,
-        TriggerType,
+        AccountType, ContingencyType, OmsType, OrderSide, OrderStatus, OrderType, TimeInForce,
+        TrailingOffsetType, TriggerType,
     },
-    events::{AccountState, OrderEventAny},
+    events::{AccountState, OrderAccepted, OrderEventAny, OrderUpdated},
     identifiers::{
         AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, TraderId, VenueOrderId,
     },
@@ -166,6 +167,8 @@ enum CommandResponse {
 #[derive(Clone, Copy)]
 struct CommandResponses {
     submit: CommandResponse,
+    actual_order_query: CommandResponse,
+    invalid_actual_order: bool,
     cancel: CommandResponse,
     modify: CommandResponse,
     batch_cancel: CommandResponse,
@@ -175,6 +178,8 @@ impl Default for CommandResponses {
     fn default() -> Self {
         Self {
             submit: CommandResponse::Success,
+            actual_order_query: CommandResponse::Success,
+            invalid_actual_order: false,
             cancel: CommandResponse::Success,
             modify: CommandResponse::Success,
             batch_cancel: CommandResponse::Success,
@@ -205,6 +210,8 @@ type CapturedWsTradingMessages = Arc<std::sync::Mutex<Vec<serde_json::Value>>>;
 enum ReportFixtureMode {
     Empty,
     Populated,
+    MismatchedAlgoId,
+    DirectAlgo,
 }
 
 fn record_query(state: &CommandResponseState, path: &'static str, query: HashMap<String, String>) {
@@ -406,6 +413,7 @@ fn create_exec_test_router_with_command_responses(state: CommandResponseState) -
             "/fapi/v1/openAlgoOrders",
             get(handle_open_algo_orders_query),
         )
+        .route("/fapi/v1/algoOrder", get(handle_algo_order_query))
         .route(
             "/fapi/v1/algoOpenOrders",
             delete(|headers: HeaderMap| async move {
@@ -416,6 +424,7 @@ fn create_exec_test_router_with_command_responses(state: CommandResponseState) -
             }),
         )
         .route("/fapi/v1/allOrders", get(handle_all_orders_query))
+        .route("/fapi/v1/allAlgoOrders", get(handle_all_algo_orders_query))
         .route("/fapi/v1/userTrades", get(handle_user_trades_query))
         .route("/ws", get(handle_ws))
         .route("/ws-fapi/v1", get(handle_ws_trading))
@@ -445,7 +454,9 @@ async fn handle_open_orders_query(
     record_query(&state, "openOrders", query);
     match state.report_fixture_mode {
         ReportFixtureMode::Empty => json_response(&json!([])),
-        ReportFixtureMode::Populated => {
+        ReportFixtureMode::Populated
+        | ReportFixtureMode::MismatchedAlgoId
+        | ReportFixtureMode::DirectAlgo => {
             json_response(&json!([load_fixture("order_response.json")]))
         }
     }
@@ -462,7 +473,72 @@ async fn handle_open_algo_orders_query(
     record_query(&state, "openAlgoOrders", query);
     match state.report_fixture_mode {
         ReportFixtureMode::Empty => json_response(&json!([])),
-        ReportFixtureMode::Populated => json_response(&load_fixture("open_algo_orders.json")),
+        ReportFixtureMode::Populated
+        | ReportFixtureMode::MismatchedAlgoId
+        | ReportFixtureMode::DirectAlgo => json_response(&load_fixture("open_algo_orders.json")),
+    }
+}
+
+async fn handle_algo_order_query(
+    State(state): State<CommandResponseState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if !has_auth_headers(&headers) {
+        return unauthorized_response();
+    }
+    record_query(&state, "algoOrder", query);
+    if matches!(state.report_fixture_mode, ReportFixtureMode::DirectAlgo) {
+        let mut orders = load_fixture("open_algo_orders.json");
+        orders[0]["actualOrderId"] = json!(22542179_i64.to_string());
+        orders[0]["actualQty"] = json!("0.001");
+        orders[0]["actualPrice"] = json!("50000.00");
+        orders[0]["algoStatus"] = json!("FINISHED");
+        return json_response(&orders[0]);
+    }
+
+    command_response(
+        CommandResponse::VenueReject {
+            code: -2013,
+            msg: "Order does not exist.",
+        },
+        &json!({}),
+    )
+}
+
+async fn handle_all_algo_orders_query(
+    State(state): State<CommandResponseState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if !has_auth_headers(&headers) {
+        return unauthorized_response();
+    }
+    let requested_algo_id = query
+        .get("algoId")
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or_default();
+    record_query(&state, "allAlgoOrders", query);
+    match state.report_fixture_mode {
+        ReportFixtureMode::Empty => json_response(&json!([])),
+        ReportFixtureMode::Populated
+        | ReportFixtureMode::MismatchedAlgoId
+        | ReportFixtureMode::DirectAlgo => {
+            let mut orders = load_fixture("open_algo_orders.json");
+            orders[0]["algoId"] = json!(if matches!(
+                state.report_fixture_mode,
+                ReportFixtureMode::MismatchedAlgoId
+            ) {
+                requested_algo_id + 1
+            } else {
+                requested_algo_id
+            });
+            orders[0]["actualOrderId"] = json!(22542179_i64.to_string());
+            orders[0]["actualQty"] = json!("0.001");
+            orders[0]["actualPrice"] = json!("50000.00");
+            orders[0]["algoStatus"] = json!("FINISHED");
+            json_response(&orders)
+        }
     }
 }
 
@@ -533,8 +609,22 @@ async fn handle_order_query(
     if !has_auth_headers(&headers) {
         return unauthorized_response();
     }
+    let is_actual_order = query.get("orderId").map(String::as_str) == Some("22542179");
     record_query(&state, "order", query);
     state.request_count.fetch_add(1, Ordering::Relaxed);
+
+    if is_actual_order {
+        let mut order = load_fixture("order_response.json");
+        order["orderId"] = json!(22542179_i64);
+        order["status"] = json!("FILLED");
+        order["executedQty"] = json!("0.001");
+        order["avgPrice"] = json!(if state.responses.invalid_actual_order {
+            "invalid"
+        } else {
+            "50000.00"
+        });
+        return command_response(state.responses.actual_order_query, &order);
+    }
     command_response(state.responses.submit, &load_fixture("order_response.json"))
 }
 
@@ -2206,6 +2296,703 @@ async fn test_query_order_uses_binance_symbol_for_futures_symbol() {
 
 #[rstest]
 #[tokio::test]
+async fn test_historical_algo_report_falls_back_by_venue_order_id() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let venue_order_id = VenueOrderId::from("123456789");
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        None,
+        Some(venue_order_id),
+        Some(algo_order_query_params()),
+        None,
+    );
+
+    let result = client
+        .generate_order_status_report(&report)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.venue_order_id, VenueOrderId::from("22542179"));
+    assert_eq!(result.order_status, OrderStatus::Filled);
+    assert_eq!(
+        result.client_order_id,
+        Some(ClientOrderId::from("test-algo-order-1"))
+    );
+    assert_eq!(result.order_type, OrderType::StopMarket);
+    assert_eq!(result.trigger_price, Some(Price::from("45000.00")));
+    assert_eq!(result.trigger_type, Some(TriggerType::MarkPrice));
+    assert_eq!(result.filled_qty, Quantity::from("0.001"));
+    assert_eq!(result.avg_px, Some(rust_decimal_macros::dec!(50000.00)));
+    let algo_query = wait_for_query(&captured_queries, "algoOrder").await;
+    assert_eq!(
+        algo_query.query.get("algoId").map(String::as_str),
+        Some("123456789")
+    );
+    assert!(!algo_query.query.contains_key("clientAlgoId"));
+    let history_query = wait_for_query(&captured_queries, "allAlgoOrders").await;
+    assert_query_symbol(&history_query.query);
+    assert_eq!(
+        history_query.query.get("algoId").map(String::as_str),
+        Some("123456789")
+    );
+    assert_eq!(
+        history_query.query.get("limit").map(String::as_str),
+        Some("1")
+    );
+    assert!(!history_query.query.contains_key("page"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_historical_algo_report_rejects_non_matching_history_result() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::MismatchedAlgoId,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        None,
+        Some(VenueOrderId::from("123456789")),
+        Some(algo_order_query_params()),
+        None,
+    );
+
+    let result = client.generate_order_status_report(&report).await.unwrap();
+
+    assert!(result.is_none());
+    let history_queries = wait_for_queries(&captured_queries, "allAlgoOrders", 1).await;
+    assert_eq!(history_queries.len(), 1);
+    assert!(
+        captured_queries
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|query| query.path == "order")
+            .all(|query| query.query.get("orderId").map(String::as_str) != Some("22542179"))
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_historical_algo_report_client_id_not_found_returns_none() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::Empty,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let client_order_id = ClientOrderId::new("missing-client-id");
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        Some(client_order_id),
+        None,
+        None,
+        None,
+    );
+
+    let result = client.generate_order_status_report(&report).await.unwrap();
+
+    assert!(result.is_none());
+    let algo_query = wait_for_query(&captured_queries, "algoOrder").await;
+    assert!(algo_query.query.contains_key("clientAlgoId"));
+    assert!(!algo_query.query.contains_key("algoId"));
+    assert!(
+        captured_queries
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|query| query.path != "allAlgoOrders")
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_unknown_order_id_collision_does_not_query_algo_by_venue_id() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        Some(ClientOrderId::from("unknown-order-id")),
+        Some(VenueOrderId::from("123456789")),
+        None,
+        None,
+    );
+
+    let result = client.generate_order_status_report(&report).await.unwrap();
+
+    assert!(result.is_none());
+    let algo_query = wait_for_query(&captured_queries, "algoOrder").await;
+    assert!(
+        algo_query
+            .query
+            .get("clientAlgoId")
+            .is_some_and(|value| value.ends_with("unknown-order-id"))
+    );
+    assert!(!algo_query.query.contains_key("algoId"));
+    assert!(
+        captured_queries
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|query| query.path != "allAlgoOrders")
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_cached_regular_order_id_collision_skips_algo_fallback() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    let client_order_id = ClientOrderId::new("regular-order-id");
+    add_limit_order_to_cache(&cache, client_order_id);
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        Some(client_order_id),
+        Some(VenueOrderId::from("123456789")),
+        None,
+        None,
+    );
+
+    let result = client.generate_order_status_report(&report).await.unwrap();
+
+    assert!(result.is_none());
+    wait_for_query(&captured_queries, "order").await;
+    assert!(
+        captured_queries
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|query| query.path != "algoOrder" && query.path != "allAlgoOrders")
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_algo_report_by_client_id_enriches_from_actual_order() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::DirectAlgo,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        Some(ClientOrderId::from("test-algo-order-1")),
+        None,
+        None,
+        None,
+    );
+
+    let result = client
+        .generate_order_status_report(&report)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        result.client_order_id,
+        Some(ClientOrderId::from("test-algo-order-1"))
+    );
+    assert_eq!(result.order_type, OrderType::StopMarket);
+    assert_eq!(result.order_status, OrderStatus::Filled);
+    assert_eq!(result.venue_order_id, VenueOrderId::from("22542179"));
+    assert_eq!(result.avg_px, Some(rust_decimal_macros::dec!(50000.00)));
+    let algo_query = wait_for_query(&captured_queries, "algoOrder").await;
+    assert!(algo_query.query.contains_key("clientAlgoId"));
+    assert!(!algo_query.query.contains_key("algoId"));
+    assert!(
+        captured_queries
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|query| query.path != "allAlgoOrders")
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_algo_report_by_client_id_falls_back_when_actual_order_enrichment_fails() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            actual_order_query: CommandResponse::AmbiguousFailure,
+            ..Default::default()
+        },
+        ReportFixtureMode::DirectAlgo,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        Some(ClientOrderId::from("test-algo-order-1")),
+        None,
+        None,
+        None,
+    );
+
+    let result = client
+        .generate_order_status_report(&report)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        result.client_order_id,
+        Some(ClientOrderId::from("test-algo-order-1"))
+    );
+    assert_eq!(result.order_type, OrderType::StopMarket);
+    assert_eq!(result.order_status, OrderStatus::Filled);
+    assert_eq!(result.venue_order_id, VenueOrderId::from("22542179"));
+    assert_eq!(result.filled_qty, Quantity::from("0.001"));
+    assert_eq!(result.avg_px, Some(rust_decimal_macros::dec!(50000.00)));
+    let actual_query = wait_for_queries(&captured_queries, "order", 2).await;
+    assert!(
+        actual_query
+            .iter()
+            .any(|query| { query.query.get("orderId").map(String::as_str) == Some("22542179") })
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_algo_report_falls_back_when_actual_order_conversion_fails() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            invalid_actual_order: true,
+            ..Default::default()
+        },
+        ReportFixtureMode::DirectAlgo,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        Some(ClientOrderId::from("test-algo-order-1")),
+        None,
+        None,
+        None,
+    );
+
+    let result = client
+        .generate_order_status_report(&report)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        result.client_order_id,
+        Some(ClientOrderId::from("test-algo-order-1"))
+    );
+    assert_eq!(result.order_type, OrderType::StopMarket);
+    assert_eq!(result.order_status, OrderStatus::Filled);
+    assert_eq!(result.venue_order_id, VenueOrderId::from("22542179"));
+    assert_eq!(result.filled_qty, Quantity::from("0.001"));
+    assert_eq!(result.avg_px, Some(rust_decimal_macros::dec!(50000.00)));
+    let actual_queries = wait_for_queries(&captured_queries, "order", 2).await;
+    assert!(
+        actual_queries
+            .iter()
+            .any(|query| query.query.get("orderId").map(String::as_str) == Some("22542179"))
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_cached_algo_actual_order_id_uses_client_id_fallback() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            actual_order_query: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    let client_order_id = ClientOrderId::new("triggered-algo-order-id");
+    let actual_order_id = VenueOrderId::from("22542179");
+    let cached_order = add_triggered_stop_market_order_to_cache(
+        &cache,
+        client_order_id,
+        VenueOrderId::from("123456789"),
+        actual_order_id,
+    );
+    assert_eq!(cached_order.venue_order_id(), Some(actual_order_id));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let report = GenerateOrderStatusReport::new(
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(test_instrument_id()),
+        Some(client_order_id),
+        Some(actual_order_id),
+        None,
+        None,
+    );
+
+    let result = client.generate_order_status_report(&report).await.unwrap();
+
+    assert!(result.is_none());
+    let algo_query = wait_for_query(&captured_queries, "algoOrder").await;
+    assert!(
+        algo_query
+            .query
+            .get("clientAlgoId")
+            .is_some_and(|value| value.ends_with("triggered-algo-order-id"))
+    );
+    assert!(!algo_query.query.contains_key("algoId"));
+    assert!(
+        captured_queries
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|query| query.path != "allAlgoOrders")
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_falls_back_by_algo_venue_order_id() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    while rx.try_recv().is_ok() {}
+
+    let client_order_id = ClientOrderId::new("synthetic-query-client-id");
+    let command = QueryOrder::new(
+        test_trader_id(),
+        Some(*BINANCE_CLIENT_ID),
+        test_strategy_id(),
+        test_instrument_id(),
+        client_order_id,
+        Some(VenueOrderId::from("123456789")),
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        Some(algo_order_query_params()),
+        None,
+    );
+
+    client.query_order(command).unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timed out waiting for query_order report")
+        .expect("execution event channel closed");
+    let ExecutionEvent::Report(ExecutionReport::Order(report)) = event else {
+        panic!("Expected OrderStatusReport, was {event:?}");
+    };
+    assert_eq!(
+        report.client_order_id,
+        Some(ClientOrderId::from("test-algo-order-1"))
+    );
+    assert_eq!(report.order_type, OrderType::StopMarket);
+    assert_eq!(report.order_status, OrderStatus::Filled);
+    assert_eq!(report.venue_order_id, VenueOrderId::from("22542179"));
+    assert_eq!(report.filled_qty, Quantity::from("0.001"));
+    assert_eq!(report.avg_px, Some(rust_decimal_macros::dec!(50000.00)));
+
+    let algo_query = wait_for_query(&captured_queries, "algoOrder").await;
+    assert_eq!(
+        algo_query.query.get("algoId").map(String::as_str),
+        Some("123456789")
+    );
+    assert!(!algo_query.query.contains_key("clientAlgoId"));
+    let history_query = wait_for_query(&captured_queries, "allAlgoOrders").await;
+    assert_query_symbol(&history_query.query);
+    assert_eq!(
+        history_query.query.get("algoId").map(String::as_str),
+        Some("123456789")
+    );
+    assert_eq!(
+        history_query.query.get("limit").map(String::as_str),
+        Some("1")
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_cached_algo_actual_id_uses_client_id_fallback() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            actual_order_query: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    let client_order_id = ClientOrderId::new("triggered-query-algo-order-id");
+    let actual_order_id = VenueOrderId::from("22542179");
+    add_triggered_stop_market_order_to_cache(
+        &cache,
+        client_order_id,
+        VenueOrderId::from("123456789"),
+        actual_order_id,
+    );
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    while rx.try_recv().is_ok() {}
+
+    let command = QueryOrder::new(
+        test_trader_id(),
+        Some(*BINANCE_CLIENT_ID),
+        test_strategy_id(),
+        test_instrument_id(),
+        client_order_id,
+        Some(actual_order_id),
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.query_order(command).unwrap();
+    let algo_query = wait_for_query(&captured_queries, "algoOrder").await;
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .is_err()
+    );
+    assert!(
+        algo_query
+            .query
+            .get("clientAlgoId")
+            .is_some_and(|value| value.ends_with("triggered-query-algo-order-id"))
+    );
+    assert!(!algo_query.query.contains_key("algoId"));
+    assert!(
+        captured_queries
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|query| query.path != "allAlgoOrders")
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_cached_regular_id_collision_skips_algo_fallback() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses {
+            submit: CommandResponse::VenueReject {
+                code: -2013,
+                msg: "Order does not exist.",
+            },
+            ..Default::default()
+        },
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    let client_order_id = ClientOrderId::new("regular-query-order-id");
+    add_limit_order_to_cache(&cache, client_order_id);
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    while rx.try_recv().is_ok() {}
+
+    let command = QueryOrder::new(
+        test_trader_id(),
+        Some(*BINANCE_CLIENT_ID),
+        test_strategy_id(),
+        test_instrument_id(),
+        client_order_id,
+        Some(VenueOrderId::from("123456789")),
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.query_order(command).unwrap();
+    wait_for_query(&captured_queries, "order").await;
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .is_err()
+    );
+    assert!(
+        captured_queries
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|query| query.path != "algoOrder" && query.path != "allAlgoOrders")
+    );
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_report_generation_uses_binance_symbol_for_futures_symbol() {
     let (addr, captured_queries) = start_exec_test_server_with_query_capture().await;
     let base_url_http = format!("http://{addr}");
@@ -2546,6 +3333,90 @@ fn add_limit_order_to_cache(
         .add_order(order_any.clone(), None, None, false)
         .unwrap();
     order_any
+}
+
+fn add_triggered_stop_market_order_to_cache(
+    cache: &Rc<RefCell<Cache>>,
+    client_order_id: ClientOrderId,
+    algo_order_id: VenueOrderId,
+    actual_order_id: VenueOrderId,
+) -> OrderAny {
+    let order = StopMarketOrder::new(
+        test_trader_id(),
+        test_strategy_id(),
+        test_instrument_id(),
+        client_order_id,
+        OrderSide::Buy,
+        Quantity::from("0.001"),
+        Price::from("45000.00"),
+        TriggerType::MarkPrice,
+        TimeInForce::Gtc,
+        None,
+        false,
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+    );
+
+    let mut order_any = OrderAny::StopMarket(order);
+    let account_id = AccountId::from("BINANCE-001");
+    let accepted = OrderAccepted::new(
+        test_trader_id(),
+        test_strategy_id(),
+        test_instrument_id(),
+        client_order_id,
+        algo_order_id,
+        account_id,
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        true,
+    );
+    order_any.apply(OrderEventAny::Accepted(accepted)).unwrap();
+    let updated = OrderUpdated::new(
+        test_trader_id(),
+        test_strategy_id(),
+        test_instrument_id(),
+        client_order_id,
+        Quantity::from("0.001"),
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        true,
+        Some(actual_order_id),
+        Some(account_id),
+        None,
+        Some(Price::from("45000.00")),
+        None,
+        false,
+    );
+    order_any.apply(OrderEventAny::Updated(updated)).unwrap();
+
+    cache
+        .borrow_mut()
+        .add_order(order_any.clone(), None, None, false)
+        .unwrap();
+    order_any
+}
+
+fn algo_order_query_params() -> Params {
+    let mut params = Params::new();
+    params.insert(
+        BINANCE_VENUE_ORDER_ID_IS_ALGO_ID_PARAM.to_string(),
+        json!(true),
+    );
+    params
 }
 
 fn add_reduce_only_limit_order_to_cache(

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -2296,15 +2296,9 @@ async fn test_query_order_uses_binance_symbol_for_futures_symbol() {
 
 #[rstest]
 #[tokio::test]
-async fn test_historical_algo_report_falls_back_by_venue_order_id() {
+async fn test_historical_algo_report_bypasses_regular_order_id_collision() {
     let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
-        CommandResponses {
-            submit: CommandResponse::VenueReject {
-                code: -2013,
-                msg: "Order does not exist.",
-            },
-            ..Default::default()
-        },
+        CommandResponses::default(),
         ReportFixtureMode::Populated,
     )
     .await;
@@ -2362,6 +2356,13 @@ async fn test_historical_algo_report_falls_back_by_venue_order_id() {
         Some("1")
     );
     assert!(!history_query.query.contains_key("page"));
+    let queries = captured_queries.lock().unwrap();
+    assert!(queries.iter().all(|query| {
+        query.path != "order" || query.query.get("orderId").map(String::as_str) != Some("123456789")
+    }));
+    assert!(queries.iter().any(|query| {
+        query.path == "order" && query.query.get("orderId").map(String::as_str) == Some("22542179")
+    }));
 }
 
 #[rstest]
@@ -2792,15 +2793,9 @@ async fn test_cached_algo_actual_order_id_uses_client_id_fallback() {
 
 #[rstest]
 #[tokio::test]
-async fn test_query_order_falls_back_by_algo_venue_order_id() {
+async fn test_query_order_bypasses_regular_order_id_collision() {
     let (addr, captured_queries) = start_exec_test_server_with_query_capture_and_responses(
-        CommandResponses {
-            submit: CommandResponse::VenueReject {
-                code: -2013,
-                msg: "Order does not exist.",
-            },
-            ..Default::default()
-        },
+        CommandResponses::default(),
         ReportFixtureMode::Populated,
     )
     .await;
@@ -2864,6 +2859,13 @@ async fn test_query_order_falls_back_by_algo_venue_order_id() {
         history_query.query.get("limit").map(String::as_str),
         Some("1")
     );
+    let queries = captured_queries.lock().unwrap();
+    assert!(queries.iter().all(|query| {
+        query.path != "order" || query.query.get("orderId").map(String::as_str) != Some("123456789")
+    }));
+    assert!(queries.iter().any(|query| {
+        query.path == "order" && query.query.get("orderId").map(String::as_str) == Some("22542179")
+    }));
 }
 
 #[rstest]


### PR DESCRIPTION
<!-- Suggested title: Fix historical Binance Futures algo order queries -->

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixes Binance Futures historical conditional-order queries when the regular order endpoint returns `-2013`. An explicit `params["venue_order_id_is_algo_id"] = true` hint declares that the command's venue ID is an Algo Service `algoId`; the execution client can then perform a single bounded `/allAlgoOrders?symbol=...&algoId=...&limit=1` fallback when `/algoOrder` no longer serves the completed order.

The explicit ID-kind guard prevents a regular matching-engine `orderId` or a triggered conditional order's `actualOrderId` from being interpreted as an unrelated `algoId` in Binance's independent numeric ID space. Known regular orders skip the Algo fallback; cached conditional and unknown orders retain the existing `clientAlgoId` lookup unless the caller supplies the explicit venue-ID hint.

When `actualOrderId` is available, matching-engine status, filled quantity, average price, venue identity, and last-update time enrich the original algo report instead of replacing it. This preserves `clientAlgoId`, conditional order type, trigger/trailing metadata, and client-ID-only not-found behavior. Matching-engine enrichment is best-effort: request or conversion failures log a warning and fall back to the valid Algo Service report, while local configuration errors and invalid base algo reports still propagate.

### Commit structure

The change is split into two independently reviewable commits:

1. `Add Binance historical algo order lookup` adds the HTTP/query primitives for typed `algoId` lookup, bounded recent-history fallback, strict ID matching, and optional matching-engine retrieval.
2. `Integrate enriched Binance algo order reports` wires the lookup into execution requery flows, merges matching-engine execution state into Algo Service metadata, refines algo status conversion, and adds the regression coverage.

### Compatibility and risk

The regular-order success path is unchanged: a successful `/order` response is converted and returned without querying the Algo Service. Known cached regular orders now skip the Algo fallback after `-2013`, preventing regular `orderId` values from colliding with Binance's independent `algoId` space.

Unknown and cached conditional orders retain the existing `clientAlgoId` fallback unless the caller explicitly marks the venue ID as an `algoId`. A triggered conditional order whose current venue ID is an `actualOrderId` is therefore not reinterpreted as an `algoId`.

Existing Algo Service queries with an `actualOrderId` now perform best-effort matching-engine enrichment. This intentionally improves report status, filled quantity, average price, venue identity, and update time; request or conversion failures fall back to the valid base algo report. The change is limited to algo requery/report semantics and is covered by regular-order, unknown-order, triggered-order collision, client-ID fallback, and enrichment-failure regression tests.

### Order requery flow

Before this change, the regular-query fallback discarded the parsed venue order ID and could only retry the Algo Service with the Nautilus client order ID:

```text
query order
└── GET /order by orderId or origClientOrderId
    ├── found
    │   └── return regular OrderStatusReport
    ├── error other than -2013
    │   └── propagate the error
    └── -2013
        ├── no client_order_id
        │   └── return no report
        └── client_order_id available
            └── GET /algoOrder by clientAlgoId
                ├── found
                │   └── return Algo Service OrderStatusReport
                └── not found or request failed
                    └── return no report
```

The command's `venue_order_id` is not used by the Algo Service fallback, and completed orders are not searched in `/allAlgoOrders`.

After this change, the adapter first classifies how an Algo Service retry may identify the order. A venue ID is treated as `algoId` only when the caller explicitly declares its ID kind:

```text
resolve Algo Service lookup
├── params["venue_order_id_is_algo_id"] == true
│   └── lookup = AlgoId
├── cached order is known regular
│   └── lookup = Skip
└── cached conditional order or unknown order
    └── lookup = ClientAlgoId

query order
└── GET /order by orderId or origClientOrderId
    ├── found
    │   └── return regular OrderStatusReport
    ├── error other than -2013
    │   └── propagate the error
    └── -2013
        ├── lookup = Skip
        │   └── return no report
        ├── lookup = ClientAlgoId
        │   └── GET /algoOrder by clientAlgoId
        │       ├── found
        │       │   └── build algo report
        │       ├── -2013
        │       │   └── return no report
        │       └── other error
        │           └── propagate to caller/task error handling
        └── lookup = AlgoId
            └── GET /algoOrder by algoId=venue_order_id
                ├── found
                │   └── build algo report
                ├── error other than -2013
                │   └── propagate to caller/task error handling
                └── -2013
                    └── GET /allAlgoOrders by symbol + algoId, limit=1
                        ├── exact algoId match
                        │   └── build historical algo report
                        ├── no exact match
                        │   └── return no report
                        └── request error
                            └── propagate to caller/task error handling

build algo report
├── no actualOrderId
│   └── return Algo Service report
└── actualOrderId available
    ├── invalid actualOrderId or local configuration error
    │   └── propagate the error
    └── GET /order by actualOrderId
        ├── request and conversion succeed
        │   └── merge matching-engine execution state into algo metadata
        └── remote request or enrichment conversion fails
            └── warn and return the valid Algo Service report

invalid base Algo Service report
└── propagate the conversion error
```

## Related Issues/PRs

Closes #4448

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

No documentation changes are required for this adapter bug fix.

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

No release-note entry is included in this focused patch.

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

- `cargo +1.97.0 test -p nautilus-binance --features high-precision` (734 library, 149 Futures integration, and 110 Spot integration tests)
- `cargo +1.97.0 clippy -p nautilus-binance --all-targets --features high-precision -- -D warnings`
- `cargo +1.97.0 fmt --all -- --check`
- `git diff --check`
- Focused coverage for bounded `algoId` history lookup, strict ID matching, explicit venue-ID typing, regular-order and triggered-`actualOrderId` collision prevention, client-ID-only not-found and enrichment, request/conversion enrichment fallback, official `actualQty` / `actualPrice` fields, partial fills, and the `OrderStatusReport` emitted by asynchronous `query_order`.
- Pre-rebase live Binance USD-M verification with a filled DOGEUSDT `STOP_MARKET` order: the query returned `FILLED`, preserved the algo client ID and `STOP_MARKET` metadata, and generated an inferred fill of `69 @ 0.074450` without `-2013`. The final ID-kind hardening and rebase were revalidated by the complete deterministic test suite rather than another live run that would submit real diagnostic probes.
