### PR TITLE
Fix position reconciliation tolerance lookup for routing clients

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -57,7 +57,7 @@ use nautilus_model::{
     events::{OrderCanceled, OrderEventAny, OrderFilled, OrderInitialized},
     identifiers::{
         AccountId, ClientId, ClientOrderId, InstrumentId, PositionId, StrategyId, TradeId,
-        TraderId, Venue, VenueOrderId,
+        TraderId, VenueOrderId,
     },
     instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny, TRIGGERABLE_ORDER_TYPES},
@@ -294,7 +294,7 @@ pub struct ExecutionManager {
     // Monotonic (`dst::time`) instants, not `self.clock`; see `record_position_activity`.
     position_local_activity: RecencyMap<InstrumentAccountKey>,
     position_recon_retries: IndexMap<InstrumentAccountKey, u32>,
-    position_reconciliation_tolerances: IndexMap<(Venue, AccountId), Decimal>,
+    position_reconciliation_tolerances: IndexMap<AccountId, Decimal>,
     recent_fills_cache: RecencyMap<FillKey>,
     missing_order_coverage_warnings: IndexSet<ClientOrderId>,
     unresolved_order_coverage: IndexSet<ClientOrderId>,
@@ -340,30 +340,25 @@ impl ExecutionManager {
 
     pub(crate) fn set_position_reconciliation_tolerance(
         &mut self,
-        venue: Venue,
         account_id: AccountId,
         tolerance: Decimal,
     ) {
         let tolerance = if tolerance < Decimal::ZERO {
             log::error!(
                 "Invalid negative position reconciliation tolerance {tolerance} for \
-                 {venue}/{account_id}; using the default"
+                 {account_id}; using the default"
             );
             DEFAULT_POSITION_RECONCILIATION_TOLERANCE
         } else {
             tolerance
         };
         self.position_reconciliation_tolerances
-            .insert((venue, account_id), tolerance);
+            .insert(account_id, tolerance);
     }
 
-    fn position_reconciliation_tolerance(
-        &self,
-        instrument_id: InstrumentId,
-        account_id: AccountId,
-    ) -> Decimal {
+    fn position_reconciliation_tolerance(&self, account_id: AccountId) -> Decimal {
         self.position_reconciliation_tolerances
-            .get(&(instrument_id.venue, account_id))
+            .get(&account_id)
             .copied()
             .unwrap_or(DEFAULT_POSITION_RECONCILIATION_TOLERANCE)
     }
@@ -1581,7 +1576,6 @@ impl ExecutionManager {
             let client_id = client.client_id();
             queried_clients.insert(client_id);
             self.set_position_reconciliation_tolerance(
-                client.venue(),
                 client.account_id(),
                 client.position_reconciliation_tolerance(),
             );
@@ -2209,7 +2203,7 @@ impl ExecutionManager {
         }
         let venue_signed_qty = venue_report.map_or(Decimal::ZERO, |r| r.signed_decimal_qty);
 
-        let tolerance = self.position_reconciliation_tolerance(instrument_id, account_id);
+        let tolerance = self.position_reconciliation_tolerance(account_id);
         if (cached_signed_qty - venue_signed_qty).abs() <= tolerance {
             self.position_recon_retries.shift_remove(&key);
             return None;
@@ -2821,7 +2815,7 @@ impl ExecutionManager {
 
         log::debug!("venue_signed_qty={venue_signed_qty}, cached_signed_qty={cached_signed_qty}");
 
-        let tolerance = self.position_reconciliation_tolerance(instrument_id, account_id);
+        let tolerance = self.position_reconciliation_tolerance(account_id);
         if (cached_signed_qty - venue_signed_qty).abs() <= tolerance {
             log::debug!("Position quantities match for {instrument_id}, no reconciliation needed");
             return None;

--- a/crates/live/src/node/builder.rs
+++ b/crates/live/src/node/builder.rs
@@ -702,7 +702,6 @@ impl LiveNodeBuilder {
 
         for client in &exec_clients {
             exec_manager.set_position_reconciliation_tolerance(
-                client.venue(),
                 client.account_id(),
                 client.position_reconciliation_tolerance(),
             );

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -9611,6 +9611,11 @@ impl MockPositionExecutionClient {
         self
     }
 
+    fn with_position_reports(mut self, position_reports: Vec<PositionStatusReport>) -> Self {
+        self.position_reports = RefCell::new(position_reports);
+        self
+    }
+
     fn failing_position_reports() -> Self {
         Self {
             client_id: test_client_id(),
@@ -9816,6 +9821,233 @@ async fn test_position_check_uses_client_tolerance_for_observed_smoke_difference
     let events = ctx.manager.check_positions_consistency(&clients).await;
 
     assert!(events.is_empty());
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_position_check_uses_routing_client_tolerance() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = AccountId::from("IB-ROUTING-CHECK");
+    let position = create_test_position_for_account(
+        &instrument,
+        PositionId::from("P-ROUTING-TOLERANCE-CHECK"),
+        OrderSide::Buy,
+        "5.000000",
+        "3000.00",
+        account_id,
+    );
+    let venue_report = PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.005000"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    ctx.add_instrument(instrument);
+    ctx.add_margin_account(account_id);
+    ctx.add_position(&position);
+
+    let routing_client = MockPositionExecutionClient::configured(
+        ClientId::from("IB-ROUTING-CHECK"),
+        account_id,
+        Venue::from("IB"),
+        IndexSet::from([instrument_id.venue]),
+        false,
+    )
+    .with_position_reports(vec![venue_report])
+    .with_position_reconciliation_tolerance(dec!(0.010000));
+    let clients: Vec<&dyn ExecutionClient> = vec![&routing_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_mass_status_netting_uses_routing_client_tolerance() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = AccountId::from("IB-ROUTING-MASS-STATUS");
+    let position = create_test_position_for_account(
+        &instrument,
+        PositionId::from("P-ROUTING-TOLERANCE-MASS-STATUS"),
+        OrderSide::Buy,
+        "5.000000",
+        "3000.00",
+        account_id,
+    );
+    let matching_report = PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.000000"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    ctx.add_instrument(instrument);
+    ctx.add_margin_account(account_id);
+    ctx.add_position(&position);
+
+    let routing_client = MockPositionExecutionClient::configured(
+        ClientId::from("IB-ROUTING-MASS-STATUS"),
+        account_id,
+        Venue::from("IB"),
+        IndexSet::from([instrument_id.venue]),
+        false,
+    )
+    .with_position_reports(vec![matching_report])
+    .with_position_reconciliation_tolerance(dec!(0.010000));
+    let clients: Vec<&dyn ExecutionClient> = vec![&routing_client];
+    // Seed the manager's per-account tolerance state (production seeds this in the builder);
+    // the matching report must not itself generate reconciliation events.
+    let seed_events = ctx.manager.check_positions_consistency(&clients).await;
+    assert!(seed_events.is_empty());
+
+    let mut mass_status = ExecutionMassStatus::new(
+        routing_client.client_id(),
+        account_id,
+        routing_client.venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    let drift_report = PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.005000"),
+        UnixNanos::from(2_000_000),
+        UnixNanos::from(2_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    mass_status.add_position_reports(vec![drift_report]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert!(result.events.is_empty());
+}
+
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_routing_clients_on_same_venue_use_account_tolerances_independently() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let tolerant_account_id = AccountId::from("IB-TOLERANT");
+    let strict_account_id = AccountId::from("IB-STRICT");
+    let tolerant_position = create_test_position_for_account(
+        &instrument,
+        PositionId::from("P-ROUTING-TOLERANT"),
+        OrderSide::Buy,
+        "5.000000",
+        "3000.00",
+        tolerant_account_id,
+    );
+    let strict_position = create_test_position_for_account(
+        &instrument,
+        PositionId::from("P-ROUTING-STRICT"),
+        OrderSide::Buy,
+        "5.000000",
+        "3000.00",
+        strict_account_id,
+    );
+    let tolerant_report = PositionStatusReport::new(
+        tolerant_account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.005000"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    let strict_report = PositionStatusReport::new(
+        strict_account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.005000"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    ctx.add_instrument(instrument);
+    ctx.add_margin_account(tolerant_account_id);
+    ctx.add_margin_account(strict_account_id);
+    ctx.add_position(&tolerant_position);
+    ctx.add_position(&strict_position);
+
+    let tolerant_client = MockPositionExecutionClient::configured(
+        ClientId::from("IB-TOLERANT"),
+        tolerant_account_id,
+        Venue::from("IB"),
+        IndexSet::from([instrument_id.venue]),
+        false,
+    )
+    .with_position_reports(vec![tolerant_report])
+    .with_position_reconciliation_tolerance(dec!(0.010000));
+    let strict_client = MockPositionExecutionClient::configured(
+        ClientId::from("IB-STRICT"),
+        strict_account_id,
+        Venue::from("IB"),
+        IndexSet::from([instrument_id.venue]),
+        false,
+    )
+    .with_position_reports(vec![strict_report])
+    .with_position_reconciliation_tolerance(dec!(0.001000));
+    let clients: Vec<&dyn ExecutionClient> = vec![&tolerant_client, &strict_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+    let fill_account_ids = events
+        .iter()
+        .filter_map(|event| match event {
+            OrderEventAny::Filled(fill) => Some(fill.account_id),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(fill_account_ids, vec![strict_account_id]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
A follow-up to the routing-client identity work in #4479.

**Position reconciliation tolerance never resolved for routing clients**

The per-account reconciliation tolerance (`ExecutionClient::position_reconciliation_tolerance`) was stored in `ExecutionManager` under `(client.venue(), account_id)` (`set_position_reconciliation_tolerance`) but looked up under `(instrument_id.venue, account_id)` (`position_reconciliation_tolerance`). For a single-venue client the two venues are identical and the lookup resolved. For a routing broker they are not: IB uses a broker `venue()` while claiming the instrument's exchange venue through `handles_order_venue` (the exact surface #4479 keyed its guard to), so `instrument_id.venue != client.venue()`, the lookup missed, and the tolerance silently fell back to `DEFAULT_POSITION_RECONCILIATION_TOLERANCE` (`1e-8`). A routing client's configured tolerance therefore never applied, and any sub-tolerance position drift was "reconciled" with a spurious market order/fill - on both the continuous check (`check_position_discrepancy`) and the startup mass-status netting path (`reconcile_position_report_netting`).

The fix keys the tolerance map on `AccountId` alone. The `ExecutionClient` trait binds each client to exactly one `account_id` and one tolerance, and `account_id` is already the component both call sites share and agree on - only the venue component ever mismatched, and only for routing clients. Keying by account resolves routing clients correctly and needs nothing threaded into the mass-status path, which already carries the account id.

**Testing**

- `test_position_check_uses_routing_client_tolerance` - a routing client (broker `venue()` `IB`, an exchange-venue instrument claimed via `handles_order_venue`, configured tolerance `0.01`) with a `0.005` cached-vs-venue drift generates no reconciliation event on the continuous `check_position_discrepancy` path.
- `test_mass_status_netting_uses_routing_client_tolerance` - the same routing setup exercised through `reconcile_execution_mass_status` -> `reconcile_position_report_netting`, after seeding tolerance state the way the builder does in production (the seeding report is asserted to generate no events).
- `test_routing_clients_on_same_venue_use_account_tolerances_independently` - two IB accounts on one venue with tolerances `0.01` and `0.001` and an identical `0.005` drift: only the strict account produces a fill, proving per-account resolution and no cross-account collision.

All tests use paused/virtual time with no wall-clock waits. Each assertion was verified to FAIL against the unfixed venue-keyed code: the routing lookup misses and falls to the `1e-8` default, so the `0.005` drift exceeds tolerance and a spurious reconciliation order/fill is emitted (and the two-account test yields fills for both accounts instead of only the strict one).
