### PR TITLE
Remove unsound Send/Sync impls from TimeEventCallback

### DIFF
--- a/crates/common/src/live/clock.rs
+++ b/crates/common/src/live/clock.rs
@@ -28,7 +28,7 @@ use crate::{
         CallbackRegistry, Clock, replace_existing_timer, validate_and_prepare_time_alert,
         validate_and_prepare_timer,
     },
-    runner::{TimeEventSender, try_get_time_event_sender},
+    runner::{TimeEventSender, purge_closed_time_event_callbacks, try_get_time_event_sender},
     timer::{TimeEvent, TimeEventCallback, TimeEventHandler, create_valid_interval},
 };
 
@@ -66,6 +66,7 @@ impl LiveClock {
 
     fn clear_expired_timers(&mut self) {
         self.timers.retain(|_, timer| !timer.is_expired());
+        purge_closed_time_event_callbacks();
     }
 
     fn replace_existing_timer_if_needed(&mut self, name: &Ustr) {
@@ -298,9 +299,9 @@ mod tests {
     use super::*;
     use crate::{
         clock::Clock,
-        runner::TimeEventSender,
+        runner::{TimeEventMessage, TimeEventSender},
         testing::wait_until,
-        timer::{TimeEvent, TimeEventCallback, TimeEventHandler},
+        timer::{TimeEvent, TimeEventCallback},
     };
 
     #[derive(Debug)]
@@ -315,15 +316,14 @@ mod tests {
     }
 
     impl TimeEventSender for CollectingSender {
-        fn send(&self, handler: TimeEventHandler) {
-            let TimeEventHandler { event, callback } = handler;
+        fn send(&self, message: TimeEventMessage) {
             let now_ns = get_atomic_clock_realtime().get_time_ns();
-            let event_clone = event.clone();
-            callback.call(event);
+            let event = message.event().clone();
+            message.dispatch();
             self.events
                 .lock()
                 .expect(MUTEX_POISONED)
-                .push((event_clone, now_ns));
+                .push((event, now_ns));
         }
     }
 

--- a/crates/common/src/live/timer.rs
+++ b/crates/common/src/live/timer.rs
@@ -39,8 +39,11 @@ use super::dst::{
 #[cfg(not(all(feature = "simulation", madsim)))]
 use super::runtime::get_runtime;
 use crate::{
-    runner::TimeEventSender,
-    timer::{TimeEvent, TimeEventCallback, TimeEventHandler, Timer},
+    runner::{
+        TimeEventCallbackToken, TimeEventMessage, TimeEventMessageFactory, TimeEventSender,
+        register_time_event_callback,
+    },
+    timer::{TimeEvent, TimeEventCallback, Timer},
 };
 
 const TIMER_STARTUP_OVERHEAD: Duration = Duration::from_millis(1);
@@ -112,10 +115,31 @@ pub struct LiveTimer {
     /// If the timer should fire immediately at start time.
     pub fire_immediately: bool,
     next_time_ns: Arc<AtomicU64>,
-    callback: TimeEventCallback,
+    callback: OwnerCallback,
     task_handle: Option<JoinHandle<()>>,
     canceled: bool,
     sender: Option<Arc<dyn TimeEventSender>>,
+}
+
+#[derive(Debug)]
+enum OwnerCallback {
+    Direct(TimeEventMessageFactory),
+    /// The callback is retained owner-side so a restarted timer (cancel or
+    /// natural expiry closed the token) can register a fresh token.
+    Registered {
+        token: TimeEventCallbackToken,
+        callback: TimeEventCallback,
+    },
+    Senderless(TimeEventCallback),
+}
+
+#[derive(Clone, Debug)]
+enum WorkerDispatch {
+    Direct(TimeEventMessageFactory),
+    Registered(TimeEventCallbackToken),
+    #[cfg(feature = "python")]
+    SenderlessPython(Arc<crate::timer::PythonTimeEventCallback>),
+    SenderlessRust,
 }
 
 impl LiveTimer {
@@ -144,6 +168,19 @@ impl LiveTimer {
 
         log::trace!("Creating timer '{name}'");
 
+        let owner_callback = if sender.is_some() {
+            if callback.is_local() {
+                OwnerCallback::Registered {
+                    token: register_time_event_callback(callback.clone()),
+                    callback,
+                }
+            } else {
+                OwnerCallback::Direct(TimeEventMessageFactory::new(&callback))
+            }
+        } else {
+            OwnerCallback::Senderless(callback)
+        };
+
         Self {
             name,
             interval_ns,
@@ -151,7 +188,7 @@ impl LiveTimer {
             stop_time_ns,
             fire_immediately,
             next_time_ns: Arc::new(AtomicU64::new(next_time_ns)),
-            callback,
+            callback: owner_callback,
             task_handle: None,
             canceled: false,
             sender,
@@ -184,6 +221,10 @@ impl LiveTimer {
     /// Time events will begin triggering at the specified intervals.
     /// The generated events are handled by the provided callback function.
     ///
+    /// Starting a timer whose task is still active aborts that task first
+    /// (restart semantics); a previously fired event that is already queued
+    /// still dispatches.
+    ///
     /// # Panics
     ///
     /// Panics if using a Rust callback (`Rust` or `RustLocal`) without a `TimeEventSender`.
@@ -193,14 +234,38 @@ impl LiveTimer {
         let stop_time_ns = self.stop_time_ns;
         let interval_ns = self.interval_ns.get();
 
-        if self.callback.is_local() {
-            log::debug!(
-                "Timer '{event_name}' uses a RustLocal callback on a live Tokio timer; \
-                 callback registry dispatch is needed to avoid cloning Rc on worker threads"
-            );
+        // An active previous task must not share the registered token with
+        // the new one. Close BEFORE aborting: abort() does not join, and a
+        // task already past its tick can still run its synchronous fire
+        // path - its late close() must land on the old, already-closed
+        // token (a no-op) rather than on the token the new task uses. Any
+        // lease it acquired first stays valid, matching cancel semantics.
+        if let Some(handle) = self.task_handle.take() {
+            self.close_registered_callback();
+            handle.abort();
         }
 
-        let callback = self.callback.clone();
+        let worker_dispatch = match &mut self.callback {
+            OwnerCallback::Registered { token, callback } => {
+                // A cancel or a final stop-time fire closed the token; a
+                // restart needs a fresh registration or acquire() would
+                // return None on every fire.
+                if token.is_closed() {
+                    *token = register_time_event_callback(callback.clone());
+                }
+                WorkerDispatch::Registered(token.clone())
+            }
+            OwnerCallback::Direct(factory) => WorkerDispatch::Direct(factory.clone()),
+            OwnerCallback::Senderless(callback) => match callback {
+                #[cfg(feature = "python")]
+                TimeEventCallback::Python(callback) => {
+                    WorkerDispatch::SenderlessPython(callback.clone())
+                }
+                TimeEventCallback::Rust(_) | TimeEventCallback::RustLocal(_) => {
+                    WorkerDispatch::SenderlessRust
+                }
+            },
+        };
 
         // Get current time
         let clock = get_atomic_clock_realtime();
@@ -259,6 +324,15 @@ impl LiveTimer {
                 // enforced on the scheduled time (matching `TestTimer`), not on
                 // the wall-clock read used only for `ts_init`.
                 if !should_fire_scheduled_time(next_time_ns, stop_time_ns) {
+                    if let (Some(sender), WorkerDispatch::Registered(token)) =
+                        (sender.as_ref(), &worker_dispatch)
+                        && let Some(lease) = token.acquire()
+                    {
+                        token.close();
+                        let now_ns = clock.get_time_ns();
+                        let event = TimeEvent::new(event_name, UUID4::new(), next_time_ns, now_ns);
+                        sender.send(TimeEventMessage::cleanup(event, lease));
+                    }
                     break; // Timer expired before this event
                 }
 
@@ -269,32 +343,44 @@ impl LiveTimer {
 
                 let event = TimeEvent::new(event_name, UUID4::new(), next_time_ns, now_ns);
 
-                if let Some(sender) = sender.as_ref() {
-                    // TODO: `RustLocal` still clones an `Rc` on the timer worker.
-                    // Move callbacks into an event-loop registry and send an id instead.
-                    let handler = TimeEventHandler::new(event, callback.clone());
-                    sender.send(handler);
-                } else {
-                    #[cfg(feature = "python")]
-                    if matches!(&callback, TimeEventCallback::Python(_)) {
-                        callback.call(event);
-                    } else {
-                        panic!("timer event sender was unset for Rust callback system");
-                    }
-
-                    #[cfg(not(feature = "python"))]
-                    {
-                        panic!("timer event sender was unset for Rust callback system");
-                    }
-                }
-
                 // The event scheduled exactly at the stop time fires (inclusive
                 // boundary), then the timer expires.
                 let expires_after_fire = expires_after_scheduled_time(next_time_ns, stop_time_ns);
 
-                // Prepare next time interval
-                next_time_ns += interval_ns;
-                next_time_atomic.store(next_time_ns.as_u64(), atomic::Ordering::SeqCst);
+                // Publish the advanced schedule BEFORE a channel send so a
+                // restart that snapshots `next_time_ns` mid-fire cannot
+                // re-schedule the event being emitted. Senderless dispatch
+                // advances after invocation instead, preserving the
+                // pre-advance value a reentrant callback observes.
+                if sender.is_some() {
+                    next_time_ns += interval_ns;
+                    next_time_atomic.store(next_time_ns.as_u64(), atomic::Ordering::SeqCst);
+                }
+
+                match (&sender, &worker_dispatch) {
+                    (Some(sender), WorkerDispatch::Direct(factory)) => {
+                        sender.send(factory.message(event));
+                    }
+                    (Some(sender), WorkerDispatch::Registered(token)) => {
+                        if let Some(lease) = token.acquire() {
+                            if expires_after_fire {
+                                token.close();
+                            }
+                            sender.send(TimeEventMessage::registered(event, lease));
+                        }
+                    }
+                    #[cfg(feature = "python")]
+                    (None, WorkerDispatch::SenderlessPython(callback)) => callback.call(event),
+                    (None, WorkerDispatch::SenderlessRust) => {
+                        panic!("timer event sender was unset for Rust callback system");
+                    }
+                    _ => unreachable!("timer callback dispatch did not match its sender"),
+                }
+
+                if sender.is_none() {
+                    next_time_ns += interval_ns;
+                    next_time_atomic.store(next_time_ns.as_u64(), atomic::Ordering::SeqCst);
+                }
 
                 if expires_after_fire {
                     break; // Timer expired at the stop boundary
@@ -317,10 +403,18 @@ impl LiveTimer {
     pub fn cancel(&mut self) {
         log::trace!("Cancel timer '{}'", self.name);
 
+        self.close_registered_callback();
+
         if let Some(handle) = self.task_handle.take() {
             handle.abort();
         }
         self.canceled = true;
+    }
+
+    fn close_registered_callback(&self) {
+        if let OwnerCallback::Registered { token, .. } = &self.callback {
+            token.close();
+        }
     }
 }
 
@@ -336,6 +430,8 @@ impl Timer for LiveTimer {
 
 impl Drop for LiveTimer {
     fn drop(&mut self) {
+        self.close_registered_callback();
+
         if let Some(handle) = self.task_handle.take() {
             handle.abort();
         }
@@ -346,7 +442,7 @@ impl Drop for LiveTimer {
 mod tests {
     #[cfg(all(feature = "simulation", madsim))]
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::{num::NonZeroU64, sync::Arc};
+    use std::{num::NonZeroU64, rc::Rc, sync::Arc};
     #[cfg(any(feature = "python", not(all(feature = "simulation", madsim))))]
     use std::{
         sync::{Mutex, mpsc},
@@ -366,24 +462,24 @@ mod tests {
     #[cfg(not(all(feature = "simulation", madsim)))]
     use crate::testing::wait_until;
     use crate::{
-        runner::TimeEventSender,
-        timer::{TimeEventCallback, TimeEventHandler},
+        runner::{TimeEventMessage, TimeEventSender},
+        timer::TimeEventCallback,
     };
 
     #[cfg(any(feature = "python", not(all(feature = "simulation", madsim))))]
     #[derive(Debug)]
     struct ChannelSender {
-        tx: Mutex<mpsc::Sender<TimeEventHandler>>,
+        tx: Mutex<mpsc::Sender<TimeEventMessage>>,
     }
 
     #[cfg(any(feature = "python", not(all(feature = "simulation", madsim))))]
     impl TimeEventSender for ChannelSender {
-        fn send(&self, handler: TimeEventHandler) {
+        fn send(&self, message: TimeEventMessage) {
             self.tx
                 .lock()
                 .expect("sender mutex should lock")
-                .send(handler)
-                .expect("handler should send");
+                .send(message)
+                .expect("message should send");
         }
     }
 
@@ -395,7 +491,7 @@ mod tests {
 
     #[cfg(all(feature = "simulation", madsim))]
     impl TimeEventSender for CountingSender {
-        fn send(&self, _handler: TimeEventHandler) {
+        fn send(&self, _message: TimeEventMessage) {
             self.count.fetch_add(1, Ordering::Relaxed);
         }
     }
@@ -594,13 +690,190 @@ mod tests {
         );
 
         timer.start();
-        let handler = rx
+        let message = rx
             .recv_timeout(StdDuration::from_secs(1))
-            .expect("timer handler should arrive on the global runtime");
+            .expect("timer message should arrive on the global runtime");
         wait_until(|| timer.is_expired(), StdDuration::from_secs(1));
 
-        assert_eq!(handler.event.ts_event, now);
+        assert_eq!(message.event().ts_event, now);
         assert!(timer.is_expired());
+    }
+
+    #[cfg(not(all(feature = "simulation", madsim)))]
+    #[rstest]
+    fn test_live_timer_dispatches_rust_local_callback_on_owner_thread() {
+        let (tx, rx) = mpsc::channel();
+        let sender = Arc::new(ChannelSender { tx: Mutex::new(tx) });
+        let count = Rc::new(std::cell::Cell::new(0));
+        let callback_count = count.clone();
+        let callback: Rc<dyn Fn(crate::timer::TimeEvent)> =
+            Rc::new(move |_| callback_count.set(callback_count.get() + 1));
+        let now = get_atomic_clock_realtime().get_time_ns();
+        let mut timer = LiveTimer::new(
+            Ustr::from("LOCAL_TIMER"),
+            NonZeroU64::new(1_000_000).unwrap(),
+            now,
+            Some(now),
+            TimeEventCallback::RustLocal(callback),
+            true,
+            Some(sender),
+        );
+
+        timer.start();
+        let message = rx
+            .recv_timeout(StdDuration::from_secs(1))
+            .expect("registered timer message should arrive");
+
+        assert!(message.dispatch());
+        assert_eq!(count.get(), 1);
+    }
+
+    #[cfg(not(all(feature = "simulation", madsim)))]
+    #[rstest]
+    fn test_live_timer_cancel_preserves_queued_rust_local_callback_lease() {
+        let (tx, rx) = mpsc::channel();
+        let sender = Arc::new(ChannelSender { tx: Mutex::new(tx) });
+        let count = Rc::new(std::cell::Cell::new(0));
+        let callback_count = count.clone();
+        let callback: Rc<dyn Fn(crate::timer::TimeEvent)> =
+            Rc::new(move |_| callback_count.set(callback_count.get() + 1));
+        let callback_weak = Rc::downgrade(&callback);
+        let now = get_atomic_clock_realtime().get_time_ns();
+        let mut timer = LiveTimer::new(
+            Ustr::from("CANCEL_QUEUED"),
+            NonZeroU64::new(1_000_000).unwrap(),
+            now,
+            None,
+            TimeEventCallback::RustLocal(callback),
+            true,
+            Some(sender),
+        );
+
+        timer.start();
+        let message = rx
+            .recv_timeout(StdDuration::from_secs(1))
+            .expect("registered timer message should arrive");
+        timer.cancel();
+
+        assert!(callback_weak.upgrade().is_some());
+        assert!(message.dispatch());
+        assert_eq!(count.get(), 1);
+
+        // The timer retains an owner-side clone for restart; only after it
+        // drops must no registry copy remain.
+        drop(timer);
+        assert!(callback_weak.upgrade().is_none());
+    }
+
+    #[cfg(not(all(feature = "simulation", madsim)))]
+    #[rstest]
+    fn test_live_timer_restart_after_cancel_re_registers_rust_local_callback() {
+        let (tx, rx) = mpsc::channel();
+        let sender = Arc::new(ChannelSender { tx: Mutex::new(tx) });
+        let count = Rc::new(std::cell::Cell::new(0));
+        let callback_count = count.clone();
+        let callback: Rc<dyn Fn(crate::timer::TimeEvent)> =
+            Rc::new(move |_| callback_count.set(callback_count.get() + 1));
+        let now = get_atomic_clock_realtime().get_time_ns();
+        let mut timer = LiveTimer::new(
+            Ustr::from("RESTART_TIMER"),
+            NonZeroU64::new(1_000_000).unwrap(),
+            now,
+            None,
+            TimeEventCallback::RustLocal(callback),
+            true,
+            Some(sender),
+        );
+
+        timer.start();
+        let first = rx
+            .recv_timeout(StdDuration::from_secs(1))
+            .expect("first registered timer message should arrive");
+        timer.cancel();
+        assert!(first.dispatch());
+
+        timer.start();
+        let second = rx
+            .recv_timeout(StdDuration::from_secs(1))
+            .expect("restarted timer should re-register and fire");
+        timer.cancel();
+
+        assert!(second.dispatch());
+        assert_eq!(count.get(), 2);
+    }
+
+    #[cfg(not(all(feature = "simulation", madsim)))]
+    #[rstest]
+    fn test_live_timer_start_while_active_restarts_and_keeps_dispatching() {
+        let (tx, rx) = mpsc::channel();
+        let sender = Arc::new(ChannelSender { tx: Mutex::new(tx) });
+        let count = Rc::new(std::cell::Cell::new(0));
+        let callback_count = count.clone();
+        let callback: Rc<dyn Fn(crate::timer::TimeEvent)> =
+            Rc::new(move |_| callback_count.set(callback_count.get() + 1));
+        let now = get_atomic_clock_realtime().get_time_ns();
+        let mut timer = LiveTimer::new(
+            Ustr::from("DOUBLE_START_TIMER"),
+            NonZeroU64::new(1_000_000).unwrap(),
+            now,
+            None,
+            TimeEventCallback::RustLocal(callback),
+            true,
+            Some(sender),
+        );
+
+        timer.start();
+        let first = rx
+            .recv_timeout(StdDuration::from_secs(1))
+            .expect("first task message should arrive");
+
+        // Second start with the first task still active: the old task is
+        // aborted and the token stays live for the new one.
+        timer.start();
+        let second = rx
+            .recv_timeout(StdDuration::from_secs(1))
+            .expect("restarted task should keep dispatching");
+        timer.cancel();
+
+        assert!(first.dispatch());
+        assert!(second.dispatch());
+        assert_eq!(count.get(), 2);
+    }
+
+    #[cfg(not(all(feature = "simulation", madsim)))]
+    #[rstest]
+    fn test_live_timer_stop_before_first_fire_sends_cleanup_message() {
+        let (tx, rx) = mpsc::channel();
+        let sender = Arc::new(ChannelSender { tx: Mutex::new(tx) });
+        let count = Rc::new(std::cell::Cell::new(0));
+        let callback_count = count.clone();
+        let callback: Rc<dyn Fn(crate::timer::TimeEvent)> =
+            Rc::new(move |_| callback_count.set(callback_count.get() + 1));
+        let callback_weak = Rc::downgrade(&callback);
+        let now = get_atomic_clock_realtime().get_time_ns();
+        let mut timer = LiveTimer::new(
+            Ustr::from("CLEANUP_TIMER"),
+            NonZeroU64::new(1_000_000).unwrap(),
+            now,
+            Some(now),
+            TimeEventCallback::RustLocal(callback),
+            false,
+            Some(sender),
+        );
+
+        timer.start();
+        let cleanup = rx
+            .recv_timeout(StdDuration::from_secs(1))
+            .expect("cleanup message should arrive");
+
+        assert!(callback_weak.upgrade().is_some());
+        assert!(!cleanup.dispatch());
+        assert_eq!(count.get(), 0);
+
+        // The timer retains an owner-side clone for restart; only after it
+        // drops must no registry copy remain.
+        drop(timer);
+        assert!(callback_weak.upgrade().is_none());
     }
 
     #[cfg(all(feature = "simulation", madsim))]
@@ -656,13 +929,13 @@ mod tests {
             );
 
             timer.start();
-            let handler = rx
+            let message = rx
                 .recv_timeout(StdDuration::from_secs(1))
-                .expect("timer handler should arrive without acquiring the GIL on the worker");
+                .expect("timer message should arrive without acquiring the GIL on the worker");
             timer.cancel();
 
             assert_eq!(py_list.len(), 0);
-            handler.run();
+            assert!(message.dispatch());
             assert_eq!(py_list.len(), 1);
         });
     }

--- a/crates/common/src/python/clock.rs
+++ b/crates/common/src/python/clock.rs
@@ -308,8 +308,8 @@ mod tests {
     use crate::{
         clock::{Clock, TestClock},
         python::clock::PyClock,
-        runner::{TimeEventSender, set_time_event_sender},
-        timer::{TimeEventCallback, TimeEventHandler},
+        runner::{TimeEventMessage, TimeEventSender, set_time_event_sender},
+        timer::TimeEventCallback,
     };
 
     fn ensure_sender() {
@@ -323,7 +323,7 @@ mod tests {
     struct DummySender;
 
     impl TimeEventSender for DummySender {
-        fn send(&self, _handler: TimeEventHandler) {}
+        fn send(&self, _message: TimeEventMessage) {}
     }
 
     #[fixture]

--- a/crates/common/src/python/timer.rs
+++ b/crates/common/src/python/timer.rs
@@ -182,7 +182,7 @@ mod tests {
 
     use crate::{
         live::timer::LiveTimer,
-        runner::{TimeEventSender, set_time_event_sender},
+        runner::{TimeEventMessage, TimeEventSender, set_time_event_sender},
         testing::wait_until,
         timer::{TimeEvent, TimeEventCallback},
     };
@@ -196,7 +196,7 @@ mod tests {
     struct TestTimeEventSender;
 
     impl TimeEventSender for TestTimeEventSender {
-        fn send(&self, _handler: crate::timer::TimeEventHandler) {
+        fn send(&self, _message: TimeEventMessage) {
             // Test implementation - just ignore the events
         }
     }

--- a/crates/common/src/runner.rs
+++ b/crates/common/src/runner.rs
@@ -19,13 +19,334 @@
 //! message queues, and time event channels. It manages thread-local storage for
 //! system-wide components that need to be accessible across threads.
 
-use std::{cell::RefCell, fmt::Debug, sync::Arc};
+use std::{
+    cell::RefCell,
+    fmt::Debug,
+    num::NonZeroU64,
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+    thread::{self, ThreadId},
+};
+
+use ahash::AHashMap;
 
 use crate::{
     messages::{data::DataCommand, execution::TradingCommand},
     msgbus::{self, MessagingSwitchboard},
-    timer::TimeEventHandler,
+    timer::{TimeEvent, TimeEventCallback, TimeEventHandler},
 };
+
+const CALLBACK_CLOSED: usize = 1 << (usize::BITS - 1);
+const CALLBACK_LEASES: usize = CALLBACK_CLOSED - 1;
+static NEXT_TIME_EVENT_CALLBACK_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct TimeEventCallbackId(NonZeroU64);
+
+#[derive(Debug)]
+struct TimeEventCallbackTokenInner {
+    id: TimeEventCallbackId,
+    owner: ThreadId,
+    state: AtomicUsize,
+}
+
+struct TimeEventCallbackEntry {
+    callback: TimeEventCallback,
+    token: Weak<TimeEventCallbackTokenInner>,
+}
+
+/// A send-safe handle to a thread-local time event callback.
+#[derive(Clone, Debug)]
+pub(crate) struct TimeEventCallbackToken(Arc<TimeEventCallbackTokenInner>);
+
+impl TimeEventCallbackToken {
+    fn register(callback: TimeEventCallback) -> Self {
+        debug_assert!(callback.is_local());
+        purge_closed_time_event_callbacks();
+
+        let raw_id = NEXT_TIME_EVENT_CALLBACK_ID.fetch_add(1, Ordering::Relaxed);
+        let id = TimeEventCallbackId(
+            NonZeroU64::new(raw_id).expect("time event callback IDs exhausted"),
+        );
+        let token = Self(Arc::new(TimeEventCallbackTokenInner {
+            id,
+            owner: thread::current().id(),
+            state: AtomicUsize::new(0),
+        }));
+        TIME_EVENT_CALLBACKS.with(|callbacks| {
+            let previous = callbacks.borrow_mut().insert(
+                id,
+                TimeEventCallbackEntry {
+                    callback,
+                    token: Arc::downgrade(&token.0),
+                },
+            );
+            debug_assert!(previous.is_none());
+        });
+        token
+    }
+
+    pub(crate) fn acquire(&self) -> Option<TimeEventCallbackLease> {
+        let mut state = self.0.state.load(Ordering::Acquire);
+        loop {
+            if state & CALLBACK_CLOSED != 0 {
+                return None;
+            }
+            let leases = state & CALLBACK_LEASES;
+            assert!(
+                leases < CALLBACK_LEASES,
+                "time event callback lease count overflow"
+            );
+
+            match self.0.state.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Some(TimeEventCallbackLease(self.0.clone())),
+                Err(actual) => state = actual,
+            }
+        }
+    }
+
+    #[cfg(any(feature = "live", test))]
+    pub(crate) fn is_closed(&self) -> bool {
+        self.0.state.load(Ordering::Acquire) & CALLBACK_CLOSED != 0
+    }
+
+    pub(crate) fn close(&self) {
+        let previous = self.0.state.fetch_or(CALLBACK_CLOSED, Ordering::AcqRel);
+        if previous & CALLBACK_LEASES == 0 {
+            self.remove_on_owner_thread();
+        }
+    }
+
+    fn remove_on_owner_thread(&self) {
+        if self.0.owner == thread::current().id() {
+            TIME_EVENT_CALLBACKS.with(|callbacks| {
+                callbacks.borrow_mut().remove(&self.0.id);
+            });
+        }
+    }
+
+    #[cfg(test)]
+    fn is_registered(&self) -> bool {
+        TIME_EVENT_CALLBACKS.with(|callbacks| callbacks.borrow().contains_key(&self.0.id))
+    }
+}
+
+/// A per-message hold on a registered callback entry.
+///
+/// The final lease of a closed token removes the TLS entry when it drops on
+/// the owner thread. A final lease dropped on another thread (failed send,
+/// receiver shutdown on a foreign thread) cannot touch the owner's TLS map;
+/// the closed entry is then reclaimed lazily by the next owner-thread
+/// registration or [`purge_closed_time_event_callbacks`] call (`LiveClock`
+/// invokes the latter from `clear_expired_timers`). That is bounded
+/// retention of the callback, never a leak across registrations and never
+/// a cross-thread `Rc` access.
+#[derive(Debug)]
+pub(crate) struct TimeEventCallbackLease(Arc<TimeEventCallbackTokenInner>);
+
+impl Drop for TimeEventCallbackLease {
+    fn drop(&mut self) {
+        let previous = self.0.state.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous & CALLBACK_LEASES > 0);
+        if previous == CALLBACK_CLOSED | 1 && self.0.owner == thread::current().id() {
+            TIME_EVENT_CALLBACKS.with(|callbacks| {
+                callbacks.borrow_mut().remove(&self.0.id);
+            });
+        }
+    }
+}
+
+#[derive(Clone)]
+enum SendTimeEventCallback {
+    #[cfg(feature = "python")]
+    Python(Arc<crate::timer::PythonTimeEventCallback>),
+    Rust(Arc<dyn Fn(TimeEvent) + Send + Sync>),
+}
+
+impl Debug for SendTimeEventCallback {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "python")]
+            Self::Python(_) => f.write_str("Python callback"),
+            Self::Rust(_) => f.write_str("Rust callback (thread-safe)"),
+        }
+    }
+}
+
+impl SendTimeEventCallback {
+    fn into_callback(self) -> TimeEventCallback {
+        match self {
+            #[cfg(feature = "python")]
+            Self::Python(callback) => TimeEventCallback::Python(callback),
+            Self::Rust(callback) => TimeEventCallback::Rust(callback),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+#[cfg(feature = "live")]
+pub(crate) struct TimeEventMessageFactory(SendTimeEventCallback);
+
+#[cfg(feature = "live")]
+impl TimeEventMessageFactory {
+    pub(crate) fn new(callback: &TimeEventCallback) -> Self {
+        match callback {
+            #[cfg(feature = "python")]
+            TimeEventCallback::Python(callback) => {
+                Self(SendTimeEventCallback::Python(callback.clone()))
+            }
+            TimeEventCallback::Rust(callback) => {
+                Self(SendTimeEventCallback::Rust(callback.clone()))
+            }
+            TimeEventCallback::RustLocal(_) => {
+                unreachable!("RustLocal callbacks require registered dispatch")
+            }
+        }
+    }
+
+    pub(crate) fn message(&self, event: TimeEvent) -> TimeEventMessage {
+        TimeEventMessage {
+            event,
+            dispatch: TimeEventDispatch::Direct(self.0.clone()),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum TimeEventDispatch {
+    Direct(SendTimeEventCallback),
+    Registered(TimeEventCallbackLease),
+    #[cfg(any(feature = "live", test))]
+    Cleanup(TimeEventCallbackLease),
+}
+
+/// A send-safe live time event channel payload.
+///
+/// The dispatch representation is private so local callbacks can never be
+/// embedded in a cross-thread message.
+#[derive(Debug)]
+pub struct TimeEventMessage {
+    event: TimeEvent,
+    dispatch: TimeEventDispatch,
+}
+
+impl TimeEventMessage {
+    /// Creates a message from a time event and callback.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the process-wide callback ID or lease count is exhausted.
+    #[must_use]
+    pub fn new(event: TimeEvent, callback: TimeEventCallback) -> Self {
+        match callback {
+            #[cfg(feature = "python")]
+            TimeEventCallback::Python(callback) => Self {
+                event,
+                dispatch: TimeEventDispatch::Direct(SendTimeEventCallback::Python(callback)),
+            },
+            TimeEventCallback::Rust(callback) => Self {
+                event,
+                dispatch: TimeEventDispatch::Direct(SendTimeEventCallback::Rust(callback)),
+            },
+            callback @ TimeEventCallback::RustLocal(_) => {
+                let token = TimeEventCallbackToken::register(callback);
+                let lease = token
+                    .acquire()
+                    .expect("new time event callback token should be open");
+                token.close();
+                Self::registered(event, lease)
+            }
+        }
+    }
+
+    /// Returns the time event carried by this message.
+    #[must_use]
+    pub const fn event(&self) -> &TimeEvent {
+        &self.event
+    }
+
+    pub(crate) const fn registered(event: TimeEvent, lease: TimeEventCallbackLease) -> Self {
+        Self {
+            event,
+            dispatch: TimeEventDispatch::Registered(lease),
+        }
+    }
+
+    #[cfg(any(feature = "live", test))]
+    pub(crate) const fn cleanup(event: TimeEvent, lease: TimeEventCallbackLease) -> Self {
+        Self {
+            event,
+            dispatch: TimeEventDispatch::Cleanup(lease),
+        }
+    }
+
+    /// Resolves and runs this message on the receiving thread.
+    ///
+    /// Returns `true` when a callback was dispatched. Cleanup messages and
+    /// wrong-thread registered messages return `false`.
+    pub fn dispatch(self) -> bool {
+        let Self { event, dispatch } = self;
+        match dispatch {
+            TimeEventDispatch::Direct(callback) => {
+                TimeEventHandler::new(event, callback.into_callback()).run();
+                true
+            }
+            TimeEventDispatch::Registered(lease) => {
+                if lease.0.owner != thread::current().id() {
+                    log::error!(
+                        "Dropping time event '{}' drained outside its callback owner thread",
+                        event.name
+                    );
+                    return false;
+                }
+                let callback = TIME_EVENT_CALLBACKS.with(|callbacks| {
+                    callbacks
+                        .borrow()
+                        .get(&lease.0.id)
+                        .map(|entry| entry.callback.clone())
+                });
+
+                if let Some(callback) = callback {
+                    TimeEventHandler::new(event, callback).run();
+                    true
+                } else {
+                    log::error!("Dropping time event with an unregistered callback token");
+                    false
+                }
+            }
+            #[cfg(any(feature = "live", test))]
+            TimeEventDispatch::Cleanup(lease) => {
+                if lease.0.owner != thread::current().id() {
+                    log::error!("Dropping timer cleanup message outside its callback owner thread");
+                }
+                false
+            }
+        }
+    }
+}
+
+#[cfg(any(feature = "live", test))]
+pub(crate) fn register_time_event_callback(callback: TimeEventCallback) -> TimeEventCallbackToken {
+    TimeEventCallbackToken::register(callback)
+}
+
+pub(crate) fn purge_closed_time_event_callbacks() {
+    TIME_EVENT_CALLBACKS.with(|callbacks| {
+        callbacks.borrow_mut().retain(|_, entry| {
+            entry
+                .token
+                .upgrade()
+                .is_some_and(|token| token.state.load(Ordering::Acquire) != CALLBACK_CLOSED)
+        });
+    });
+}
 
 /// Trait for data command sending that can be implemented for both sync and async runners.
 pub trait DataCommandSender {
@@ -106,8 +427,8 @@ pub fn replace_data_cmd_sender(sender: Arc<dyn DataCommandSender>) {
 
 /// Trait for time event sending that can be implemented for both sync and async runners.
 pub trait TimeEventSender: Debug + Send + Sync {
-    /// Sends a time event handler.
-    fn send(&self, handler: TimeEventHandler);
+    /// Sends a live time event message.
+    fn send(&self, message: TimeEventMessage);
 }
 
 /// Gets the global time event sender.
@@ -245,6 +566,7 @@ pub fn replace_exec_cmd_sender(sender: Arc<dyn TradingCommandSender>) {
 }
 
 thread_local! {
+    static TIME_EVENT_CALLBACKS: RefCell<AHashMap<TimeEventCallbackId, TimeEventCallbackEntry>> = RefCell::new(AHashMap::new());
     static TIME_EVENT_SENDER: RefCell<Option<Arc<dyn TimeEventSender>>> = const { RefCell::new(None) };
     static DATA_CMD_SENDER: RefCell<Option<Arc<dyn DataCommandSender>>> = const { RefCell::new(None) };
     static EXEC_CMD_SENDER: RefCell<Option<Arc<dyn TradingCommandSender>>> = const { RefCell::new(None) };
@@ -254,9 +576,15 @@ thread_local! {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{
+        cell::{Cell, RefCell},
+        rc::Rc,
+        sync::Arc,
+    };
 
+    use nautilus_core::{UUID4, UnixNanos};
     use rstest::rstest;
+    use ustr::Ustr;
 
     use super::*;
 
@@ -264,7 +592,198 @@ mod tests {
     struct NoopTimeEventSender;
 
     impl TimeEventSender for NoopTimeEventSender {
-        fn send(&self, _handler: TimeEventHandler) {}
+        fn send(&self, _message: TimeEventMessage) {}
+    }
+
+    fn event(name: &str) -> TimeEvent {
+        TimeEvent::new(
+            Ustr::from(name),
+            UUID4::new(),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+        )
+    }
+
+    fn local_callback(count: Rc<Cell<usize>>) -> TimeEventCallback {
+        TimeEventCallback::RustLocal(Rc::new(move |_| count.set(count.get() + 1)))
+    }
+
+    #[rstest]
+    fn test_time_event_message_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<TimeEventMessage>();
+    }
+
+    #[rstest]
+    fn test_registered_time_event_dispatches_on_owner_thread() {
+        let count = Rc::new(Cell::new(0));
+        let token = register_time_event_callback(local_callback(count.clone()));
+        let lease = token.acquire().unwrap();
+        let message = TimeEventMessage::registered(event("same-thread"), lease);
+
+        assert!(message.dispatch());
+        assert_eq!(count.get(), 1);
+        assert!(token.is_registered());
+
+        token.close();
+        assert!(!token.is_registered());
+    }
+
+    #[rstest]
+    fn test_registered_time_event_dropped_on_wrong_thread() {
+        let count = Rc::new(Cell::new(0));
+        let token = register_time_event_callback(local_callback(count.clone()));
+        let lease = token.acquire().unwrap();
+        let message = TimeEventMessage::registered(event("wrong-thread"), lease);
+
+        let dispatched = std::thread::spawn(move || message.dispatch())
+            .join()
+            .unwrap();
+
+        assert!(!dispatched);
+        assert_eq!(count.get(), 0);
+        assert!(token.is_registered());
+
+        token.close();
+        assert!(!token.is_registered());
+    }
+
+    #[rstest]
+    fn test_closing_registered_callback_without_leases_removes_it_immediately() {
+        let token = register_time_event_callback(local_callback(Rc::new(Cell::new(0))));
+        assert!(!token.is_closed());
+
+        token.close();
+
+        assert!(token.is_closed());
+        assert!(!token.is_registered());
+    }
+
+    #[rstest]
+    fn test_closing_registered_callback_preserves_queued_leases_until_last_dispatch() {
+        let count = Rc::new(Cell::new(0));
+        let token = register_time_event_callback(local_callback(count.clone()));
+        let first = TimeEventMessage::registered(event("first"), token.acquire().unwrap());
+        let second = TimeEventMessage::registered(event("second"), token.acquire().unwrap());
+
+        token.close();
+        assert!(token.is_registered());
+
+        assert!(first.dispatch());
+        assert_eq!(count.get(), 1);
+        assert!(token.is_registered());
+
+        assert!(second.dispatch());
+        assert_eq!(count.get(), 2);
+        assert!(!token.is_registered());
+    }
+
+    #[rstest]
+    fn test_replaced_registered_callbacks_have_distinct_lifecycles() {
+        let old_count = Rc::new(Cell::new(0));
+        let old = register_time_event_callback(local_callback(old_count.clone()));
+        let old_message = TimeEventMessage::registered(event("same-name"), old.acquire().unwrap());
+        old.close();
+
+        let new_count = Rc::new(Cell::new(0));
+        let new = register_time_event_callback(local_callback(new_count.clone()));
+
+        assert_ne!(old.0.id, new.0.id);
+        assert!(old_message.dispatch());
+        assert_eq!(old_count.get(), 1);
+        assert_eq!(new_count.get(), 0);
+        assert!(new.is_registered());
+
+        new.close();
+        assert!(!new.is_registered());
+    }
+
+    #[rstest]
+    fn test_one_shot_callback_can_rearm_same_name_without_old_lease_removing_new_callback() {
+        let replacement = Rc::new(RefCell::new(None));
+        let replacement_slot = replacement.clone();
+        let callback = TimeEventCallback::RustLocal(Rc::new(move |_| {
+            let token = register_time_event_callback(TimeEventCallback::RustLocal(Rc::new(|_| {})));
+            replacement_slot.replace(Some(token));
+        }));
+        let old = register_time_event_callback(callback);
+        let message = TimeEventMessage::registered(event("rearm"), old.acquire().unwrap());
+        old.close();
+
+        assert!(message.dispatch());
+        assert!(!old.is_registered());
+
+        let new = replacement.borrow_mut().take().unwrap();
+        assert_ne!(old.0.id, new.0.id);
+        assert!(new.is_registered());
+        new.close();
+        assert!(!new.is_registered());
+    }
+
+    #[rstest]
+    fn test_wrong_thread_final_lease_is_lazily_purged_on_owner_thread() {
+        let callback: Rc<dyn Fn(TimeEvent)> = Rc::new(|_| {});
+        let callback_weak = Rc::downgrade(&callback);
+        let token = register_time_event_callback(TimeEventCallback::RustLocal(callback));
+        let message = TimeEventMessage::registered(event("lazy-purge"), token.acquire().unwrap());
+        token.close();
+        drop(token);
+
+        let dispatched = std::thread::spawn(move || message.dispatch())
+            .join()
+            .unwrap();
+
+        assert!(!dispatched);
+        assert!(callback_weak.upgrade().is_some());
+
+        let next = register_time_event_callback(local_callback(Rc::new(Cell::new(0))));
+        assert!(callback_weak.upgrade().is_none());
+        next.close();
+    }
+
+    #[rstest]
+    #[cfg(any(feature = "live", test))]
+    fn test_cleanup_message_removes_callback_without_dispatching() {
+        let count = Rc::new(Cell::new(0));
+        let token = register_time_event_callback(local_callback(count.clone()));
+        let cleanup = TimeEventMessage::cleanup(event("cleanup"), token.acquire().unwrap());
+        token.close();
+
+        assert!(!cleanup.dispatch());
+        assert_eq!(count.get(), 0);
+        assert!(!token.is_registered());
+    }
+
+    #[rstest]
+    fn test_purge_retains_closed_entry_while_final_lease_is_queued() {
+        let count = Rc::new(Cell::new(0));
+        let token = register_time_event_callback(local_callback(count.clone()));
+        let message = TimeEventMessage::registered(event("purge-queued"), token.acquire().unwrap());
+        token.close();
+
+        purge_closed_time_event_callbacks();
+        assert!(token.is_registered());
+
+        assert!(message.dispatch());
+        assert_eq!(count.get(), 1);
+        assert!(!token.is_registered());
+    }
+
+    #[rstest]
+    fn test_off_owner_final_lease_drop_is_reclaimed_by_owner_purge() {
+        let count = Rc::new(Cell::new(0));
+        let token = register_time_event_callback(local_callback(count.clone()));
+        let lease = token.acquire().unwrap();
+        token.close();
+
+        std::thread::spawn(move || drop(lease)).join().unwrap();
+
+        assert!(token.is_registered());
+
+        purge_closed_time_event_callbacks();
+        assert!(!token.is_registered());
+        assert_eq!(count.get(), 0);
     }
 
     #[rstest]

--- a/crates/common/src/timer.rs
+++ b/crates/common/src/timer.rs
@@ -204,8 +204,8 @@ impl Debug for PythonTimeEventCallback {
 /// - The callback captures `Rc<RefCell<...>>` for shared mutable state.
 /// - Thread safety constraints prevent using `Arc`.
 ///
-/// `RustLocal` works with `TestClock`. With `LiveClock`, use it only for existing
-/// single-threaded callback paths; live timer callback registry dispatch is still pending.
+/// `RustLocal` works with `TestClock` and with `LiveClock` when its event channel
+/// is drained on the callback's originating thread.
 ///
 /// # Automatic Conversion
 ///
@@ -321,26 +321,6 @@ impl TimeEventCallback {
         )))
     }
 }
-
-// SAFETY: TimeEventCallback is Send + Sync with the following invariants:
-//
-// - Python variant: Arc clone/drop does not require the GIL, and the callable is
-//   only invoked after acquiring the GIL.
-//
-// - Rust variant: Arc<dyn Fn + Send + Sync> is inherently Send + Sync.
-//
-// - RustLocal variant: Rc<dyn Fn> is not Send/Sync. This unsafe impl preserves
-//   existing API compatibility and relies on callers to keep RustLocal callbacks
-//   on the originating event-loop thread. LiveTimer logs a warning because its
-//   callback registry dispatch follow-up is still pending.
-//
-//   INVARIANT: RustLocal callbacks must only be cloned, dropped, or called from
-//   the thread that created them. Violating this invariant causes undefined behavior.
-//   Use the Rust variant with Arc if cross-thread execution is needed.
-#[allow(unsafe_code)]
-unsafe impl Send for TimeEventCallback {}
-#[allow(unsafe_code)]
-unsafe impl Sync for TimeEventCallback {}
 
 #[cfg(feature = "python")]
 fn call_legacy_python_time_event_callback(

--- a/crates/live/benches/runner.rs
+++ b/crates/live/benches/runner.rs
@@ -22,7 +22,7 @@ use nautilus_common::{
         self, MessageBus, TypedIntoHandler, register_data_endpoint,
         switchboard::MessagingSwitchboard,
     },
-    timer::TimeEventHandler,
+    runner::TimeEventMessage,
 };
 use nautilus_core::UnixNanos;
 use nautilus_live::runner::AsyncRunner;
@@ -83,7 +83,7 @@ fn bench_channel_operations(c: &mut Criterion) {
     group.bench_function("channel_creation", |b| {
         b.iter(|| {
             let (_tx1, _rx1) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
-            let (_tx2, _rx2) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+            let (_tx2, _rx2) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
             let (_tx3, _rx3) = tokio::sync::mpsc::unbounded_channel::<()>();
         });
     });
@@ -100,7 +100,7 @@ fn bench_runner_components(c: &mut Criterion) {
             // Simulate what AsyncRunner::new() does without the global state
             let (_data_tx, _data_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
             let (_cmd_tx, _cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
-            let (_time_tx, _time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+            let (_time_tx, _time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
             let (_signal_tx, _signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
         });
     });

--- a/crates/live/src/node/metrics.rs
+++ b/crates/live/src/node/metrics.rs
@@ -20,7 +20,7 @@ use std::{
 
 use nautilus_common::{
     messages::{DataEvent, ExecutionEvent, data::DataCommand, execution::TradingCommand},
-    timer::TimeEventHandler,
+    runner::TimeEventMessage,
 };
 
 /// Primitive metrics for one `LiveNode::run` dispatch channel after startup.
@@ -315,7 +315,7 @@ pub(crate) struct RunnerChannelQueueDepths {
 
 impl RunnerChannelQueueDepths {
     pub(crate) fn from_receivers(
-        time_events: &tokio::sync::mpsc::UnboundedReceiver<TimeEventHandler>,
+        time_events: &tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
         exec_events: &tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
         exec_commands: &tokio::sync::mpsc::UnboundedReceiver<TradingCommand>,
         data_events: &tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
@@ -556,7 +556,7 @@ mod tests {
 
     #[rstest]
     fn test_runner_metrics_queue_depths_use_receiver_lengths() {
-        let (time_tx, time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (time_tx, time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (data_evt_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
@@ -655,8 +655,8 @@ mod tests {
         ]
     }
 
-    fn stub_time_event_handler() -> TimeEventHandler {
-        TimeEventHandler::new(
+    fn stub_time_event_handler() -> TimeEventMessage {
+        TimeEventMessage::new(
             TimeEvent::new(
                 Ustr::from("test-timer"),
                 UUID4::new(),

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -95,7 +95,7 @@ use nautilus_common::{
         execution::{GenerateOrderStatusReports, GeneratePositionStatusReports, TradingCommand},
     },
     msgbus::{self, BusMessage},
-    timer::TimeEventHandler,
+    runner::TimeEventMessage,
 };
 use nautilus_core::{
     UUID4,
@@ -1252,19 +1252,21 @@ impl LiveNode {
                 // when the biased select polls receivers each iteration.
                 Some(handler) = time_evt_rx.recv() => {
                     let dispatch_start = dst::time::Instant::now();
-                    AsyncRunner::handle_time_event(handler);
+                    let dispatched = AsyncRunner::handle_time_event(handler);
 
-                    if is_shutting_down {
+                    if dispatched && is_shutting_down {
                         log::debug!("Residual time event");
                         residual_events += 1;
                     }
 
-                    record_runner_dispatch(
-                        &metrics,
-                        RunnerMetricChannel::TimeEvents,
-                        dispatch_start,
-                        metrics_start,
-                    );
+                    if dispatched {
+                        record_runner_dispatch(
+                            &metrics,
+                            RunnerMetricChannel::TimeEvents,
+                            dispatch_start,
+                            metrics_start,
+                        );
+                    }
                 }
                 Some(evt) = exec_evt_rx.recv() => {
                     let dispatch_start = dst::time::Instant::now();
@@ -1588,7 +1590,7 @@ impl LiveNode {
     }
 
     fn drain_channels(
-        time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventHandler>,
+        time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
         data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
         data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
         exec_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
@@ -1597,7 +1599,7 @@ impl LiveNode {
         let mut drained = 0;
 
         while let Ok(handler) = time_evt_rx.try_recv() {
-            AsyncRunner::handle_time_event(handler);
+            let _ = AsyncRunner::handle_time_event(handler);
             drained += 1;
         }
 
@@ -2298,7 +2300,7 @@ fn flush_pending_data(
 /// select did not poll before the connect future resolved.
 fn flush_all_pending(
     pending: &mut PendingEvents,
-    time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventHandler>,
+    time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
     data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
     data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
     exec_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
@@ -2306,7 +2308,7 @@ fn flush_all_pending(
 ) {
     // Flush channel receivers into pending
     while let Ok(handler) = time_evt_rx.try_recv() {
-        AsyncRunner::handle_time_event(handler);
+        let _ = AsyncRunner::handle_time_event(handler);
     }
 
     while let Ok(evt) = data_evt_rx.try_recv() {
@@ -2360,7 +2362,7 @@ fn flush_all_pending(
 async fn drive_with_event_buffering<F: std::future::Future>(
     future: F,
     pending: &mut PendingEvents,
-    time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventHandler>,
+    time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
     data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
     data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
     exec_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
@@ -2376,7 +2378,7 @@ async fn drive_with_event_buffering<F: std::future::Future>(
                 break result;
             }
             Some(handler) = time_evt_rx.recv() => {
-                AsyncRunner::handle_time_event(handler);
+                let _ = AsyncRunner::handle_time_event(handler);
             }
             Some(evt) = exec_evt_rx.recv() => {
                 // Account events are safe to process immediately. Report and
@@ -4116,14 +4118,17 @@ mod tests {
         assert!(cmd_rx.try_recv().is_err());
     }
 
-    fn stub_time_event_handler() -> TimeEventHandler {
+    fn stub_time_event_handler() -> TimeEventMessage {
         use std::rc::Rc;
 
-        use nautilus_common::timer::{TimeEvent, TimeEventCallback, TimeEventHandler};
+        use nautilus_common::{
+            runner::TimeEventMessage,
+            timer::{TimeEvent, TimeEventCallback},
+        };
         use nautilus_core::{UUID4, UnixNanos};
         use ustr::Ustr;
 
-        TimeEventHandler::new(
+        TimeEventMessage::new(
             TimeEvent::new(
                 Ustr::from("test-timer"),
                 UUID4::new(),
@@ -4178,7 +4183,7 @@ mod tests {
 
     #[rstest]
     fn test_flush_all_pending_drains_buffered_channels() {
-        let (time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (data_evt_tx, mut data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
@@ -4249,7 +4254,7 @@ mod tests {
 
     #[rstest]
     fn test_flush_all_pending_routes_order_event_to_order_evts() {
-        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_data_evt_tx, mut data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
@@ -4279,7 +4284,7 @@ mod tests {
 
     #[rstest]
     fn test_flush_all_pending_routes_account_event_immediately() {
-        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_data_evt_tx, mut data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
@@ -4398,7 +4403,7 @@ mod tests {
 
     #[rstest]
     fn test_flush_all_pending_buffers_submitted_batch_as_individual_events() {
-        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_data_evt_tx, mut data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
@@ -4426,7 +4431,7 @@ mod tests {
 
     #[rstest]
     fn test_flush_all_pending_buffers_canceled_batch_as_individual_events() {
-        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_data_evt_tx, mut data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =

--- a/crates/live/src/runner.rs
+++ b/crates/live/src/runner.rs
@@ -70,10 +70,9 @@ use nautilus_common::{
     },
     msgbus::{self, MessagingSwitchboard},
     runner::{
-        DataCommandSender, TimeEventSender, TradingCommandSender, replace_data_cmd_sender,
-        replace_exec_cmd_sender, replace_time_event_sender,
+        DataCommandSender, TimeEventMessage, TimeEventSender, TradingCommandSender,
+        replace_data_cmd_sender, replace_exec_cmd_sender, replace_time_event_sender,
     },
-    timer::TimeEventHandler,
 };
 use nautilus_model::events::OrderEventAny;
 
@@ -101,20 +100,20 @@ impl DataCommandSender for AsyncDataCommandSender {
 /// Asynchronous implementation of `TimeEventSender` for live environments.
 #[derive(Debug, Clone)]
 pub struct AsyncTimeEventSender {
-    time_tx: tokio::sync::mpsc::UnboundedSender<TimeEventHandler>,
+    time_tx: tokio::sync::mpsc::UnboundedSender<TimeEventMessage>,
 }
 
 impl AsyncTimeEventSender {
     #[must_use]
-    pub const fn new(time_tx: tokio::sync::mpsc::UnboundedSender<TimeEventHandler>) -> Self {
+    pub const fn new(time_tx: tokio::sync::mpsc::UnboundedSender<TimeEventMessage>) -> Self {
         Self { time_tx }
     }
 }
 
 impl TimeEventSender for AsyncTimeEventSender {
-    fn send(&self, handler: TimeEventHandler) {
-        if let Err(e) = self.time_tx.send(handler) {
-            log::error!("Failed to send time event handler: {e}");
+    fn send(&self, message: TimeEventMessage) {
+        if let Err(e) = self.time_tx.send(message) {
+            log::error!("Failed to send time event message: {e}");
         }
     }
 }
@@ -150,7 +149,7 @@ pub trait Runner {
 /// the event loop directly on the same thread as the msgbus endpoints.
 #[derive(Debug)]
 pub struct AsyncRunnerChannels {
-    pub time_evt_rx: tokio::sync::mpsc::UnboundedReceiver<TimeEventHandler>,
+    pub time_evt_rx: tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
     pub exec_evt_rx: tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
     pub exec_cmd_rx: tokio::sync::mpsc::UnboundedReceiver<TradingCommand>,
     pub data_evt_rx: tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
@@ -159,7 +158,7 @@ pub struct AsyncRunnerChannels {
 
 pub struct AsyncRunner {
     channels: AsyncRunnerChannels,
-    time_evt_tx: tokio::sync::mpsc::UnboundedSender<TimeEventHandler>,
+    time_evt_tx: tokio::sync::mpsc::UnboundedSender<TimeEventMessage>,
     signal_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
     signal_tx: tokio::sync::mpsc::UnboundedSender<()>,
     exec_cmd_tx: tokio::sync::mpsc::UnboundedSender<TradingCommand>,
@@ -205,7 +204,7 @@ impl AsyncRunner {
     pub fn new() -> Self {
         use tokio::sync::mpsc::unbounded_channel; // tokio-import-ok
 
-        let (time_evt_tx, time_evt_rx) = unbounded_channel::<TimeEventHandler>();
+        let (time_evt_tx, time_evt_rx) = unbounded_channel::<TimeEventMessage>();
         let (signal_tx, signal_rx) = unbounded_channel::<()>();
         let (exec_cmd_tx, exec_cmd_rx) = unbounded_channel::<TradingCommand>();
         let (exec_evt_tx, exec_evt_rx) = unbounded_channel::<ExecutionEvent>();
@@ -330,7 +329,7 @@ impl AsyncRunner {
                     return;
                 },
                 Some(handler) = self.channels.time_evt_rx.recv() => {
-                    Self::handle_time_event(handler);
+                    let _ = Self::handle_time_event(handler);
                 },
                 Some(cmd) = self.channels.exec_cmd_rx.recv() => {
                     Self::handle_exec_command(cmd);
@@ -354,8 +353,9 @@ impl AsyncRunner {
 
     /// Handles a time event by running its callback.
     #[inline]
-    pub fn handle_time_event(handler: TimeEventHandler) {
-        handler.run();
+    #[must_use]
+    pub fn handle_time_event(message: TimeEventMessage) -> bool {
+        message.dispatch()
     }
 
     /// Handles a data command by sending to the `DataEngine`.
@@ -461,10 +461,10 @@ mod tests {
             execution::{CancelAllOrders, TradingCommand},
         },
         runner::{
-            get_data_cmd_sender, get_time_event_sender, get_trading_cmd_sender,
+            TimeEventMessage, get_data_cmd_sender, get_time_event_sender, get_trading_cmd_sender,
             try_get_time_event_sender, try_get_trading_cmd_sender,
         },
-        timer::{TimeEvent, TimeEventCallback, TimeEventHandler},
+        timer::{TimeEvent, TimeEventCallback},
     };
     use nautilus_core::{UUID4, UnixNanos};
     use nautilus_model::{
@@ -507,7 +507,7 @@ mod tests {
     // Sender halves are dummies (not connected to the test receivers) since
     // these tests exercise the event loop, not TLS binding.
     fn create_test_runner(
-        time_evt_rx: tokio::sync::mpsc::UnboundedReceiver<TimeEventHandler>,
+        time_evt_rx: tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
         data_evt_rx: tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
         data_cmd_rx: tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
         exec_evt_rx: tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
@@ -595,9 +595,9 @@ mod tests {
             UnixNanos::from(2),
         );
         let callback = TimeEventCallback::from(|_: TimeEvent| {});
-        let handler = TimeEventHandler::new(event, callback);
+        let message = TimeEventMessage::new(event, callback);
 
-        sender.send(handler);
+        sender.send(message);
 
         assert!(rx.recv().await.is_some());
     }
@@ -607,7 +607,7 @@ mod tests {
         // Create runner with manual channels to avoid global state
         let (_data_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
-        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (_exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -639,7 +639,7 @@ mod tests {
     async fn test_runner_closes_on_channel_drop() {
         let (data_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
-        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (_exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -678,7 +678,7 @@ mod tests {
         let (data_evt_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_data_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (_time_evt_tx, time_evt_rx) =
-            tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+            tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (_exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -788,7 +788,7 @@ mod tests {
         let (_data_evt_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_data_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (_time_evt_tx, time_evt_rx) =
-            tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+            tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -832,7 +832,7 @@ mod tests {
         let (_data_evt_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_data_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (_time_evt_tx, time_evt_rx) =
-            tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+            tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -1030,7 +1030,7 @@ mod tests {
     async fn test_runner_stop_method() {
         let (_data_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
-        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (_exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -1060,7 +1060,7 @@ mod tests {
     async fn test_all_event_types_integration() {
         let (data_evt_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (data_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
-        let (time_evt_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (time_evt_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (_exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -1105,8 +1105,8 @@ mod tests {
             UnixNanos::from(2),
         );
         let callback = TimeEventCallback::from(|_: TimeEvent| {});
-        let handler = TimeEventHandler::new(event, callback);
-        time_evt_tx.send(handler).unwrap();
+        let message = TimeEventMessage::new(event, callback);
+        time_evt_tx.send(message).unwrap();
 
         // Send execution order event
         let order_event = OrderSubmittedSpec::builder()
@@ -1211,7 +1211,7 @@ mod tests {
     async fn test_runner_handle_stops_runner() {
         let (_data_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
-        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (_exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -1256,7 +1256,7 @@ mod tests {
     async fn test_runner_processes_events_before_stop() {
         let (data_evt_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
         let (_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
-        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventHandler>();
+        let (_time_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (_exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         let (_exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TradingCommand>();
         let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -1345,7 +1345,7 @@ mod tests {
                 UnixNanos::from(2),
             );
             let callback = TimeEventCallback::from(|_: TimeEvent| {});
-            get_time_event_sender().send(TimeEventHandler::new(event, callback));
+            get_time_event_sender().send(TimeEventMessage::new(event, callback));
             assert!(runner.channels.time_evt_rx.try_recv().is_ok());
 
             get_data_event_sender()


### PR DESCRIPTION
Removes the unsound `unsafe impl Send`/`Sync` on `TimeEventCallback` and gives the live timer channel a send-safe payload, implementing the registry dispatch the TODO in `LiveTimer::start` calls for.

**1. `RustLocal` callbacks crossed threads through the unsafe impls**

`TimeEventCallback` carries `RustLocal(Rc<dyn Fn(TimeEvent)>)`, yet `timer.rs` declared the whole enum `Send`/`Sync`. `LiveTimer::start` moved a clone into its tokio task and cloned it again on a worker thread on every fire (`TimeEventHandler::new(event, callback.clone())`) before sending the handler to the event-loop drain.

For a `RustLocal` callback that is an unsynchronized `Rc` refcount mutation across threads: a data race on the count, with premature free or double free as the failure mode. The path is reachable in production - the bar-aggregation timers register `RustLocal` callbacks on `LiveClock` in the live data engine.

Both unsafe impls are removed. `TimeEventCallback` and `TimeEventHandler` are now `!Send`, so moving a `RustLocal` callback across threads no longer compiles. `TestClock`, the backtest accumulator, and the FFI/Python handler wrappers keep the callback-bearing `TimeEventHandler` unchanged.

**2. The live channel now carries a send-safe `TimeEventMessage`**

The live channels carry a new opaque `TimeEventMessage` (compile-time asserted `Send + Sync`) instead of `TimeEventHandler`, with two private dispatch modes fixed per timer.

`Python` and `Rust` callbacks travel as Direct messages holding only their `Arc`-backed forms; any drain thread rebuilds a local `TimeEventHandler` and runs it, so behavior is unchanged - including cancel-with-queued-events and spawned runners draining on another thread.

`RustLocal` callbacks never enter the channel. They live in a thread-local registry keyed by a per-timer-instance token; the task sends only the token, and the drain resolves it after an owner-`ThreadId` check. A message drained on the wrong thread is dropped with an error log instead of touching the foreign `Rc`.

Token lifecycle is one atomic word (closed flag + in-flight lease count). Each fire acquires a lease before sending, so cancellation still lets already-queued events dispatch; a stop before the first fire sends a cleanup message that unregisters without invoking; same-name replacement mints a distinct token, so a queued old event can neither call nor unregister the re-armed callback.

**3. `start()` restart semantics under the token design**

`start()` resets `canceled` and previously re-cloned the stored callback, so restart-after-cancel is a public contract. The owner side now retains the `RustLocal` callback next to its token and `start()` registers a fresh token when the current one is closed - otherwise a restarted timer would acquire no leases and silently stop dispatching.

Starting a still-active timer stops the old task first, closing its token before the abort: `abort()` does not join, and a task already past its tick could otherwise close the reused token under the new one. The worker also publishes the advanced `next_time_ns` before a channel send, so a restart snapshotting the schedule mid-fire cannot re-emit the in-flight event (senderless dispatch keeps its original invoke-then-advance ordering).

**Migration notes**

FFI/Python wrapper layouts and clock method signatures are unchanged. For Rust consumers this is source-breaking where it must be: `TimeEventSender::send` and the live channel types now use `TimeEventMessage`, and types embedding `TimeEventCallback` (including `TestClock`, `LiveClock`, `LiveTimer`) lose their erroneous `Send`/`Sync`.

**Testing**

- `test_time_event_message_is_send_and_sync` pins the channel-payload bound at compile time; on the fixed tree, moving a `RustLocal` callback into `std::thread::spawn` fails with E0277.
- Registry lifecycle tests cover same-thread dispatch, wrong-thread drop, close/lease interactions (immediate removal, queued leases surviving close, off-owner drop reclaimed by purge), same-name replacement, one-shot re-arm from inside a callback, and cleanup messages not counting as dispatched.
- Live timer tests cover `RustLocal` dispatch through the registry, cancel preserving a queued lease, stop-before-first-fire cleanup, restart-after-cancel re-registering, and start-while-active restarting and continuing to dispatch.
- All `#[rstest]`, no wall-clock waits beyond bounded 1s channel receives.
- Differential verification: the wrong-thread and cancel-with-queued-lease tests fail against the unfixed implementation, and the restart test fails (silent non-fire) with the re-registration removed.
