### PR TITLE
Fix Binance Spot SBE initialization timestamps

### DIFF
--- a/crates/adapters/binance/src/spot/data.rs
+++ b/crates/adapters/binance/src/spot/data.rs
@@ -338,12 +338,14 @@ impl BinanceSpotDataClient {
         http_client: &BinanceSpotHttpClient,
         clock: &'static AtomicTime,
     ) {
+        let ts_init = clock.get_time_ns();
+
         match msg {
             BinanceSpotWsMessage::Trades(ref event) => {
                 let symbol = Ustr::from(&event.symbol);
                 let cache = ws_instruments.load();
                 if let Some(instrument) = cache.get(&symbol) {
-                    let trades = parse_trades_event(event, instrument);
+                    let trades = parse_trades_event(event, instrument, ts_init);
                     for data in trades {
                         Self::send_data(data_sender, data);
                     }
@@ -353,7 +355,7 @@ impl BinanceSpotDataClient {
                 let symbol = Ustr::from(&event.symbol);
                 let cache = ws_instruments.load();
                 if let Some(instrument) = cache.get(&symbol) {
-                    let quote = parse_bbo_event(event, instrument);
+                    let quote = parse_bbo_event(event, instrument, ts_init);
                     Self::send_data(data_sender, Data::from(quote));
                 }
             }
@@ -361,7 +363,7 @@ impl BinanceSpotDataClient {
                 let symbol = Ustr::from(&event.symbol);
                 let cache = ws_instruments.load();
                 if let Some(instrument) = cache.get(&symbol)
-                    && let Some(deltas) = parse_depth_snapshot(event, instrument)
+                    && let Some(deltas) = parse_depth_snapshot(event, instrument, ts_init)
                 {
                     Self::send_data(data_sender, Data::Deltas(OrderBookDeltas_API::new(deltas)));
                 }
@@ -370,7 +372,7 @@ impl BinanceSpotDataClient {
                 let symbol = Ustr::from(&event.symbol);
                 let cache = ws_instruments.load();
                 if let Some(instrument) = cache.get(&symbol)
-                    && let Some(deltas) = parse_depth_diff(event, instrument)
+                    && let Some(deltas) = parse_depth_diff(event, instrument, ts_init)
                 {
                     let first_update_id = event.first_book_update_id as u64;
                     let final_update_id = event.last_book_update_id as u64;
@@ -2043,24 +2045,94 @@ impl DataClient for BinanceSpotDataClient {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{
+        sync::{Arc, RwLock},
+        time::Duration,
+    };
 
-    use nautilus_core::nanos::UnixNanos;
+    use nautilus_common::messages::DataEvent;
+    use nautilus_core::{AtomicMap, nanos::UnixNanos, time::AtomicTime};
     use nautilus_model::{
-        data::{BookOrder, OrderBookDelta, OrderBookDeltas},
+        data::{BookOrder, Data, OrderBookDelta, OrderBookDeltas},
         enums::{BookAction, OrderSide, RecordFlag},
         identifiers::InstrumentId,
+        instruments::{Instrument, InstrumentAny, stubs::currency_pair_btcusdt},
         types::{Price, Quantity},
     };
     use rstest::rstest;
     use rust_decimal_macros::dec;
+    use ustr::Ustr;
 
     use super::{
-        BinanceDepth, BinanceEnvironment, BinanceSpotMarketDataMode, BufferedDepthUpdate,
-        first_applicable_spot_update, parse_spot_depth_snapshot, resolve_spot_json_ws_url,
-        spot_continuity_ok, spot_overlap_valid, spot_snapshot_retry_backoff,
+        BinanceDepth, BinanceEnvironment, BinanceSpotDataClient, BinanceSpotMarketDataMode,
+        BookBuffer, BufferedDepthUpdate, first_applicable_spot_update, parse_spot_depth_snapshot,
+        resolve_spot_json_ws_url, spot_continuity_ok, spot_overlap_valid,
+        spot_snapshot_retry_backoff,
     };
-    use crate::{common::consts::BINANCE_SPOT_WS_URL, spot::http::BinancePriceLevel};
+    use crate::{
+        common::consts::BINANCE_SPOT_WS_URL,
+        spot::{
+            http::{BinancePriceLevel, BinanceSpotHttpClient},
+            sbe::stream::BestBidAskStreamEvent,
+            websocket::streams::messages::BinanceSpotWsMessage,
+        },
+    };
+
+    #[rstest]
+    fn handle_ws_message_uses_clock_timestamp_for_sbe_bbo_ts_init() {
+        let ts_init = UnixNanos::from(1_800_000_000_000_000_000u64);
+        let clock = Box::leak(Box::new(AtomicTime::new(false, ts_init)));
+        let instrument = InstrumentAny::CurrencyPair(currency_pair_btcusdt());
+        let instruments = Arc::new(AtomicMap::new());
+        instruments.insert(instrument.id(), instrument.clone());
+        let ws_instruments = Arc::new(AtomicMap::new());
+        ws_instruments.insert(Ustr::from("BTCUSDT"), instrument);
+        let book_buffers = Arc::new(AtomicMap::<InstrumentId, BookBuffer>::new());
+        let book_subscriptions = Arc::new(AtomicMap::<InstrumentId, u32>::new());
+        let book_epoch = Arc::new(RwLock::new(0));
+        let http_client = BinanceSpotHttpClient::new(
+            BinanceEnvironment::Testnet,
+            clock,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let event_time_us = 1_700_000_000_000_000;
+        let message = BinanceSpotWsMessage::BestBidAsk(BestBidAskStreamEvent {
+            event_time_us,
+            book_update_id: 123,
+            price_exponent: -2,
+            qty_exponent: -4,
+            bid_price_mantissa: 12_345,
+            bid_qty_mantissa: 25_000,
+            ask_price_mantissa: 12_350,
+            ask_qty_mantissa: 30_000,
+            symbol: Ustr::from("BTCUSDT"),
+        });
+
+        BinanceSpotDataClient::handle_ws_message(
+            message,
+            &sender,
+            &instruments,
+            &ws_instruments,
+            &book_buffers,
+            &book_subscriptions,
+            &book_epoch,
+            &http_client,
+            clock,
+        );
+
+        let DataEvent::Data(Data::Quote(quote)) = receiver.try_recv().unwrap() else {
+            panic!("expected quote data event");
+        };
+        assert_eq!(quote.ts_event, UnixNanos::from_micros(event_time_us as u64));
+        assert_eq!(quote.ts_init, ts_init);
+    }
 
     #[rstest]
     fn overlap_accepts_first_diff_straddling_snapshot() {

--- a/crates/adapters/binance/src/spot/websocket/streams/parse.rs
+++ b/crates/adapters/binance/src/spot/websocket/streams/parse.rs
@@ -72,8 +72,13 @@ pub fn decode_market_data(buf: &[u8]) -> Result<MarketDataMessage, StreamDecodeE
     }
 }
 
-/// Parses a trades stream event into a vector of `TradeTick`.
-pub fn parse_trades_event(event: &TradesStreamEvent, instrument: &InstrumentAny) -> Vec<Data> {
+/// Parses a trades stream event into a vector of `TradeTick` using the supplied
+/// adapter initialization timestamp.
+pub fn parse_trades_event(
+    event: &TradesStreamEvent,
+    instrument: &InstrumentAny,
+    ts_init: UnixNanos,
+) -> Vec<Data> {
     let instrument_id = instrument.id();
     let price_precision = instrument.price_precision();
     let size_precision = instrument.size_precision();
@@ -105,15 +110,20 @@ pub fn parse_trades_event(event: &TradesStreamEvent, instrument: &InstrumentAny)
                 },
                 TradeId::new(t.id.to_string()),
                 ts_event,
-                ts_event,
+                ts_init,
             );
             Data::from(trade)
         })
         .collect()
 }
 
-/// Parses a best bid/ask event into a `QuoteTick`.
-pub fn parse_bbo_event(event: &BestBidAskStreamEvent, instrument: &InstrumentAny) -> QuoteTick {
+/// Parses a best bid/ask event into a `QuoteTick` using the supplied adapter
+/// initialization timestamp.
+pub fn parse_bbo_event(
+    event: &BestBidAskStreamEvent,
+    instrument: &InstrumentAny,
+    ts_init: UnixNanos,
+) -> QuoteTick {
     let instrument_id = instrument.id();
     let price_precision = instrument.price_precision();
     let size_precision = instrument.size_precision();
@@ -147,16 +157,18 @@ pub fn parse_bbo_event(event: &BestBidAskStreamEvent, instrument: &InstrumentAny
         bid_size,
         ask_size,
         ts_event,
-        ts_event,
+        ts_init,
     )
 }
 
-/// Parses a depth snapshot event into `OrderBookDeltas`.
+/// Parses a depth snapshot event into `OrderBookDeltas` using the supplied
+/// adapter initialization timestamp for the aggregate and every inner delta.
 ///
 /// Returns `None` if the snapshot contains no levels.
 pub fn parse_depth_snapshot(
     event: &DepthSnapshotStreamEvent,
     instrument: &InstrumentAny,
+    ts_init: UnixNanos,
 ) -> Option<OrderBookDeltas> {
     let instrument_id = instrument.id();
     let price_precision = instrument.price_precision();
@@ -171,7 +183,7 @@ pub fn parse_depth_snapshot(
         instrument_id,
         sequence,
         ts_event,
-        ts_event,
+        ts_init,
     ));
 
     // Add bid levels
@@ -201,7 +213,7 @@ pub fn parse_depth_snapshot(
             flags,
             sequence,
             ts_event,
-            ts_event,
+            ts_init,
         ));
     }
 
@@ -232,7 +244,7 @@ pub fn parse_depth_snapshot(
             flags,
             sequence,
             ts_event,
-            ts_event,
+            ts_init,
         ));
     }
 
@@ -245,12 +257,14 @@ pub fn parse_depth_snapshot(
     Some(OrderBookDeltas::new(instrument_id, deltas))
 }
 
-/// Parses a depth diff event into `OrderBookDeltas`.
+/// Parses a depth diff event into `OrderBookDeltas` using the supplied adapter
+/// initialization timestamp for the aggregate and every inner delta.
 ///
 /// Returns `None` if the diff contains no updates.
 pub fn parse_depth_diff(
     event: &DepthDiffStreamEvent,
     instrument: &InstrumentAny,
+    ts_init: UnixNanos,
 ) -> Option<OrderBookDeltas> {
     let instrument_id = instrument.id();
     let price_precision = instrument.price_precision();
@@ -295,7 +309,7 @@ pub fn parse_depth_diff(
             flags,
             sequence,
             ts_event,
-            ts_event,
+            ts_init,
         ));
     }
 
@@ -333,7 +347,7 @@ pub fn parse_depth_diff(
             flags,
             sequence,
             ts_event,
-            ts_event,
+            ts_init,
         ));
     }
 
@@ -481,6 +495,7 @@ mod tests {
     #[rstest]
     fn test_parse_trades_event() {
         let instrument = sample_instrument();
+        let ts_init = UnixNanos::from(1_800_000_000_000_000_000u64);
         let event = TradesStreamEvent {
             event_time_us: 1_700_000_000_000_000,
             transact_time_us: 1_700_000_000_100_000,
@@ -503,7 +518,7 @@ mod tests {
             symbol: Ustr::from("ETHUSDT"),
         };
 
-        let data = parse_trades_event(&event, &instrument);
+        let data = parse_trades_event(&event, &instrument, ts_init);
 
         assert_eq!(data.len(), 2);
         match &data[0] {
@@ -517,13 +532,16 @@ mod tests {
                     trade.ts_event,
                     UnixNanos::from(1_700_000_000_100_000_000u64)
                 );
-                assert_eq!(trade.ts_init, UnixNanos::from(1_700_000_000_100_000_000u64));
+                assert_eq!(trade.ts_init, ts_init);
             }
             other => panic!("Expected trade data, was {other:?}"),
         }
 
         match &data[1] {
-            Data::Trade(trade) => assert_eq!(trade.aggressor_side, AggressorSide::Seller),
+            Data::Trade(trade) => {
+                assert_eq!(trade.aggressor_side, AggressorSide::Seller);
+                assert_eq!(trade.ts_init, ts_init);
+            }
             other => panic!("Expected trade data, was {other:?}"),
         }
     }
@@ -531,6 +549,7 @@ mod tests {
     #[rstest]
     fn test_parse_bbo_event() {
         let instrument = sample_instrument();
+        let ts_init = UnixNanos::from(1_800_000_000_000_000_000u64);
         let event = BestBidAskStreamEvent {
             event_time_us: 1_700_000_000_000_000,
             book_update_id: 123,
@@ -543,7 +562,7 @@ mod tests {
             symbol: Ustr::from("ETHUSDT"),
         };
 
-        let quote = parse_bbo_event(&event, &instrument);
+        let quote = parse_bbo_event(&event, &instrument, ts_init);
 
         assert_eq!(quote.instrument_id, instrument.id());
         assert_eq!(quote.bid_price, Price::new(123.45, 2));
@@ -554,12 +573,13 @@ mod tests {
             quote.ts_event,
             UnixNanos::from(1_700_000_000_000_000_000u64)
         );
-        assert_eq!(quote.ts_init, UnixNanos::from(1_700_000_000_000_000_000u64));
+        assert_eq!(quote.ts_init, ts_init);
     }
 
     #[rstest]
     fn test_parse_depth_snapshot() {
         let instrument = sample_instrument();
+        let ts_init = UnixNanos::from(1_800_000_000_000_000_000u64);
         let event = DepthSnapshotStreamEvent {
             event_time_us: 1_700_000_000_000_000,
             book_update_id: 123,
@@ -576,7 +596,7 @@ mod tests {
             symbol: Ustr::from("ETHUSDT"),
         };
 
-        let deltas = parse_depth_snapshot(&event, &instrument).unwrap();
+        let deltas = parse_depth_snapshot(&event, &instrument, ts_init).unwrap();
 
         assert_eq!(deltas.instrument_id, instrument.id());
         assert_eq!(deltas.deltas.len(), 3);
@@ -596,6 +616,8 @@ mod tests {
             deltas.ts_event,
             UnixNanos::from(1_700_000_000_000_000_000u64)
         );
+        assert_eq!(deltas.ts_init, ts_init);
+        assert!(deltas.deltas.iter().all(|delta| delta.ts_init == ts_init));
     }
 
     #[rstest]
@@ -611,7 +633,7 @@ mod tests {
             symbol: Ustr::from("ETHUSDT"),
         };
 
-        let deltas = parse_depth_snapshot(&event, &instrument);
+        let deltas = parse_depth_snapshot(&event, &instrument, UnixNanos::from(2));
 
         assert!(deltas.is_none());
     }
@@ -619,6 +641,7 @@ mod tests {
     #[rstest]
     fn test_parse_depth_diff() {
         let instrument = sample_instrument();
+        let ts_init = UnixNanos::from(1_800_000_000_000_000_000u64);
         let event = DepthDiffStreamEvent {
             event_time_us: 1_700_000_000_000_000,
             first_book_update_id: 100,
@@ -642,7 +665,7 @@ mod tests {
             symbol: Ustr::from("ETHUSDT"),
         };
 
-        let deltas = parse_depth_diff(&event, &instrument).unwrap();
+        let deltas = parse_depth_diff(&event, &instrument, ts_init).unwrap();
 
         assert_eq!(deltas.instrument_id, instrument.id());
         assert_eq!(deltas.deltas.len(), 3);
@@ -659,6 +682,8 @@ mod tests {
             deltas.ts_event,
             UnixNanos::from(1_700_000_000_000_000_000u64)
         );
+        assert_eq!(deltas.ts_init, ts_init);
+        assert!(deltas.deltas.iter().all(|delta| delta.ts_init == ts_init));
     }
 
     #[rstest]
@@ -675,7 +700,7 @@ mod tests {
             symbol: Ustr::from("ETHUSDT"),
         };
 
-        let deltas = parse_depth_diff(&event, &instrument);
+        let deltas = parse_depth_diff(&event, &instrument, UnixNanos::from(2));
 
         assert!(deltas.is_none());
     }


### PR DESCRIPTION
## Summary

- capture one adapter initialization timestamp for each decoded Binance Spot SBE message
- preserve Binance timestamps as `ts_event` while using the adapter timestamp as `ts_init`
- propagate the same initialization timestamp through trades, quotes, snapshots, inner deltas, and aggregate wrappers
- add deliberately unequal timestamp coverage at parser and production-handler boundaries

Closes #4473.

## Rationale

The SBE path currently copies the provider timestamp into both timestamp fields. The JSON stream path already captures the adapter clock before parser dispatch. This change aligns the SBE path with that ownership boundary without changing provider event-time semantics.

The four public SBE parser functions gain a required trailing `ts_init: UnixNanos` argument. All in-repository callers are updated.

## Verification

- `cargo test -p nautilus-binance --lib` — 742 passed
- `cargo clippy -p nautilus-binance --lib --tests -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

No live Binance connection test was run.
