### PR TITLE
Add SimulatedExchange.purge_instrument for long-window backtest memory release

### DIFF
--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -432,6 +432,68 @@ impl SimulatedExchange {
         Ok(())
     }
 
+    /// Purges the instrument with the given `instrument_id` from the venue (if found).
+    ///
+    /// Drops the entry from both `instruments` and the `matching_engines` map,
+    /// releasing the per-instrument order matching engine and any book state it owned.
+    /// Callers should typically also purge the corresponding cache-side state via
+    /// [`Cache::purge_instrument`] in the same lifecycle event so that both venue-owned
+    /// and cache-owned per-instrument state are released together.
+    ///
+    /// For safety, an instrument is prevented from being purged while any associated
+    /// order is open or any associated position is open on this venue. When such state
+    /// exists the call is a no-op and a warning is logged, mirroring the behavior of
+    /// [`Cache::purge_instrument`].
+    ///
+    /// Active data or execution engine subscriptions are not touched here; those belong
+    /// to the data and execution engines.
+    ///
+    /// # Warning
+    ///
+    /// Intended for actors and strategies that have their own lifecycle logic for
+    /// deciding when an instrument is no longer needed (for example on weekly or monthly
+    /// option expiry rollover during a long-window backtest). Purging an instrument that
+    /// any other actor, strategy, or engine still relies on may cause incorrect behavior
+    /// (missing instrument lookups, matching-engine misses on subsequent market data).
+    /// The caller is responsible for ensuring the instrument is no longer in use before
+    /// purging.
+    pub fn purge_instrument(&mut self, instrument_id: InstrumentId) {
+        let found = self.instruments.contains_key(&instrument_id)
+            || self.matching_engines.contains_key(&instrument_id);
+
+        if !found {
+            log::warn!("Instrument {instrument_id} not found when purging");
+            return;
+        }
+
+        let cache = self.cache.borrow();
+        if cache.has_orders_open(None, Some(&instrument_id), None, None, None) {
+            log::warn!(
+                "Instrument {instrument_id} has open orders when purging, skipping purge"
+            );
+            return;
+        }
+
+        if cache.has_positions_open(None, Some(&instrument_id), None, None, None) {
+            log::warn!(
+                "Instrument {instrument_id} has open positions when purging, skipping purge"
+            );
+            return;
+        }
+        drop(cache);
+
+        self.instruments.remove(&instrument_id);
+        // Use `shift_remove` on the matching-engine `IndexMap` so remaining engines keep
+        // their relative registration order (mirrors the iteration-stability invariant
+        // asserted by `test_matching_engine_iteration_order_is_stable_across_rebuilds`).
+        self.matching_engines.shift_remove(&instrument_id);
+        self.settlement_prices.remove(&instrument_id);
+        self.pending_funding_rates.remove(&instrument_id);
+        self.funding_settled_through.remove(&instrument_id);
+
+        log::info!("Purged instrument {instrument_id}");
+    }
+
     /// Returns the best bid price for the given instrument, if available.
     #[must_use]
     pub fn best_bid_price(&self, instrument_id: InstrumentId) -> Option<Price> {

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -59,7 +59,7 @@ use nautilus_model::{
     },
     identifiers::{
         AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TradeId, TraderId,
-        Venue,
+        Venue, VenueOrderId,
     },
     instruments::{
         CryptoOption, CryptoPerpetual, Instrument, InstrumentAny, OptionContract,
@@ -3054,4 +3054,150 @@ fn test_module_pre_process_and_process_call_order(crypto_perpetual_ethusdt: Cryp
 
     assert_eq!(counts.pre_process.get(), 2);
     assert_eq!(counts.process.get(), 1);
+}
+
+// --- SimulatedExchange::purge_instrument -------------------------------------------------------
+
+#[rstest]
+fn test_purge_instrument_removes_entry_and_matching_engine(
+    crypto_perpetual_ethusdt: CryptoPerpetual,
+) {
+    let exchange = get_exchange(
+        Venue::new("BINANCE"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        None,
+    );
+    let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
+    let instrument_id = instrument.id();
+
+    exchange.borrow_mut().add_instrument(instrument).unwrap();
+
+    assert!(exchange.borrow().get_matching_engine(&instrument_id).is_some());
+    assert!(
+        exchange
+            .borrow()
+            .instrument_ids()
+            .any(|id| id == &instrument_id)
+    );
+
+    exchange.borrow_mut().purge_instrument(instrument_id);
+
+    assert!(exchange.borrow().get_matching_engine(&instrument_id).is_none());
+    assert!(
+        exchange
+            .borrow()
+            .instrument_ids()
+            .all(|id| id != &instrument_id)
+    );
+}
+
+#[rstest]
+fn test_purge_instrument_when_not_present_is_noop() {
+    let exchange = get_exchange(
+        Venue::new("BINANCE"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        None,
+    );
+    let instrument_id = InstrumentId::from("ETHUSDT-PERP.BINANCE");
+
+    // No add_instrument call — purge should log a warning and return quietly.
+    exchange.borrow_mut().purge_instrument(instrument_id);
+
+    assert!(exchange.borrow().get_matching_engine(&instrument_id).is_none());
+}
+
+#[rstest]
+fn test_purge_instrument_preserves_matching_engine_registration_order(
+    crypto_perpetual_ethusdt: CryptoPerpetual,
+) {
+    let first_instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt.clone());
+    let mut second = crypto_perpetual_ethusdt.clone();
+    second.id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    second.raw_symbol = Symbol::from("BTCUSDT");
+    second.base_currency = Currency::from("BTC");
+    let second_instrument = InstrumentAny::CryptoPerpetual(second);
+    let mut third = crypto_perpetual_ethusdt;
+    third.id = InstrumentId::from("SOLUSDT-PERP.BINANCE");
+    third.raw_symbol = Symbol::from("SOLUSDT");
+    third.base_currency = Currency::from("SOL");
+    let third_instrument = InstrumentAny::CryptoPerpetual(third);
+
+    let exchange = get_exchange(
+        Venue::new("BINANCE"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        None,
+    );
+    exchange
+        .borrow_mut()
+        .add_instrument(first_instrument.clone())
+        .unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(second_instrument.clone())
+        .unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(third_instrument.clone())
+        .unwrap();
+
+    // Purge the middle instrument — remaining engines must keep their relative
+    // registration order.
+    exchange
+        .borrow_mut()
+        .purge_instrument(second_instrument.id());
+
+    let remaining = exchange
+        .borrow()
+        .get_matching_engines()
+        .keys()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(remaining, vec![first_instrument.id(), third_instrument.id()]);
+}
+
+#[rstest]
+fn test_purge_instrument_refuses_when_orders_open(crypto_perpetual_ethusdt: CryptoPerpetual) {
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let exchange = get_exchange(
+        Venue::new("BINANCE"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
+    let instrument_id = instrument.id();
+    exchange
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+
+    // Register the instrument in the cache and add an accepted (open) order for it.
+    cache.borrow_mut().add_instrument(instrument).unwrap();
+
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_id)
+        .side(OrderSide::Buy)
+        .price(Price::from("1000.00"))
+        .quantity(Quantity::from("1.000"))
+        .build();
+    cache
+        .borrow_mut()
+        .add_order(order.clone(), None, None, false)
+        .unwrap();
+    let account_id = AccountId::test_default();
+    let submitted = TestOrderEventStubs::submitted(&order, account_id);
+    order.apply(submitted.clone()).unwrap();
+    cache.borrow_mut().update_order(&submitted).unwrap();
+    let accepted = TestOrderEventStubs::accepted(&order, account_id, VenueOrderId::new("V-1"));
+    order.apply(accepted.clone()).unwrap();
+    cache.borrow_mut().update_order(&accepted).unwrap();
+    assert!(order.is_open());
+
+    // Purge should refuse and be a no-op while the order remains open.
+    exchange.borrow_mut().purge_instrument(instrument_id);
+
+    assert!(exchange.borrow().get_matching_engine(&instrument_id).is_some());
 }

--- a/nautilus_trader/backtest/engine.pxd
+++ b/nautilus_trader/backtest/engine.pxd
@@ -293,6 +293,7 @@ cdef class SimulatedExchange:
     cpdef void set_latency_model(self, LatencyModel latency_model)
     cpdef void initialize_account(self)
     cpdef void add_instrument(self, Instrument instrument)
+    cpdef void purge_instrument(self, InstrumentId instrument_id)
 
 # -- QUERIES --------------------------------------------------------------------------------------
 

--- a/nautilus_trader/backtest/engine.pyx
+++ b/nautilus_trader/backtest/engine.pyx
@@ -3075,6 +3075,78 @@ cdef class SimulatedExchange:
 
         self._log.info(f"Added instrument {instrument.id} and created matching engine")
 
+    cpdef void purge_instrument(self, InstrumentId instrument_id):
+        """
+        Purge the instrument for the given instrument ID from the exchange (if found).
+
+        Drops the instrument entry from ``instruments`` and the corresponding
+        ``OrderMatchingEngine`` from ``_matching_engines``. Any tracked next-instrument
+        expiration state is recomputed from the remaining engines so the venue does not
+        continue timing off a purged instrument's expiration.
+
+        For safety, the instrument is prevented from being purged while any associated
+        order is open or any associated position is open on the exchange venue. Callers
+        should typically purge cache-side state via ``Cache.purge_instrument`` in the
+        same lifecycle event so both cache-owned and venue-owned per-instrument state
+        are released together.
+
+        Active data or execution engine subscriptions are not touched here; those
+        belong to the data and execution engines.
+
+        Parameters
+        ----------
+        instrument_id : InstrumentId
+            The instrument ID to purge.
+
+        Warnings
+        --------
+        Intended for actors and strategies that have their own lifecycle logic for
+        deciding when an instrument is no longer needed (for example on weekly or
+        monthly option expiry rollover during a long-window backtest). Purging an
+        instrument that any other actor, strategy, or engine still relies on may cause
+        incorrect behavior (missing instrument lookups, matching-engine misses on
+        subsequent market data). The caller is responsible for ensuring the instrument
+        is no longer in use before purging.
+
+        """
+        Condition.not_none(instrument_id, "instrument_id")
+
+        if instrument_id not in self.instruments and instrument_id not in self._matching_engines:
+            self._log.warning(f"Instrument {instrument_id} not found when purging")
+            return
+
+        if self.cache is not None and self.cache.orders_open_count(
+            venue=None,
+            instrument_id=instrument_id,
+        ) > 0:
+            self._log.warning(
+                f"Instrument {instrument_id} has open orders when purging, skipping purge",
+            )
+            return
+
+        if self.cache is not None and self.cache.positions_open_count(
+            venue=None,
+            instrument_id=instrument_id,
+        ) > 0:
+            self._log.warning(
+                f"Instrument {instrument_id} has open positions when purging, skipping purge",
+            )
+            return
+
+        self.instruments.pop(instrument_id, None)
+        self._matching_engines.pop(instrument_id, None)
+
+        # Recompute next-instrument-expiration tracking from any remaining engines so
+        # the venue does not continue timing off the purged instrument's expiration.
+        self._has_next_instrument_expiration = False
+        self._next_instrument_expiration_ns = 0
+
+        cdef OrderMatchingEngine matching_engine
+        for matching_engine in self._matching_engines.values():
+            self._update_next_instrument_expiration(matching_engine)
+
+        self._log.info(f"Purged instrument {instrument_id}")
+
 # -- QUERIES --------------------------------------------------------------------------------------
 
     cpdef Price best_bid_price(self, InstrumentId instrument_id):

--- a/tests/unit_tests/backtest/test_engine.py
+++ b/tests/unit_tests/backtest/test_engine.py
@@ -420,6 +420,60 @@ class TestBacktestEngineCashAccount:
             self.engine.add_instrument(self.usdjpy)
 
 
+class TestBacktestEnginePurgeInstrument:
+    def setup(self) -> None:
+        # Fixture Setup
+        self.venue = Venue("SIM")
+        self.engine = BacktestEngine(
+            BacktestEngineConfig(logging=LoggingConfig(bypass_logging=True)),
+        )
+        self.engine.add_venue(
+            venue=self.venue,
+            oms_type=OmsType.HEDGING,
+            account_type=AccountType.MARGIN,
+            base_currency=USD,
+            starting_balances=[Money(1_000_000, USD)],
+            fill_model=FillModel(),
+        )
+        self.engine.add_instrument(AUDUSD_SIM)
+        self.engine.add_instrument(GBPUSD_SIM)
+
+    def teardown(self):
+        self.engine.reset()
+        self.engine.dispose()
+
+    def _exchange(self):
+        return self.engine._venues[self.venue]
+
+    def test_purge_instrument_removes_from_venue_state(self):
+        # Arrange
+        exchange = self._exchange()
+        instrument_id = AUDUSD_SIM.id
+        assert instrument_id in exchange.instruments
+        assert instrument_id in exchange.get_matching_engines()
+
+        # Act
+        exchange.purge_instrument(instrument_id)
+
+        # Assert
+        assert instrument_id not in exchange.instruments
+        assert instrument_id not in exchange.get_matching_engines()
+        # Other registered instrument remains untouched.
+        assert GBPUSD_SIM.id in exchange.instruments
+        assert GBPUSD_SIM.id in exchange.get_matching_engines()
+
+    def test_purge_instrument_when_not_present_is_noop(self):
+        # Arrange
+        exchange = self._exchange()
+
+        # Act (never added to the venue) — should log a warning and return quietly.
+        exchange.purge_instrument(ETHUSDT_BINANCE.id)
+
+        # Assert — pre-existing instruments untouched.
+        assert AUDUSD_SIM.id in exchange.instruments
+        assert GBPUSD_SIM.id in exchange.instruments
+
+
 class TestBacktestEngineData:
     def setup(self):
         # Fixture Setup


### PR DESCRIPTION
Refs #4442

## Summary

Adds `SimulatedExchange.purge_instrument(instrument_id)` on both the Cython production surface (`nautilus_trader/backtest/engine.pyx`) and the parallel Rust venue in `crates/backtest/src/exchange.rs`. Mirrors the existing `Cache.purge_instrument` shape and semantics so an actor implementing an expiry-rollover lifecycle can release both cache-owned and venue-owned per-instrument state in the same event.

This is the primitive requested in issue #4442 (part 1 of the three-part enhancement — the documentation + CI RSS regression parts remain open and can be addressed separately). It is complementary to `Cache.purge_instrument` and does **not** modify any existing purge logic.

## Motivation

Long-window multi-instrument backtests (options universes with weekly / monthly expiry rollover in particular) accumulate venue-owned state in the `SimulatedExchange.instruments` and `_matching_engines` maps for the full run. Framework code has no existing primitive to release that state, so an actor that already invokes `Cache.purge_instrument` on rollover cannot reach the venue-owned side.

A representative failure mode: an options backtest running 18–24 months against a ~22k-strike universe hits container memory ceilings (>10 GiB RSS) before the first bar processes, dominated by accumulated per-instrument matching-engine state. Adding this primitive lets long-window backtests bound memory at `O(active_instruments)` instead of `O(all_touched_instruments_over_window)`, which is essential for regime-change / walk-forward analysis over multi-year windows on standard cloud VM tiers.

## Design

Both implementations follow the same shape as `Cache.purge_instrument`:

1. Return quietly with a warning if the instrument is not registered on the venue.
2. Refuse and log a warning if any associated order is open, or any associated position is open (via `Cache.has_orders_open` / `has_positions_open` on the venue's wired cache). This mirrors the guard on the cache-side purge and stays defensive by default — callers whose lifecycle logic has already invalidated order/position state cache-side can safely call this after; callers who have not will get a no-op and a log message rather than a torn matching engine.
3. Drop the instrument entry, drop the matching engine, and drop any per-instrument settlement / funding state.
4. On the Cython side, recompute `_has_next_instrument_expiration` and `_next_instrument_expiration_ns` from the remaining engines so the venue does not continue timing off a purged instrument's expiration.
5. On the Rust side, use `IndexMap::shift_remove` on `matching_engines` to preserve the registration-order invariant covered by `test_matching_engine_iteration_order_is_stable_across_rebuilds`.

Active data or execution engine subscriptions are intentionally not touched here — those belong to the data and execution engines, matching the boundary drawn by `Cache.purge_instrument`.

## Usage example

```python
class MemoryHousekeepingActor(Actor):
    def on_weekly_expiry(self, expired_instrument_ids: list[InstrumentId]) -> None:
        for iid in expired_instrument_ids:
            self.cache.purge_instrument(iid)  # existing primitive (cache-side)
            self.exchange.purge_instrument(iid)  # new primitive (venue-side)
```

The guard means a mistimed call is a no-op with a log message rather than a silent tear-down of active state.

## Tests

Rust integration tests (`crates/backtest/tests/exchange.rs`):
- `test_purge_instrument_removes_entry_and_matching_engine` — happy path
- `test_purge_instrument_when_not_present_is_noop` — noop when not registered
- `test_purge_instrument_preserves_matching_engine_registration_order` — guards the `IndexMap` iteration-order invariant when removing a middle instrument from a 3-instrument venue
- `test_purge_instrument_refuses_when_orders_open` — refusal guard for open orders

Python unit tests (`tests/unit_tests/backtest/test_engine.py::TestBacktestEnginePurgeInstrument`):
- `test_purge_instrument_removes_from_venue_state` — asserts the instrument leaves both `instruments` and `_matching_engines` while a sibling instrument on the same venue remains
- `test_purge_instrument_when_not_present_is_noop`

Ran locally on macOS aarch64 with rustc 1.97.1:

```
cargo test -p nautilus-backtest --test exchange
# 56 passed (52 pre-existing + 4 new)

cargo clippy -p nautilus-backtest --tests --no-deps
# clean
```

## Not in scope for this PR

- The docs addition (`docs/how_to/multi_config_backtest.md`) and CI-gated RSS acceptance test from parts 2 and 3 of issue #4442 are left for follow-ups — they are independent of this primitive and touching them here would over-scope the review.
- `Cache.purge_instrument` and `Cache.purge_instrument_skip_order_guard` are not modified.
- No changes to `BacktestNode.dispose()` semantics.

## Willing to iterate

Happy to adjust the guard shape, method placement, error semantics, or docstring per maintainer preference. Also willing to open the follow-up docs / CI PRs referenced above once this primitive lands.