### PR TITLE
Fix Clock trait consistency for expired timers and failed alerts

### DIFF
--- a/crates/common/src/clock.rs
+++ b/crates/common/src/clock.rs
@@ -225,7 +225,7 @@ pub trait Clock: Debug + Any {
 
     /// Returns the time interval in which the timer `name` is triggered.
     ///
-    /// If the timer doesn't exist `None` is returned.
+    /// If no active (not expired) timer with `name` exists, `None` is returned.
     fn next_time_ns(&self, name: &str) -> Option<UnixNanos>;
 
     /// Cancels the timer with `name`.
@@ -621,7 +621,7 @@ impl<'a> ClockApi<'a> {
         }
     }
 
-    /// Returns the next trigger timestamp for the timer `name`.
+    /// Returns the next trigger timestamp for the active (not expired) timer `name`.
     ///
     /// # Panics
     ///
@@ -1097,12 +1097,12 @@ impl Clock for TestClock {
         let (name, alert_time_ns) =
             validate_and_prepare_time_alert(name, alert_time_ns, allow_past, ts_now)?;
 
-        self.replace_existing_timer_if_needed(&name);
-
         check_predicate_true(
             callback.is_some() | self.callbacks.has_any_callback(&name),
             "No callbacks provided",
         )?;
+
+        self.replace_existing_timer_if_needed(&name);
 
         if let Some(callback) = callback {
             self.callbacks.register_callback(name, callback);
@@ -1174,6 +1174,7 @@ impl Clock for TestClock {
     fn next_time_ns(&self, name: &str) -> Option<UnixNanos> {
         self.timers
             .get(&Ustr::from(name))
+            .filter(|timer| !timer.is_expired())
             .map(TestTimer::next_time_ns)
     }
 
@@ -2061,6 +2062,33 @@ mod tests {
             err.to_string().contains("No callbacks provided"),
             "unexpected error: {err}"
         );
+    }
+
+    #[rstest]
+    fn test_failed_set_time_alert_ns_preserves_existing_timer() {
+        // Fresh clock with no default handler
+        let mut clock = TestClock::new();
+        let alert_time: UnixNanos = (*clock.timestamp_ns() + 1000).into();
+        let callback = TimeEventCallback::from(TestCallback::default());
+        clock
+            .set_time_alert_ns("alert", alert_time, Some(callback), None)
+            .unwrap();
+        assert_eq!(clock.next_time_ns("alert"), Some(alert_time));
+
+        // Callbacks released (e.g. partial component teardown) while the alert still lives
+        clock.cancel_callbacks();
+
+        // Rescheduling without a callback fails the predicate check; the error
+        // return must not have destroyed the previously scheduled alert
+        let err = clock
+            .set_time_alert_ns("alert", (*alert_time + 1000).into(), None, None)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("No callbacks provided"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(clock.timer_count(), 1);
+        assert_eq!(clock.next_time_ns("alert"), Some(alert_time));
     }
 
     #[rstest]

--- a/crates/common/src/live/clock.rs
+++ b/crates/common/src/live/clock.rs
@@ -160,12 +160,12 @@ impl Clock for LiveClock {
         let (name, alert_time_ns) =
             validate_and_prepare_time_alert(name, alert_time_ns, allow_past, ts_now)?;
 
-        self.replace_existing_timer_if_needed(&name);
-
         check_predicate_true(
             callback.is_some() | self.callbacks.has_any_callback(&name),
             "No callbacks provided",
         )?;
+
+        self.replace_existing_timer_if_needed(&name);
 
         let callback = if let Some(callback) = callback {
             self.callbacks.register_callback(name, callback.clone());
@@ -258,6 +258,7 @@ impl Clock for LiveClock {
     fn next_time_ns(&self, name: &str) -> Option<UnixNanos> {
         self.timers
             .get(&Ustr::from(name))
+            .filter(|timer| !timer.is_expired())
             .map(LiveTimer::next_time_ns)
     }
 
@@ -472,11 +473,51 @@ mod tests {
         wait_until(|| clock.timer_count() == 0, Duration::from_secs(2));
 
         // An expired timer is purged only lazily on the next set/cancel call,
-        // so the entry still sits in the map; the three introspection surfaces
+        // so the entry still sits in the map; the introspection surfaces
         // must nevertheless agree it is gone
         assert!(clock.timers.contains_key(&name));
         assert!(!clock.timer_exists(&name));
         assert_eq!(clock.timer_count(), 0);
         assert!(clock.timer_names().is_empty());
+        assert!(clock.next_time_ns(name.as_str()).is_none());
+    }
+
+    #[rstest]
+    fn test_live_clock_failed_set_time_alert_ns_preserves_existing_timer() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let sender = Arc::new(CollectingSender::new(Arc::clone(&events)));
+
+        // No default handler registered
+        let mut clock = LiveClock::new(Some(sender));
+
+        let now = clock.timestamp_ns();
+        let alert_time = now + Duration::from_mins(1).as_nanos() as u64;
+
+        clock
+            .set_time_alert_ns(
+                "alert",
+                alert_time,
+                Some(TimeEventCallback::from(|_| {})),
+                None,
+            )
+            .unwrap();
+        assert_eq!(clock.next_time_ns("alert"), Some(alert_time));
+
+        // Callbacks released (e.g. partial component teardown) while the alert still lives
+        clock.cancel_callbacks();
+
+        // Rescheduling without a callback fails the predicate check; the error
+        // return must not have destroyed the previously scheduled alert
+        let err = clock
+            .set_time_alert_ns("alert", alert_time + 1000u64, None, None)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("No callbacks provided"),
+            "unexpected error: {err}"
+        );
+        assert!(clock.timer_exists(&Ustr::from("alert")));
+        assert_eq!(clock.next_time_ns("alert"), Some(alert_time));
+
+        clock.cancel_timers();
     }
 }


### PR DESCRIPTION
Two follow-ups to the timer-introspection alignment in #4400, both making the `Clock` trait surfaces behave uniformly across `TestClock` and `LiveClock`.

**1. `next_time_ns` reported expired timers**

#4400 aligned `timer_exists` with `timer_names`/`timer_count` by filtering on `!is_expired()`, but `next_time_ns` was left as a bare map read. `LiveClock` purges expired entries only lazily (on the next `set_*`/cancel), so there is an unbounded window where a fired-and-done timer answers `timer_exists == false` and `timer_count == 0` while `next_time_ns` still returns its stale scheduled time. `TestClock` removes expired timers eagerly and returns `None` for the same state, so the two impls also disagreed with each other. Both impls now filter on `!is_expired()`, and the trait / `ClockApi` docs say "active (not expired)".

Consumers are unaffected or corrected: the backtest engine's `process_next_timer` gates on `Some`, which is exactly the active-timer semantics it wants.

**2. `set_time_alert_ns` destroyed the existing timer on its error path**

`set_time_alert_ns` called `replace_existing_timer_if_needed` *before* the "No callbacks provided" predicate check, while `set_timer_ns` checks first. A failing call (e.g. re-arming an alert with `callback: None` after callbacks were released during a partial component teardown) therefore returned an error *and* silently cancelled the previously scheduled alert under that name, so the old deadline never fired. Both impls now check the predicate before touching the existing timer, matching `set_timer_ns`. The predicate reads only the callback registry, which the replace path never mutates, so the reordering changes nothing on the success path.

**Testing**

- Extended `test_live_clock_timer_exists_consistent_after_expiry` (the #4400 regression) to assert `next_time_ns` is `None` while the expired entry still physically sits in the map.
- New `test_failed_set_time_alert_ns_preserves_existing_timer` on `TestClock` and its `LiveClock` twin - both deterministic, no wall-clock waits (the live test uses a far-future alert that never fires).
- All three assertions were verified to fail against the unfixed implementations before the fix was applied.
