### PR TITLE
Recover IB data feeds per farm service

### DIFF
--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -8,11 +8,9 @@
 // -------------------------------------------------------------------------------------------------
 
 use std::{
+    collections::{HashMap, VecDeque},
     fmt::Debug,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -77,103 +75,264 @@ impl IntoSubscriptionTick for SubscriptionItem<TickTypes> {
 }
 
 const SUBSCRIPTION_DISCONNECTED_CODE: i32 = 10182;
+const DATA_FARM_RECOVERY_HISTORY_LIMIT: usize = 1_024;
 const HISTORICAL_BAR_MIN_COUNT: i64 = 300;
 const HISTORICAL_BAR_RETRY_DELAY: Duration = Duration::from_secs(1);
 const IB_GENERIC_TICK_OPTION_OPEN_INTEREST: &str = "101";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum DataFarmKind {
+    MarketData,
+    HistoricalData,
+    SecurityDefinition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum DataFarmRecoveryScope {
+    MarketData,
+    HistoricalData,
+    SecurityDefinition,
+    HistoricalBars,
+}
+
+impl From<DataFarmKind> for DataFarmRecoveryScope {
+    fn from(kind: DataFarmKind) -> Self {
+        match kind {
+            DataFarmKind::MarketData => Self::MarketData,
+            DataFarmKind::HistoricalData => Self::HistoricalData,
+            DataFarmKind::SecurityDefinition => Self::SecurityDefinition,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DataFarmIdentity {
+    kind: DataFarmKind,
+    name: Option<String>,
+}
+
+impl DataFarmIdentity {
+    fn from_notice(notice: &Notice) -> Option<Self> {
+        let kind = match notice.code {
+            2103 | 2104 => DataFarmKind::MarketData,
+            2105 | 2106 => DataFarmKind::HistoricalData,
+            2157 | 2158 => DataFarmKind::SecurityDefinition,
+            _ => return None,
+        };
+        let name = notice
+            .message
+            .rsplit_once(':')
+            .map(|(_, name)| name.trim())
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned);
+
+        Some(Self { kind, name })
+    }
+}
+
+#[derive(Debug, Default)]
+struct DataFarmRecoveryState {
+    recoveries: VecDeque<(u64, UnixNanos)>,
+    recovery_generation: u64,
+}
+
+impl DataFarmRecoveryState {
+    fn record_recovery(&mut self, degraded_since_ns: UnixNanos) {
+        self.recovery_generation = self.recovery_generation.wrapping_add(1);
+        self.recoveries
+            .push_back((self.recovery_generation, degraded_since_ns));
+
+        if self.recoveries.len() > DATA_FARM_RECOVERY_HISTORY_LIMIT {
+            let (_, pruned_since_ns) = self.recoveries.pop_front().unwrap();
+            if let Some((_, retained_since_ns)) = self.recoveries.front_mut() {
+                // Preserve the earliest replay boundary for streams lagging behind the history
+                *retained_since_ns = (*retained_since_ns).min(pruned_since_ns);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct DataFarmState {
+    degraded_farms: HashMap<DataFarmIdentity, UnixNanos>,
+    degraded_scopes: AHashMap<DataFarmRecoveryScope, UnixNanos>,
+    market_data: DataFarmRecoveryState,
+    historical_data: DataFarmRecoveryState,
+    security_definition: DataFarmRecoveryState,
+    historical_bars: DataFarmRecoveryState,
+}
+
+impl DataFarmState {
+    fn recovery(&self, scope: DataFarmRecoveryScope) -> &DataFarmRecoveryState {
+        match scope {
+            DataFarmRecoveryScope::MarketData => &self.market_data,
+            DataFarmRecoveryScope::HistoricalData => &self.historical_data,
+            DataFarmRecoveryScope::SecurityDefinition => &self.security_definition,
+            DataFarmRecoveryScope::HistoricalBars => &self.historical_bars,
+        }
+    }
+
+    fn recovery_mut(&mut self, scope: DataFarmRecoveryScope) -> &mut DataFarmRecoveryState {
+        match scope {
+            DataFarmRecoveryScope::MarketData => &mut self.market_data,
+            DataFarmRecoveryScope::HistoricalData => &mut self.historical_data,
+            DataFarmRecoveryScope::SecurityDefinition => &mut self.security_definition,
+            DataFarmRecoveryScope::HistoricalBars => &mut self.historical_bars,
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub(super) struct DataFarmConnectionState {
-    degraded_since_ns: Mutex<Option<UnixNanos>>,
-    last_recovery: Mutex<Option<(u64, UnixNanos)>>,
-    recovery_generation: AtomicU64,
+    state: Mutex<DataFarmState>,
     recovery_notify: tokio::sync::Notify,
 }
 
 impl DataFarmConnectionState {
     pub(super) fn handle_notice(&self, notice: &Notice, clock: &'static AtomicTime) {
-        if is_data_farm_broken_code(notice.code) {
-            self.mark_degraded(clock.get_time_ns());
-            tracing::debug!(
-                "IB data farm degraded by notice {} - {}; waiting for farm OK before resubscribe",
-                notice.code,
-                notice.message
-            );
-        } else if is_data_farm_ok_code(notice.code) && self.mark_ok() {
-            tracing::info!(
-                "IB data farm recovered by notice {} - {}; resubscribing data feeds",
-                notice.code,
-                notice.message
-            );
-        }
-    }
-
-    pub(super) fn mark_degraded(&self, degraded_since_ns: UnixNanos) {
-        let mut guard = self
-            .degraded_since_ns
-            .lock()
-            .expect("data farm state mutex poisoned");
-
-        if guard.is_none() {
-            *guard = Some(degraded_since_ns);
-        }
-    }
-
-    fn mark_ok(&self) -> bool {
-        let Some(degraded_since_ns) = self
-            .degraded_since_ns
-            .lock()
-            .expect("data farm state mutex poisoned")
-            .take()
-        else {
-            return false;
+        let Some(farm) = DataFarmIdentity::from_notice(notice) else {
+            return;
         };
 
-        let generation = self.recovery_generation.fetch_add(1, Ordering::Relaxed) + 1;
-        *self
-            .last_recovery
-            .lock()
-            .expect("data farm recovery mutex poisoned") = Some((generation, degraded_since_ns));
+        match notice.connectivity_status() {
+            Some(ConnectivityStatus::Broken) => {
+                self.mark_farm_degraded(farm, clock.get_time_ns());
+                tracing::debug!(
+                    "IB data farm degraded by notice {} - {}; waiting for farm OK before resubscribe",
+                    notice.code,
+                    notice.message
+                );
+            }
+            Some(ConnectivityStatus::Ok) if self.mark_ok(&farm) => {
+                tracing::info!(
+                    "IB data farm recovered by notice {} - {}; resubscribing data feeds",
+                    notice.code,
+                    notice.message
+                );
+            }
+            _ => {}
+        }
+    }
+
+    pub(super) fn mark_degraded(&self, generation: u64, degraded_since_ns: UnixNanos) {
+        self.mark_degraded_for(
+            DataFarmRecoveryScope::MarketData,
+            generation,
+            degraded_since_ns,
+        );
+    }
+
+    fn mark_degraded_for(
+        &self,
+        scope: DataFarmRecoveryScope,
+        generation: u64,
+        degraded_since_ns: UnixNanos,
+    ) {
+        let mut state = self.state.lock().expect("data farm state mutex poisoned");
+
+        if state.recovery(scope).recovery_generation != generation {
+            return;
+        }
+
+        state
+            .degraded_scopes
+            .entry(scope)
+            .and_modify(|current| *current = (*current).min(degraded_since_ns))
+            .or_insert(degraded_since_ns);
+    }
+
+    fn mark_farm_degraded(&self, farm: DataFarmIdentity, degraded_since_ns: UnixNanos) {
+        let mut state = self.state.lock().expect("data farm state mutex poisoned");
+
+        state
+            .degraded_farms
+            .entry(farm)
+            .and_modify(|current| *current = (*current).min(degraded_since_ns))
+            .or_insert(degraded_since_ns);
+    }
+
+    fn mark_ok(&self, farm: &DataFarmIdentity) -> bool {
+        let mut state = self.state.lock().expect("data farm state mutex poisoned");
+
+        let family_scope = DataFarmRecoveryScope::from(farm.kind);
+        let farm_degraded_since_ns = state.degraded_farms.remove(farm);
+        let scope_degraded_since_ns = state.degraded_scopes.remove(&family_scope);
+        let family_degraded_since_ns =
+            earliest_data_loss_ns(farm_degraded_since_ns, scope_degraded_since_ns);
+        let historical_bars_recovery_since_ns = match farm.kind {
+            DataFarmKind::MarketData | DataFarmKind::HistoricalData => earliest_data_loss_ns(
+                family_degraded_since_ns,
+                state
+                    .degraded_scopes
+                    .remove(&DataFarmRecoveryScope::HistoricalBars),
+            ),
+            DataFarmKind::SecurityDefinition => None,
+        };
+
+        if let Some(degraded_since_ns) = family_degraded_since_ns {
+            state
+                .recovery_mut(family_scope)
+                .record_recovery(degraded_since_ns);
+        }
+
+        if let Some(degraded_since_ns) = historical_bars_recovery_since_ns {
+            state
+                .recovery_mut(DataFarmRecoveryScope::HistoricalBars)
+                .record_recovery(degraded_since_ns);
+        }
+
+        if family_degraded_since_ns.is_none() && historical_bars_recovery_since_ns.is_none() {
+            return false;
+        }
+        drop(state);
         self.recovery_notify.notify_waiters();
         true
     }
 
     fn recovery_generation(&self) -> u64 {
-        self.recovery_generation.load(Ordering::Relaxed)
+        self.recovery_generation_for(DataFarmRecoveryScope::MarketData)
     }
 
-    fn last_recovery_since_ns(&self, generation: u64) -> Option<UnixNanos> {
-        self.last_recovery
+    fn recovery_generation_for(&self, scope: DataFarmRecoveryScope) -> u64 {
+        self.state
             .lock()
-            .expect("data farm recovery mutex poisoned")
-            .and_then(|(recovery_generation, degraded_since_ns)| {
-                (recovery_generation == generation).then_some(degraded_since_ns)
+            .expect("data farm state mutex poisoned")
+            .recovery(scope)
+            .recovery_generation
+    }
+
+    fn recovery_since_ns_after_for(
+        &self,
+        scope: DataFarmRecoveryScope,
+        generation: u64,
+    ) -> Option<UnixNanos> {
+        self.state
+            .lock()
+            .expect("data farm state mutex poisoned")
+            .recovery(scope)
+            .recoveries
+            .iter()
+            .filter_map(|(recovery_generation, degraded_since_ns)| {
+                (*recovery_generation > generation).then_some(*degraded_since_ns)
             })
+            .min()
     }
 
     async fn wait_for_recovery_after(&self, generation: u64) {
+        self.wait_for_recovery_after_for(DataFarmRecoveryScope::MarketData, generation)
+            .await;
+    }
+
+    async fn wait_for_recovery_after_for(&self, scope: DataFarmRecoveryScope, generation: u64) {
         loop {
             let notified = self.recovery_notify.notified();
 
-            if self.recovery_generation() != generation {
+            if self.recovery_generation_for(scope) != generation {
                 return;
             }
             notified.await;
         }
     }
-}
-
-fn is_data_farm_broken_code(code: i32) -> bool {
-    matches!(
-        ConnectivityStatus::from_code(code),
-        Some(ConnectivityStatus::Broken)
-    )
-}
-
-fn is_data_farm_ok_code(code: i32) -> bool {
-    matches!(
-        ConnectivityStatus::from_code(code),
-        Some(ConnectivityStatus::Ok)
-    )
 }
 
 fn is_subscription_disconnected_error(error: &Error) -> bool {
@@ -194,8 +353,23 @@ async fn wait_for_data_farm_recovery_or_cancel(
     generation: u64,
     cancellation_token: &CancellationToken,
 ) -> bool {
+    wait_for_data_farm_recovery_or_cancel_for(
+        data_farm_state,
+        DataFarmRecoveryScope::MarketData,
+        generation,
+        cancellation_token,
+    )
+    .await
+}
+
+async fn wait_for_data_farm_recovery_or_cancel_for(
+    data_farm_state: &DataFarmConnectionState,
+    scope: DataFarmRecoveryScope,
+    generation: u64,
+    cancellation_token: &CancellationToken,
+) -> bool {
     tokio::select! {
-        () = data_farm_state.wait_for_recovery_after(generation) => true,
+        () = data_farm_state.wait_for_recovery_after_for(scope, generation) => true,
         () = cancellation_token.cancelled() => false,
     }
 }
@@ -288,7 +462,8 @@ pub(super) async fn handle_historical_bars_subscription(
 
     let first_start_ns = resolve_historical_bar_start_ns(start_ns, clock.get_time_ns());
     let mut last_disconnection_ns = None;
-    let mut farm_generation = data_farm_state.recovery_generation();
+    let mut farm_generation =
+        data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars);
     // Only stamp last_disconnection_ns after receiving real data, mirroring the Python
     // adapter's _had_ib_connection guard. historical_data_streaming() returns Ok after
     // sending the request; server-side errors arrive later via subscription.next(). A
@@ -404,15 +579,20 @@ pub(super) async fn handle_historical_bars_subscription(
                         }
                         Some(Err(e)) => {
                             if is_subscription_disconnected_error(&e) {
-                                data_farm_state.mark_degraded(clock.get_time_ns());
+                                data_farm_state.mark_degraded_for(
+                                    DataFarmRecoveryScope::HistoricalBars,
+                                    farm_generation,
+                                    clock.get_time_ns(),
+                                );
                                 tracing::warn!(
                                     "Historical bars subscription disconnected for {}; waiting for data farm recovery: {:?}",
                                     bar_type,
                                     e
                                 );
 
-                                if !wait_for_data_farm_recovery_or_cancel(
+                                if !wait_for_data_farm_recovery_or_cancel_for(
                                     &data_farm_state,
+                                    DataFarmRecoveryScope::HistoricalBars,
                                     farm_generation,
                                     &cancellation_token,
                                 )
@@ -421,10 +601,14 @@ pub(super) async fn handle_historical_bars_subscription(
                                     subscription.cancel().await;
                                     return Ok(());
                                 }
-                                let recovered_generation = data_farm_state.recovery_generation();
+                                let recovered_generation = data_farm_state
+                                    .recovery_generation_for(DataFarmRecoveryScope::HistoricalBars);
                                 last_disconnection_ns = earliest_data_loss_ns(
                                     last_disconnection_ns,
-                                    data_farm_state.last_recovery_since_ns(recovered_generation),
+                                    data_farm_state.recovery_since_ns_after_for(
+                                        DataFarmRecoveryScope::HistoricalBars,
+                                        farm_generation,
+                                    ),
                                 );
                                 farm_generation = recovered_generation;
                                 break;
@@ -460,11 +644,18 @@ pub(super) async fn handle_historical_bars_subscription(
                         }
                     }
                 }
-                () = data_farm_state.wait_for_recovery_after(farm_generation) => {
-                    let recovered_generation = data_farm_state.recovery_generation();
+                () = data_farm_state.wait_for_recovery_after_for(
+                    DataFarmRecoveryScope::HistoricalBars,
+                    farm_generation,
+                ) => {
+                    let recovered_generation = data_farm_state
+                        .recovery_generation_for(DataFarmRecoveryScope::HistoricalBars);
                     last_disconnection_ns = earliest_data_loss_ns(
                         last_disconnection_ns,
-                        data_farm_state.last_recovery_since_ns(recovered_generation),
+                        data_farm_state.recovery_since_ns_after_for(
+                            DataFarmRecoveryScope::HistoricalBars,
+                            farm_generation,
+                        ),
                     );
                     farm_generation = recovered_generation;
                     subscription.cancel().await;
@@ -535,7 +726,7 @@ pub(super) async fn handle_quote_subscription(
                     if let Err(e) = &tick_result
                         && is_subscription_disconnected_error(e)
                     {
-                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        data_farm_state.mark_degraded(farm_generation, clock.get_time_ns());
                         tracing::warn!(
                             "Quote subscription disconnected for {}; waiting for data farm recovery: {:?}",
                             instrument_id,
@@ -638,7 +829,7 @@ pub(super) async fn handle_option_greeks_subscription(
                     if let Err(e) = &tick_result
                         && is_subscription_disconnected_error(e)
                     {
-                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        data_farm_state.mark_degraded(farm_generation, clock.get_time_ns());
                         tracing::warn!(
                             "Option greeks subscription disconnected for {}; waiting for data farm recovery: {:?}",
                             instrument_id,
@@ -739,7 +930,7 @@ pub(super) async fn handle_index_price_subscription(
                     if let Err(e) = &tick_result
                         && is_subscription_disconnected_error(e)
                     {
-                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        data_farm_state.mark_degraded(farm_generation, clock.get_time_ns());
                         tracing::warn!(
                             "Index price subscription disconnected for {}; waiting for data farm recovery: {:?}",
                             instrument_id,
@@ -875,7 +1066,7 @@ pub(super) async fn handle_tick_by_tick_quote_subscription(
                             );
                         }
                         Some(Err(e)) if is_subscription_disconnected_error(&e) => {
-                            data_farm_state.mark_degraded(clock.get_time_ns());
+                            data_farm_state.mark_degraded(farm_generation, clock.get_time_ns());
                             tracing::warn!(
                                 "Tick-by-tick quote subscription disconnected for {}; waiting for data farm recovery: {:?}",
                                 instrument_id,
@@ -1095,7 +1286,7 @@ async fn process_trade_stream(
                         );
                     }
                     Some(Err(e)) if is_subscription_disconnected_error(&e) => {
-                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        data_farm_state.mark_degraded(farm_generation, clock.get_time_ns());
                         tracing::warn!(
                             "Trade subscription disconnected for {}; waiting for data farm recovery: {:?}",
                             instrument_id,
@@ -1195,7 +1386,7 @@ async fn process_realtime_bar_stream(
                         );
                     }
                     Some(Err(e)) if is_subscription_disconnected_error(&e) => {
-                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        data_farm_state.mark_degraded(farm_generation, clock.get_time_ns());
                         tracing::warn!(
                             "Realtime bar subscription disconnected for {}; waiting for data farm recovery: {:?}",
                             bar_type,
@@ -1317,7 +1508,7 @@ async fn process_market_depth_stream(
                         );
                     }
                     Some(Err(e)) if is_subscription_disconnected_error(&e) => {
-                        data_farm_state.mark_degraded(clock.get_time_ns());
+                        data_farm_state.mark_degraded(farm_generation, clock.get_time_ns());
                         tracing::warn!(
                             "Market depth subscription disconnected for {}; waiting for data farm recovery: {:?}",
                             instrument_id,
@@ -1829,7 +2020,7 @@ async fn process_option_open_interest_tick(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{sync::Arc, time::Duration};
 
     use ahash::AHashMap;
     use ibapi::{
@@ -1851,11 +2042,11 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::{
-        DataFarmConnectionState, OptionGreeksCache, QuoteCache, StreamAction,
-        process_index_price_tick_result, process_market_depth_stream,
-        process_option_greeks_tick_result, process_quote_tick_result, process_realtime_bar_stream,
-        process_trade_stream, send_quote_tick, update_quote_from_price_tick,
-        update_revised_bar_tracking,
+        DataFarmConnectionState, DataFarmIdentity, DataFarmKind, DataFarmRecoveryScope,
+        OptionGreeksCache, QuoteCache, StreamAction, process_index_price_tick_result,
+        process_market_depth_stream, process_option_greeks_tick_result, process_quote_tick_result,
+        process_realtime_bar_stream, process_trade_stream, send_quote_tick,
+        update_quote_from_price_tick, update_revised_bar_tracking,
     };
 
     fn instrument_id() -> InstrumentId {
@@ -1950,9 +2141,360 @@ mod tests {
         assert_eq!(data_farm_state.recovery_generation(), 1);
         assert!(
             data_farm_state
-                .last_recovery_since_ns(data_farm_state.recovery_generation())
+                .recovery_since_ns_after_for(DataFarmRecoveryScope::MarketData, 0)
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn test_historical_bar_recovery_tracks_market_data_recovery() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = Arc::new(DataFarmConnectionState::default());
+        let initial_generation =
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars);
+        let state_for_waiter = Arc::clone(&data_farm_state);
+        let waiter = tokio::spawn(async move {
+            state_for_waiter
+                .wait_for_recovery_after_for(
+                    DataFarmRecoveryScope::HistoricalBars,
+                    initial_generation,
+                )
+                .await;
+            state_for_waiter.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars)
+        });
+
+        data_farm_state.handle_notice(
+            &notice(2103, "Market data farm connection is broken:usfarm"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:usfarm"),
+            clock,
+        );
+
+        let observed_generation = tokio::time::timeout(Duration::from_millis(100), waiter)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(observed_generation, 1);
+        assert!(
+            data_farm_state
+                .recovery_since_ns_after_for(
+                    DataFarmRecoveryScope::HistoricalBars,
+                    initial_generation,
+                )
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_historical_bar_recovery_tracks_historical_data_recovery() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = Arc::new(DataFarmConnectionState::default());
+        let initial_generation =
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars);
+        let state_for_waiter = Arc::clone(&data_farm_state);
+        let waiter = tokio::spawn(async move {
+            state_for_waiter
+                .wait_for_recovery_after_for(
+                    DataFarmRecoveryScope::HistoricalBars,
+                    initial_generation,
+                )
+                .await;
+            state_for_waiter.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars)
+        });
+
+        data_farm_state.handle_notice(
+            &notice(2105, "HMDS data farm connection is broken:ushmds"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2106, "HMDS data farm connection is OK:ushmds"),
+            clock,
+        );
+
+        let observed_generation = tokio::time::timeout(Duration::from_millis(100), waiter)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(data_farm_state.recovery_generation(), 0);
+        assert_eq!(
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalData),
+            1
+        );
+        assert_eq!(observed_generation, 1);
+    }
+
+    #[rstest]
+    fn test_historical_bar_recovery_ignores_stale_subscription_degradation() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
+        let initial_generation =
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars);
+
+        data_farm_state.mark_degraded_for(
+            DataFarmRecoveryScope::HistoricalBars,
+            initial_generation,
+            UnixNanos::from(10),
+        );
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:usfarm"),
+            clock,
+        );
+        data_farm_state.mark_degraded_for(
+            DataFarmRecoveryScope::HistoricalBars,
+            initial_generation,
+            UnixNanos::from(20),
+        );
+        data_farm_state.handle_notice(
+            &notice(2106, "HMDS data farm connection is OK:ushmds"),
+            clock,
+        );
+
+        let state = data_farm_state
+            .state
+            .lock()
+            .expect("data farm state mutex poisoned");
+        assert_eq!(state.historical_bars.recovery_generation, 1);
+        assert_eq!(
+            state.historical_bars.recoveries.front(),
+            Some(&(1, UnixNanos::from(10)))
+        );
+        assert_eq!(state.market_data.recovery_generation, 0);
+        assert_eq!(state.historical_data.recovery_generation, 0);
+        assert!(state.degraded_scopes.is_empty());
+    }
+
+    #[rstest]
+    fn test_historical_bar_recovery_preserves_earliest_cross_family_boundary() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
+
+        data_farm_state.mark_farm_degraded(
+            DataFarmIdentity {
+                kind: DataFarmKind::MarketData,
+                name: Some(String::from("usfarm")),
+            },
+            UnixNanos::from(20),
+        );
+        data_farm_state.mark_farm_degraded(
+            DataFarmIdentity {
+                kind: DataFarmKind::HistoricalData,
+                name: Some(String::from("ushmds")),
+            },
+            UnixNanos::from(10),
+        );
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:usfarm"),
+            clock,
+        );
+        let market_recovery_generation =
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars);
+        data_farm_state.handle_notice(
+            &notice(2106, "HMDS data farm connection is OK:ushmds"),
+            clock,
+        );
+
+        assert_eq!(market_recovery_generation, 1);
+        assert_eq!(
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars),
+            2
+        );
+        assert_eq!(
+            data_farm_state.recovery_since_ns_after_for(DataFarmRecoveryScope::HistoricalBars, 0),
+            Some(UnixNanos::from(10))
+        );
+        assert_eq!(
+            data_farm_state.recovery_since_ns_after_for(
+                DataFarmRecoveryScope::HistoricalBars,
+                market_recovery_generation,
+            ),
+            Some(UnixNanos::from(10))
+        );
+    }
+
+    #[rstest]
+    fn test_security_definition_recovery_does_not_advance_historical_bars() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
+
+        data_farm_state.handle_notice(
+            &notice(2157, "Sec-def data farm connection is broken:secdefil"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2158, "Sec-def data farm connection is OK:secdefil"),
+            clock,
+        );
+
+        assert_eq!(
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::SecurityDefinition),
+            1
+        );
+        assert_eq!(
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalBars),
+            0
+        );
+        assert_eq!(
+            data_farm_state.recovery_since_ns_after_for(DataFarmRecoveryScope::HistoricalBars, 0),
+            None
+        );
+    }
+
+    #[rstest]
+    fn test_data_farm_state_recovers_each_reported_farm_independently() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
+
+        data_farm_state.handle_notice(
+            &notice(2103, "Market data farm connection is broken:usfarm.nj"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2103, "Market data farm connection is broken:cashfarm"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2105, "HMDS data farm connection is broken:ushmds"),
+            clock,
+        );
+
+        data_farm_state.handle_notice(&notice(2104, "Market data farm connection is OK"), clock);
+        assert_eq!(data_farm_state.recovery_generation(), 0);
+
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:usfarm.nj"),
+            clock,
+        );
+        assert_eq!(data_farm_state.recovery_generation(), 1);
+        assert_eq!(
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalData),
+            0
+        );
+
+        data_farm_state.handle_notice(
+            &notice(2106, "HMDS data farm connection is OK:ushmds"),
+            clock,
+        );
+        assert_eq!(data_farm_state.recovery_generation(), 1);
+        assert_eq!(
+            data_farm_state.recovery_generation_for(DataFarmRecoveryScope::HistoricalData),
+            1
+        );
+
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:cashfarm"),
+            clock,
+        );
+        assert_eq!(data_farm_state.recovery_generation(), 2);
+    }
+
+    #[rstest]
+    fn test_data_farm_state_preserves_each_farm_degradation_time() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
+
+        data_farm_state.mark_farm_degraded(
+            DataFarmIdentity {
+                kind: DataFarmKind::MarketData,
+                name: Some(String::from("usfarm.nj")),
+            },
+            UnixNanos::from(20),
+        );
+        data_farm_state.mark_farm_degraded(
+            DataFarmIdentity {
+                kind: DataFarmKind::MarketData,
+                name: Some(String::from("cashfarm")),
+            },
+            UnixNanos::from(10),
+        );
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:usfarm.nj"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:cashfarm"),
+            clock,
+        );
+        let latest_generation = data_farm_state.recovery_generation();
+
+        assert_eq!(latest_generation, 2);
+        assert_eq!(
+            data_farm_state.recovery_since_ns_after_for(DataFarmRecoveryScope::MarketData, 0),
+            Some(UnixNanos::from(10))
+        );
+        assert_eq!(
+            data_farm_state.recovery_since_ns_after_for(DataFarmRecoveryScope::MarketData, 1),
+            Some(UnixNanos::from(10))
+        );
+    }
+
+    #[rstest]
+    fn test_data_farm_state_ignores_stale_subscription_degradation() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = DataFarmConnectionState::default();
+        let initial_generation = data_farm_state.recovery_generation();
+
+        data_farm_state.mark_degraded(initial_generation, UnixNanos::from(10));
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:usfarm.nj"),
+            clock,
+        );
+        data_farm_state.mark_degraded(initial_generation, UnixNanos::from(20));
+
+        let state = data_farm_state
+            .state
+            .lock()
+            .expect("data farm state mutex poisoned");
+        assert_eq!(state.market_data.recovery_generation, 1);
+        assert!(state.degraded_farms.is_empty());
+        assert!(state.degraded_scopes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_data_farm_state_preserves_recovery_during_resubscription() {
+        let clock = get_atomic_clock_realtime();
+        let data_farm_state = Arc::new(DataFarmConnectionState::default());
+        let initial_generation = data_farm_state.recovery_generation();
+
+        data_farm_state.handle_notice(
+            &notice(2103, "Market data farm connection is broken:usfarm.nj"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:usfarm.nj"),
+            clock,
+        );
+        data_farm_state
+            .wait_for_recovery_after(initial_generation)
+            .await;
+        let resubscription_generation = data_farm_state.recovery_generation();
+
+        let (release_sender, release_receiver) = tokio::sync::oneshot::channel();
+        let state_for_resubscription = Arc::clone(&data_farm_state);
+
+        let resubscription_task = tokio::spawn(async move {
+            release_receiver.await.unwrap();
+            state_for_resubscription
+                .wait_for_recovery_after(resubscription_generation)
+                .await;
+            state_for_resubscription.recovery_generation()
+        });
+
+        data_farm_state.handle_notice(
+            &notice(2103, "Market data farm connection is broken:cashfarm"),
+            clock,
+        );
+        data_farm_state.handle_notice(
+            &notice(2104, "Market data farm connection is OK:cashfarm"),
+            clock,
+        );
+        release_sender.send(()).unwrap();
+        let observed_generation = resubscription_task.await.unwrap();
+
+        assert_eq!(observed_generation, 2);
     }
 
     #[tokio::test]
@@ -2464,10 +3006,11 @@ mod tests {
         let recovery_task = tokio::spawn(async move {
             loop {
                 if state_for_recovery
-                    .degraded_since_ns
+                    .state
                     .lock()
                     .expect("data farm state mutex poisoned")
-                    .is_some()
+                    .degraded_scopes
+                    .contains_key(&DataFarmRecoveryScope::MarketData)
                 {
                     state_for_recovery.handle_notice(
                         &notice(2104, "Market data farm connection is OK:usfarm"),


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Extends the Rust Interactive Brokers recovery added in `#4457` so each recovered farm restarts
  its service family without waiting for every other farm to become healthy.
- Tracks each outstanding farm by its notice-code family and the optional farm-name suffix from
  the Interactive Brokers notice message.
- Maintains separate recovery scopes for market data, historical data, security definitions, and
  streaming historical bars. The historical-bar scope advances after either market-data or HMDS
  recovery because `reqHistoricalData(..., keepUpToDate=true)` depends on both services.
- Keeps the existing family scopes unchanged for other subscription types. A market-data recovery
  does not advance the HMDS scope, and an HMDS outage does not block working live feeds.
- Preserves every recovery boundary needed by historical-bar subscriptions. The bounded history
  retains the earliest loss timestamp across overlapping market-data and HMDS recoveries.
- Rejects stale subscription error `10182` reports after a newer recovery generation so an old
  stream cannot leave a degradation marker waiting for an unrelated recovery.

### Design decisions

- Keeps recovery policy in Nautilus. The sibling `rust-ibapi` checkout is at `v3.2.0`, which matches
  `Cargo.lock` and already exposes the raw `Notice`, `ConnectivityStatus`, and notice stream needed
  by the adapter.
- Separates physical `DataFarmKind` values from `DataFarmRecoveryScope` values. Market data,
  historical data, and security definitions map directly to farm notice families, while
  `HistoricalBars` is a composite subscription scope.
- Derives farm identity from the code pairs `2103/2104` (market data), `2105/2106` (historical data),
  and `2157/2158` (security definitions). Interactive Brokers includes the named farm after the
  final colon in live notice messages, such as `usfarm.nj` or `cashfarm`.
- Stores an outage timestamp for each named farm identity and each generic recovery scope. The
  state, generations, and recovery histories share one mutex so each transition is atomic.
- Records each market-data or HMDS recovery in both its family scope and the `HistoricalBars`
  scope. Security-definition recovery remains isolated and does not wake historical-bar tasks.
- Records a historical-bar `10182` against the `HistoricalBars` generation. Either `2104` or `2106`
  can recover a current marker, while the generation guard ignores a marker from a stale stream.
- Retains the per-subscription generation loop from `#4457`. A second recovery completed while a
  replacement subscription is being created remains visible and triggers another resubscription.
- Requires exact family/name pairing for physical farms. An unnamed OK notice does not clear named
  outstanding farms, and one named farm cannot clear another farm or service family.

### Farm state coordination

```mermaid
flowchart TD
    A[IB notice or subscription error] --> B{Event type}
    B -- Broken 2103, 2105, or 2157 --> C[Parse farm family and optional name]
    B -- Subscription error 10182 --> D[Record the subscription recovery scope]
    B -- OK 2104, 2106, or 2158 --> E[Parse matching farm identity]
    C --> F[Store the farm outage and earliest timestamp]
    D --> G[Store the scoped outage with a generation guard]
    E --> H[Remove the exact farm and matching family marker]
    H --> I{Recorded family outage?}
    I -- Yes --> J[Record recovery in the family history]
    I -- No --> K[Leave the family generation unchanged]
    H --> L{Market data or HMDS?}
    L -- Yes --> M[Combine family and HistoricalBars loss timestamps]
    L -- No --> N[Keep HistoricalBars unchanged]
    M --> O{Relevant loss recorded?}
    O -- Yes --> P[Record HistoricalBars recovery]
    O -- No --> Q[Ignore duplicate or unrelated OK]
    J --> R[Notify subscription tasks]
    P --> R
    R --> S[Each changed scope retries independently]
```

### Overlapping recovery sequence

```mermaid
sequenceDiagram
    participant IB as Interactive Brokers
    participant Monitor as Notice monitor
    participant State as DataFarmConnectionState
    participant Live as Live subscription
    participant Bars as Historical-bar subscription

    IB->>Monitor: 2103 broken usfarm.nj
    Monitor->>State: record market/usfarm.nj
    IB->>Monitor: 2105 broken ushmds
    Monitor->>State: record historical/ushmds
    IB->>Monitor: 2104 OK usfarm.nj
    Monitor->>State: recover MarketData and HistoricalBars
    State-->>Live: market generation N + 1
    State-->>Bars: historical-bar generation B + 1
    Bars->>Bars: retain market outage timestamp
    IB->>Monitor: 2106 OK ushmds
    Monitor->>State: recover HistoricalData and HistoricalBars
    State-->>Bars: historical-bar generation B + 2
    Bars->>Bars: retain minimum timestamp across both recoveries
    Bars->>IB: replay from earliest loss point
```

### Historical-bar replay

```mermaid
flowchart TD
    A[Historical bar stream observes HistoricalBars generation N] --> B{Recovery source}
    B -- Market data 2104 --> C[Record market-data outage timestamp]
    B -- HMDS 2106 --> D[Record HMDS outage timestamp]
    B -- Current 10182 marker --> E[Wait for either relevant OK notice]
    C --> F[Advance HistoricalBars generation]
    D --> F
    E --> F
    F --> G[Wake or finish the current resubscription]
    G --> H[Read minimum loss timestamp after generation N]
    H --> I[Combine with prior socket disconnection timestamp]
    I --> J[Request replacement stream from earliest loss point]
    J --> K[Filter and publish recovered bars]
```

### Relevant files and sources

- [`core_streams.rs`](../nautilus_trader/crates/adapters/interactive_brokers/src/data/core_streams.rs):
  owns farm identity, recovery scopes, bounded timestamp history, resubscription waits, and tests.
- [`rust-ibapi` messages](../rust-ibapi/src/messages.rs): defines `Notice` and classifies the pinned
  farm connectivity codes for `v3.2.0`.
- [Interactive Brokers message codes](https://interactivebrokers.github.io/tws-api/message_codes.html):
  documents the market-data and historical-data farm broken/OK code pairs.

### Verification

- The original regression left the `HistoricalData` generation unchanged after `2103 -> 2104`, so
  a historical-bar waiter returned to sleep. The `HistoricalBars` generation now advances and wakes
  for both `2103 -> 2104` and `2105 -> 2106`.
- Focused historical-bar recovery tests: 4 passed.
- Security-definition isolation test for `2157 -> 2158`: 1 passed.
- `cargo test -p nautilus-interactive-brokers --lib`: 370 passed.
- `make build-debug`: passed. The macOS linker emitted its existing `__eh_frame` size warning.
- `make cargo-test-core-local`: 10,472 passed and 14 skipped.
- `cargo fmt -p nautilus-interactive-brokers -- --check`: passed.
- `git diff --check`: passed.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
