### PR TITLE
Fix nondeterministic event ordering in backtests

### DIFF
--- a/crates/backtest/src/accumulator.rs
+++ b/crates/backtest/src/accumulator.rs
@@ -15,7 +15,10 @@
 
 //! Time event accumulation and scheduling for the backtest engine.
 
-use std::{cmp::Reverse, collections::BinaryHeap};
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::BinaryHeap,
+};
 
 use nautilus_common::{clock::TestClock, timer::TimeEventHandler};
 use nautilus_core::UnixNanos;
@@ -26,7 +29,47 @@ use nautilus_core::UnixNanos;
 /// retrieval of the next event to process.
 #[derive(Debug)]
 pub struct TimeEventAccumulator {
-    heap: BinaryHeap<Reverse<TimeEventHandler>>,
+    heap: BinaryHeap<Reverse<AccumulatedTimeEventHandler>>,
+    next_sequence: u64,
+}
+
+#[derive(Debug)]
+struct AccumulatedTimeEventHandler {
+    handler: TimeEventHandler,
+    // Replaces the handler's random event ID as the final heap tie-break.
+    sequence: u64,
+}
+
+impl AccumulatedTimeEventHandler {
+    fn cmp_key(&self, other: &Self) -> Ordering {
+        self.handler
+            .event
+            .ts_event
+            .cmp(&other.handler.event.ts_event)
+            .then_with(|| self.handler.event.name.cmp(&other.handler.event.name))
+            .then_with(|| self.handler.event.ts_init.cmp(&other.handler.event.ts_init))
+            .then_with(|| self.sequence.cmp(&other.sequence))
+    }
+}
+
+impl PartialOrd for AccumulatedTimeEventHandler {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for AccumulatedTimeEventHandler {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp_key(other).is_eq()
+    }
+}
+
+impl Eq for AccumulatedTimeEventHandler {}
+
+impl Ord for AccumulatedTimeEventHandler {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.cmp_key(other)
+    }
 }
 
 impl TimeEventAccumulator {
@@ -35,7 +78,18 @@ impl TimeEventAccumulator {
     pub fn new() -> Self {
         Self {
             heap: BinaryHeap::new(),
+            next_sequence: 0,
         }
+    }
+
+    fn push(&mut self, handler: TimeEventHandler) {
+        let sequence = self.next_sequence;
+        self.next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .expect("Time event accumulator sequence overflow");
+        self.heap
+            .push(Reverse(AccumulatedTimeEventHandler { handler, sequence }));
     }
 
     /// Advance the given clock to the `to_time_ns` and push events to the heap.
@@ -43,7 +97,7 @@ impl TimeEventAccumulator {
         let events = clock.advance_time(to_time_ns, set_time);
         let handlers = clock.match_handlers(events);
         for handler in handlers {
-            self.heap.push(Reverse(handler));
+            self.push(handler);
         }
     }
 
@@ -52,15 +106,19 @@ impl TimeEventAccumulator {
     /// Returns `None` if the heap is empty.
     #[must_use]
     pub fn peek_next_time(&self) -> Option<UnixNanos> {
-        self.heap.peek().map(|h| h.0.event.ts_event)
+        self.heap.peek().map(|h| h.0.handler.event.ts_event)
     }
 
     /// Pop the next event if its timestamp is at or before `ts`.
     ///
     /// Returns `None` if the heap is empty or the next event is after `ts`.
     pub fn pop_next_at_or_before(&mut self, ts: UnixNanos) -> Option<TimeEventHandler> {
-        if self.heap.peek().is_some_and(|h| h.0.event.ts_event <= ts) {
-            self.heap.pop().map(|h| h.0)
+        if self
+            .heap
+            .peek()
+            .is_some_and(|h| h.0.handler.event.ts_event <= ts)
+        {
+            self.heap.pop().map(|h| h.0.handler)
         } else {
             None
         }
@@ -81,6 +139,7 @@ impl TimeEventAccumulator {
     /// Clear all events from the heap.
     pub fn clear(&mut self) {
         self.heap.clear();
+        self.next_sequence = 0;
     }
 
     /// Drain all events from the heap in timestamp order.
@@ -90,7 +149,7 @@ impl TimeEventAccumulator {
     pub fn drain(&mut self) -> Vec<TimeEventHandler> {
         let mut handlers = Vec::with_capacity(self.heap.len());
         while let Some(scheduled) = self.heap.pop() {
-            handlers.push(scheduled.0);
+            handlers.push(scheduled.0.handler);
         }
         handlers
     }
@@ -100,6 +159,42 @@ impl Default for TimeEventAccumulator {
     /// Creates a new default [`TimeEventAccumulator`] instance.
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod determinism_tests {
+    use nautilus_common::timer::{TimeEvent, TimeEventCallback};
+    use nautilus_core::UUID4;
+    use rstest::rstest;
+    use ustr::Ustr;
+
+    use super::*;
+
+    #[rstest]
+    fn test_accumulator_preserves_fifo_order_for_identical_timer_keys() {
+        let callback = TimeEventCallback::from(|_: TimeEvent| {});
+        let first_event = TimeEvent::new(
+            Ustr::from("REBALANCE"),
+            UUID4::from("ffffffff-ffff-4fff-bfff-ffffffffffff"),
+            100.into(),
+            100.into(),
+        );
+        let second_event = TimeEvent::new(
+            Ustr::from("REBALANCE"),
+            UUID4::from("00000000-0000-4000-8000-000000000000"),
+            100.into(),
+            100.into(),
+        );
+
+        let mut accumulator = TimeEventAccumulator::new();
+        accumulator.push(TimeEventHandler::new(first_event.clone(), callback.clone()));
+        accumulator.push(TimeEventHandler::new(second_event, callback));
+
+        let popped = accumulator
+            .pop_next_at_or_before(100.into())
+            .expect("Expected first accumulated timer");
+        assert_eq!(popped.event.event_id, first_event.event_id);
     }
 }
 
@@ -147,9 +242,9 @@ mod tests {
             let handler2 = TimeEventHandler::new(time_event2.clone(), callback.clone());
             let handler3 = TimeEventHandler::new(time_event3.clone(), callback);
 
-            accumulator.heap.push(Reverse(handler1));
-            accumulator.heap.push(Reverse(handler2));
-            accumulator.heap.push(Reverse(handler3));
+            accumulator.push(handler1);
+            accumulator.push(handler2);
+            accumulator.push(handler3);
             assert_eq!(accumulator.len(), 3);
 
             let popped1 = accumulator.pop_next_at_or_before(1000.into()).unwrap();
@@ -188,14 +283,11 @@ mod tests {
                 100.into(),
             );
 
-            accumulator.heap.push(Reverse(TimeEventHandler::new(
+            accumulator.push(TimeEventHandler::new(
                 time_bar_event.clone(),
                 callback.clone(),
-            )));
-            accumulator.heap.push(Reverse(TimeEventHandler::new(
-                spread_event.clone(),
-                callback,
-            )));
+            ));
+            accumulator.push(TimeEventHandler::new(spread_event.clone(), callback));
 
             let popped1 = accumulator.pop_next_at_or_before(100.into()).unwrap();
             assert_eq!(popped1.event.ts_event, spread_event.ts_event);
@@ -231,14 +323,8 @@ mod tests {
 
             let callback = TimeEventCallback::from(py_append.into_any());
 
-            accumulator.heap.push(Reverse(TimeEventHandler::new(
-                time_event1.clone(),
-                callback.clone(),
-            )));
-            accumulator.heap.push(Reverse(TimeEventHandler::new(
-                time_event2.clone(),
-                callback,
-            )));
+            accumulator.push(TimeEventHandler::new(time_event1.clone(), callback.clone()));
+            accumulator.push(TimeEventHandler::new(time_event2.clone(), callback));
 
             let popped1 = accumulator.pop_next_at_or_before(200.into()).unwrap();
             assert_eq!(popped1.event.ts_event, time_event1.ts_event);
@@ -275,15 +361,10 @@ mod tests {
                 100.into(),
             );
 
-            accumulator.heap.push(Reverse(TimeEventHandler::new(
-                time_event1,
-                callback.clone(),
-            )));
+            accumulator.push(TimeEventHandler::new(time_event1, callback.clone()));
             assert_eq!(accumulator.peek_next_time(), Some(200.into()));
 
-            accumulator
-                .heap
-                .push(Reverse(TimeEventHandler::new(time_event2, callback)));
+            accumulator.push(TimeEventHandler::new(time_event2, callback));
             assert_eq!(accumulator.peek_next_time(), Some(100.into()));
         });
     }
@@ -300,9 +381,7 @@ mod tests {
 
             for ts in [300u64, 100, 200] {
                 let event = TimeEvent::new(Ustr::from("TEST"), UUID4::new(), ts.into(), ts.into());
-                accumulator
-                    .heap
-                    .push(Reverse(TimeEventHandler::new(event, callback.clone())));
+                accumulator.push(TimeEventHandler::new(event, callback.clone()));
             }
 
             let handlers = accumulator.drain();
@@ -328,9 +407,7 @@ mod tests {
 
             for ts in [100u64, 300] {
                 let event = TimeEvent::new(Ustr::from("TEST"), UUID4::new(), ts.into(), ts.into());
-                accumulator
-                    .heap
-                    .push(Reverse(TimeEventHandler::new(event, callback.clone())));
+                accumulator.push(TimeEventHandler::new(event, callback.clone()));
             }
 
             let handler = accumulator.pop_next_at_or_before(1000.into()).unwrap();
@@ -338,9 +415,7 @@ mod tests {
 
             // Simulate callback scheduling new event at 150 (between popped 100 and pending 300)
             let event = TimeEvent::new(Ustr::from("NEW"), UUID4::new(), 150.into(), 150.into());
-            accumulator
-                .heap
-                .push(Reverse(TimeEventHandler::new(event, callback)));
+            accumulator.push(TimeEventHandler::new(event, callback));
 
             while let Some(handler) = accumulator.pop_next_at_or_before(1000.into()) {
                 popped_timestamps.push(handler.event.ts_event.as_u64());
@@ -367,9 +442,7 @@ mod tests {
                     100.into(),
                     100.into(),
                 );
-                accumulator
-                    .heap
-                    .push(Reverse(TimeEventHandler::new(event, callback.clone())));
+                accumulator.push(TimeEventHandler::new(event, callback.clone()));
             }
 
             let mut count = 0;
@@ -393,19 +466,17 @@ mod tests {
             let mut accumulator = TimeEventAccumulator::new();
 
             let event = TimeEvent::new(Ustr::from("TEST"), UUID4::new(), 100.into(), 100.into());
-            accumulator
-                .heap
-                .push(Reverse(TimeEventHandler::new(event, callback)));
+            accumulator.push(TimeEventHandler::new(event, callback));
 
             let handler = accumulator.pop_next_at_or_before(100.into());
             assert!(handler.is_some());
             assert_eq!(handler.unwrap().event.ts_event.as_u64(), 100);
 
             let event2 = TimeEvent::new(Ustr::from("TEST2"), UUID4::new(), 200.into(), 200.into());
-            accumulator.heap.push(Reverse(TimeEventHandler::new(
+            accumulator.push(TimeEventHandler::new(
                 event2,
                 TimeEventCallback::from(Py::from(py_list.getattr("append").unwrap()).into_any()),
-            )));
+            ));
 
             assert!(accumulator.pop_next_at_or_before(199.into()).is_none());
             assert!(accumulator.pop_next_at_or_before(200.into()).is_some());

--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -24,6 +24,7 @@ use std::{
 };
 
 use ahash::{AHashMap, AHashSet};
+use indexmap::IndexMap;
 use nautilus_analysis::analyzer::PortfolioAnalyzer;
 use nautilus_common::{
     actor::{DataActor, DataActorNative},
@@ -94,7 +95,7 @@ pub struct BacktestEngine {
     accumulator: TimeEventAccumulator,
     run_config_id: Option<String>,
     run_id: Option<UUID4>,
-    venues: AHashMap<Venue, Rc<RefCell<SimulatedExchange>>>,
+    venues: IndexMap<Venue, Rc<RefCell<SimulatedExchange>>>,
     exec_clients: Vec<BacktestExecutionClient>,
     has_data: AHashSet<InstrumentId>,
     has_book_data: AHashSet<InstrumentId>,
@@ -159,7 +160,7 @@ impl BacktestEngine {
             accumulator: TimeEventAccumulator::new(),
             run_config_id: None,
             run_id: None,
-            venues: AHashMap::new(),
+            venues: IndexMap::new(),
             exec_clients: Vec::new(),
             has_data: AHashSet::new(),
             has_book_data: AHashSet::new(),

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -135,7 +135,7 @@ pub struct SimulatedExchange {
     fill_model: FillModelHandle,
     latency_model: Option<Box<dyn LatencyModel>>,
     instruments: AHashMap<InstrumentId, InstrumentAny>,
-    matching_engines: AHashMap<InstrumentId, OrderMatchingEngine>,
+    matching_engines: IndexMap<InstrumentId, OrderMatchingEngine>,
     settlement_prices: AHashMap<InstrumentId, Price>,
     pending_funding_rates: AHashMap<InstrumentId, FundingRateUpdate>,
     funding_settled_through: AHashMap<InstrumentId, UnixNanos>,
@@ -220,7 +220,7 @@ impl SimulatedExchange {
             fill_model: config.fill_model,
             latency_model: config.latency_model,
             instruments: AHashMap::new(),
-            matching_engines: AHashMap::new(),
+            matching_engines: IndexMap::new(),
             settlement_prices: config.settlement_prices,
             pending_funding_rates: AHashMap::new(),
             funding_settled_through: AHashMap::new(),
@@ -466,7 +466,7 @@ impl SimulatedExchange {
 
     /// Returns a reference to all matching engines keyed by instrument ID.
     #[must_use]
-    pub const fn get_matching_engines(&self) -> &AHashMap<InstrumentId, OrderMatchingEngine> {
+    pub const fn get_matching_engines(&self) -> &IndexMap<InstrumentId, OrderMatchingEngine> {
         &self.matching_engines
     }
 
@@ -1216,6 +1216,9 @@ impl SimulatedExchange {
             valued_positions.push((position, pnl_change));
         }
 
+        let mut account_adjustments = account_adjustments.into_values().collect::<Vec<_>>();
+        account_adjustments.sort_unstable_by_key(|adjustment| adjustment.currency.code);
+
         if !self.frozen_account {
             let cache = self.cache.borrow();
             let Some(account) = cache.account_for_venue(&account_venue) else {
@@ -1223,7 +1226,7 @@ impl SimulatedExchange {
                 return false;
             };
 
-            for adjustment in account_adjustments.values() {
+            for adjustment in &account_adjustments {
                 let Some(balance) = account.balance(Some(adjustment.currency)) else {
                     log::error!(
                         "Cannot settle funding: no account balance for currency {}",
@@ -1304,7 +1307,7 @@ impl SimulatedExchange {
             }
         }
 
-        for adjustment in account_adjustments.values() {
+        for adjustment in &account_adjustments {
             if !self.adjust_account(*adjustment) {
                 let mut cache = self.cache.borrow_mut();
                 for (original, _, _) in adjusted_positions.iter().rev() {

--- a/crates/backtest/src/modules/fx_rollover.rs
+++ b/crates/backtest/src/modules/fx_rollover.rs
@@ -227,16 +227,19 @@ impl FXRolloverInterestModule {
             mid_prices.insert(*instrument_id, mid);
         }
 
-        for (instrument_id, &mid) in &mid_prices {
+        let mut mid_prices = mid_prices.into_iter().collect::<Vec<_>>();
+        mid_prices.sort_unstable_by_key(|(instrument_id, _)| *instrument_id);
+
+        for (instrument_id, mid) in mid_prices {
             let positions =
                 ctx.cache
-                    .positions_open(Some(&ctx.venue), Some(instrument_id), None, None, None);
+                    .positions_open(Some(&ctx.venue), Some(&instrument_id), None, None, None);
 
             if positions.is_empty() {
                 continue;
             }
 
-            let interest_rate = match self.calculator.calc_overnight_rate(*instrument_id, date) {
+            let interest_rate = match self.calculator.calc_overnight_rate(instrument_id, date) {
                 Ok(rate) => rate,
                 Err(e) => {
                     log::warn!("Skipping rollover for {instrument_id}: {e}");
@@ -253,7 +256,7 @@ impl FXRolloverInterestModule {
                 rollover *= 3.0;
             }
 
-            let instrument = &ctx.instruments[instrument_id];
+            let instrument = &ctx.instruments[&instrument_id];
             let currency = if let Some(base) = ctx.base_currency {
                 // Rollover math is still f64; convert the Decimal rate at the boundary
                 let xrate = ctx

--- a/crates/backtest/src/modules/mod.rs
+++ b/crates/backtest/src/modules/mod.rs
@@ -19,6 +19,7 @@ pub mod fx_rollover;
 
 use ahash::AHashMap;
 pub use fx_rollover::FXRolloverInterestModule;
+use indexmap::IndexMap;
 use nautilus_common::cache::Cache;
 use nautilus_core::UnixNanos;
 use nautilus_execution::matching_engine::engine::OrderMatchingEngine;
@@ -39,7 +40,7 @@ pub struct ExchangeContext<'a> {
     /// All instruments registered on the exchange.
     pub instruments: &'a AHashMap<InstrumentId, InstrumentAny>,
     /// All matching engines, providing order book access.
-    pub matching_engines: &'a AHashMap<InstrumentId, OrderMatchingEngine>,
+    pub matching_engines: &'a IndexMap<InstrumentId, OrderMatchingEngine>,
     /// Read-only cache access for querying positions and other state.
     pub cache: &'a Cache,
 }

--- a/crates/backtest/tests/backtest_engine.rs
+++ b/crates/backtest/tests/backtest_engine.rs
@@ -3899,8 +3899,7 @@ fn test_list_venues_multiple() {
         )
         .unwrap();
 
-    let mut venues = engine.list_venues();
-    venues.sort_by_key(|v| v.to_string());
+    let venues = engine.list_venues();
     assert_eq!(venues.len(), 2);
     assert_eq!(venues[0], Venue::from("BINANCE"));
     assert_eq!(venues[1], Venue::from("BITMEX"));

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -172,6 +172,149 @@ fn test_cash_account_trading_futures_or_perpetuals(crypto_perpetual_ethusdt: Cry
 }
 
 #[rstest]
+fn test_matching_engine_iteration_order_is_stable_across_rebuilds(
+    crypto_perpetual_ethusdt: CryptoPerpetual,
+) {
+    let first_instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt.clone());
+    let mut second = crypto_perpetual_ethusdt;
+    second.id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    second.raw_symbol = Symbol::from("BTCUSDT");
+    second.base_currency = Currency::from("BTC");
+    let second_instrument = InstrumentAny::CryptoPerpetual(second);
+    let expected = vec![first_instrument.id(), second_instrument.id()];
+
+    for _ in 0..32 {
+        let exchange = get_exchange(
+            Venue::new("BINANCE"),
+            AccountType::Margin,
+            BookType::L1_MBP,
+            None,
+        );
+        exchange
+            .borrow_mut()
+            .add_instrument(first_instrument.clone())
+            .unwrap();
+        exchange
+            .borrow_mut()
+            .add_instrument(second_instrument.clone())
+            .unwrap();
+
+        let actual = exchange
+            .borrow()
+            .get_matching_engines()
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
+}
+
+#[rstest]
+fn test_same_timestamp_fills_follow_matching_engine_registration_order(
+    crypto_perpetual_ethusdt: CryptoPerpetual,
+) {
+    let saving_handler = register_order_event_saving_handler();
+    let first_instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt.clone());
+    let mut second = crypto_perpetual_ethusdt;
+    second.id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    second.raw_symbol = Symbol::from("BTCUSDT");
+    second.base_currency = Currency::from("BTC");
+    let second_instrument = InstrumentAny::CryptoPerpetual(second);
+    let instruments = [&first_instrument, &second_instrument];
+    let expected = vec![first_instrument.id(), second_instrument.id()];
+
+    for rebuild in 0..32 {
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let exchange = get_exchange(
+            Venue::new("BINANCE"),
+            AccountType::Margin,
+            BookType::L1_MBP,
+            Some(cache.clone()),
+        );
+
+        for (index, instrument) in instruments.iter().enumerate() {
+            exchange
+                .borrow_mut()
+                .add_instrument((*instrument).clone())
+                .unwrap();
+
+            let initial_quote = QuoteTick::new(
+                instrument.id(),
+                Price::from("1000.00"),
+                Price::from("1001.00"),
+                Quantity::from("10.000"),
+                Quantity::from("10.000"),
+                UnixNanos::from(1),
+                UnixNanos::from(1),
+            );
+            exchange.borrow_mut().process_quote_tick(&initial_quote);
+
+            let client_order_id = ClientOrderId::from(format!("O-{rebuild}-{index}").as_str());
+            let order = OrderTestBuilder::new(OrderType::Limit)
+                .instrument_id(instrument.id())
+                .client_order_id(client_order_id)
+                .side(OrderSide::Buy)
+                .quantity(Quantity::from("1.000"))
+                .price(Price::from("1000.00"))
+                .build();
+            submit_matching_option_limit(&exchange, &cache, &order, UnixNanos::from(2));
+
+            let closed = InstrumentStatus::new(
+                instrument.id(),
+                MarketStatusAction::Close,
+                UnixNanos::from(3),
+                UnixNanos::from(3),
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+            exchange.borrow_mut().process_instrument_status(closed);
+
+            let crossing_quote = QuoteTick::new(
+                instrument.id(),
+                Price::from("998.00"),
+                Price::from("999.00"),
+                Quantity::from("10.000"),
+                Quantity::from("10.000"),
+                UnixNanos::from(100),
+                UnixNanos::from(100),
+            );
+            exchange.borrow_mut().process_quote_tick(&crossing_quote);
+
+            let reopened = InstrumentStatus::new(
+                instrument.id(),
+                MarketStatusAction::Trading,
+                UnixNanos::from(100),
+                UnixNanos::from(100),
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+            exchange.borrow_mut().process_instrument_status(reopened);
+        }
+
+        saving_handler.clear();
+        exchange
+            .borrow_mut()
+            .iterate_matching_engines(UnixNanos::from(100));
+
+        let actual = saving_handler
+            .get_messages()
+            .iter()
+            .filter_map(|event| match event {
+                OrderEventAny::Filled(fill) => Some(fill.instrument_id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
+}
+
+#[rstest]
 fn test_exchange_process_quote_tick(crypto_perpetual_ethusdt: CryptoPerpetual) {
     let exchange = get_exchange(
         Venue::new("BINANCE"),

--- a/crates/system/src/trader.rs
+++ b/crates/system/src/trader.rs
@@ -22,6 +22,7 @@
 use std::{cell::RefCell, fmt::Debug, rc::Rc};
 
 use ahash::AHashMap;
+use indexmap::IndexMap;
 #[cfg(feature = "python")]
 use nautilus_common::{actor::data_actor::ImportableActorConfig, python::actor::PyDataActor};
 use nautilus_common::{
@@ -119,7 +120,7 @@ pub struct Trader {
     /// Registered exec algorithm IDs (algorithms stored in global registry).
     exec_algorithm_ids: Vec<ExecAlgorithmId>,
     /// Component clocks for individual components.
-    clocks: AHashMap<ComponentId, Rc<RefCell<dyn Clock>>>,
+    clocks: IndexMap<ComponentId, Rc<RefCell<dyn Clock>>>,
     /// Timestamp when the trader was created.
     ts_created: UnixNanos,
     /// Timestamp when the trader was last started.
@@ -161,7 +162,7 @@ impl Trader {
             strategy_stop_fns: AHashMap::new(),
             strategy_handler_ids: AHashMap::new(),
             exec_algorithm_ids: Vec::new(),
-            clocks: AHashMap::new(),
+            clocks: IndexMap::new(),
             ts_created,
             ts_started: None,
             ts_stopped: None,
@@ -1157,7 +1158,7 @@ impl Trader {
             if let Some(clock) = self.clocks.get(&component_id) {
                 clock.borrow_mut().cancel_timers();
             }
-            self.clocks.remove(&component_id);
+            self.clocks.shift_remove(&component_id);
 
             // Remove only this strategy's own msgbus handlers
             if let Some((order_hid, position_hid)) = self.strategy_handler_ids.get(strategy_id) {
@@ -1196,7 +1197,7 @@ impl Trader {
             if let Some(clock) = self.clocks.get(&component_id) {
                 clock.borrow_mut().cancel_timers();
             }
-            self.clocks.remove(&component_id);
+            self.clocks.shift_remove(&component_id);
         }
 
         self.actor_ids.clear();
@@ -1219,7 +1220,7 @@ impl Trader {
             if let Some(clock) = self.clocks.get(&component_id) {
                 clock.borrow_mut().cancel_timers();
             }
-            self.clocks.remove(&component_id);
+            self.clocks.shift_remove(&component_id);
         }
 
         self.exec_algorithm_ids.clear();
@@ -1277,7 +1278,7 @@ impl Trader {
         if let Some(clock) = self.clocks.get(&component_id) {
             clock.borrow_mut().cancel_timers();
         }
-        self.clocks.remove(&component_id);
+        self.clocks.shift_remove(&component_id);
 
         log::info!("Removed actor {actor_id} from trader {}", self.trader_id);
         Ok(())
@@ -1403,7 +1404,7 @@ impl Trader {
         if let Some(clock) = self.clocks.get(&component_id) {
             clock.borrow_mut().cancel_timers();
         }
-        self.clocks.remove(&component_id);
+        self.clocks.shift_remove(&component_id);
 
         log::info!(
             "Removed strategy {strategy_id} from trader {}",
@@ -2678,6 +2679,32 @@ mod tests {
             primary_clock.as_ptr() as *const _
         );
         assert_ne!(clock_a.as_ptr() as *const _, clock_b.as_ptr() as *const _);
+    }
+
+    #[rstest]
+    fn test_get_component_clocks_returns_registration_order() {
+        let (_msgbus, cache, portfolio, _data_engine, _risk_engine, _exec_engine, clock_factory) =
+            create_trader_components();
+        let mut trader = Trader::new(
+            TraderId::test_default(),
+            UUID4::new(),
+            Environment::Backtest,
+            clock_factory,
+            cache,
+            portfolio,
+        );
+        let mut registered = Vec::new();
+
+        for index in 0..32 {
+            let component_id = ComponentId::new(format!("ACTOR-{index:02}").as_str());
+            registered.push(trader.create_component_clock(component_id));
+        }
+
+        let returned = trader.get_component_clocks();
+        assert_eq!(returned.len(), registered.len());
+        for (actual, expected) in returned.iter().zip(&registered) {
+            assert!(Rc::ptr_eq(actual, expected));
+        }
     }
 
     #[rstest]


### PR DESCRIPTION
Backtest runs of the same binary on the same data could produce different event streams, because randomly seeded hash-map iteration and a random tie-break leaked into behavior-bearing ordering. The Cython implementation these files port used insertion-ordered Python dicts and a stable sort, so the port introduced the nondeterminism. Three sources, closed together:

**1. Venue and matching-engine iteration order**

`BacktestEngine::venues` and `SimulatedExchange::matching_engines` were `AHashMap`s; ahash's default `runtime-rng` feature seeds every map per process, so iteration order differs between runs. These maps drive venue settle order (`settle_venues`, `run_venue_modules`, `run_venue_liquidations`), per-instrument fill iteration (`iterate_matching_engines`), expiration processing, and liquidation order - and fill callbacks can synchronously submit further commands, so the order is observable well beyond logging. Both are now insertion-ordered `IndexMap`s (registration order, matching the Python dict semantics). `IndexMap::insert` on an existing key keeps its position, so the instrument re-add path does not reorder. FX-rollover per-instrument adjustments and funding-settlement account adjustments now iterate in sorted order (`InstrumentId` / currency code - `Ustr`'s `Ord` compares string contents, so both keys are content-ordered and stable across processes).

**2. Equal-timestamp time events tie-broke on a random UUID**

`TimeEventHandler` ordering falls through `ts_event`, `name`, `ts_init` to the event UUID text, and the backtest accumulator's heap consumed that ordering directly - so same-name timers firing at the same nanosecond on different component clocks (e.g. two strategies each running a `REBALANCE` timer with the same interval) popped in random order run to run. The accumulator now assigns a monotonic FIFO sequence at push and orders by `(ts_event, name, ts_init, sequence)`, restoring the Cython stable-sort semantics. The sequence resets with `clear()` and the increment is overflow-checked. `TimeEventHandler`'s own `Ord` is unchanged - the wrapper lives entirely in the accumulator.

**3. Component-clock enumeration order (completes fix 2)**

The FIFO sequence is assigned in clock-advance order, and `Trader::get_component_clocks` enumerated `Trader.clocks` - itself an `AHashMap` - so cross-clock ties would have merely traded UUID randomness for clock-enumeration randomness. `Trader.clocks` is now a registration-ordered `IndexMap`, with `shift_remove` at every removal site so surviving order is preserved when a component is removed.

The repo already treats these orderings as significant elsewhere (`ahash::RandomState::with_seeds(0, 0, 0, 0)` in orderbook aggregation, the explicit "Sort for deterministic insertion order" in `SimulatedExchange::load_open_orders`); these were the remaining behavior-bearing sites. Non-behavior-bearing maps (instrument lookups, settlement price caches, membership sets) are deliberately left on `AHashMap`.

**Testing**

- `test_accumulator_preserves_fifo_order_for_identical_timer_keys` - two events with identical `(ts_event, name, ts_init)` and adversarially ordered UUIDs (the first pushed carries the lexically larger UUID, so the old tie-break pops it second) assert FIFO pop order.
- `test_matching_engine_iteration_order_is_stable_across_rebuilds` - registration order of matching-engine keys across 32 exchange rebuilds.
- `test_same_timestamp_fills_follow_matching_engine_registration_order` - behavioral: two instruments with resting orders and a crossing quote parked behind a market-closed status, reopened, then a single `iterate_matching_engines` pass; asserts emitted `OrderFilled` order across 32 rebuilds.
- `test_get_component_clocks_returns_registration_order` - 32 registered component clocks asserted in registration order by `Rc` pointer identity.
- Each test was verified to fail against the unfixed implementation (the fill test failed with fills in hash order; the clock test failed with pointer-order mismatches).
- `test_list_venues_multiple` previously sorted its result to work around the nondeterminism; it now asserts insertion order directly.
