### PR TITLE
Fix missing-order resolution and failed-report handling in live reconciliation

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -84,6 +84,13 @@ static TAG_RECONCILIATION: LazyLock<Ustr> = LazyLock::new(|| Ustr::from("RECONCI
 pub type InstrumentAccountKey = (InstrumentId, AccountId);
 type FillKey = (AccountId, InstrumentId, TradeId);
 
+/// Execution clients responsible for reporting one cached entity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReportClientCoverage {
+    Resolved(IndexSet<ClientId>),
+    Unresolved,
+}
+
 /// Metadata for an external order that needs to be registered with the execution client.
 #[derive(Debug, Clone)]
 pub struct ExternalOrderMetadata {
@@ -117,6 +124,7 @@ pub struct InflightCheckResult {
 pub(crate) struct OpenOrderReportCheck {
     pub command: GenerateOrderStatusReports,
     pub filtered_orders: Vec<OrderAny>,
+    pub client_coverage: IndexMap<ClientOrderId, ReportClientCoverage>,
     pub start: Option<UnixNanos>,
 }
 
@@ -125,6 +133,7 @@ pub(crate) struct OpenOrderReportCheck {
 pub(crate) struct PositionReportCheck {
     pub command: GeneratePositionStatusReports,
     pub positions_by_key: IndexMap<InstrumentAccountKey, Vec<Position>>,
+    pub client_coverage: IndexMap<InstrumentAccountKey, ReportClientCoverage>,
 }
 
 struct RetainedFillState {
@@ -287,6 +296,8 @@ pub struct ExecutionManager {
     position_recon_retries: IndexMap<InstrumentAccountKey, u32>,
     position_reconciliation_tolerances: IndexMap<(Venue, AccountId), Decimal>,
     recent_fills_cache: RecencyMap<FillKey>,
+    missing_order_coverage_warnings: IndexSet<ClientOrderId>,
+    unresolved_order_coverage: IndexSet<ClientOrderId>,
 }
 
 impl Debug for ExecutionManager {
@@ -322,6 +333,8 @@ impl ExecutionManager {
             position_recon_retries: IndexMap::new(),
             position_reconciliation_tolerances: IndexMap::new(),
             recent_fills_cache: RecencyMap::default(),
+            missing_order_coverage_warnings: IndexSet::new(),
+            unresolved_order_coverage: IndexSet::new(),
         }
     }
 
@@ -1069,10 +1082,43 @@ impl ExecutionManager {
 
     /// Prepares a bulk open-order report request and snapshots cached open orders.
     pub(crate) fn prepare_open_order_report_check(
-        &self,
+        &mut self,
         command_id: UUID4,
+        clients: &[&dyn ExecutionClient],
     ) -> OpenOrderReportCheck {
         let filtered_orders = self.filtered_open_orders_for_reconciliation();
+        let active_order_ids: IndexSet<ClientOrderId> = filtered_orders
+            .iter()
+            .map(|order| order.client_order_id())
+            .collect();
+        self.missing_order_coverage_warnings
+            .retain(|client_order_id| active_order_ids.contains(client_order_id));
+        self.unresolved_order_coverage
+            .retain(|client_order_id| active_order_ids.contains(client_order_id));
+
+        let mut client_coverage = IndexMap::new();
+
+        for order in &filtered_orders {
+            let client_order_id = order.client_order_id();
+            let coverage = self.resolve_order_report_client_coverage(order, clients);
+
+            match &coverage {
+                ReportClientCoverage::Resolved(_) => {
+                    if self
+                        .unresolved_order_coverage
+                        .shift_remove(&client_order_id)
+                    {
+                        self.missing_order_coverage_warnings
+                            .shift_remove(&client_order_id);
+                    }
+                }
+                ReportClientCoverage::Unresolved => {
+                    self.unresolved_order_coverage.insert(client_order_id);
+                }
+            }
+
+            client_coverage.insert(client_order_id, coverage);
+        }
 
         log::debug!(
             "Found {} order{} open in cache",
@@ -1101,7 +1147,42 @@ impl ExecutionManager {
         OpenOrderReportCheck {
             command,
             filtered_orders,
+            client_coverage,
             start,
+        }
+    }
+
+    fn resolve_order_report_client_coverage(
+        &self,
+        order: &OrderAny,
+        clients: &[&dyn ExecutionClient],
+    ) -> ReportClientCoverage {
+        if let Some(client_id) = self.cache.borrow().client_id(&order.client_order_id()) {
+            return ReportClientCoverage::Resolved(IndexSet::from([*client_id]));
+        }
+
+        if let Some(account_id) = order.account_id() {
+            let account_clients = clients
+                .iter()
+                .filter(|client| client.account_id() == account_id)
+                .map(|client| client.client_id())
+                .collect::<IndexSet<_>>();
+
+            if !account_clients.is_empty() {
+                return ReportClientCoverage::Resolved(account_clients);
+            }
+        }
+
+        let venue_clients = clients
+            .iter()
+            .filter(|client| client.handles_order_venue(order.instrument_id().venue))
+            .map(|client| client.client_id())
+            .collect::<IndexSet<_>>();
+
+        if venue_clients.is_empty() {
+            ReportClientCoverage::Unresolved
+        } else {
+            ReportClientCoverage::Resolved(venue_clients)
         }
     }
 
@@ -1211,15 +1292,21 @@ impl ExecutionManager {
     ) -> Vec<OrderEventAny> {
         log::debug!("Checking order consistency between cached-state and venues");
 
-        let check = self.prepare_open_order_report_check(UUID4::new());
+        let check = self.prepare_open_order_report_check(UUID4::new(), clients);
         let mut all_reports = Vec::new();
+        let mut queried_clients = IndexSet::new();
+        let mut failed_clients = IndexSet::new();
 
         for client in clients {
+            let client_id = client.client_id();
+            queried_clients.insert(client_id);
+
             match client.generate_order_status_reports(&check.command).await {
                 Ok(reports) => {
                     all_reports.extend(reports);
                 }
                 Err(e) => {
+                    failed_clients.insert(client_id);
                     log::warn!(
                         "Failed to query order reports from {}: {e}",
                         client.client_id()
@@ -1228,7 +1315,7 @@ impl ExecutionManager {
             }
         }
 
-        self.reconcile_open_order_reports(&check, all_reports)
+        self.reconcile_open_order_reports(&check, all_reports, &queried_clients, &failed_clients)
     }
 
     /// Reconciles bulk open-order report responses against a cached order snapshot.
@@ -1236,12 +1323,36 @@ impl ExecutionManager {
         &mut self,
         check: &OpenOrderReportCheck,
         all_reports: Vec<OrderStatusReport>,
+        queried_clients: &IndexSet<ClientId>,
+        failed_clients: &IndexSet<ClientId>,
     ) -> Vec<OrderEventAny> {
         let mut venue_reported_ids = IndexSet::new();
 
         for report in &all_reports {
             if let Some(client_order_id) = &report.client_order_id {
                 venue_reported_ids.insert(*client_order_id);
+                self.missing_order_coverage_warnings
+                    .shift_remove(client_order_id);
+                // A positive report is proof the venue still knows the order:
+                // reset the missing-order ladder so only consecutive misses
+                // accumulate (mirrors the Python engine's per-report clear).
+                self.recon_check_retries.shift_remove(client_order_id);
+            } else {
+                let mapped_client_order_id = self
+                    .cache
+                    .borrow()
+                    .client_order_id(&report.venue_order_id)
+                    .copied();
+
+                // The mapped order was positively reported: it must receive
+                // the full positive-report bookkeeping or the missing-order
+                // loop below immediately re-increments the cleared counter.
+                if let Some(client_order_id) = mapped_client_order_id {
+                    venue_reported_ids.insert(client_order_id);
+                    self.missing_order_coverage_warnings
+                        .shift_remove(&client_order_id);
+                    self.recon_check_retries.shift_remove(&client_order_id);
+                }
             }
         }
 
@@ -1314,14 +1425,64 @@ impl ExecutionManager {
             } else {
                 check.filtered_orders.iter().collect()
             };
-            let cached_ids: IndexSet<ClientOrderId> =
-                candidates.iter().map(|o| o.client_order_id()).collect();
-            let missing_at_venue: IndexSet<ClientOrderId> = cached_ids
-                .difference(&venue_reported_ids)
-                .copied()
-                .collect();
 
-            for client_order_id in missing_at_venue {
+            for order in candidates {
+                let client_order_id = order.client_order_id();
+                if venue_reported_ids.contains(&client_order_id) {
+                    continue;
+                }
+
+                let coverage = check
+                    .client_coverage
+                    .get(&client_order_id)
+                    .unwrap_or(&ReportClientCoverage::Unresolved);
+
+                let ReportClientCoverage::Resolved(responsible_clients) = coverage else {
+                    if self.missing_order_coverage_warnings.insert(client_order_id) {
+                        log::warn!(
+                            "Skipping order reconciliation for {client_order_id}: responsible execution client coverage is unresolved"
+                        );
+                    }
+                    continue;
+                };
+
+                if responsible_clients.is_empty() {
+                    if self.missing_order_coverage_warnings.insert(client_order_id) {
+                        log::warn!(
+                            "Skipping order reconciliation for {client_order_id}: responsible execution client coverage is unresolved"
+                        );
+                    }
+                    continue;
+                }
+
+                let missing_clients = responsible_clients
+                    .difference(queried_clients)
+                    .copied()
+                    .collect::<IndexSet<_>>();
+
+                if !missing_clients.is_empty() {
+                    if self.missing_order_coverage_warnings.insert(client_order_id) {
+                        log::warn!(
+                            "Skipping order reconciliation for {client_order_id}: responsible execution clients were not queried: {missing_clients:?}"
+                        );
+                    }
+                    continue;
+                }
+
+                let failed_responsible_clients = responsible_clients
+                    .intersection(failed_clients)
+                    .copied()
+                    .collect::<IndexSet<_>>();
+
+                if !failed_responsible_clients.is_empty() {
+                    log::warn!(
+                        "Skipping order reconciliation for {client_order_id}: failed to query responsible execution clients: {failed_responsible_clients:?}"
+                    );
+                    continue;
+                }
+
+                self.missing_order_coverage_warnings
+                    .shift_remove(&client_order_id);
                 events.extend(self.handle_missing_order(client_order_id));
             }
         }
@@ -1331,8 +1492,21 @@ impl ExecutionManager {
 
     /// Prepares a bulk position report request and snapshots cached positions.
     #[must_use]
-    pub(crate) fn prepare_position_report_check(&self, command_id: UUID4) -> PositionReportCheck {
+    pub(crate) fn prepare_position_report_check(
+        &self,
+        command_id: UUID4,
+        clients: &[&dyn ExecutionClient],
+    ) -> PositionReportCheck {
         let positions_by_key = self.open_positions_by_key_for_reconciliation();
+        let client_coverage = positions_by_key
+            .keys()
+            .map(|key| {
+                (
+                    *key,
+                    Self::resolve_position_report_client_coverage(*key, clients),
+                )
+            })
+            .collect();
 
         log::debug!(
             "Found {} unique instrument/account combination{} with open positions",
@@ -1354,6 +1528,34 @@ impl ExecutionManager {
         PositionReportCheck {
             command,
             positions_by_key,
+            client_coverage,
+        }
+    }
+
+    fn resolve_position_report_client_coverage(
+        key: InstrumentAccountKey,
+        clients: &[&dyn ExecutionClient],
+    ) -> ReportClientCoverage {
+        let account_clients = clients
+            .iter()
+            .filter(|client| client.account_id() == key.1)
+            .map(|client| client.client_id())
+            .collect::<IndexSet<_>>();
+
+        if !account_clients.is_empty() {
+            return ReportClientCoverage::Resolved(account_clients);
+        }
+
+        let venue_clients = clients
+            .iter()
+            .filter(|client| client.handles_order_venue(key.0.venue))
+            .map(|client| client.client_id())
+            .collect::<IndexSet<_>>();
+
+        if venue_clients.is_empty() {
+            ReportClientCoverage::Unresolved
+        } else {
+            ReportClientCoverage::Resolved(venue_clients)
         }
     }
 
@@ -1370,11 +1572,14 @@ impl ExecutionManager {
         &mut self,
         clients: &[&dyn ExecutionClient],
     ) -> Vec<OrderEventAny> {
-        let check = self.prepare_position_report_check(UUID4::new());
+        let check = self.prepare_position_report_check(UUID4::new(), clients);
         let mut reports = Vec::new();
-        let mut failed_venues = IndexSet::new();
+        let mut queried_clients = IndexSet::new();
+        let mut failed_clients = IndexSet::new();
 
         for client in clients {
+            let client_id = client.client_id();
+            queried_clients.insert(client_id);
             self.set_position_reconciliation_tolerance(
                 client.venue(),
                 client.account_id(),
@@ -1389,7 +1594,7 @@ impl ExecutionManager {
                     reports.extend(client_reports);
                 }
                 Err(e) => {
-                    failed_venues.insert(client.venue());
+                    failed_clients.insert(client_id);
                     log::warn!(
                         "Failed to query position reports from {}: {e}",
                         client.client_id()
@@ -1398,7 +1603,7 @@ impl ExecutionManager {
             }
         }
 
-        self.reconcile_position_reports(&check, reports, &failed_venues)
+        self.reconcile_position_reports(&check, reports, &queried_clients, &failed_clients)
     }
 
     /// Reconciles cached positions against venue position reports.
@@ -1407,7 +1612,8 @@ impl ExecutionManager {
         &mut self,
         check: &PositionReportCheck,
         reports: Vec<PositionStatusReport>,
-        failed_venues: &IndexSet<Venue>,
+        queried_clients: &IndexSet<ClientId>,
+        failed_clients: &IndexSet<ClientId>,
     ) -> Vec<OrderEventAny> {
         log::debug!("Checking position consistency between cached-state and venues");
 
@@ -1426,14 +1632,53 @@ impl ExecutionManager {
         for (key, cached_positions) in &check.positions_by_key {
             let venue_report = venue_positions.get(key);
 
-            if venue_report.is_none()
-                && Self::position_query_failed_for_instrument(failed_venues, &key.0)
-            {
-                log::warn!(
-                    "Skipping position reconciliation for {}: failed to query venue position status",
-                    key.0
-                );
-                continue;
+            if venue_report.is_none() {
+                match check.client_coverage.get(key) {
+                    Some(ReportClientCoverage::Resolved(responsible_clients))
+                        if !responsible_clients.is_empty()
+                            && responsible_clients.is_subset(queried_clients)
+                            && responsible_clients.is_disjoint(failed_clients) => {}
+                    Some(ReportClientCoverage::Resolved(responsible_clients))
+                        if responsible_clients.is_empty() =>
+                    {
+                        log::warn!(
+                            "Skipping position reconciliation for {}/{}: responsible execution client coverage is unresolved",
+                            key.0,
+                            key.1,
+                        );
+                        continue;
+                    }
+                    Some(ReportClientCoverage::Resolved(responsible_clients))
+                        if !responsible_clients.is_subset(queried_clients) =>
+                    {
+                        log::warn!(
+                            "Skipping position reconciliation for {}/{}: responsible execution clients were not all queried",
+                            key.0,
+                            key.1,
+                        );
+                        continue;
+                    }
+                    Some(ReportClientCoverage::Resolved(responsible_clients)) => {
+                        let failed_responsible_clients = responsible_clients
+                            .intersection(failed_clients)
+                            .copied()
+                            .collect::<IndexSet<_>>();
+                        log::warn!(
+                            "Skipping position reconciliation for {}/{}: failed to query responsible execution clients: {failed_responsible_clients:?}",
+                            key.0,
+                            key.1,
+                        );
+                        continue;
+                    }
+                    Some(ReportClientCoverage::Unresolved) | None => {
+                        log::warn!(
+                            "Skipping position reconciliation for {}/{}: responsible execution client coverage is unresolved",
+                            key.0,
+                            key.1,
+                        );
+                        continue;
+                    }
+                }
             }
 
             if let Some(discrepancy_events) =
@@ -1474,13 +1719,6 @@ impl ExecutionManager {
             .retain(|k, _| active_keys.contains(k));
 
         events
-    }
-
-    fn position_query_failed_for_instrument(
-        failed_venues: &IndexSet<Venue>,
-        instrument_id: &InstrumentId,
-    ) -> bool {
-        failed_venues.contains(&instrument_id.venue)
     }
 
     fn position_snapshot_avg_px(cached_positions: &[Position]) -> Option<Decimal> {
@@ -1535,6 +1773,9 @@ impl ExecutionManager {
     pub fn clear_recon_tracking(&mut self, client_order_id: &ClientOrderId, drop_last_query: bool) {
         self.inflight_checks.shift_remove(client_order_id);
         self.recon_check_retries.shift_remove(client_order_id);
+        self.missing_order_coverage_warnings
+            .shift_remove(client_order_id);
+        self.unresolved_order_coverage.shift_remove(client_order_id);
 
         if drop_last_query {
             self.order_query_recency.remove(client_order_id);
@@ -1590,6 +1831,16 @@ impl ExecutionManager {
     #[must_use]
     pub fn position_recon_retry_count(&self, key: &InstrumentAccountKey) -> u32 {
         self.position_recon_retries.get(key).copied().unwrap_or(0)
+    }
+
+    /// Returns the current missing-order reconciliation retry count for the
+    /// given client order ID, or zero if no entry exists.
+    #[must_use]
+    pub fn recon_check_retry_count(&self, client_order_id: &ClientOrderId) -> u32 {
+        self.recon_check_retries
+            .get(client_order_id)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Observes a local order event and updates tracking state.
@@ -1844,6 +2095,18 @@ impl ExecutionManager {
             return events;
         };
 
+        // The order may have closed while the report request was in flight;
+        // the check must come before the retry increment or the stale empty
+        // response recreates tracking state that nothing prunes afterwards.
+        if order.status().is_closed() {
+            log::debug!(
+                "Skipping missing-order resolution for {client_order_id}: already {}",
+                order.status()
+            );
+            self.clear_recon_tracking(&client_order_id, true);
+            return events;
+        }
+
         // Recent local activity is the real-time settling window for missing
         // orders. Venue/domain timestamps can be ahead of the trading clock and
         // must not stall reconciliation.
@@ -1858,18 +2121,65 @@ impl ExecutionManager {
         let retries = self.recon_check_retries.entry(client_order_id).or_insert(0);
         *retries += 1;
 
-        // If max retries exceeded, generate rejection event
+        // If max retries exceeded, resolve according to the current order status.
         if *retries >= self.config.open_check_missing_retries {
-            log::warn!(
-                "Order {client_order_id} not found at venue after {retries} retries, marking as REJECTED"
-            );
-
             let ts_now = self.clock.borrow().timestamp_ns();
 
-            if let Some(rejected) =
-                create_reconciliation_rejected(&order, Some("NOT_FOUND_AT_VENUE"), ts_now)
-            {
-                events.push(rejected);
+            match order.status() {
+                OrderStatus::Accepted | OrderStatus::Submitted => {
+                    log::warn!(
+                        "Order {client_order_id} not found at venue after {retries} retries, marking as REJECTED"
+                    );
+
+                    if let Some(rejected) =
+                        create_reconciliation_rejected(&order, Some("NOT_FOUND_AT_VENUE"), ts_now)
+                    {
+                        events.push(rejected);
+                    }
+                }
+                OrderStatus::PartiallyFilled => {
+                    log::warn!(
+                        "Order {client_order_id} not found at venue after {retries} retries, marking as CANCELED"
+                    );
+                    events.push(OrderEventAny::Canceled(OrderCanceled::new(
+                        order.trader_id(),
+                        order.strategy_id(),
+                        order.instrument_id(),
+                        client_order_id,
+                        UUID4::new(),
+                        ts_now,
+                        ts_now,
+                        true,
+                        order.venue_order_id(),
+                        order.account_id(),
+                    )));
+                }
+                OrderStatus::PendingUpdate | OrderStatus::PendingCancel => {
+                    log::debug!(
+                        "Deferring resolution for {client_order_id}: still inflight as {}",
+                        order.status()
+                    );
+                    // Narrow tracking reset mirroring the Python engine:
+                    // zero the retry ladder and stamp the query time so the
+                    // inflight checker first observes a full threshold delay
+                    // and then retries from scratch. The order must stay
+                    // registered in `inflight_checks` - the inflight checker
+                    // walks that map, unlike Python which rescans cached
+                    // inflight orders every cycle - and keeps its
+                    // local-activity mark.
+                    self.recon_check_retries.shift_remove(&client_order_id);
+                    if let Some(check) = self.inflight_checks.get_mut(&client_order_id) {
+                        check.retry_count = 0;
+                        check.last_query_at = Some(dst::time::Instant::now());
+                    }
+                    self.order_query_recency.mark(client_order_id);
+                    return events;
+                }
+                status => {
+                    log::warn!(
+                        "Skipping missing-order resolution for {client_order_id}: unexpected status {status}"
+                    );
+                }
             }
 
             self.clear_recon_tracking(&client_order_id, true);
@@ -3201,7 +3511,7 @@ mod tests {
         let lookback_ns = lookback_mins * 60 * NANOSECONDS_IN_SECOND;
         let clock = Rc::new(RefCell::new(TestClock::new()));
         let cache = Rc::new(RefCell::new(Cache::default()));
-        let manager = ExecutionManager::new(
+        let mut manager = ExecutionManager::new(
             clock.clone(),
             cache.clone(),
             ExecutionManagerConfig {
@@ -3244,7 +3554,7 @@ mod tests {
 
         let ts_now = clock.borrow().timestamp_ns();
         let command_id = UUID4::new();
-        let check = manager.prepare_open_order_report_check(command_id);
+        let check = manager.prepare_open_order_report_check(command_id, &[]);
 
         assert_eq!(check.command.command_id, command_id);
         assert_eq!(check.command.ts_init, ts_now);
@@ -3303,7 +3613,7 @@ mod tests {
 
         let ts_now = clock.borrow().timestamp_ns();
         let command_id = UUID4::new();
-        let check = manager.prepare_position_report_check(command_id);
+        let check = manager.prepare_position_report_check(command_id, &[]);
         let key = (
             included_position.instrument_id,
             included_position.account_id,

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -84,6 +84,7 @@ use indexmap::IndexSet;
 use nautilus_common::{
     actor::{Actor, DataActor, DataActorNative},
     cache::database::CacheDatabaseAdapter,
+    clients::ExecutionClient,
     component::Component,
     enums::{Environment, LogColor},
     live::dst,
@@ -102,7 +103,7 @@ use nautilus_core::{
 };
 use nautilus_model::{
     events::OrderEventAny,
-    identifiers::{ClientOrderId, InstrumentId, StrategyId, TraderId, Venue},
+    identifiers::{ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId},
     orders::Order,
     reports::{OrderStatusReport, PositionStatusReport},
 };
@@ -1125,9 +1126,12 @@ impl LiveNode {
                     let maintenance_start = dst::time::Instant::now();
 
                     open_order_report_task = None;
-                    let events = self
-                        .exec_manager
-                        .reconcile_open_order_reports(&result.check, result.reports);
+                    let events = self.exec_manager.reconcile_open_order_reports(
+                        &result.check,
+                        result.reports,
+                        &result.queried_clients,
+                        &result.failed_clients,
+                    );
                     self.process_reconciliation_events(&events);
                     record_runner_maintenance(&metrics, maintenance_start, metrics_start);
                 }
@@ -1143,7 +1147,8 @@ impl LiveNode {
                     let events = self.exec_manager.reconcile_position_reports(
                         &result.check,
                         result.reports,
-                        &result.failed_venues,
+                        &result.queried_clients,
+                        &result.failed_clients,
                     );
                     self.process_reconciliation_events(&events);
                     record_runner_maintenance(&metrics, maintenance_start, metrics_start);
@@ -1967,22 +1972,32 @@ impl LiveNode {
         }
     }
 
-    fn start_open_order_report_check(&self) -> Option<OpenOrderReportTask> {
+    fn start_open_order_report_check(&mut self) -> Option<OpenOrderReportTask> {
         if self.exec_clients.is_empty() {
             log::debug!("No execution clients to check orders consistency");
             return None;
         }
 
+        let client_refs = self
+            .exec_clients
+            .iter()
+            .map(|client| client as &dyn ExecutionClient)
+            .collect::<Vec<_>>();
         let check = self
             .exec_manager
-            .prepare_open_order_report_check(UUID4::new());
+            .prepare_open_order_report_check(UUID4::new(), &client_refs);
         let command = check.command.clone();
         let clients = self.exec_clients.clone();
 
         Some(OpenOrderReportTask {
             future: Box::pin(async move {
-                let reports = request_open_order_reports(clients, command).await;
-                OpenOrderReportResult { check, reports }
+                let result = request_open_order_reports(clients, command).await;
+                OpenOrderReportResult {
+                    check,
+                    reports: result.reports,
+                    queried_clients: result.queried_clients,
+                    failed_clients: result.failed_clients,
+                }
             }),
         })
     }
@@ -1993,9 +2008,14 @@ impl LiveNode {
             return None;
         }
 
+        let client_refs = self
+            .exec_clients
+            .iter()
+            .map(|client| client as &dyn ExecutionClient)
+            .collect::<Vec<_>>();
         let check = self
             .exec_manager
-            .prepare_position_report_check(UUID4::new());
+            .prepare_position_report_check(UUID4::new(), &client_refs);
         let command = check.command.clone();
         let clients = self.exec_clients.clone();
 
@@ -2005,7 +2025,8 @@ impl LiveNode {
                 PositionReportResult {
                     check,
                     reports: result.reports,
-                    failed_venues: result.failed_venues,
+                    queried_clients: result.queried_clients,
+                    failed_clients: result.failed_clients,
                 }
             }),
         })
@@ -2062,15 +2083,21 @@ async fn recv_external_msgbus_message(
 async fn request_open_order_reports(
     clients: Vec<LiveExecutionClient>,
     command: GenerateOrderStatusReports,
-) -> Vec<OrderStatusReport> {
+) -> OpenOrderReportQueryResult {
     let mut all_reports = Vec::new();
+    let mut queried_clients = IndexSet::new();
+    let mut failed_clients = IndexSet::new();
 
     for client in clients {
+        let client_id = client.client_id();
+        queried_clients.insert(client_id);
+
         match client.generate_order_status_reports(&command).await {
             Ok(reports) => {
                 all_reports.extend(reports);
             }
             Err(e) => {
+                failed_clients.insert(client_id);
                 log::warn!(
                     "Failed to generate order status reports from {}: {e}",
                     client.client_id()
@@ -2079,7 +2106,11 @@ async fn request_open_order_reports(
         }
     }
 
-    all_reports
+    OpenOrderReportQueryResult {
+        reports: all_reports,
+        queried_clients,
+        failed_clients,
+    }
 }
 
 async fn request_position_reports(
@@ -2087,16 +2118,19 @@ async fn request_position_reports(
     command: GeneratePositionStatusReports,
 ) -> PositionReportQueryResult {
     let mut all_reports = Vec::new();
-    let mut failed_venues = IndexSet::new();
+    let mut queried_clients = IndexSet::new();
+    let mut failed_clients = IndexSet::new();
 
     for client in clients {
-        let venue = client.venue();
+        let client_id = client.client_id();
+        queried_clients.insert(client_id);
+
         match client.generate_position_status_reports(&command).await {
             Ok(reports) => {
                 all_reports.extend(reports);
             }
             Err(e) => {
-                failed_venues.insert(venue);
+                failed_clients.insert(client_id);
                 log::warn!(
                     "Failed to generate position status reports from {}: {e}",
                     client.client_id()
@@ -2107,7 +2141,8 @@ async fn request_position_reports(
 
     PositionReportQueryResult {
         reports: all_reports,
-        failed_venues,
+        queried_clients,
+        failed_clients,
     }
 }
 
@@ -2146,6 +2181,14 @@ struct OpenOrderReportTask {
 struct OpenOrderReportResult {
     check: OpenOrderReportCheck,
     reports: Vec<OrderStatusReport>,
+    queried_clients: IndexSet<ClientId>,
+    failed_clients: IndexSet<ClientId>,
+}
+
+struct OpenOrderReportQueryResult {
+    reports: Vec<OrderStatusReport>,
+    queried_clients: IndexSet<ClientId>,
+    failed_clients: IndexSet<ClientId>,
 }
 
 type PositionReportFuture = Pin<Box<dyn Future<Output = PositionReportResult>>>;
@@ -2157,12 +2200,14 @@ struct PositionReportTask {
 struct PositionReportResult {
     check: PositionReportCheck,
     reports: Vec<PositionStatusReport>,
-    failed_venues: IndexSet<Venue>,
+    queried_clients: IndexSet<ClientId>,
+    failed_clients: IndexSet<ClientId>,
 }
 
 struct PositionReportQueryResult {
     reports: Vec<PositionStatusReport>,
-    failed_venues: IndexSet<Venue>,
+    queried_clients: IndexSet<ClientId>,
+    failed_clients: IndexSet<ClientId>,
 }
 
 /// Flushes data events and commands from both `pending` and the channel receivers

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -8032,7 +8032,10 @@ struct MockExecutionClient {
     client_id: ClientId,
     account_id: AccountId,
     venue: Venue,
+    handled_venues: Option<IndexSet<Venue>>,
     order_reports: RefCell<Vec<OrderStatusReport>>,
+    fail_order_reports: bool,
+    on_order_reports_query: RefCell<Option<Box<dyn FnOnce()>>>,
 }
 
 impl MockExecutionClient {
@@ -8041,8 +8044,50 @@ impl MockExecutionClient {
             client_id: test_client_id(),
             account_id: test_account_id(),
             venue: test_venue(),
+            handled_venues: None,
             order_reports: RefCell::new(order_reports),
+            fail_order_reports: false,
+            on_order_reports_query: RefCell::new(None),
         }
+    }
+
+    fn for_venue(client_id: ClientId, venue: Venue, order_reports: Vec<OrderStatusReport>) -> Self {
+        Self {
+            client_id,
+            account_id: test_account_id(),
+            venue,
+            handled_venues: None,
+            order_reports: RefCell::new(order_reports),
+            fail_order_reports: false,
+            on_order_reports_query: RefCell::new(None),
+        }
+    }
+
+    fn failing(client_id: ClientId, venue: Venue) -> Self {
+        Self {
+            client_id,
+            account_id: test_account_id(),
+            venue,
+            handled_venues: None,
+            order_reports: RefCell::new(Vec::new()),
+            fail_order_reports: true,
+            on_order_reports_query: RefCell::new(None),
+        }
+    }
+
+    fn with_account_id(mut self, account_id: AccountId) -> Self {
+        self.account_id = account_id;
+        self
+    }
+
+    fn with_handled_venues(mut self, handled_venues: IndexSet<Venue>) -> Self {
+        self.handled_venues = Some(handled_venues);
+        self
+    }
+
+    fn with_on_order_reports_query(self, callback: Box<dyn FnOnce()>) -> Self {
+        *self.on_order_reports_query.borrow_mut() = Some(callback);
+        self
     }
 }
 
@@ -8062,6 +8107,12 @@ impl ExecutionClient for MockExecutionClient {
 
     fn venue(&self) -> Venue {
         self.venue
+    }
+
+    fn handles_order_venue(&self, venue: Venue) -> bool {
+        self.handled_venues
+            .as_ref()
+            .map_or(self.venue == venue, |handled| handled.contains(&venue))
     }
 
     fn oms_type(&self) -> OmsType {
@@ -8126,6 +8177,14 @@ impl ExecutionClient for MockExecutionClient {
         &self,
         _cmd: &GenerateOrderStatusReports,
     ) -> anyhow::Result<Vec<OrderStatusReport>> {
+        if let Some(callback) = self.on_order_reports_query.borrow_mut().take() {
+            callback();
+        }
+
+        if self.fail_order_reports {
+            anyhow::bail!("order reports unavailable");
+        }
+
         Ok(self.order_reports.borrow().clone())
     }
 }
@@ -8688,6 +8747,495 @@ async fn test_check_open_orders_submitted_missing_at_venue_generates_rejected() 
     }
 }
 
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_partially_filled_missing_at_venue_generates_canceled() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 1,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    ctx.add_instrument(instrument.clone());
+
+    let client_order_id = ClientOrderId::from("O-PARTIAL-MISSING");
+    let venue_order_id = VenueOrderId::from("V-PARTIAL-MISSING");
+    insert_accepted_limit_order(&ctx, client_order_id, venue_order_id, test_client_id());
+    let order = ctx.get_order(&client_order_id).unwrap();
+    let fill = OrderFilledTestBuilder::new(&order, &instrument)
+        .last_qty(Quantity::from("4.0"))
+        .without_position_id()
+        .build();
+    ctx.cache.borrow_mut().update_order(&fill).unwrap();
+
+    let mock_client = MockExecutionClient::new(vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_open_orders(&clients).await;
+
+    assert_eq!(events.len(), 1);
+    assert!(
+        matches!(&events[0], OrderEventAny::Canceled(canceled) if canceled.client_order_id == client_order_id),
+        "expected OrderCanceled event, was {:?}",
+        events[0],
+    );
+
+    ctx.cache.borrow_mut().update_order(&events[0]).unwrap();
+    let order = ctx.get_order(&client_order_id).unwrap();
+    assert_eq!(order.status(), OrderStatus::Canceled);
+    assert_eq!(order.filled_qty(), Quantity::from("4.0"));
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_failed_client_does_not_advance_missing_retries() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 2,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    ctx.add_instrument(test_instrument());
+    ctx.add_instrument(test_instrument2());
+
+    let healthy_order_id = ClientOrderId::from("O-HEALTHY-MISSING");
+    let failed_order_id = ClientOrderId::from("O-FAILED-VENUE");
+    let healthy_client_id = test_client_id();
+    let failed_client_id = ClientId::from("BITMEX");
+    let failed_venue = Venue::from("BITMEX");
+
+    insert_accepted_limit_order(
+        &ctx,
+        healthy_order_id,
+        VenueOrderId::from("V-HEALTHY-MISSING"),
+        healthy_client_id,
+    );
+    insert_accepted_limit_order_for_instrument(
+        &ctx,
+        failed_order_id,
+        VenueOrderId::from("V-FAILED-VENUE"),
+        test_instrument_id2(),
+        failed_client_id,
+    );
+
+    let healthy_client = MockExecutionClient::for_venue(healthy_client_id, test_venue(), vec![]);
+    let failed_client = MockExecutionClient::failing(failed_client_id, failed_venue);
+    let clients: Vec<&dyn ExecutionClient> = vec![&healthy_client, &failed_client];
+
+    let first_events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(first_events.is_empty());
+
+    advance_clock(dst::time::Duration::from_millis(1)).await;
+
+    let recovered_client = MockExecutionClient::for_venue(failed_client_id, failed_venue, vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&healthy_client, &recovered_client];
+    let second_events = ctx.manager.check_open_orders(&clients).await;
+
+    assert_eq!(second_events.len(), 1);
+    assert!(
+        matches!(&second_events[0], OrderEventAny::Rejected(rejected) if rejected.client_order_id == healthy_order_id),
+        "only the healthy venue order should exhaust its retry budget",
+    );
+    assert_eq!(
+        ctx.get_order(&failed_order_id).unwrap().status(),
+        OrderStatus::Accepted,
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_failed_routing_client_does_not_resolve_exchange_order() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 1,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let client_order_id = ClientOrderId::from("O-FAILED-ROUTING");
+    let routing_client_id = ClientId::from("IB");
+    ctx.add_instrument(instrument);
+    insert_accepted_limit_order(
+        &ctx,
+        client_order_id,
+        VenueOrderId::from("V-FAILED-ROUTING"),
+        routing_client_id,
+    );
+
+    let routing_client = MockExecutionClient::failing(routing_client_id, Venue::from("IB"))
+        .with_account_id(AccountId::from("IB-001"))
+        .with_handled_venues(IndexSet::from([instrument_id.venue]));
+    let clients: Vec<&dyn ExecutionClient> = vec![&routing_client];
+
+    let events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(
+        ctx.get_order(&client_order_id).unwrap().status(),
+        OrderStatus::Accepted,
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_failed_client_does_not_suppress_healthy_client_same_venue() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 1,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    ctx.add_instrument(test_instrument());
+
+    let failed_order_id = ClientOrderId::from("O-FAILED-SHARED-VENUE");
+    let healthy_order_id = ClientOrderId::from("O-HEALTHY-SHARED-VENUE");
+    let failed_client_id = ClientId::from("SHARED-FAILED");
+    let healthy_client_id = ClientId::from("SHARED-HEALTHY");
+    insert_accepted_limit_order(
+        &ctx,
+        failed_order_id,
+        VenueOrderId::from("V-FAILED-SHARED-VENUE"),
+        failed_client_id,
+    );
+    insert_accepted_limit_order(
+        &ctx,
+        healthy_order_id,
+        VenueOrderId::from("V-HEALTHY-SHARED-VENUE"),
+        healthy_client_id,
+    );
+
+    let failed_client = MockExecutionClient::failing(failed_client_id, test_venue());
+    let healthy_client = MockExecutionClient::for_venue(healthy_client_id, test_venue(), vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&failed_client, &healthy_client];
+
+    let events = ctx.manager.check_open_orders(&clients).await;
+
+    assert_eq!(events.len(), 1);
+    assert!(
+        matches!(&events[0], OrderEventAny::Rejected(rejected) if rejected.client_order_id == healthy_order_id),
+        "only the healthy-client order should be rejected",
+    );
+    assert_eq!(
+        ctx.get_order(&failed_order_id).unwrap().status(),
+        OrderStatus::Accepted,
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_failed_routing_client_fallback_coverage_does_not_advance() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 1,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let client_order_id = ClientOrderId::from("O-FAILED-ROUTING-FALLBACK");
+    ctx.add_instrument(instrument);
+
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .client_order_id(client_order_id)
+        .instrument_id(instrument_id)
+        .quantity(Quantity::from("10.0"))
+        .price(Price::from("100.0"))
+        .build();
+    let submitted = TestOrderEventStubs::submitted(&order, test_account_id());
+    ctx.add_order(order);
+    let order = ctx.cache.borrow_mut().update_order(&submitted).unwrap();
+    let accepted = TestOrderEventStubs::accepted(
+        &order,
+        test_account_id(),
+        VenueOrderId::from("V-FAILED-ROUTING-FALLBACK"),
+    );
+    ctx.cache.borrow_mut().update_order(&accepted).unwrap();
+
+    let routing_client = MockExecutionClient::failing(ClientId::from("IB"), Venue::from("IB"))
+        .with_account_id(AccountId::from("IB-001"))
+        .with_handled_venues(IndexSet::from([instrument_id.venue]));
+    let clients: Vec<&dyn ExecutionClient> = vec![&routing_client];
+
+    let events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(
+        ctx.get_order(&client_order_id).unwrap().status(),
+        OrderStatus::Accepted,
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_positive_report_resets_missing_retry_ladder() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 2,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    ctx.add_instrument(test_instrument());
+
+    let client_order_id = ClientOrderId::from("O-RETRY-RESET");
+    let venue_order_id = VenueOrderId::from("V-RETRY-RESET");
+    insert_accepted_limit_order(&ctx, client_order_id, venue_order_id, test_client_id());
+
+    let empty_client = MockExecutionClient::new(vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&empty_client];
+    let first_events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(first_events.is_empty());
+    assert_eq!(ctx.manager.recon_check_retry_count(&client_order_id), 1);
+
+    advance_clock(dst::time::Duration::from_millis(1)).await;
+
+    let report = create_order_status_report(
+        Some(client_order_id),
+        venue_order_id,
+        test_instrument_id(),
+        OrderStatus::Accepted,
+        Quantity::from("10.0"),
+        Quantity::from("0.0"),
+    );
+    let reporting_client = MockExecutionClient::new(vec![report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&reporting_client];
+    let second_events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(
+        !second_events
+            .iter()
+            .any(|e| matches!(e, OrderEventAny::Rejected(_) | OrderEventAny::Canceled(_))),
+        "a positive matching report must not resolve the order",
+    );
+    assert_eq!(ctx.manager.recon_check_retry_count(&client_order_id), 0);
+
+    advance_clock(dst::time::Duration::from_millis(1)).await;
+
+    let empty_again = MockExecutionClient::new(vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&empty_again];
+    let third_events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(
+        third_events.is_empty(),
+        "non-consecutive misses must not exhaust the retry budget",
+    );
+    assert_eq!(ctx.manager.recon_check_retry_count(&client_order_id), 1);
+    assert_eq!(
+        ctx.get_order(&client_order_id).unwrap().status(),
+        OrderStatus::Accepted,
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_venue_id_only_report_resets_missing_retry_ladder() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 2,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    ctx.add_instrument(test_instrument());
+
+    let client_order_id = ClientOrderId::from("O-VENUE-ID-ONLY");
+    let venue_order_id = VenueOrderId::from("V-VENUE-ID-ONLY");
+    insert_accepted_limit_order(&ctx, client_order_id, venue_order_id, test_client_id());
+
+    let empty_client = MockExecutionClient::new(vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&empty_client];
+    let first_events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(first_events.is_empty());
+    assert_eq!(ctx.manager.recon_check_retry_count(&client_order_id), 1);
+
+    advance_clock(dst::time::Duration::from_millis(1)).await;
+
+    // The report carries no client order ID; the manager must map it through
+    // the cached venue-order-ID index and give it full positive-report
+    // bookkeeping, not walk it as missing in the same pass.
+    let report = create_order_status_report(
+        None,
+        venue_order_id,
+        test_instrument_id(),
+        OrderStatus::Accepted,
+        Quantity::from("10.0"),
+        Quantity::from("0.0"),
+    );
+    let reporting_client = MockExecutionClient::new(vec![report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&reporting_client];
+    let second_events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(
+        !second_events
+            .iter()
+            .any(|e| matches!(e, OrderEventAny::Rejected(_) | OrderEventAny::Canceled(_))),
+        "a venue-ID-only positive report must not resolve the order",
+    );
+    assert_eq!(ctx.manager.recon_check_retry_count(&client_order_id), 0);
+
+    advance_clock(dst::time::Duration::from_millis(1)).await;
+
+    let empty_again = MockExecutionClient::new(vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&empty_again];
+    let third_events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(
+        third_events.is_empty(),
+        "a single miss after a venue-ID-only positive report must not reject",
+    );
+    assert_eq!(ctx.manager.recon_check_retry_count(&client_order_id), 1);
+    assert_eq!(
+        ctx.get_order(&client_order_id).unwrap().status(),
+        OrderStatus::Accepted,
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_order_closed_during_query_leaves_no_retry_state() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 2,
+        open_check_open_only: false,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    ctx.add_instrument(test_instrument());
+
+    let client_order_id = ClientOrderId::from("O-CLOSED-DURING-QUERY");
+    let venue_order_id = VenueOrderId::from("V-CLOSED-DURING-QUERY");
+    insert_accepted_limit_order(&ctx, client_order_id, venue_order_id, test_client_id());
+
+    // The callback fires inside the report query, after the prepare-time
+    // snapshot captured the order as an open missing-candidate.
+    let cache = ctx.cache.clone();
+    let client =
+        MockExecutionClient::new(vec![]).with_on_order_reports_query(Box::new(move || {
+            let order = cache.borrow().order(&client_order_id).unwrap().clone();
+            let canceled =
+                TestOrderEventStubs::canceled(&order, test_account_id(), Some(venue_order_id));
+            cache.borrow_mut().update_order(&canceled).unwrap();
+        }));
+    let clients: Vec<&dyn ExecutionClient> = vec![&client];
+
+    let events = ctx.manager.check_open_orders(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(
+        ctx.manager.recon_check_retry_count(&client_order_id),
+        0,
+        "an order that closed during the query must leave no retry state behind",
+    );
+    assert_eq!(
+        ctx.get_order(&client_order_id).unwrap().status(),
+        OrderStatus::Canceled,
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_check_open_orders_deferred_pending_order_keeps_inflight_registration() {
+    let config = ExecutionManagerConfig {
+        open_check_threshold_ns: 0,
+        open_check_missing_retries: 1,
+        open_check_open_only: false,
+        inflight_threshold_ms: 100,
+        inflight_max_retries: 2,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    ctx.add_instrument(test_instrument());
+
+    let client_order_id = ClientOrderId::from("O-PENDING-DEFER");
+    let venue_order_id = VenueOrderId::from("V-PENDING-DEFER");
+    insert_accepted_limit_order(&ctx, client_order_id, venue_order_id, test_client_id());
+    let order = ctx.get_order(&client_order_id).unwrap();
+    let pending = OrderEventAny::PendingCancel(
+        OrderPendingCancelSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(order.instrument_id())
+            .client_order_id(client_order_id)
+            .account_id(test_account_id())
+            .venue_order_id(venue_order_id)
+            .build(),
+    );
+    ctx.cache.borrow_mut().update_order(&pending).unwrap();
+    assert_eq!(
+        ctx.get_order(&client_order_id).unwrap().status(),
+        OrderStatus::PendingCancel,
+    );
+    ctx.manager.register_inflight(client_order_id);
+
+    // Prime one inflight retry so the retained check carries a nonzero count
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
+    let primed = ctx.manager.check_inflight_orders();
+    assert!(primed.events.is_empty());
+    assert_eq!(primed.queries.len(), 1);
+
+    // Missing at venue at max retries: the inflight status defers resolution
+    let mock_client = MockExecutionClient::new(vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+    let events = ctx.manager.check_open_orders(&clients).await;
+    assert!(events.is_empty());
+
+    // The deferral must not unregister the order from inflight recovery, and
+    // must reset the inflight retry ladder: past the threshold the checker
+    // queries again from scratch instead of escalating to a stale-count
+    // cancellation
+    ctx.advance_both(dst::time::Duration::from_millis(200))
+        .await;
+    let result = ctx.manager.check_inflight_orders();
+    assert!(
+        result.events.is_empty(),
+        "deferral must reset the inflight retry ladder, was {:?}",
+        result.events,
+    );
+    assert_eq!(
+        result.queries.len(),
+        1,
+        "deferred pending order should remain registered for inflight recovery",
+    );
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_check_open_orders_open_only_missing_venue_order_does_not_reject() {
@@ -9034,6 +9582,7 @@ struct MockPositionExecutionClient {
     client_id: ClientId,
     account_id: AccountId,
     venue: Venue,
+    handled_venues: Option<IndexSet<Venue>>,
     order_reports: RefCell<Vec<OrderStatusReport>>,
     position_reports: RefCell<Vec<PositionStatusReport>>,
     fail_position_reports: bool,
@@ -9049,6 +9598,7 @@ impl MockPositionExecutionClient {
             client_id: test_client_id(),
             account_id: test_account_id(),
             venue: test_venue(),
+            handled_venues: None,
             order_reports: RefCell::new(order_reports),
             position_reports: RefCell::new(position_reports),
             fail_position_reports: false,
@@ -9066,9 +9616,29 @@ impl MockPositionExecutionClient {
             client_id: test_client_id(),
             account_id: test_account_id(),
             venue: test_venue(),
+            handled_venues: None,
             order_reports: RefCell::new(Vec::new()),
             position_reports: RefCell::new(Vec::new()),
             fail_position_reports: true,
+            position_reconciliation_tolerance: dec!(0.00000001),
+        }
+    }
+
+    fn configured(
+        client_id: ClientId,
+        account_id: AccountId,
+        venue: Venue,
+        handled_venues: IndexSet<Venue>,
+        fail_position_reports: bool,
+    ) -> Self {
+        Self {
+            client_id,
+            account_id,
+            venue,
+            handled_venues: Some(handled_venues),
+            order_reports: RefCell::new(Vec::new()),
+            position_reports: RefCell::new(Vec::new()),
+            fail_position_reports,
             position_reconciliation_tolerance: dec!(0.00000001),
         }
     }
@@ -9090,6 +9660,12 @@ impl ExecutionClient for MockPositionExecutionClient {
 
     fn venue(&self) -> Venue {
         self.venue
+    }
+
+    fn handles_order_venue(&self, venue: Venue) -> bool {
+        self.handled_venues
+            .as_ref()
+            .map_or(self.venue == venue, |handled| handled.contains(&venue))
     }
 
     fn oms_type(&self) -> OmsType {
@@ -9285,7 +9861,7 @@ async fn test_position_check_reconciles_at_client_tolerance_boundary() {
 }
 
 #[tokio::test]
-async fn test_position_check_failed_venue_query_skips_cached_position() {
+async fn test_position_check_failed_client_query_skips_cached_position() {
     let config = ExecutionManagerConfig {
         position_check_retries: 3,
         position_check_threshold_ns: 0,
@@ -9329,6 +9905,119 @@ async fn test_position_check_failed_venue_query_skips_cached_position() {
         ctx.manager
             .position_recon_retry_count(&(instrument_id, test_account_id())),
         1
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_position_check_failed_routing_client_leaves_exchange_retry_untouched() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = AccountId::from("IB-001");
+    let position = create_test_position_for_account(
+        &instrument,
+        PositionId::from("P-FAILED-ROUTING"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        account_id,
+    );
+    ctx.add_margin_account(account_id);
+    ctx.add_position(&position);
+
+    let routing_client = MockPositionExecutionClient::configured(
+        ClientId::from("IB"),
+        account_id,
+        Venue::from("IB"),
+        IndexSet::from([instrument_id.venue]),
+        true,
+    );
+    let clients: Vec<&dyn ExecutionClient> = vec![&routing_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, account_id)),
+        0,
+    );
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_position_check_failed_client_does_not_suppress_healthy_account_same_venue() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let failed_account_id = AccountId::from("BINANCE-FAILED");
+    let healthy_account_id = AccountId::from("BINANCE-HEALTHY");
+    let failed_position = create_test_position_for_account(
+        &instrument,
+        PositionId::from("P-FAILED-SHARED-VENUE"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        failed_account_id,
+    );
+    let healthy_position = create_test_position_for_account(
+        &instrument,
+        PositionId::from("P-HEALTHY-SHARED-VENUE"),
+        OrderSide::Buy,
+        "7.0",
+        "3000.00",
+        healthy_account_id,
+    );
+    ctx.add_margin_account(failed_account_id);
+    ctx.add_margin_account(healthy_account_id);
+    ctx.add_position(&failed_position);
+    ctx.add_position(&healthy_position);
+
+    let failed_client = MockPositionExecutionClient::configured(
+        ClientId::from("SHARED-FAILED"),
+        failed_account_id,
+        test_venue(),
+        IndexSet::from([instrument_id.venue]),
+        true,
+    );
+    let healthy_client = MockPositionExecutionClient::configured(
+        ClientId::from("SHARED-HEALTHY"),
+        healthy_account_id,
+        test_venue(),
+        IndexSet::from([instrument_id.venue]),
+        false,
+    );
+    let clients: Vec<&dyn ExecutionClient> = vec![&failed_client, &healthy_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, failed_account_id)),
+        0,
+    );
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, healthy_account_id)),
+        1,
     );
 }
 


### PR DESCRIPTION
Fixes to the continuous open-order check in `ExecutionManager`, aligning it with the Python reference engine's `_resolve_order_not_found_at_venue` and hardening the failed-report guard to client identity per review. Continues the reconciliation-correctness work from #4366/#4376/#4387.

**1. Missing-order resolution emitted an event the order FSM cannot apply**

`handle_missing_order` resolved every order missing at the venue (after `open_check_missing_retries` cycles) with `OrderRejected`, regardless of status. The order FSM has no `(PartiallyFilled, Rejected)` transition, so for a partially filled resting order whose remainder disappeared from the venue's open-order response the event could never apply: the engine logged an invalid-transition error, the order stayed open in the cache, and `clear_recon_tracking` reset the retry counter - so the node emitted a doomed `Rejected` and an engine error every retry ladder, forever.

Resolution is now status-aware, matching the Python engine: `Accepted`/`Submitted` resolve to `Rejected` as before, `PartiallyFilled` resolves to `Canceled` (preserving filled quantity - a valid FSM transition), `PendingUpdate`/`PendingCancel` defer, closed orders are skipped (expected for `FILLED`), and unexpected statuses are logged and skipped.

The defer branch needs care beyond a direct port: Python's inflight checker rescans cached inflight orders every cycle, while Rust's `check_inflight_orders` walks the `inflight_checks` registration map exclusively - so the broad `clear_recon_tracking` would have permanently removed a deferred order from stuck-order recovery. The retained `InflightCheck` also carries its own `retry_count`/`last_query_at` ladder, and leaving it stale would escalate a primed order straight to a spurious stale-count cancellation on the next inflight pass. The defer branch therefore performs a narrow reset: retry ladders zeroed (both the shared map and the retained `InflightCheck`), query time stamped (so the checker first observes a full threshold delay, then retries from scratch - Python's `_clear_recon_tracking(..., drop_last_query=False)` plus `ts_last_query` stamp), registration and local-activity mark preserved.

**2. Failed bulk report queries converted into "venue has no orders"**

The open-order bulk path logged per-client `generate_order_status_reports` errors and collapsed them into the merged (possibly empty) report vector. With `open_check_open_only: false`, a transient report-endpoint outage lasting `open_check_missing_retries` check cycles marked every recently active cached order missing and walked each one up the retry ladder toward a spurious local rejection - while the venue kept working the orders (the trading channel being healthy is exactly the scenario where only the report endpoint 500s).

Per review, the guard is keyed to client identity rather than raw venue, since `failed_venues` recording `client.venue()` neither covers routing clients (IB's `handles_order_venue` returns true for exchange venues while `venue()` is the broker venue, so a failed IB query would still walk its orders toward local rejection) nor isolates two clients sharing one venue (one failure would suppress reconciliation for the healthy client). The pre-existing venue-keyed guard on the position path is consolidated onto the same mechanism.

At check-preparation time each snapshotted open order / position key is resolved to its responsible client set: orders through the cache's `client_order_id -> ClientId` index first, then an exact `account_id` match, then the set of clients whose `handles_order_venue` claims the instrument venue; position keys by exact `account_id` match, then `handles_order_venue`. The query loops carry queried and failed `ClientId` sets through reconciliation (the node's async report tasks transport only these plain sets - no venue policy remains in `node/mod.rs`). Missing-at-venue resolution runs only when the responsible set is nonempty and every member was queried successfully; otherwise the entry is skipped without advancing retry state. Unresolvable coverage (no claiming client, or a cached client ID no longer registered - the order-client index is persisted, so a client rename in config leaves open orders pointing at the old ID) logs a warning once per order rather than resolving destructively on state that was never obtained.

Consumers unaffected: with all clients healthy every responsible set is queried-and-succeeded and the flow is unchanged; a report that did arrive is always reconciled normally regardless of other clients' failures.

**3. Missing-order retry ladder counted non-consecutive and stale misses**

Two adjacent defects in the same ladder surfaced while testing the rework. First, a positive report did not reset `recon_check_retries` (the Python engine clears per report), so misses separated by successful confirmations still accumulated toward a spurious rejection; the report scan now clears the counter for every reported order, including reports carrying only a `venue_order_id`, which are mapped through the cache index and given full positive-report bookkeeping (Python shares the venue-ID-only gap). Second, `handle_missing_order` incremented the retry counter before checking for a terminal status, so an order that closed while the bulk report request was in flight re-created tracking state that nothing afterwards prunes; the closed check now precedes the increment.

Deliberately out of scope: wiring the dormant single-order verification query machinery (`check_open_order_queries`) into the loop. Python performs that targeted query as a last-chance verification before resolving; the Rust port's divergence there (and its currently dead config knobs `max_single_order_queries_per_cycle` / `single_order_query_delay_ms`) remains a tracked follow-up.

**Testing**

- `test_check_open_orders_partially_filled_missing_at_venue_generates_canceled` - a partially filled order missing at max retries produces `Canceled`, which applies cleanly to the cache with `filled_qty` preserved.
- `test_check_open_orders_failed_routing_client_does_not_resolve_exchange_order` - a failing routing client (broker `venue()`, exchange-venue order claimed via `handles_order_venue`, cached client-ID mapping) does not resolve its order.
- `test_check_open_orders_failed_client_does_not_suppress_healthy_client_same_venue` - two clients on one venue, one failing: only the healthy client's order resolves; the failed client's order keeps its retry budget.
- `test_check_open_orders_failed_routing_client_fallback_coverage_does_not_advance` - an order with no cached client-ID mapping, claimed only through `handles_order_venue`, is protected by the fallback coverage rung.
- `test_position_check_failed_routing_client_leaves_exchange_retry_untouched` / `test_position_check_failed_client_does_not_suppress_healthy_account_same_venue` - position-path twins of the two scenarios above, keyed by account.
- `test_check_open_orders_failed_client_does_not_advance_missing_retries` / `test_position_check_failed_client_query_skips_cached_position` - the original guard tests, rekeyed to client identity, retaining their multi-cycle retry assertions.
- `test_check_open_orders_positive_report_resets_missing_retry_ladder` / `test_check_open_orders_venue_id_only_report_resets_missing_retry_ladder` - miss, positive report (with and without `client_order_id`), miss: the counter returns to zero in between and a single subsequent miss does not resolve.
- `test_check_open_orders_order_closed_during_query_leaves_no_retry_state` - a mock's report callback cancels the order in the cache after the prepare-time snapshot, pinning the prepare/reconcile race: no event, no retry state.
- `test_check_open_orders_deferred_pending_order_keeps_inflight_registration` - primes one inflight retry (`inflight_max_retries: 2`) before the open-check deferral, then asserts the inflight checker issues a fresh query rather than escalating to a stale-count cancellation, proving both the surviving registration and the ladder reset.
- All paused virtual time, no wall-clock waits. Each new assertion was verified to fail against its unfixed variant: the venue-keyed guard neutralized (all five coverage tests fail) and over-suppressing (both healthy-side assertions fail), the retry-ladder clears removed, the closed-status check removed, and the deferral test against both partial variants (the broad clear loses the registration entirely; preserving registration without the ladder reset produces exactly the stale-count `Canceled`).
