### PR TITLE
Fix underflow panics on out-of-order fill events

### DIFF
--- a/crates/execution/src/reconciliation/orders.rs
+++ b/crates/execution/src/reconciliation/orders.rs
@@ -553,7 +553,7 @@ fn create_reconciliation_fill_voids(
         });
         let prior_qty = previous.map_or_else(
             || Quantity::zero(fill.last_qty.precision),
-            |voided| voided.voided_qty,
+            |voided| voided.voided_qty.min(fill.last_qty),
         );
         let effective = fill.last_qty - prior_qty;
         if effective.is_zero() {

--- a/crates/execution/src/reconciliation/tests.rs
+++ b/crates/execution/src/reconciliation/tests.rs
@@ -23,8 +23,8 @@ use nautilus_model::{
         OrderAccepted, OrderEventAny, OrderFilled, OrderPendingCancel, OrderPendingUpdate,
         OrderSubmitted,
         order::spec::{
-            OrderAcceptedSpec, OrderFilledSpec, OrderPendingCancelSpec, OrderPendingUpdateSpec,
-            OrderSubmittedSpec, OrderUpdatedSpec,
+            OrderAcceptedSpec, OrderFillVoidedSpec, OrderFilledSpec, OrderPendingCancelSpec,
+            OrderPendingUpdateSpec, OrderSubmittedSpec, OrderUpdatedSpec,
         },
     },
     identifiers::{
@@ -5268,6 +5268,84 @@ fn test_terminal_fill_void_uses_remaining_leaves_after_fill_correction(instrumen
     assert_eq!(after.status(), OrderStatus::Voided);
     assert_eq!(after.filled_qty(), Quantity::from(0));
     assert_eq!(after.voided_qty(), Quantity::from(100));
+}
+
+#[rstest]
+fn test_fill_void_stored_before_smaller_fill_does_not_underflow_snapshot_reconciliation(
+    instrument: InstrumentAny,
+) {
+    let client_order_id = ClientOrderId::from("O-FILL-VOID-OOO");
+    let venue_order_id = VenueOrderId::from("V-FILL-VOID-OOO");
+    let account_id = AccountId::from("SIM-001");
+    let trade_id = TradeId::from("T-FILL-VOID-OOO");
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .client_order_id(client_order_id)
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100))
+        .price(Price::from("1.00000"))
+        .build();
+    submit_accept(&mut order, account_id, venue_order_id);
+    // A void arriving before its fill is only bounded by the order quantity,
+    // so the stored voided_qty can exceed the eventual fill's last_qty
+    order
+        .apply(OrderEventAny::FillVoided(
+            OrderFillVoidedSpec::builder()
+                .trader_id(order.trader_id())
+                .strategy_id(order.strategy_id())
+                .instrument_id(order.instrument_id())
+                .client_order_id(order.client_order_id())
+                .venue_order_id(venue_order_id)
+                .account_id(account_id)
+                .trade_id(trade_id)
+                .voided_qty(Quantity::from(60))
+                .order_side(OrderSide::Buy)
+                .order_type(OrderType::Limit)
+                .last_px(Price::from("1.00000"))
+                .currency(instrument.quote_currency())
+                .is_reopened(true)
+                .build(),
+        ))
+        .unwrap();
+    order
+        .apply(OrderEventAny::Filled(
+            OrderFilledSpec::builder()
+                .trader_id(order.trader_id())
+                .strategy_id(order.strategy_id())
+                .instrument_id(order.instrument_id())
+                .client_order_id(order.client_order_id())
+                .venue_order_id(venue_order_id)
+                .account_id(account_id)
+                .trade_id(trade_id)
+                .order_side(OrderSide::Buy)
+                .order_type(OrderType::Limit)
+                .last_qty(Quantity::from(40))
+                .last_px(Price::from("1.00000"))
+                .currency(instrument.quote_currency())
+                .build(),
+        ))
+        .unwrap();
+    let mut report = create_test_order_status_report(
+        client_order_id,
+        venue_order_id,
+        instrument.id(),
+        OrderType::Limit,
+        OrderStatus::Voided,
+        Quantity::from(100),
+        Quantity::from(0),
+    );
+    report.avg_px = Some(dec!(1.0));
+
+    let events = generate_reconciliation_order_snapshot_events(
+        &order,
+        &report,
+        Some(&instrument),
+        UnixNanos::from(10),
+    );
+    let after = apply_events(&order, &events);
+
+    assert_eq!(after.status(), OrderStatus::Voided);
+    assert_eq!(after.filled_qty(), Quantity::from(0));
 }
 
 #[rstest]

--- a/crates/model/src/orders/mod.rs
+++ b/crates/model/src/orders/mod.rs
@@ -1131,7 +1131,7 @@ impl OrderCore {
             }
             let removed = correction.map_or_else(
                 || Quantity::zero(fill.last_qty.precision),
-                |event| event.voided_qty,
+                |event| event.voided_qty.min(fill.last_qty),
             );
             let effective = fill.last_qty - removed;
             voided_raw = voided_raw.saturating_add(removed.raw);
@@ -1151,6 +1151,7 @@ impl OrderCore {
             if let Some(commission) = fill.commission {
                 let surviving = correction
                     .and_then(|event| event.commission_voided)
+                    .filter(|voided| !voided.is_zero())
                     .map_or(commission, |voided| commission - voided);
                 if !surviving.is_zero() {
                     commissions
@@ -1688,6 +1689,90 @@ mod tests {
         assert_eq!(order.voided_qty(), Quantity::from(40_000));
         assert_eq!(order.leaves_qty(), Quantity::from(0));
         assert!(order.is_closed());
+    }
+
+    #[rstest]
+    fn test_fill_void_before_smaller_fill_clamps_recomputed_quantity() {
+        let trade_id = TradeId::from("TRADE-OUT-OF-ORDER");
+        let init = OrderInitializedSpec::builder()
+            .quantity(Quantity::from(100_000))
+            .build();
+        let early_void = OrderFillVoidedSpec::builder()
+            .trade_id(trade_id)
+            .voided_qty(Quantity::from(60_000))
+            .is_reopened(true)
+            .build();
+        let late_fill = OrderFilledSpec::builder()
+            .trade_id(trade_id)
+            .last_qty(Quantity::from(40_000))
+            .build();
+        let recompute_trigger = OrderFillVoidedSpec::builder()
+            .trade_id(TradeId::from("TRADE-RECOMPUTE"))
+            .voided_qty(Quantity::from(10_000))
+            .is_reopened(true)
+            .build();
+        let mut order: MarketOrder = init.try_into().unwrap();
+        order
+            .apply(OrderEventAny::Accepted(
+                OrderAcceptedSpec::builder().build(),
+            ))
+            .unwrap();
+
+        order.apply(OrderEventAny::FillVoided(early_void)).unwrap();
+        order.apply(OrderEventAny::Filled(late_fill)).unwrap();
+        order
+            .apply(OrderEventAny::FillVoided(recompute_trigger))
+            .unwrap();
+
+        assert_eq!(order.status(), OrderStatus::Accepted);
+        assert_eq!(order.filled_qty(), Quantity::from(0));
+        assert_eq!(order.voided_qty(), Quantity::from(50_000));
+        assert_eq!(order.leaves_qty(), Quantity::from(100_000));
+        assert!(order.is_open());
+    }
+
+    #[rstest]
+    fn test_zero_commission_fill_void_before_fill_in_other_currency() {
+        let trade_id = TradeId::from("TRADE-ZERO-COMMISSION");
+        let init = OrderInitializedSpec::builder()
+            .quantity(Quantity::from(100_000))
+            .build();
+        let early_void = OrderFillVoidedSpec::builder()
+            .trade_id(trade_id)
+            .voided_qty(Quantity::from(10_000))
+            .commission_voided(Money::from("0 USD"))
+            .is_reopened(true)
+            .build();
+        let late_fill = OrderFilledSpec::builder()
+            .trade_id(trade_id)
+            .last_qty(Quantity::from(40_000))
+            .commission(Money::from("2 ETH"))
+            .build();
+        let recompute_trigger = OrderFillVoidedSpec::builder()
+            .trade_id(TradeId::from("TRADE-RECOMPUTE"))
+            .voided_qty(Quantity::from(10_000))
+            .is_reopened(true)
+            .build();
+        let mut order: MarketOrder = init.try_into().unwrap();
+        order
+            .apply(OrderEventAny::Accepted(
+                OrderAcceptedSpec::builder().build(),
+            ))
+            .unwrap();
+
+        order.apply(OrderEventAny::FillVoided(early_void)).unwrap();
+        order.apply(OrderEventAny::Filled(late_fill)).unwrap();
+        order
+            .apply(OrderEventAny::FillVoided(recompute_trigger))
+            .unwrap();
+
+        assert_eq!(order.status(), OrderStatus::PartiallyFilled);
+        assert_eq!(order.filled_qty(), Quantity::from(30_000));
+        assert_eq!(order.voided_qty(), Quantity::from(20_000));
+        assert_eq!(
+            order.commissions().get(&Currency::ETH()),
+            Some(&Money::from("2 ETH"))
+        );
     }
 
     #[rstest]

--- a/crates/model/src/position.rs
+++ b/crates/model/src/position.rs
@@ -412,7 +412,7 @@ impl Position {
             self.closing_order_id = Some(fill.client_order_id);
             self.ts_closed = Some(fill.ts_event);
             self.duration_ns = if let Some(ts_closed) = self.ts_closed {
-                ts_closed.as_u64() - self.ts_opened.as_u64()
+                ts_closed.as_u64().saturating_sub(self.ts_opened.as_u64())
             } else {
                 0
             };
@@ -4747,6 +4747,57 @@ mod tests {
         assert_eq!(position.ts_opened, UnixNanos::from(2_000u64));
         assert_eq!(position.opening_order_id, order1.client_order_id());
         assert_eq!(position.events.len(), 2);
+    }
+
+    #[rstest]
+    fn test_position_close_before_open_clamps_duration(audusd_sim: CurrencyPair) {
+        let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim);
+        let opening_order = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(audusd_sim.id())
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from(100_000))
+            .build();
+        let closing_order = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(audusd_sim.id())
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from(100_000))
+            .build();
+        let opening_fill = TestOrderEventStubs::filled(
+            &opening_order,
+            &audusd_sim,
+            Some(TradeId::new("OPEN")),
+            None,
+            Some(Price::from("1.00001")),
+            None,
+            None,
+            None,
+            Some(UnixNanos::from(2_000u64)),
+            None,
+        );
+        let closing_fill = TestOrderEventStubs::filled(
+            &closing_order,
+            &audusd_sim,
+            Some(TradeId::new("CLOSE")),
+            None,
+            Some(Price::from("1.00002")),
+            None,
+            None,
+            None,
+            Some(UnixNanos::from(1_000u64)),
+            None,
+        );
+        let mut position = Position::new(&audusd_sim, opening_fill.into());
+
+        position.apply(&closing_fill.into());
+
+        assert_eq!(position.side, PositionSide::Flat);
+        assert_eq!(position.ts_opened, UnixNanos::from(2_000u64));
+        assert_eq!(position.ts_closed, Some(UnixNanos::from(1_000u64)));
+        assert_eq!(position.duration_ns, 0);
+        assert_eq!(
+            position.closing_order_id,
+            Some(closing_order.client_order_id())
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
Four guards against unsigned-arithmetic panics in the order and position
event paths, all reachable from out-of-order venue event streams that the
surrounding code already tolerates by design (warn-and-continue on early
timestamps, validate-and-store on corrections that arrive before their
fills). Same class of defensive alignment as the reconciliation fixes in
#4479.

**Position duration_ns underflow on an out-of-order closing fill**

`Position::apply_fill` deliberately tolerates `fill.ts_event < ts_opened`
(it logs a warning and proceeds), but the flat-close branch then computes
`ts_closed.as_u64() - self.ts_opened.as_u64()` as a plain `u64`
subtraction. A closing fill stamped earlier than the position open panics
in debug builds and wraps `duration_ns` to a value near `u64::MAX` in
release. The existing out-of-order regression
(`test_position_apply_fill_with_earlier_timestamp_adjusts_ts_opened`) only
covers an increasing fill, which never reaches the duration branch.

Fixed with `saturating_sub`, clamping the duration to zero. The legacy
Cython implementation has the same wrap (`uint64_t` fields in
`position.pxd`); this PR is scoped to the Rust engine.

**Quantity underflow when an `OrderFillVoided` precedes its fill**

`validate_fill_void` has a dedicated branch for a void whose fill has not
arrived yet: it bounds `voided_qty` only against the order quantity, since
there is no fill to compare with, and stores the event. When the fill
later arrives with `last_qty < voided_qty`, the next recompute
(`OrderCore::recompute_fill_state`, triggered by any subsequent
`OrderFillVoided`) matches the stored correction against the fill and
computes `fill.last_qty - removed`, which lands in `Quantity::sub`'s
`checked_sub(...).expect(...)` - a process panic from an ordinary
out-of-order message pair.

Fixed by clamping the matched correction to the fill's quantity
(`event.voided_qty.min(fill.last_qty)`) inside the recompute, consistent
with the saturating arithmetic already used throughout that accumulator.

**The same underflow in snapshot reconciliation**

`create_reconciliation_fill_voids` in nautilus-execution reads the same
stored corrections when projecting fill voids from an authoritative venue
snapshot, and computed `fill.last_qty - prior_qty` with the raw stored
`voided_qty`. Reconciling an order that carries a pre-fill oversized void
therefore panicked on exactly the event data the model-side fix tolerates.
Fixed with the identical clamp.

**Currency-mismatch panic on a zero-commission pre-fill void**

The same no-fill validation branch accepts `commission_voided` when it is
zero - in any currency, since there is no fill commission to compare
against. `recompute_fill_state` then subtracts it from the fill's
commission, and `Money::sub` asserts currency equality: a zero-USD void
meeting a fill commissioned in ETH aborts the process. Fixed by filtering
zero voided commissions out of the subtraction.

**Testing**

- `test_position_close_before_open_clamps_duration` pins the flat-close
  state for an out-of-order close: `duration_ns == 0`, `ts_closed` set
  from the fill, `ts_opened` and `closing_order_id` intact (proving the
  clamp is not achieved by rewriting the open timestamp).
- `test_fill_void_before_smaller_fill_clamps_recomputed_quantity` stages
  void(60,000) before fill(40,000) and triggers the recompute; it pins the
  clamped totals (`voided_qty == 50,000` proves the matched correction was
  clamped to 40,000 while an unmatched 10,000 correction stayed counted)
  plus status, filled, and leaves.
- `test_fill_void_stored_before_smaller_fill_does_not_underflow_snapshot_reconciliation`
  drives the same stored state through the public
  `generate_reconciliation_order_snapshot_events` with a filled=0 voided
  snapshot and pins the projected terminal state.
- `test_zero_commission_fill_void_before_fill_in_other_currency` stages a
  zero-USD pre-fill void against a 2-ETH-commission fill and pins the
  surviving commission.

Each was verified to FAIL against the unfixed code with its specific fix
hunk reverted: the two quantity tests and the reconciliation test panic at
the respective subtraction sites, and the commission test hits the
`Money::sub` currency assertion.
