### PR TITLE
Make execution order-event log level configurable

### DIFF
--- a/nautilus_trader/execution/config.py
+++ b/nautilus_trader/execution/config.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import Literal
 
 import msgspec
 
@@ -84,6 +85,9 @@ class ExecEngineConfig(NautilusConfig, frozen=True):
     purge_from_database : bool, default False
         If purging operations will also delete from the backing database, in addition to the
         in-memory cache.
+    order_event_log_level : {"DEBUG", "INFO"}, default "DEBUG"
+        The level for logging received order events. ``DEBUG`` preserves the existing debug-mode
+        behavior. ``INFO`` logs order events independently of debug mode.
     debug : bool, default False
         If debug mode is active (will provide extra debug logging).
 
@@ -103,6 +107,7 @@ class ExecEngineConfig(NautilusConfig, frozen=True):
     purge_account_events_interval_mins: PositiveInt | None = None
     purge_account_events_lookback_mins: NonNegativeInt | None = None
     purge_from_database: bool = False
+    order_event_log_level: Literal["DEBUG", "INFO"] = "DEBUG"
     debug: bool = False
 
 

--- a/nautilus_trader/execution/engine.pxd
+++ b/nautilus_trader/execution/engine.pxd
@@ -65,6 +65,8 @@ cdef class ExecutionEngine(Component):
 
     cdef readonly bint debug
     """If debug mode is active (will provide extra debug logging).\n\n:returns: `bool`"""
+    cdef readonly str order_event_log_level
+    """The level for logging received order events.\n\n:returns: `str`"""
     cdef readonly bint allow_overfills
     """If order fills exceeding order quantity are allowed (logs warning instead of raising).\n\n:returns: `bool`"""
     cdef readonly bint manage_own_order_books

--- a/nautilus_trader/execution/engine.pyx
+++ b/nautilus_trader/execution/engine.pyx
@@ -165,6 +165,7 @@ cdef class ExecutionEngine(Component):
 
         # Configuration
         self.debug: bool = config.debug
+        self.order_event_log_level: str = config.order_event_log_level
         self.allow_overfills = config.allow_overfills
         self.manage_own_order_books = config.manage_own_order_books
         self.snapshot_orders = config.snapshot_orders
@@ -1243,7 +1244,9 @@ cdef class ExecutionEngine(Component):
 # -- EVENT HANDLERS -------------------------------------------------------------------------------
 
     cpdef void _handle_event(self, OrderEvent event):
-        if self.debug:
+        if self.order_event_log_level == "INFO":
+            self._log.info(f"{RECV}{EVT} {event}", LogColor.MAGENTA)
+        elif self.debug:
             self._log.debug(f"{RECV}{EVT} {event}", LogColor.MAGENTA)
 
         self.event_count += 1


### PR DESCRIPTION
Implements the proposal in #4510.

High-frequency order lifecycle events (submit/accept/cancel churn from quoting strategies) currently log at a fixed level, which either floods INFO or forces global suppression. This adds an execution-engine config knob for the order-event log level, defaulting to current behavior (no change unless set).

Tested with config round-trip and level-emission assertions on our fork.