### PR TITLE
Fix persistence session runtime ownership

### DIFF
--- a/crates/persistence/src/backend/kmerge_batch.rs
+++ b/crates/persistence/src/backend/kmerge_batch.rs
@@ -13,11 +13,10 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::{sync::Arc, vec::IntoIter};
+use std::vec::IntoIter;
 
 use futures::{Stream, StreamExt};
 use tokio::{
-    runtime::Runtime,
     sync::mpsc::{self, Receiver},
     task::JoinHandle,
 };
@@ -30,11 +29,11 @@ use super::{
 pub struct EagerStream<T> {
     rx: Receiver<T>,
     task: JoinHandle<()>,
-    runtime: Arc<Runtime>,
+    runtime: tokio::runtime::Handle,
 }
 
 impl<T> EagerStream<T> {
-    pub fn from_stream_with_runtime<S>(stream: S, runtime: Arc<Runtime>) -> Self
+    pub fn from_stream_with_runtime<S>(stream: S, runtime: tokio::runtime::Handle) -> Self
     where
         S: Stream<Item = T> + Send + 'static,
         T: Send + 'static,

--- a/crates/persistence/src/backend/session.rs
+++ b/crates/persistence/src/backend/session.rs
@@ -21,6 +21,7 @@ use datafusion::{
     physical_plan::SendableRecordBatchStream, prelude::*,
 };
 use futures::StreamExt;
+use nautilus_common::live::get_runtime;
 use nautilus_core::{UnixNanos, ffi::cvec::CVec};
 use nautilus_model::data::{Data, HasTsInit};
 use nautilus_serialization::arrow::{
@@ -68,7 +69,7 @@ pub type QueryResult = KMerge<EagerStream<std::vec::IntoIter<Data>>, Data, TsIni
 )]
 pub struct DataBackendSession {
     pub chunk_size: usize,
-    pub runtime: Arc<tokio::runtime::Runtime>,
+    pub runtime: tokio::runtime::Handle,
     session_ctx: SessionContext,
     batch_streams: Vec<EagerStream<IntoIter<Data>>>,
     registered_tables: AHashSet<String>,
@@ -76,16 +77,8 @@ pub struct DataBackendSession {
 
 impl DataBackendSession {
     /// Creates a new [`DataBackendSession`] instance.
-    ///
-    /// # Panics
-    ///
-    /// Panics if Tokio cannot create the worker runtime.
     #[must_use]
     pub fn new(chunk_size: usize) -> Self {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .unwrap();
         let session_cfg = SessionConfig::new()
             .set_str("datafusion.optimizer.repartition_file_scans", "false")
             .set_str("datafusion.optimizer.prefer_existing_sort", "true");
@@ -94,7 +87,7 @@ impl DataBackendSession {
             session_ctx,
             batch_streams: Vec::default(),
             chunk_size,
-            runtime: Arc::new(runtime),
+            runtime: get_runtime().handle().clone(),
             registered_tables: AHashSet::new(),
         }
     }
@@ -434,5 +427,22 @@ impl Drop for DataQueryResult {
     fn drop(&mut self) {
         self.drop_chunk();
         self.result.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_common::live::get_runtime;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn data_backend_sessions_share_global_runtime() {
+        let first = DataBackendSession::new(10);
+        let second = DataBackendSession::new(10);
+
+        assert_eq!(first.runtime.id(), second.runtime.id());
+        assert_eq!(first.runtime.id(), get_runtime().handle().id());
     }
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2–3 sentences). -->

- Fixes [#4493](https://github.com/nautechsystems/nautilus_trader/issues/4493), where Python garbage collection can synchronously drop a catalog-owned Tokio runtime and block indefinitely inside PyO3 deallocation.
- Replaces the runtime owned by each `DataBackendSession` with a cloned handle to the global Nautilus runtime.
- Makes `EagerStream` retain the same lightweight runtime handle instead of extending ownership through `Arc<Runtime>`.
- Adds a regression test proving independently created backend sessions use the same global runtime.

### Design decisions

- Reuses `nautilus_common::live::get_runtime()` to match the existing single-runtime design and avoid repeated worker startup and shutdown.
- Keeps the runtime handle on `DataBackendSession` because synchronous DataFusion operations still need `block_on`, `spawn`, and runtime context access.
- Keeps the runtime handle on `EagerStream` so its blocking iterator can receive from the Tokio channel without owning runtime shutdown.
- Uses runtime identity as the regression contract because the reported livelock is timing-dependent, while distinct per-session runtimes reproduce deterministically.

### Runtime ownership

```mermaid
flowchart LR
    Global[Global Nautilus runtime] -->|clone Handle| Session[DataBackendSession]
    Session -->|clone Handle| Stream[EagerStream]
    Catalog[ParquetDataCatalog] -->|owns| Session
    Python[Python garbage collection] -->|drops| Catalog
    Session -. no shutdown ownership .-> Global
    Stream -. no shutdown ownership .-> Global
```

### Relevant files

- `crates/persistence/src/backend/session.rs`: uses the global runtime handle and verifies shared runtime identity.
- `crates/persistence/src/backend/kmerge_batch.rs`: stores a runtime handle in `EagerStream`.

### Verification

- `cargo test -p nautilus-persistence data_backend_sessions_share_global_runtime --lib`
- `cargo test -p nautilus-persistence backend::kmerge_batch::tests --lib`
- `cargo fmt --all -- --check`
- Repository pre-commit hooks, including Clippy and documentation checks.


## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

https://github.com/nautechsystems/nautilus_trader/issues/4493

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
