### PR TITLE
Fix legacy Equity round trips dropping quantity constraints

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -76,6 +76,7 @@ releases as feedback arrives, before the final `2.0.0` release.
 - Fixed v2 multi-currency cash equity double-counting assets already credited to account balances
 - Fixed v2 quanto position notionals using quote currency instead of settlement currency
 - Fixed v2 portfolio valuations labeling and converting cost-currency amounts as settlement currency
+- Fixed legacy `Equity` round trips dropping `max_quantity` and `min_quantity` through `from_dict` and the `ParquetDataCatalog` (#4461)
 - Fixed v2 composite bar aggregation (`@` source) to deliver aggregated bars to subscribed actors and strategies
 - Fixed v2 tick, tick-imbalance, and tick-runs aggregators to emit bars with the standard bar type for composite subscriptions, matching all other aggregators
 - Fixed v2 volume-runs and value-runs aggregators dropping leftover volume when a trade spanned a bar boundary and the next trade continued the same side

--- a/nautilus_trader/model/instruments/equity.pyx
+++ b/nautilus_trader/model/instruments/equity.pyx
@@ -138,6 +138,8 @@ cdef class Equity(Instrument):
     @staticmethod
     cdef Equity from_dict_c(dict values):
         Condition.not_none(values, "values")
+        cdef str max_q = values.get("max_quantity")
+        cdef str min_q = values.get("min_quantity")
         return Equity(
             instrument_id=InstrumentId.from_str_c(values["id"]),
             raw_symbol=Symbol(values["raw_symbol"]),
@@ -145,6 +147,8 @@ cdef class Equity(Instrument):
             price_precision=values["price_precision"],
             price_increment=Price.from_str(values["price_increment"]),
             lot_size=Quantity.from_str(values["lot_size"]),
+            max_quantity=Quantity.from_str_c(max_q) if max_q is not None else None,
+            min_quantity=Quantity.from_str_c(min_q) if min_q is not None else None,
             isin=values.get("isin"),  # Can be None,
             margin_init=Decimal(values.get("margin_init", 0)) if values.get("margin_init") is not None else None,
             margin_maint=Decimal(values.get("margin_maint", 0)) if values.get("margin_maint") is not None else None,

--- a/nautilus_trader/persistence/catalog/parquet.py
+++ b/nautilus_trader/persistence/catalog/parquet.py
@@ -62,6 +62,7 @@ from nautilus_trader.model.data import OrderBookDepth10
 from nautilus_trader.model.data import QuoteTick
 from nautilus_trader.model.data import TradeTick
 from nautilus_trader.model.data import capsule_to_list
+from nautilus_trader.model.instruments import Equity
 from nautilus_trader.model.instruments import Instrument
 from nautilus_trader.persistence.catalog.base import BaseDataCatalog
 from nautilus_trader.persistence.funcs import class_to_filename
@@ -69,6 +70,7 @@ from nautilus_trader.persistence.funcs import combine_filters
 from nautilus_trader.persistence.funcs import filename_to_class
 from nautilus_trader.persistence.funcs import urisafe_identifier
 from nautilus_trader.serialization.arrow.serializer import ArrowSerializer
+from nautilus_trader.serialization.arrow.serializer import get_schema
 
 
 TimestampLike = int | str | float
@@ -2061,7 +2063,18 @@ class ParquetDataCatalog(BaseDataCatalog):
         if not file_list:
             return []
 
-        dataset = pds.dataset(file_list, filesystem=self.fs)
+        # Use the registered Equity schema so fragments written before it gained
+        # max_quantity/min_quantity don't mask those fields on newer fragments
+        # (pyarrow otherwise infers the schema from the first fragment only).
+        # Scoped to Equity: other instruments have had schema/type migrations
+        # (e.g. legacy Betting ISO-string timestamps) that an enforced schema
+        # would reject, and subclasses may carry their own registered metadata.
+        schema = None
+
+        if data_cls is Equity:
+            schema = get_schema(Equity).with_metadata({"class": Equity.__name__})
+
+        dataset = pds.dataset(file_list, filesystem=self.fs, schema=schema)
 
         # Filter dataset
         used_start: pd.Timestamp | None = time_object_to_dt(start)

--- a/nautilus_trader/serialization/arrow/implementations/instruments.py
+++ b/nautilus_trader/serialization/arrow/implementations/instruments.py
@@ -310,6 +310,8 @@ SCHEMAS = {
             "price_precision": pa.uint8(),
             "price_increment": pa.dictionary(pa.int16(), pa.string()),
             "lot_size": pa.dictionary(pa.int16(), pa.string()),
+            "max_quantity": pa.dictionary(pa.int16(), pa.string()),
+            "min_quantity": pa.dictionary(pa.int16(), pa.string()),
             "isin": pa.string(),
             "margin_init": pa.string(),
             "margin_maint": pa.string(),

--- a/tests/unit_tests/model/instruments/test_equity_pyo3.py
+++ b/tests/unit_tests/model/instruments/test_equity_pyo3.py
@@ -121,3 +121,48 @@ def test_pyo3_cython_conversion_with_fees():
     equity_cython_dict = Equity.to_dict(equity_cython)
     equity_pyo3_back = nautilus_pyo3.Equity.from_dict(equity_cython_dict)
     assert equity_pyo3_back == equity_pyo3
+
+
+def test_legacy_equity_dict_round_trip_preserves_quantity_constraints():
+    # Arrange
+    equity_pyo3 = nautilus_pyo3.Equity(
+        instrument_id=InstrumentId.from_str("TEST.XNAS"),
+        raw_symbol=nautilus_pyo3.Symbol("TEST"),
+        isin=None,
+        currency=nautilus_pyo3.Currency.from_str("USD"),
+        price_precision=2,
+        price_increment=Price.from_str("0.01"),
+        lot_size=Quantity.from_int(100),
+        max_quantity=Quantity.from_int(10000),
+        min_quantity=Quantity.from_int(1),
+        max_price=None,
+        min_price=None,
+        margin_init=Decimal(0),
+        margin_maint=Decimal(0),
+        maker_fee=Decimal(0),
+        taker_fee=Decimal(0),
+        ts_event=0,
+        ts_init=0,
+    )
+    equity_cython = Equity.from_pyo3(equity_pyo3)
+
+    # Act
+    equity_back = Equity.from_dict(Equity.to_dict(equity_cython))
+
+    # Assert
+    assert equity_back.max_quantity == equity_cython.max_quantity
+    assert equity_back.min_quantity == equity_cython.min_quantity
+
+    # None values should also survive the round trip
+    equity_none = Equity.from_pyo3(TestInstrumentProviderPyo3.aapl_equity())
+    equity_none_back = Equity.from_dict(Equity.to_dict(equity_none))
+    assert equity_none_back.max_quantity is None
+    assert equity_none_back.min_quantity is None
+
+    # dicts from older catalogs without the keys must still deserialize
+    legacy_dict = Equity.to_dict(equity_cython)
+    del legacy_dict["max_quantity"]
+    del legacy_dict["min_quantity"]
+    equity_legacy = Equity.from_dict(legacy_dict)
+    assert equity_legacy.max_quantity is None
+    assert equity_legacy.min_quantity is None

--- a/tests/unit_tests/persistence/test_catalog.py
+++ b/tests/unit_tests/persistence/test_catalog.py
@@ -49,6 +49,7 @@ from nautilus_trader.model.identifiers import TradeId
 from nautilus_trader.model.identifiers import Venue
 from nautilus_trader.model.instruments import BettingInstrument
 from nautilus_trader.model.instruments import CurrencyPair
+from nautilus_trader.model.instruments import Equity
 from nautilus_trader.model.objects import Price
 from nautilus_trader.model.objects import Quantity
 from nautilus_trader.persistence.catalog.parquet import ParquetDataCatalog
@@ -680,6 +681,70 @@ def test_catalog_instrument_roundtrip_with_info_params(
     assert by_ts[2000].info == {"venue_extra": "v2", "count": 2, "enabled": False}
     assert by_ts[1000].id == inst1.id
     assert by_ts[2000].id == inst2.id
+
+
+def test_catalog_equity_roundtrip_preserves_quantity_constraints(
+    catalog: ParquetDataCatalog,
+) -> None:
+    # Quantity constraints must survive the catalog round trip (GH #4461)
+    base = TestInstrumentProvider.equity()
+    equity = Equity.from_dict(
+        {
+            **Equity.to_dict(base),
+            "max_quantity": "1000",
+            "min_quantity": "1",
+        },
+    )
+    catalog.write_data([equity])
+    read = catalog.instruments(instrument_ids=[equity.id.value])
+    assert len(read) == 1
+    assert read[0].max_quantity == Quantity.from_int(1000)
+    assert read[0].min_quantity == Quantity.from_int(1)
+
+
+def test_catalog_equity_mixed_schema_fragments(
+    catalog: ParquetDataCatalog,
+    monkeypatch,
+) -> None:
+    # Fragments written before the Equity schema gained max_quantity/min_quantity
+    # must not mask those fields on newer fragments in the same catalog (GH #4461)
+    from nautilus_trader.serialization.arrow.implementations import (
+        instruments as instruments_schemas,
+    )
+
+    new_schema = instruments_schemas.SCHEMAS[Equity]
+    old_schema = pa.schema(
+        {
+            field.name: field.type
+            for field in new_schema
+            if field.name not in ("max_quantity", "min_quantity")
+        },
+    )
+    base = TestInstrumentProvider.equity()
+
+    # write one fragment with the pre-fix schema, then one with the current schema
+    monkeypatch.setitem(instruments_schemas.SCHEMAS, Equity, old_schema)
+    catalog.write_data([Equity.from_dict({**Equity.to_dict(base), "ts_init": 0})])
+    monkeypatch.setitem(instruments_schemas.SCHEMAS, Equity, new_schema)
+    catalog.write_data(
+        [
+            Equity.from_dict(
+                {
+                    **Equity.to_dict(base),
+                    "max_quantity": "1000",
+                    "min_quantity": "1",
+                    "ts_event": 1,
+                    "ts_init": 1,
+                },
+            ),
+        ],
+    )
+
+    read = {equity.ts_init: equity for equity in catalog.instruments()}
+    assert read[0].max_quantity is None
+    assert read[0].min_quantity is None
+    assert read[1].max_quantity == Quantity.from_int(1000)
+    assert read[1].min_quantity == Quantity.from_int(1)
 
 
 def test_list_backtest_runs(


### PR DESCRIPTION
- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

`Equity.to_dict` serializes `max_quantity` and `min_quantity`, but they were not restored on the way back: `from_dict` never read the keys, and the legacy `ParquetDataCatalog` Arrow schema for `Equity` did not declare either field. Both paths therefore silently deserialized these execution-relevant constraints as `None`. This restores them through direct dicts and the catalog.

## Related Issues/PRs

Closes #4461.

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

None. Older dicts/catalogs without these keys still deserialize to `None`, and the read-side schema is applied only to the built-in `Equity` class so other instruments (including legacy Betting catalogs with historical timestamp types) and `Equity` subclasses keep their existing inferred-schema path.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

- [x] I added/updated tests to cover new or changed logic

Three parts, each covered by tests:
1. `Equity.from_dict` now reads `max_quantity`/`min_quantity` back (prebind idiom matching `cfd.pyx`).
2. The `Equity` Arrow schema declares both fields so the catalog persists them.
3. `_query_pyarrow` applies the registered `Equity` schema when reading, so fragments written before the fields existed don't mask them on newer fragments (pyarrow otherwise infers the schema from the first fragment only).

Added `test_legacy_equity_dict_round_trip_preserves_quantity_constraints` (round trip incl. `None` and absent-key cases), `test_catalog_equity_roundtrip_preserves_quantity_constraints`, and `test_catalog_equity_mixed_schema_fragments` (old fragment then new fragment). Full model, persistence, and serialization suites pass locally (2,886 passed).

Note: `Equity.to_dict` also emits `min_price`/`max_price`, but the legacy `Equity` constructor does not accept them; restoring those is a separate change and left out of scope here.