### PR TITLE
Fix Bybit missing due_post_only flag on post-only rejections

### DIFF
--- a/crates/adapters/bybit/src/common/parse.rs
+++ b/crates/adapters/bybit/src/common/parse.rs
@@ -172,6 +172,15 @@ use crate::{
 
 const BYBIT_HOUR_INTERVALS: &[u64] = &[1, 2, 4, 6, 12];
 
+const BYBIT_POST_ONLY_REJECT_REASON: &str = "EC_PostOnlyWillTakeLiquidity";
+
+/// Returns whether a Bybit rejection reason indicates a post-only order that
+/// would have taken liquidity (crossed the book).
+#[must_use]
+pub fn bybit_rejection_due_post_only(reason: &str) -> bool {
+    reason.contains(BYBIT_POST_ONLY_REJECT_REASON)
+}
+
 /// Extracts the raw symbol from a Bybit symbol by removing the product type suffix.
 #[must_use]
 pub fn extract_raw_symbol(symbol: &str) -> &str {
@@ -1883,6 +1892,16 @@ mod tests {
         let instrument = &response.result.list[0];
         let fee_rate = sample_fee_rate("BTCUSDT", "0.00055", "0.0001", Some("BTC"));
         parse_linear_instrument(instrument, &fee_rate, TS, TS).unwrap()
+    }
+
+    #[rstest]
+    #[case::post_only_cross("EC_PostOnlyWillTakeLiquidity", true)]
+    #[case::post_only_cross_with_prefix("Order rejected: EC_PostOnlyWillTakeLiquidity", true)]
+    #[case::other_reason("EC_OrigClOrdIDDoesNotExist", false)]
+    #[case::generic("Order rejected by venue", false)]
+    #[case::empty("", false)]
+    fn test_bybit_rejection_due_post_only(#[case] reason: &str, #[case] expected: bool) {
+        assert_eq!(bybit_rejection_due_post_only(reason), expected);
     }
 
     #[rstest]

--- a/crates/adapters/bybit/src/common/parse.rs
+++ b/crates/adapters/bybit/src/common/parse.rs
@@ -1405,6 +1405,15 @@ pub fn parse_order_status_report(
         }
         BybitOrderStatus::PartiallyFilled => OrderStatus::PartiallyFilled,
         BybitOrderStatus::Filled => OrderStatus::Filled,
+        // A post-only order that would take liquidity is reported as Cancelled with
+        // rejectReason=EC_PostOnlyWillTakeLiquidity (not Rejected). Surface it as Rejected
+        // for consistency with the tracked-order event path.
+        BybitOrderStatus::Canceled
+            if filled_qty.is_zero()
+                && bybit_rejection_due_post_only(order.reject_reason.as_str()) =>
+        {
+            OrderStatus::Rejected
+        }
         BybitOrderStatus::Canceled | BybitOrderStatus::PartiallyFilledCanceled => {
             OrderStatus::Canceled
         }

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -65,8 +65,8 @@ use crate::{
             resolve_trigger_type,
         },
         parse::{
-            BybitTpSlParams, extract_raw_symbol, get_price_str, make_hedge_venue_position_id,
-            nanos_to_millis, parse_bybit_tp_sl_params,
+            BybitTpSlParams, bybit_rejection_due_post_only, extract_raw_symbol, get_price_str,
+            make_hedge_venue_position_id, nanos_to_millis, parse_bybit_tp_sl_params,
             resolve_position_idx as resolve_bybit_position_idx, spot_leverage, spot_market_unit,
             trigger_direction,
         },
@@ -1256,7 +1256,7 @@ impl ExecutionClient for BybitExecutionClient {
                             client_order_id,
                             reason,
                             ts_event,
-                            false,
+                            bybit_rejection_due_post_only(reason),
                         );
                         anyhow::bail!("submit order rejected: {reason}");
                     }
@@ -1559,7 +1559,7 @@ impl ExecutionClient for BybitExecutionClient {
                                 cid,
                                 reason,
                                 ts_event,
-                                false,
+                                bybit_rejection_due_post_only(reason),
                             );
                             continue;
                         }

--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -97,11 +97,12 @@ use crate::common::{
     },
     models::{BybitCursorListResponse, BybitErrorCheck, BybitResponseCheck},
     parse::{
-        bar_spec_to_bybit_interval, make_bybit_symbol, map_time_in_force, parse_account_state,
-        parse_fill_report, parse_funding_rate, parse_inverse_instrument, parse_kline_bar,
-        parse_linear_instrument, parse_option_instrument, parse_order_status_report,
-        parse_orderbook, parse_position_status_report, parse_spot_instrument, parse_trade_tick,
-        spot_leverage, spot_market_unit, trigger_direction,
+        bar_spec_to_bybit_interval, bybit_rejection_due_post_only, make_bybit_symbol,
+        map_time_in_force, parse_account_state, parse_fill_report, parse_funding_rate,
+        parse_inverse_instrument, parse_kline_bar, parse_linear_instrument,
+        parse_option_instrument, parse_order_status_report, parse_orderbook,
+        parse_position_status_report, parse_spot_instrument, parse_trade_tick, spot_leverage,
+        spot_market_unit, trigger_direction,
     },
     symbol::BybitSymbol,
     urls::bybit_http_base_url,
@@ -2567,10 +2568,13 @@ impl BybitHttpClient {
             .map_err(|source| BybitSubmitOrderError::PostSubmitLookup { source })?;
 
         // Only bail on rejection if there are no fills
-        // If the order has fills (cum_exec_qty > 0), let the parser remap Rejected -> Canceled
-        if order.order_status == crate::common::enums::BybitOrderStatus::Rejected
-            && (order.cum_exec_qty.as_str() == "0" || order.cum_exec_qty.is_empty())
-        {
+        // If the order has fills (cum_exec_qty > 0), let the parser remap Rejected -> Canceled.
+        // A post-only order that would take liquidity is reported as Cancelled with
+        // rejectReason=EC_PostOnlyWillTakeLiquidity (not Rejected), so treat that as a rejection too.
+        let is_rejection = order.order_status == crate::common::enums::BybitOrderStatus::Rejected
+            || (order.order_status == crate::common::enums::BybitOrderStatus::Canceled
+                && bybit_rejection_due_post_only(order.reject_reason.as_str()));
+        if is_rejection && (order.cum_exec_qty.as_str() == "0" || order.cum_exec_qty.is_empty()) {
             return Err(BybitSubmitOrderError::Rejected {
                 reason: order.reject_reason.to_string(),
             }

--- a/crates/adapters/bybit/src/websocket/dispatch.rs
+++ b/crates/adapters/bybit/src/websocket/dispatch.rs
@@ -548,29 +548,53 @@ fn dispatch_order_update(
             BybitOrderStatus::Canceled
             | BybitOrderStatus::PartiallyFilledCanceled
             | BybitOrderStatus::Deactivated => {
-                ensure_accepted_emitted(
-                    client_order_id,
-                    account_id,
-                    venue_order_id,
-                    &identity,
-                    emitter,
-                    state,
-                    ts_init,
-                );
-                let canceled = OrderCanceled::new(
-                    emitter.trader_id(),
-                    identity.strategy_id,
-                    identity.instrument_id,
-                    client_order_id,
-                    UUID4::new(),
-                    ts_init,
-                    ts_init,
-                    false,
-                    Some(venue_order_id),
-                    Some(account_id),
-                );
-                cleanup_terminal(client_order_id, state);
-                emitter.send_order_event(OrderEventAny::Canceled(canceled));
+                let filled_qty = parse_quantity_with_precision(
+                    &order.cum_exec_qty,
+                    instrument.size_precision(),
+                    "order.cumExecQty",
+                )
+                .unwrap_or_default();
+
+                // Bybit reports a post-only order that would take liquidity as
+                // Cancelled with rejectReason=EC_PostOnlyWillTakeLiquidity,
+                // not Rejected. Surface it as OrderRejected carrying due_post_only.
+                if filled_qty.is_zero()
+                    && bybit_rejection_due_post_only(order.reject_reason.as_str())
+                {
+                    cleanup_terminal(client_order_id, state);
+                    emitter.emit_order_rejected_event(
+                        identity.strategy_id,
+                        identity.instrument_id,
+                        client_order_id,
+                        order.reject_reason.as_str(),
+                        ts_init,
+                        true,
+                    );
+                } else {
+                    ensure_accepted_emitted(
+                        client_order_id,
+                        account_id,
+                        venue_order_id,
+                        &identity,
+                        emitter,
+                        state,
+                        ts_init,
+                    );
+                    let canceled = OrderCanceled::new(
+                        emitter.trader_id(),
+                        identity.strategy_id,
+                        identity.instrument_id,
+                        client_order_id,
+                        UUID4::new(),
+                        ts_init,
+                        ts_init,
+                        false,
+                        Some(venue_order_id),
+                        Some(account_id),
+                    );
+                    cleanup_terminal(client_order_id, state);
+                    emitter.send_order_event(OrderEventAny::Canceled(canceled));
+                }
             }
         }
     } else {
@@ -1239,6 +1263,48 @@ mod tests {
             matches!(event2, ExecutionEvent::Order(OrderEventAny::Canceled(_))),
             "Expected Canceled, found {event2:?}"
         );
+    }
+
+    #[rstest]
+    fn test_dispatch_tracked_post_only_cancel_emits_rejected() {
+        const BYBIT_POST_ONLY_REJECT_REASON: &str = "EC_PostOnlyWillTakeLiquidity";
+
+        let instrument = linear_instrument();
+        let instruments = build_instruments(std::slice::from_ref(&instrument));
+        let (emitter, mut rx) = create_emitter();
+        let clock = get_atomic_clock_realtime();
+        let state = WsDispatchState::default();
+
+        // Bybit reports a post-only order that would take liquidity as
+        // orderStatus=Cancelled with rejectReason=EC_PostOnlyWillTakeLiquidity.
+        let json = load_test_json("ws_account_order.json");
+        let mut msg: crate::websocket::messages::BybitWsAccountOrderMsg =
+            serde_json::from_str(&json).unwrap();
+
+        let order = msg.data.first_mut().expect("fixture has an order");
+        order.reject_reason = Ustr::from(BYBIT_POST_ONLY_REJECT_REASON);
+        order.cum_exec_qty = "0".to_string();
+        let cid = ClientOrderId::new(order.order_link_id.as_str());
+        state.order_identities.insert(cid, default_identity());
+
+        let ws_msg = BybitWsMessage::AccountOrder(msg);
+        dispatch_ws_message(
+            &ws_msg,
+            &emitter,
+            &state,
+            test_account_id(),
+            &instruments,
+            clock,
+        );
+
+        let event = rx.try_recv().unwrap();
+        let ExecutionEvent::Order(OrderEventAny::Rejected(rejected)) = event else {
+            panic!("Expected Rejected, found {event:?}");
+        };
+        assert!(rejected.due_post_only);
+        assert_eq!(rejected.reason.as_str(), BYBIT_POST_ONLY_REJECT_REASON);
+        assert_eq!(rejected.client_order_id, cid);
+        assert!(rx.try_recv().is_err(), "expected only a single event");
     }
 
     #[rstest]

--- a/crates/adapters/bybit/src/websocket/dispatch.rs
+++ b/crates/adapters/bybit/src/websocket/dispatch.rs
@@ -55,8 +55,8 @@ use crate::{
     common::{
         enums::BybitOrderStatus,
         parse::{
-            make_bybit_symbol, parse_millis_timestamp, parse_price_with_precision,
-            parse_quantity_with_precision,
+            bybit_rejection_due_post_only, make_bybit_symbol, parse_millis_timestamp,
+            parse_price_with_precision, parse_quantity_with_precision,
         },
     },
     http::error::is_bybit_ambiguous_order_error_code,
@@ -459,7 +459,7 @@ fn dispatch_order_update(
                         client_order_id,
                         reason.as_str(),
                         ts_init,
-                        false,
+                        bybit_rejection_due_post_only(reason.as_str()),
                     );
                 }
             }

--- a/crates/adapters/bybit/src/websocket/parse.rs
+++ b/crates/adapters/bybit/src/websocket/parse.rs
@@ -50,8 +50,9 @@ use super::{
 use crate::common::{
     enums::{BybitOrderStatus, BybitPositionSide, BybitTimeInForce},
     parse::{
-        get_currency, make_hedge_venue_position_id, parse_book_level, parse_bybit_order_type,
-        parse_millis_timestamp, parse_price_with_precision, parse_quantity_with_precision,
+        bybit_rejection_due_post_only, get_currency, make_hedge_venue_position_id,
+        parse_book_level, parse_bybit_order_type, parse_millis_timestamp,
+        parse_price_with_precision, parse_quantity_with_precision,
     },
 };
 
@@ -780,6 +781,15 @@ pub fn parse_ws_order_status_report(
         }
         BybitOrderStatus::PartiallyFilled => OrderStatus::PartiallyFilled,
         BybitOrderStatus::Filled => OrderStatus::Filled,
+        // A post-only order that would take liquidity is reported as Cancelled with
+        // rejectReason=EC_PostOnlyWillTakeLiquidity (not Rejected). Surface it as Rejected
+        // for consistency with the tracked-order event path.
+        BybitOrderStatus::Canceled
+            if filled_qty.is_zero()
+                && bybit_rejection_due_post_only(order.reject_reason.as_str()) =>
+        {
+            OrderStatus::Rejected
+        }
         BybitOrderStatus::Canceled | BybitOrderStatus::PartiallyFilledCanceled => {
             OrderStatus::Canceled
         }
@@ -1391,6 +1401,28 @@ mod tests {
             "O-20251001-164609-APEX-000-49"
         );
         assert_eq!(report.cancel_reason, Some("UNKNOWN".to_string()));
+    }
+
+    #[rstest]
+    fn parse_ws_order_post_only_cancel_maps_to_rejected() {
+        let instrument = linear_instrument();
+        let json = load_test_json("ws_account_order.json");
+        let mut msg: crate::websocket::messages::BybitWsAccountOrderMsg =
+            serde_json::from_str(&json).unwrap();
+
+        let order = msg.data.first_mut().unwrap();
+        order.reject_reason = Ustr::from("EC_PostOnlyWillTakeLiquidity");
+        order.cum_exec_qty = "0".to_string();
+        let account_id = AccountId::new("BYBIT-001");
+
+        let report =
+            parse_ws_order_status_report(&msg.data[0], &instrument, account_id, TS).unwrap();
+
+        assert_eq!(report.order_status, OrderStatus::Rejected);
+        assert_eq!(
+            report.cancel_reason,
+            Some("EC_PostOnlyWillTakeLiquidity".to_string())
+        );
     }
 
     #[rstest]

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -1782,7 +1782,7 @@ async fn test_exec_client_demo_submit_confirmed_rejection_emits_order_rejected()
     assert_eq!(event.client_order_id, cid);
     assert_eq!(event.reason.to_string(), "EC_PostOnlyWillTakeLiquidity");
     assert!(!event.reconciliation);
-    assert!(!event.due_post_only);
+    assert!(event.due_post_only);
 
     client.disconnect().await.unwrap();
 }

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -246,7 +246,7 @@ async fn handle_get_orders_realtime(
             .and_then(|list| list.first_mut())
             .expect("orders realtime fixture has first order");
         order["orderId"] = json!("test-order-id-12345");
-        order["orderStatus"] = json!("Rejected");
+        order["orderStatus"] = json!("Cancelled");
         order["cumExecQty"] = json!("0");
         order["rejectReason"] = json!("EC_PostOnlyWillTakeLiquidity");
 


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Bybit never set `due_post_only` on rejections, so a post-only order that crossed the book (`EC_PostOnlyWillTakeLiquidity`) was emitted as an ordinary `OrderRejected` with `due_post_only = false`, unlike every other adapter (OKX, Coinbase, Derive, etc.). This adds a `bybit_rejection_due_post_only` helper and wires it into the three reachable rejection sites (WS order-status stream, plus the single and batch HTTP submit paths).

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
