### PR TITLE
Fix portfolio PnL resolution for broker-routed instruments

### DIFF
--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -821,7 +821,7 @@ impl Portfolio {
                 Some(id) => cache.account(id),
                 None => cache.account_for_venue(venue).or_else(|| {
                     cache
-                        .positions_open(Some(venue), None, None, None, None)
+                        .positions(Some(venue), None, None, None, None)
                         .into_iter()
                         .next()
                         .and_then(|p| cache.account(&p.account_id))
@@ -2877,7 +2877,9 @@ fn update_order(
             config,
         };
 
-        match portfolio_clone.calculate_unrealized_pnl(&order_filled.instrument_id, None) {
+        match portfolio_clone
+            .calculate_unrealized_pnl(&order_filled.instrument_id, Some(&account_id))
+        {
             Some(unrealized_pnl) => {
                 inner
                     .borrow_mut()

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -1228,18 +1228,16 @@ impl Portfolio {
             return false;
         }
 
-        let equity_account_id = if mode == MarkValueMode::Equity {
-            account_id
-                .copied()
-                .or_else(|| cache.account_id(&venue).copied())
-        } else {
-            None
-        };
         let valuation_account = match account_id {
             Some(id) => cache.account(id),
             None => cache
                 .account_for_venue(&venue)
                 .or_else(|| positions.first().and_then(|p| cache.account(&p.account_id))),
+        };
+        let equity_account_id = if mode == MarkValueMode::Equity {
+            valuation_account.as_ref().map(|a| a.id())
+        } else {
+            None
         };
         let mut xrate_cache: AHashMap<Currency, Option<Decimal>> = AHashMap::new();
 

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -1516,39 +1516,49 @@ impl Portfolio {
         };
 
         for (instrument, orders_open) in &orders_and_instruments {
-            let account = {
-                let cache = self.cache.borrow();
-                if let Some(account) =
-                    resolve_account_for_instrument(&cache, &instrument.id(), None)
-                {
-                    account.clone()
-                } else {
-                    log::error!(
-                        "Cannot update initial (order) margin: no account registered for {}",
-                        instrument.id().venue
-                    );
-                    initialized = false;
-                    break;
-                }
-            };
+            let mut by_account: IndexMap<Option<AccountId>, Vec<&OrderAny>> = IndexMap::new();
+            for order in orders_open {
+                by_account
+                    .entry(order.account_id())
+                    .or_default()
+                    .push(order);
+            }
 
-            let orders_open_refs: Vec<&OrderAny> = orders_open.iter().collect();
-            let result = self.inner.borrow_mut().accounts.update_orders(
-                &account,
-                instrument,
-                &orders_open_refs,
-                self.clock.borrow().timestamp_ns(),
-            );
+            for (account_id, orders) in by_account {
+                let account = {
+                    let cache = self.cache.borrow();
+                    match resolve_account_for_instrument(
+                        &cache,
+                        &instrument.id(),
+                        account_id.as_ref(),
+                    ) {
+                        Some(account) => account.cloned(),
+                        None => {
+                            log::error!(
+                                "Cannot update initial (order) margin: no account registered for {}",
+                                instrument.id().venue
+                            );
+                            initialized = false;
+                            continue;
+                        }
+                    }
+                };
 
-            match result {
-                Some((updated_account, _)) => {
-                    self.cache
-                        .borrow_mut()
-                        .update_account(&updated_account)
-                        .unwrap();
-                }
-                None => {
-                    initialized = false;
+                let result = self.inner.borrow_mut().accounts.update_orders(
+                    &account,
+                    instrument,
+                    &orders,
+                    self.clock.borrow().timestamp_ns(),
+                );
+
+                match result {
+                    Some((updated_account, _)) => {
+                        self.cache
+                            .borrow_mut()
+                            .update_account(&updated_account)
+                            .unwrap();
+                    }
+                    None => initialized = false,
                 }
             }
         }
@@ -1633,53 +1643,57 @@ impl Portfolio {
                 self.inner.borrow_mut().pending_calcs.insert(instrument_id);
             }
 
-            let cache = self.cache.borrow();
-            let Some(account) =
-                resolve_account_for_instrument(&cache, &instrument_id, None).map(|a| a.cloned())
-            else {
-                log::error!(
-                    "Cannot update maintenance (position) margin: no account registered for {}",
-                    instrument_id.venue
-                );
-                initialized = false;
-                break;
-            };
-
-            let account = match account {
-                AccountAny::Cash(_) | AccountAny::Betting(_) => continue,
-                AccountAny::Margin(margin_account) => margin_account,
-            };
-
-            let Some(instrument) = cache.instrument(&instrument_id).cloned() else {
-                log::error!(
-                    "Cannot update maintenance (position) margin: no instrument found for {instrument_id}"
-                );
-                initialized = false;
-                break;
-            };
-            let positions: Vec<Position> = cache
-                .positions_open(None, Some(&instrument_id), None, None, None)
-                .into_iter()
-                .map(|p| p.cloned())
-                .collect();
-            drop(cache);
-
-            let result = self.inner.borrow_mut().accounts.update_positions(
-                &account,
-                &instrument,
-                positions.iter().collect(),
-                self.clock.borrow().timestamp_ns(),
-            );
-
-            match result {
-                Some((updated_account, _)) => {
-                    self.cache
-                        .borrow_mut()
-                        .update_account(&AccountAny::Margin(updated_account))
-                        .unwrap();
-                }
-                None => {
+            let instrument = {
+                let cache = self.cache.borrow();
+                let Some(instrument) = cache.instrument(&instrument_id).cloned() else {
+                    log::error!(
+                        "Cannot update maintenance (position) margin: no instrument found for {instrument_id}"
+                    );
                     initialized = false;
+                    break;
+                };
+                instrument
+            };
+
+            let mut by_account: IndexMap<AccountId, Vec<&Position>> = IndexMap::new();
+            for position in &positions_open {
+                by_account
+                    .entry(position.account_id)
+                    .or_default()
+                    .push(position);
+            }
+
+            for (account_id, positions) in by_account {
+                let account = {
+                    let cache = self.cache.borrow();
+                    let Some(account) = cache.account(&account_id).map(|a| a.cloned()) else {
+                        log::error!(
+                            "Cannot update maintenance (position) margin: no account registered for {account_id}"
+                        );
+                        initialized = false;
+                        continue;
+                    };
+                    account
+                };
+                let AccountAny::Margin(margin_account) = account else {
+                    continue;
+                };
+
+                let result = self.inner.borrow_mut().accounts.update_positions(
+                    &margin_account,
+                    &instrument,
+                    positions,
+                    self.clock.borrow().timestamp_ns(),
+                );
+
+                match result {
+                    Some((updated_account, _)) => {
+                        self.cache
+                            .borrow_mut()
+                            .update_account(&AccountAny::Margin(updated_account))
+                            .unwrap();
+                    }
+                    None => initialized = false,
                 }
             }
         }
@@ -2651,61 +2665,96 @@ fn update_instrument_id(
         return;
     }
 
-    let mut result_maint = None;
-
-    // Scoped borrow: must drop before calling AccountsManager (which borrows cache internally)
-    let (account, instrument, orders_open, positions_open) = {
-        let cache_ref = cache.borrow();
-        let account = if let Some(account) =
-            resolve_account_for_instrument(&cache_ref, instrument_id, None)
-        {
-            account.clone()
-        } else {
-            log::error!(
-                "Cannot update tick: no account registered for {}",
-                instrument_id.venue
-            );
-            return;
-        };
-        let instrument = if let Some(instrument) = cache_ref.instrument(instrument_id) {
-            instrument.clone()
-        } else {
+    let instrument = match cache.borrow().instrument(instrument_id) {
+        Some(instrument) => instrument.clone(),
+        None => {
             log::error!("Cannot update tick: no instrument found for {instrument_id}");
             return;
-        };
-        let orders_open: Vec<OrderAny> = cache_ref
+        }
+    };
+
+    let mut by_account: IndexMap<AccountId, (Vec<OrderAny>, Vec<Position>)> = IndexMap::new();
+    {
+        let cache_ref = cache.borrow();
+        for order in cache_ref
             .orders_open(None, Some(instrument_id), None, None, None)
             .iter()
             .map(|o| (*o).clone())
-            .collect();
-        let positions_open: Vec<Position> = cache_ref
+        {
+            if let Some(account_id) = order.account_id() {
+                by_account.entry(account_id).or_default().0.push(order);
+            }
+        }
+
+        for position in cache_ref
             .positions_open(None, Some(instrument_id), None, None, None)
             .iter()
             .map(|p| (*p).clone())
-            .collect();
-        (account, instrument, orders_open, positions_open)
-    };
+        {
+            by_account
+                .entry(position.account_id)
+                .or_default()
+                .1
+                .push(position);
+        }
 
-    // No cache borrow held: AccountsManager borrows cache internally for xrate lookups
-    let orders_open_refs: Vec<&OrderAny> = orders_open.iter().collect();
-    let result_init = inner.borrow().accounts.update_orders(
-        &account,
-        &instrument,
-        &orders_open_refs,
-        clock.borrow().timestamp_ns(),
-    );
-
-    if let AccountAny::Margin(ref margin_account) = account {
-        result_maint = inner.borrow().accounts.update_positions(
-            margin_account,
-            &instrument,
-            positions_open.iter().collect(),
-            clock.borrow().timestamp_ns(),
-        );
+        if by_account.is_empty()
+            && let Some(account) =
+                resolve_account_for_instrument(&cache_ref, instrument_id, None).map(|a| a.cloned())
+        {
+            by_account.entry(account.id()).or_default();
+        }
     }
 
-    if let Some((ref updated_account, _)) = result_init {
-        cache.borrow_mut().update_account(updated_account).unwrap();
+    if by_account.is_empty() {
+        log::error!(
+            "Cannot update tick: no account registered for {}",
+            instrument_id.venue
+        );
+        return;
+    }
+
+    let ts_event = clock.borrow().timestamp_ns();
+    let mut ok = true;
+    let mut any_margin = false;
+
+    for (account_id, (orders, positions)) in by_account {
+        let Some(account) = cache.borrow().account(&account_id).map(|a| a.cloned()) else {
+            log::error!("Cannot update tick: no account registered for {account_id}");
+            ok = false;
+            continue;
+        };
+
+        let orders_refs: Vec<&OrderAny> = orders.iter().collect();
+
+        if let Some((updated_account, _)) =
+            inner
+                .borrow()
+                .accounts
+                .update_orders(&account, &instrument, &orders_refs, ts_event)
+        {
+            cache.borrow_mut().update_account(&updated_account).unwrap();
+        } else {
+            ok = false;
+        }
+
+        if let AccountAny::Margin(margin_account) = &account {
+            any_margin = true;
+
+            if let Some((updated_account, _)) = inner.borrow().accounts.update_positions(
+                margin_account,
+                &instrument,
+                positions.iter().collect(),
+                ts_event,
+            ) {
+                cache
+                    .borrow_mut()
+                    .update_account(&AccountAny::Margin(updated_account))
+                    .unwrap();
+            } else {
+                ok = false;
+            }
+        }
     }
 
     let portfolio_clone = Portfolio {
@@ -2718,10 +2767,7 @@ fn update_instrument_id(
     let result_unrealized_pnl: Option<Money> =
         portfolio_clone.calculate_unrealized_pnl(instrument_id, None);
 
-    if result_init.is_some()
-        && (matches!(account, AccountAny::Cash(_) | AccountAny::Betting(_))
-            || (result_maint.is_some() && result_unrealized_pnl.is_some()))
-    {
+    if ok && (!any_margin || result_unrealized_pnl.is_some()) {
         inner.borrow_mut().pending_calcs.remove(instrument_id);
         if inner.borrow().pending_calcs.is_empty() {
             inner.borrow_mut().initialized = true;

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -23,7 +23,7 @@ use ahash::{AHashMap, AHashSet};
 use indexmap::{IndexMap, IndexSet};
 use nautilus_analysis::{analyzer::PortfolioAnalyzer, snapshot::PortfolioStatistics};
 use nautilus_common::{
-    cache::{AccountLookupError, Cache},
+    cache::{AccountLookupError, AccountRef, Cache},
     clock::Clock,
     enums::LogColor,
     msgbus::{self, MessagingSwitchboard, TypedHandler, TypedIntoHandler},
@@ -819,7 +819,13 @@ impl Portfolio {
             let cache = self.cache.borrow();
             let account = match account_id {
                 Some(id) => cache.account(id),
-                None => cache.account_for_venue(venue),
+                None => cache.account_for_venue(venue).or_else(|| {
+                    cache
+                        .positions_open(Some(venue), None, None, None, None)
+                        .into_iter()
+                        .next()
+                        .and_then(|p| cache.account(&p.account_id))
+                }),
             };
 
             match account {
@@ -1231,7 +1237,9 @@ impl Portfolio {
         };
         let valuation_account = match account_id {
             Some(id) => cache.account(id),
-            None => cache.account_for_venue(&venue),
+            None => cache
+                .account_for_venue(&venue)
+                .or_else(|| positions.first().and_then(|p| cache.account(&p.account_id))),
         };
         let mut xrate_cache: AHashMap<Currency, Option<Decimal>> = AHashMap::new();
 
@@ -1510,7 +1518,9 @@ impl Portfolio {
         for (instrument, orders_open) in &orders_and_instruments {
             let account = {
                 let cache = self.cache.borrow();
-                if let Some(account) = cache.account_for_venue(&instrument.id().venue) {
+                if let Some(account) =
+                    resolve_account_for_instrument(&cache, &instrument.id(), None)
+                {
                     account.clone()
                 } else {
                     log::error!(
@@ -1624,7 +1634,9 @@ impl Portfolio {
             }
 
             let cache = self.cache.borrow();
-            let Some(account) = cache.account_for_venue_owned(&instrument_id.venue) else {
+            let Some(account) =
+                resolve_account_for_instrument(&cache, &instrument_id, None).map(|a| a.cloned())
+            else {
                 log::error!(
                     "Cannot update maintenance (position) margin: no account registered for {}",
                     instrument_id.venue
@@ -1791,10 +1803,7 @@ impl Portfolio {
         account_id: Option<&AccountId>,
     ) -> Option<Money> {
         let cache = self.cache.borrow();
-        let account = match account_id {
-            Some(id) => cache.account(id),
-            None => cache.account_for_venue(&instrument_id.venue),
-        };
+        let account = resolve_account_for_instrument(&cache, instrument_id, account_id);
         let account = if let Some(account) = account {
             account
         } else {
@@ -2109,10 +2118,7 @@ impl Portfolio {
         self.ensure_snapshot_pnls_cached_for(instrument_id);
 
         let cache = self.cache.borrow();
-        let account = match account_id {
-            Some(id) => cache.account(id),
-            None => cache.account_for_venue(&instrument_id.venue),
-        };
+        let account = resolve_account_for_instrument(&cache, instrument_id, account_id);
         let account = if let Some(account) = account {
             account
         } else {
@@ -2609,6 +2615,26 @@ fn update_bar(
     update_instrument_id(cache, clock, inner, config, &instrument_id);
 }
 
+/// Account for an instrument. For broker-routed instruments the account lives
+/// under the broker venue (e.g. `IB`) while the instrument carries the exchange
+/// MIC (e.g. `IBIS`); on venue miss, fall back to the position-owning account.
+fn resolve_account_for_instrument<'a>(
+    cache: &'a Cache,
+    instrument_id: &InstrumentId,
+    account_id: Option<&AccountId>,
+) -> Option<AccountRef<'a>> {
+    match account_id {
+        Some(id) => cache.account(id),
+        None => cache.account_for_venue(&instrument_id.venue).or_else(|| {
+            cache
+                .positions(None, Some(instrument_id), None, None, None)
+                .into_iter()
+                .next()
+                .and_then(|p| cache.account(&p.account_id))
+        }),
+    }
+}
+
 fn update_instrument_id(
     cache: &Rc<RefCell<Cache>>,
     clock: &Rc<RefCell<dyn Clock>>,
@@ -2630,7 +2656,9 @@ fn update_instrument_id(
     // Scoped borrow: must drop before calling AccountsManager (which borrows cache internally)
     let (account, instrument, orders_open, positions_open) = {
         let cache_ref = cache.borrow();
-        let account = if let Some(account) = cache_ref.account_for_venue(&instrument_id.venue) {
+        let account = if let Some(account) =
+            resolve_account_for_instrument(&cache_ref, instrument_id, None)
+        {
             account.clone()
         } else {
             log::error!(

--- a/crates/portfolio/tests/portfolio.rs
+++ b/crates/portfolio/tests/portfolio.rs
@@ -592,6 +592,68 @@ fn test_pnl_resolves_account_via_position_when_venue_mismatches(
 }
 
 #[rstest]
+fn test_initialize_positions_splits_margin_by_account_when_broker_routed(
+    mut simple_cache: Cache,
+    clock: TestClock,
+) {
+    let account_a = AccountId::new("IB-DUN433229");
+    let account_b = AccountId::new("IB-DUN558814");
+    let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
+        Symbol::from("EUR/USD"),
+        Some(Venue::new("IBIS")),
+    ));
+    let instrument_id = instrument.id();
+    simple_cache.add_instrument(instrument.clone()).unwrap();
+
+    let mut portfolio = Portfolio::new(
+        Rc::new(RefCell::new(clock)),
+        Rc::new(RefCell::new(simple_cache)),
+        None,
+    );
+    portfolio.update_account(&get_margin_account(Some(account_a.as_str())));
+    portfolio.update_account(&get_margin_account(Some(account_b.as_str())));
+
+    for (account_id, position_id) in [(account_a, "P-A"), (account_b, "P-B")] {
+        let fill = make_fill_for_account(
+            &instrument,
+            account_id,
+            OrderSide::Buy,
+            Quantity::from("100000"),
+            Price::from("1.00000"),
+            PositionId::new(position_id),
+        );
+        let position = Position::new(&instrument, fill);
+        portfolio
+            .cache()
+            .borrow_mut()
+            .add_position(&position, OmsType::Hedging)
+            .unwrap();
+    }
+
+    let quote = get_quote_tick(&instrument, 1.0010, 1.0011, 1.0, 1.0);
+    portfolio.cache().borrow_mut().add_quote(quote).unwrap();
+    portfolio.update_quote_tick(&quote);
+
+    portfolio.initialize_positions();
+    assert!(portfolio.is_initialized());
+
+    let has_margin = |account_id: &AccountId| {
+        matches!(
+            portfolio.cache().borrow().account_owned(account_id),
+            Some(AccountAny::Margin(m)) if m.margins.contains_key(&instrument_id)
+        )
+    };
+    assert!(
+        has_margin(&account_a),
+        "account A should carry its own margin"
+    );
+    assert!(
+        has_margin(&account_b),
+        "account B should carry its own margin"
+    );
+}
+
+#[rstest]
 fn test_order_fill_resolves_pnl_before_position_cached_when_broker_routed(
     mut simple_cache: Cache,
     clock: TestClock,

--- a/crates/portfolio/tests/portfolio.rs
+++ b/crates/portfolio/tests/portfolio.rs
@@ -529,6 +529,69 @@ fn test_realized_pnl_for_venue_when_no_account_returns_empty_dict(
 }
 
 #[rstest]
+fn test_pnl_resolves_account_via_position_when_venue_mismatches(
+    mut simple_cache: Cache,
+    clock: TestClock,
+) {
+    // Broker-routed instrument: account registered under broker venue `IB`
+    // while the instrument carries the exchange MIC `IBIS`.
+    let account_id = AccountId::new("IB-DUN433229");
+    let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
+        Symbol::from("EUR/USD"),
+        Some(Venue::new("IBIS")),
+    ));
+    let instrument_id = instrument.id();
+    simple_cache.add_instrument(instrument.clone()).unwrap();
+
+    let mut portfolio = Portfolio::new(
+        Rc::new(RefCell::new(clock)),
+        Rc::new(RefCell::new(simple_cache)),
+        None,
+    );
+    portfolio.update_account(&get_margin_account(Some(account_id.as_str())));
+
+    let fill = make_fill_for_account(
+        &instrument,
+        account_id,
+        OrderSide::Buy,
+        Quantity::from("100"),
+        Price::from("1.00000"),
+        PositionId::new("P-BROKER-ROUTED"),
+    );
+    let position = Position::new(&instrument, fill);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_position(&position, OmsType::Hedging)
+        .unwrap();
+
+    let quote = get_quote_tick(&instrument, 1.0010, 1.0011, 1.0, 1.0);
+    portfolio.cache().borrow_mut().add_quote(quote).unwrap();
+    portfolio.update_quote_tick(&quote);
+
+    portfolio.initialize_positions();
+    assert!(
+        portfolio.is_initialized(),
+        "position init should resolve via the position-owning account"
+    );
+
+    assert!(
+        portfolio.unrealized_pnl(&instrument_id).is_some(),
+        "unrealized PnL should resolve via the position-owning account"
+    );
+    assert!(
+        portfolio.realized_pnl(&instrument_id).is_some(),
+        "realized PnL should resolve via the position-owning account"
+    );
+
+    let equity = portfolio.equity(&Venue::new("IBIS"), None);
+    assert!(
+        !equity.is_empty(),
+        "equity should resolve via the position-owning account"
+    );
+}
+
+#[rstest]
 fn test_net_position_when_no_positions_returns_zero(
     portfolio: Portfolio,
     instrument_audusd: InstrumentAny,

--- a/crates/portfolio/tests/portfolio.rs
+++ b/crates/portfolio/tests/portfolio.rs
@@ -592,6 +592,117 @@ fn test_pnl_resolves_account_via_position_when_venue_mismatches(
 }
 
 #[rstest]
+fn test_order_fill_resolves_pnl_before_position_cached_when_broker_routed(
+    mut simple_cache: Cache,
+    clock: TestClock,
+) {
+    let account_id = AccountId::new("IB-DUN433229");
+    let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
+        Symbol::from("EUR/USD"),
+        Some(Venue::new("IBIS")),
+    ));
+    let instrument_id = instrument.id();
+    simple_cache.add_instrument(instrument.clone()).unwrap();
+
+    let mut portfolio = Portfolio::new(
+        Rc::new(RefCell::new(clock)),
+        Rc::new(RefCell::new(simple_cache)),
+        None,
+    );
+    portfolio.update_account(&get_margin_account(Some(account_id.as_str())));
+    portfolio
+        .cache()
+        .borrow_mut()
+        .account_mut(&account_id)
+        .unwrap()
+        .set_calculate_account_state(true);
+
+    let quote = get_quote_tick(&instrument, 1.0010, 1.0011, 1.0, 1.0);
+    portfolio.cache().borrow_mut().add_quote(quote).unwrap();
+    portfolio.update_quote_tick(&quote);
+
+    let fill = make_fill_for_account(
+        &instrument,
+        account_id,
+        OrderSide::Buy,
+        Quantity::from("100000"),
+        Price::from("1.00000"),
+        PositionId::new("P-FIRST-FILL"),
+    );
+
+    portfolio.update_order(&OrderEventAny::Filled(fill));
+
+    assert!(
+        portfolio.unrealized_pnl(&instrument_id).is_some(),
+        "first fill should resolve unrealized PnL via the order account",
+    );
+}
+
+#[rstest]
+fn test_equity_resolves_when_broker_routed_position_is_flat(
+    mut simple_cache: Cache,
+    clock: TestClock,
+) {
+    let account_id = AccountId::new("IB-DUN433229");
+    let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
+        Symbol::from("EUR/USD"),
+        Some(Venue::new("IBIS")),
+    ));
+    simple_cache.add_instrument(instrument.clone()).unwrap();
+
+    let mut portfolio = Portfolio::new(
+        Rc::new(RefCell::new(clock)),
+        Rc::new(RefCell::new(simple_cache)),
+        None,
+    );
+    portfolio.update_account(&get_margin_account(Some(account_id.as_str())));
+
+    let quote = get_quote_tick(&instrument, 1.00010, 1.00011, 1.0, 1.0);
+    portfolio.cache().borrow_mut().add_quote(quote).unwrap();
+    portfolio.update_quote_tick(&quote);
+
+    let open_fill = make_fill_for_account(
+        &instrument,
+        account_id,
+        OrderSide::Buy,
+        Quantity::from("100000"),
+        Price::from("1.00000"),
+        PositionId::new("P-FLAT"),
+    );
+    let mut position = Position::new(&instrument, open_fill);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_position(&position, OmsType::Hedging)
+        .unwrap();
+    portfolio.update_position(&PositionEvent::PositionOpened(get_open_position(&position)));
+
+    let close_fill = make_fill_for_account(
+        &instrument,
+        account_id,
+        OrderSide::Sell,
+        Quantity::from("100000"),
+        Price::from("1.00010"),
+        PositionId::new("P-FLAT"),
+    );
+    position.apply(&close_fill);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .update_position(&position)
+        .unwrap();
+    portfolio.update_position(&PositionEvent::PositionClosed(get_close_position(
+        &position,
+    )));
+
+    let equity = portfolio.equity(&Venue::new("IBIS"), None);
+    assert!(
+        !equity.is_empty(),
+        "equity should resolve via the account that traded the now-flat venue",
+    );
+}
+
+#[rstest]
 fn test_net_position_when_no_positions_returns_zero(
     portfolio: Portfolio,
     instrument_audusd: InstrumentAny,

--- a/crates/portfolio/tests/portfolio.rs
+++ b/crates/portfolio/tests/portfolio.rs
@@ -654,10 +654,160 @@ fn test_initialize_positions_splits_margin_by_account_when_broker_routed(
 }
 
 #[rstest]
+fn test_initialize_orders_splits_initial_margin_by_account_when_broker_routed(
+    mut simple_cache: Cache,
+    clock: TestClock,
+) {
+    let account_a = AccountId::new("IB-DUN433229");
+    let account_b = AccountId::new("IB-DUN558814");
+    let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
+        Symbol::from("EUR/USD"),
+        Some(Venue::new("IBIS")),
+    ));
+    let instrument_id = instrument.id();
+    simple_cache.add_instrument(instrument).unwrap();
+
+    let mut portfolio = Portfolio::new(
+        Rc::new(RefCell::new(clock)),
+        Rc::new(RefCell::new(simple_cache)),
+        None,
+    );
+    portfolio.update_account(&get_margin_account(Some(account_a.as_str())));
+    portfolio.update_account(&get_margin_account(Some(account_b.as_str())));
+
+    for (account_id, order_tag, venue_tag) in [
+        (account_a, "O-BR-A", "V-BR-A"),
+        (account_b, "O-BR-B", "V-BR-B"),
+    ] {
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .client_order_id(ClientOrderId::new(order_tag))
+            .instrument_id(instrument_id)
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("100000"))
+            .price(Price::from("1.00000"))
+            .build();
+        portfolio
+            .cache()
+            .borrow_mut()
+            .add_order(order.clone(), None, None, false)
+            .unwrap();
+        let submitted = order_submitted(
+            order.trader_id(),
+            order.strategy_id(),
+            order.instrument_id(),
+            order.client_order_id(),
+            account_id,
+            uuid4(),
+        );
+        portfolio
+            .cache()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Submitted(submitted))
+            .unwrap();
+        let accepted = order_accepted(
+            order.trader_id(),
+            order.strategy_id(),
+            order.instrument_id(),
+            order.client_order_id(),
+            account_id,
+            VenueOrderId::new(venue_tag),
+            uuid4(),
+        );
+        portfolio
+            .cache()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Accepted(accepted))
+            .unwrap();
+    }
+
+    portfolio.initialize_orders();
+    assert!(portfolio.is_initialized());
+
+    let has_margin = |account_id: &AccountId| {
+        matches!(
+            portfolio.cache().borrow().account_owned(account_id),
+            Some(AccountAny::Margin(m)) if m.margins.contains_key(&instrument_id)
+        )
+    };
+    assert!(
+        has_margin(&account_a),
+        "account A should carry its own initial margin"
+    );
+    assert!(
+        has_margin(&account_b),
+        "account B should carry its own initial margin"
+    );
+}
+
+#[rstest]
+fn test_pending_tick_recovery_splits_margin_by_account_when_broker_routed(
+    mut simple_cache: Cache,
+    clock: TestClock,
+) {
+    let account_a = AccountId::new("IB-DUN433229");
+    let account_b = AccountId::new("IB-DUN558814");
+    let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
+        Symbol::from("EUR/USD"),
+        Some(Venue::new("IBIS")),
+    ));
+    let instrument_id = instrument.id();
+    simple_cache.add_instrument(instrument.clone()).unwrap();
+
+    let mut portfolio = Portfolio::new(
+        Rc::new(RefCell::new(clock)),
+        Rc::new(RefCell::new(simple_cache)),
+        None,
+    );
+    portfolio.update_account(&get_margin_account(Some(account_a.as_str())));
+    portfolio.update_account(&get_margin_account(Some(account_b.as_str())));
+
+    for (account_id, position_id) in [(account_a, "P-PT-A"), (account_b, "P-PT-B")] {
+        let fill = make_fill_for_account(
+            &instrument,
+            account_id,
+            OrderSide::Buy,
+            Quantity::from("100000"),
+            Price::from("1.00000"),
+            PositionId::new(position_id),
+        );
+        let position = Position::new(&instrument, fill);
+        portfolio
+            .cache()
+            .borrow_mut()
+            .add_position(&position, OmsType::Hedging)
+            .unwrap();
+    }
+
+    // No price yet: the PnL calc fails and the instrument goes pending.
+    portfolio.initialize_positions();
+
+    let quote = get_quote_tick(&instrument, 1.0010, 1.0011, 1.0, 1.0);
+    portfolio.cache().borrow_mut().add_quote(quote).unwrap();
+    portfolio.update_quote_tick(&quote);
+
+    let has_margin = |account_id: &AccountId| {
+        matches!(
+            portfolio.cache().borrow().account_owned(account_id),
+            Some(AccountAny::Margin(m)) if m.margins.contains_key(&instrument_id)
+        )
+    };
+    assert!(
+        has_margin(&account_a),
+        "account A should carry its own maintenance margin after tick recovery"
+    );
+    assert!(
+        has_margin(&account_b),
+        "account B should carry its own maintenance margin after tick recovery"
+    );
+}
+
+#[rstest]
 fn test_order_fill_resolves_pnl_before_position_cached_when_broker_routed(
     mut simple_cache: Cache,
     clock: TestClock,
 ) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
     let account_id = AccountId::new("IB-DUN433229");
     let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
         Symbol::from("EUR/USD"),
@@ -692,7 +842,10 @@ fn test_order_fill_resolves_pnl_before_position_cached_when_broker_routed(
         PositionId::new("P-FIRST-FILL"),
     );
 
-    portfolio.update_order(&OrderEventAny::Filled(fill));
+    msgbus::send_order_event(
+        MessagingSwitchboard::portfolio_update_order(),
+        OrderEventAny::Filled(fill),
+    );
 
     assert!(
         portfolio.unrealized_pnl(&instrument_id).is_some(),
@@ -4975,6 +5128,79 @@ fn test_equity_multi_currency_cash_fill_counts_credited_asset_once(
     assert_eq!(equity[&usd].as_decimal(), expected_usd);
     assert_eq!(snapshot_equity[&aud].as_decimal(), expected_aud);
     assert_eq!(snapshot_equity[&usd].as_decimal(), expected_usd);
+}
+
+#[rstest]
+fn test_equity_multi_currency_cash_broker_routed_counts_credited_asset_once(
+    mut simple_cache: Cache,
+    clock: TestClock,
+) {
+    let account_id = AccountId::new("IB-DUN433229");
+    let aud = Currency::AUD();
+    let usd = Currency::USD();
+    let instrument = InstrumentAny::CurrencyPair(default_fx_ccy(
+        Symbol::from("AUD/USD"),
+        Some(Venue::new("IBIS")),
+    ));
+    simple_cache.add_instrument(instrument.clone()).unwrap();
+
+    let state = AccountState::new(
+        account_id,
+        AccountType::Cash,
+        vec![
+            AccountBalance::new(Money::new(0.0, aud), Money::zero(aud), Money::new(0.0, aud)),
+            AccountBalance::new(
+                Money::new(1_000.0, usd),
+                Money::zero(usd),
+                Money::new(1_000.0, usd),
+            ),
+        ],
+        vec![],
+        true,
+        uuid4(),
+        0.into(),
+        0.into(),
+        None,
+    );
+
+    let mut portfolio = Portfolio::new(
+        Rc::new(RefCell::new(clock)),
+        Rc::new(RefCell::new(simple_cache)),
+        None,
+    );
+    portfolio.update_account(&state);
+    portfolio
+        .cache()
+        .borrow_mut()
+        .account_mut(&account_id)
+        .unwrap()
+        .set_calculate_account_state(true);
+
+    let quote = get_quote_tick(&instrument, 100.0, 101.0, 1.0, 1.0);
+    portfolio.cache().borrow_mut().add_quote(quote).unwrap();
+    portfolio.update_quote_tick(&quote);
+
+    let fill = make_fill_for_account(
+        &instrument,
+        account_id,
+        OrderSide::Buy,
+        Quantity::from("1"),
+        Price::new(100.0, 0),
+        PositionId::new("P-BR-CASH"),
+    );
+    let position = Position::new(&instrument, fill.clone());
+    portfolio
+        .cache()
+        .borrow_mut()
+        .add_position(&position, OmsType::Hedging)
+        .unwrap();
+    portfolio.update_order(&OrderEventAny::Filled(fill));
+    portfolio.update_position(&PositionEvent::PositionOpened(get_open_position(&position)));
+
+    let equity = portfolio.equity(&Venue::new("IBIS"), None);
+
+    assert_eq!(equity[&aud].as_decimal(), dec!(1));
+    assert_eq!(equity[&usd].as_decimal(), dec!(900));
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

Fixes portfolio PnL and account-state resolution for broker-routed instruments — e.g. IB, where the account is registered under the broker venue (`IB`) while the traded instrument carries the exchange MIC (`IBIS`).

The portfolio resolved accounts via `account_for_venue(instrument.venue)`, which missed for such instruments and broke PnL analytics on every fill:

```
[ERROR] Cannot calculate unrealized PnL: no account for IBIS / None
[ERROR] Cannot calculate realized PnL: no account for IBIS / None
[WARN]  Failed to calculate realized PnL for VWCE.IBIS, marking as pending
```

Resolution is centralized in `resolve_account_for_instrument`, which falls back to the account owning a position in the instrument when the venue lookup misses. Applied to every account-resolution site in the portfolio:

- `calculate_unrealized_pnl` / `calculate_realized_pnl`
- `equity` and `accumulate_mark_values` (venue-keyed account-state aggregation)
- `initialize_orders` / `initialize_positions` (startup margin init — the latter previously aborted the whole init loop on the first broker-routed miss)
- `update_instrument_id` (tick/bar PnL recompute)

Trading itself is unaffected — fills, positions, and per-position realized PnL already worked. Only the portfolio-level recompute and account-state aggregation were broken.

Closes #4450.

## Follow-ups (not addressed here)

- `initialize_orders` with an open order but no position yet still misses (position-fallback is empty); resolved once a position coexists.
- The "proper" fix is to thread `account_id` (present on every fill/position event) through the per-fill/per-position recompute instead of relying on the position fallback. Tick/bar/startup paths carry no account, so the fallback stays there.
- Public venue-scoped getters (`balances_locked`, `margins_init`, `margins_maint`, `net_exposures`) keep venue-keyed resolution; querying the broker venue works, querying the exchange MIC returns empty.

## Testing

- New test `test_pnl_resolves_account_via_position_when_venue_mismatches` covers unrealized/realized PnL, `equity`, and `initialize_positions` (`is_initialized`) for a broker-routed instrument.
- Full portfolio suite: 42 unit + 80 integration tests pass, 0 failures.
