### PR TITLE
Prevent time-event callback destructors from aborting on thread-local teardown

### DIFF
--- a/crates/adapters/architect_ax/src/data.rs
+++ b/crates/adapters/architect_ax/src/data.rs
@@ -1183,6 +1183,7 @@ fn handle_md_message(
             let quotes_subscribed = sdt_snap
                 .get(symbol.as_str())
                 .is_some_and(|entry| entry.quotes);
+
             if quotes_subscribed {
                 match parse_book_l2_quote(&book, instrument, ts_init()) {
                     Ok(quote) => {
@@ -1214,6 +1215,7 @@ fn handle_md_message(
             let quotes_subscribed = sdt_snap
                 .get(symbol.as_str())
                 .is_some_and(|entry| entry.quotes);
+
             if quotes_subscribed {
                 match parse_book_l3_quote(&book, instrument, ts_init()) {
                     Ok(quote) => {
@@ -1238,6 +1240,7 @@ fn handle_md_message(
             let mark_prices_subscribed = sdt_snap
                 .get(ticker.s.as_str())
                 .is_some_and(|e| e.mark_prices);
+
             if mark_prices_subscribed && let Some(mark_price) = ticker.m {
                 match Price::from_decimal_dp(mark_price, price_precision) {
                     Ok(price) => {
@@ -1254,6 +1257,7 @@ fn handle_md_message(
                 let status_subscribed = sdt_snap
                     .get(ticker.s.as_str())
                     .is_some_and(|e| e.instrument_status);
+
                 if status_subscribed {
                     let prev = instrument_states.insert(ticker.s, state);
                     if prev != Some(state) {

--- a/crates/adapters/architect_ax/src/python/websocket.rs
+++ b/crates/adapters/architect_ax/src/python/websocket.rs
@@ -889,6 +889,7 @@ fn handle_md_message(
             let mark_prices_subscribed = sdt_snap
                 .get(ticker.s.as_str())
                 .is_some_and(|e| e.mark_prices);
+
             if mark_prices_subscribed && let Some(mark_price) = ticker.m {
                 match Price::from_decimal_dp(mark_price, price_precision) {
                     Ok(price) => {
@@ -905,6 +906,7 @@ fn handle_md_message(
                 let status_subscribed = sdt_snap
                     .get(ticker.s.as_str())
                     .is_some_and(|e| e.instrument_status);
+
                 if status_subscribed {
                     let prev = instrument_states.insert(ticker.s, state);
                     if prev != Some(state) {

--- a/crates/adapters/binance/bin/http_public.rs
+++ b/crates/adapters/binance/bin/http_public.rs
@@ -109,6 +109,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Test 4: Recent Trades
     log::info!("=== Test 4: Trades (BTCUSDT) ===");
+
     match client.inner().trades("BTCUSDT", Some(5)).await {
         Ok(trades) => {
             log::info!(

--- a/crates/adapters/binance/src/futures/data.rs
+++ b/crates/adapters/binance/src/futures/data.rs
@@ -2087,6 +2087,7 @@ impl DataClient for BinanceFuturesDataClient {
                 }
             })
             .is_ok_and(|prev| prev == 1);
+
         if should_unsubscribe {
             self.spawn_liquidation_stream_reconcile("all-market forceOrder unsubscribe");
         }

--- a/crates/adapters/binance/tests/spot/exec_client.rs
+++ b/crates/adapters/binance/tests/spot/exec_client.rs
@@ -759,6 +759,7 @@ async fn handle_account_trades(
     let from_id = query
         .get("fromId")
         .and_then(|value| value.parse::<i64>().ok());
+
     if let Some(captured_queries) = &state.captured_queries {
         captured_queries
             .lock()

--- a/crates/adapters/deribit/src/data.rs
+++ b/crates/adapters/deribit/src/data.rs
@@ -1101,6 +1101,7 @@ impl DataClient for DeribitDataClient {
                 .load()
                 .get(&instrument_id)
                 .is_some_and(|inst| matches!(inst, InstrumentAny::CryptoPerpetual(_)));
+
             if !is_perpetual {
                 log::warn!(
                     "Funding rates subscription rejected for {instrument_id}: only available for perpetual instruments"

--- a/crates/adapters/derive/bin/spot_research.rs
+++ b/crates/adapters/derive/bin/spot_research.rs
@@ -464,6 +464,7 @@ async fn cancel_if_open(
             .and_then(|o| o.get("order_status"))
             .and_then(|s| s.as_str())
             .is_some_and(|s| s == "open");
+
         if let Some(order_id) = extract_order_id(resp)
             && is_open
         {

--- a/crates/adapters/dydx/src/data.rs
+++ b/crates/adapters/dydx/src/data.rs
@@ -1410,6 +1410,7 @@ impl DydxDataClient {
                     .status
                     .as_ref()
                     .is_none_or(|s| matches!(s, crate::common::enums::DydxMarketStatus::Active));
+
                 if ctx.instrument_cache.get_by_market(ticker).is_some() {
                     ctx.seen_tickers.insert(ticker_ustr);
                 } else if is_active {

--- a/crates/adapters/dydx/src/execution/mod.rs
+++ b/crates/adapters/dydx/src/execution/mod.rs
@@ -636,6 +636,7 @@ impl DydxExecutionClient {
                                         let is_expiry = report
                                             .expire_time
                                             .is_some_and(|exp| report.ts_last >= exp);
+
                                         if is_expiry {
                                             let expired = OrderExpired::new(
                                                 trader_id,

--- a/crates/adapters/dydx/src/python/websocket.rs
+++ b/crates/adapters/dydx/src/python/websocket.rs
@@ -1221,6 +1221,7 @@ fn handle_markets_trading_data(
                 .status
                 .as_ref()
                 .is_none_or(|s| matches!(s, crate::common::enums::DydxMarketStatus::Active));
+
             if instrument_cache.get_by_market(ticker).is_some() {
                 seen_tickers.insert(ticker_ustr);
             } else if is_active {

--- a/crates/adapters/hyperliquid/src/websocket/dispatch.rs
+++ b/crates/adapters/hyperliquid/src/websocket/dispatch.rs
@@ -510,6 +510,7 @@ impl WsDispatchState {
         chain
             .intents
             .retain(|intent| intent.generation != generation);
+
         if let Some(old) = removed_front_old
             && let Some(new_front) = chain.intents.front_mut()
         {

--- a/crates/adapters/lighter/src/http/client.rs
+++ b/crates/adapters/lighter/src/http/client.rs
@@ -1051,6 +1051,7 @@ impl LighterHttpClient {
             for bar in page {
                 let bar_start_ms = i64::try_from(bar.ts_event.as_u64() / 1_000_000)
                     .map_err(|e| LighterHttpError::Parse(e.to_string()))?;
+
                 if bar_start_ms < cursor_ms
                     || bar_start_ms >= end_ms
                     || bar_start_ms.saturating_add(interval_ms) > now_ms
@@ -1196,6 +1197,7 @@ impl LighterHttpClient {
                     .map_err(LighterHttpError::from)?;
                 let timestamp_ms = i64::try_from(update.ts_event.as_u64() / 1_000_000)
                     .map_err(|e| LighterHttpError::Parse(e.to_string()))?;
+
                 if timestamp_ms < cursor_ms || timestamp_ms > end_ms {
                     continue;
                 }

--- a/crates/adapters/polymarket/src/data/dispatch.rs
+++ b/crates/adapters/polymarket/src/data/dispatch.rs
@@ -563,6 +563,7 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                                 }
 
                                 let transient_hit = transient.iter().any(|cid| cid == &condition_id);
+
                                 if attempt < NEW_MARKET_EMPTY_RECHECK_MAX_ATTEMPTS {
                                     attempt += 1;
                                     let reason = if transient_hit {

--- a/crates/adapters/polymarket/src/execution/orders.rs
+++ b/crates/adapters/polymarket/src/execution/orders.rs
@@ -664,6 +664,7 @@ impl PolymarketExecutionClient {
             .cache()
             .order(&cmd.client_order_id)
             .map(|o| o.clone());
+
         if let Some(order) = order {
             let venue_order_id = order.venue_order_id();
             let ts_now = self.clock.get_time_ns();

--- a/crates/common/src/runner.rs
+++ b/crates/common/src/runner.rs
@@ -126,9 +126,16 @@ impl TimeEventCallbackToken {
 
     fn remove_on_owner_thread(&self) {
         if self.0.owner == thread::current().id() {
-            TIME_EVENT_CALLBACKS.with(|callbacks| {
-                callbacks.borrow_mut().remove(&self.0.id);
-            });
+            // Reachable from `Drop` (`LiveTimer::drop` -> `close`), which can
+            // run during thread-local teardown when `TIME_EVENT_CALLBACKS` is
+            // already destroyed. `try_with` returns `AccessError` rather than
+            // panicking (a panic in a TLS destructor aborts the process); the
+            // map is being torn down, so the removal is moot. The removed
+            // entry is returned out of the closure and dropped after the
+            // `RefMut` is released. Never log here: the logging TLS may also
+            // be in teardown.
+            let _ = TIME_EVENT_CALLBACKS
+                .try_with(|callbacks| callbacks.borrow_mut().remove(&self.0.id));
         }
     }
 
@@ -156,9 +163,11 @@ impl Drop for TimeEventCallbackLease {
         let previous = self.0.state.fetch_sub(1, Ordering::AcqRel);
         debug_assert!(previous & CALLBACK_LEASES > 0);
         if previous == CALLBACK_CLOSED | 1 && self.0.owner == thread::current().id() {
-            TIME_EVENT_CALLBACKS.with(|callbacks| {
-                callbacks.borrow_mut().remove(&self.0.id);
-            });
+            // As in `remove_on_owner_thread`, this final lease can drop during
+            // thread-local teardown with `TIME_EVENT_CALLBACKS` already gone;
+            // `try_with` keeps the destructor from aborting the process.
+            let _ = TIME_EVENT_CALLBACKS
+                .try_with(|callbacks| callbacks.borrow_mut().remove(&self.0.id));
         }
     }
 }
@@ -791,6 +800,64 @@ mod tests {
         purge_closed_time_event_callbacks();
         assert!(!token.is_registered());
         assert_eq!(count.get(), 0);
+    }
+
+    // The two following tests reproduce the destructor-during-TLS-teardown
+    // abort: a callback holder (a lease, or a token closed from a `Drop` as
+    // `LiveTimer::drop` does) is placed in a thread-local initialized BEFORE
+    // `TIME_EVENT_CALLBACKS`. Rust does not guarantee a destruction order
+    // between independent TLS keys, but the affected implementation (native
+    // Linux TLS) destroys keys LIFO by initialization order, so the registry
+    // is torn down first and the holder's own destructor reaches the removal
+    // path with the registry TLS already gone. On the unfixed `.with` code
+    // that access panics inside a TLS destructor and aborts the whole process
+    // (the thread never joins); the `try_with` guard makes it a no-op. This
+    // mirrors the live path where `MESSAGE_BUS` outlives the callback
+    // registry and drops the last clock owner during teardown.
+
+    #[rstest]
+    fn test_final_lease_drop_survives_registry_tls_teardown() {
+        std::thread::spawn(|| {
+            thread_local! {
+                static HELD_LEASE: RefCell<Option<TimeEventCallbackLease>> =
+                    const { RefCell::new(None) };
+            }
+
+            // Initialize the holder before the registry so it is destroyed last.
+            HELD_LEASE.with(|_| {});
+
+            let token = register_time_event_callback(local_callback(Rc::new(Cell::new(0))));
+            let lease = token.acquire().unwrap();
+            token.close();
+            HELD_LEASE.with(|slot| *slot.borrow_mut() = Some(lease));
+        })
+        .join()
+        .expect("final-lease drop after registry teardown must not abort");
+    }
+
+    #[rstest]
+    fn test_owner_close_survives_registry_tls_teardown() {
+        struct CloseOnDrop(TimeEventCallbackToken);
+
+        impl Drop for CloseOnDrop {
+            fn drop(&mut self) {
+                self.0.close();
+            }
+        }
+
+        std::thread::spawn(|| {
+            thread_local! {
+                static HELD_TOKEN: RefCell<Option<CloseOnDrop>> = const { RefCell::new(None) };
+            }
+
+            // Initialize the holder before the registry so it is destroyed last.
+            HELD_TOKEN.with(|_| {});
+
+            let token = register_time_event_callback(local_callback(Rc::new(Cell::new(0))));
+            HELD_TOKEN.with(|slot| *slot.borrow_mut() = Some(CloseOnDrop(token)));
+        })
+        .join()
+        .expect("owner close after registry teardown must not abort");
     }
 
     #[rstest]

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -1875,6 +1875,7 @@ impl ExecutionEngine {
                         .borrow()
                         .order(&cmd.client_order_id)
                         .map(|o| o.clone());
+
                     if let Some(order) = order {
                         self.deny_order(&order, &reason);
                     }
@@ -3023,6 +3024,7 @@ impl ExecutionEngine {
                         .borrow()
                         .order(&client_order_id)
                         .is_some_and(|o| o.is_closed());
+
                     if already_closed && !matches!(event, OrderEventAny::Filled(_)) {
                         log::debug!("InvalidStateTrigger: {e}, did not apply {event}");
                     } else {
@@ -3068,6 +3070,7 @@ impl ExecutionEngine {
                         .borrow()
                         .order(&client_order_id)
                         .map(|o| o.clone());
+
                     if let Some(order) = order {
                         let should_update_own_book = {
                             let cache = self.cache.borrow();

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -704,6 +704,7 @@ impl OrderMatchingEngine {
                     .borrow()
                     .order(&client_order_id)
                     .is_some_and(|o| o.order_side() == deleted_side);
+
                 if matches_side {
                     self.reduce_queue_ahead(client_order_id, order_price_raw, ahead_raw, 0);
                 }
@@ -1223,6 +1224,7 @@ impl OrderMatchingEngine {
                 .borrow()
                 .order(&client_order_id)
                 .map(|o| o.clone());
+
             if let Some(order) = order
                 && (order.is_inflight() || order.is_open())
             {
@@ -3696,6 +3698,7 @@ impl OrderMatchingEngine {
             .borrow()
             .order(&client_order_id)
             .map(|o| o.clone());
+
         if let Some(mut updated_order) = updated_order {
             self.accept_order(&mut updated_order);
         }

--- a/crates/execution/src/order_manager/manager.rs
+++ b/crates/execution/src/order_manager/manager.rs
@@ -251,6 +251,7 @@ impl OrderManager {
             .borrow()
             .order(&expired.client_order_id)
             .map(|o| o.clone());
+
         if let Some(order) = cloned_order {
             if order.contingency_type() != Some(ContingencyType::NoContingency) {
                 return self.handle_contingencies(&order);
@@ -272,6 +273,7 @@ impl OrderManager {
             .borrow()
             .order(&updated.client_order_id)
             .map(|o| o.clone());
+
         if let Some(order) = cloned_order {
             if order.contingency_type() != Some(ContingencyType::NoContingency) {
                 return self.handle_contingencies_update(&order);

--- a/crates/infrastructure/src/sql/pg.rs
+++ b/crates/infrastructure/src/sql/pg.rs
@@ -379,6 +379,7 @@ fn split_sql_statements(sql: &str) -> Vec<String> {
                 in_string = !in_string;
                 current.push(c);
             }
+
             '-' if !in_string && chars.peek() == Some(&'-') => {
                 for next in chars.by_ref() {
                     if next == '\n' {
@@ -387,6 +388,7 @@ fn split_sql_statements(sql: &str) -> Vec<String> {
                     }
                 }
             }
+
             ';' if !in_string => {
                 let trimmed = current.trim();
                 if !trimmed.is_empty() {

--- a/crates/model/src/orders/mod.rs
+++ b/crates/model/src/orders/mod.rs
@@ -1174,6 +1174,7 @@ impl OrderCore {
                     .and_then(|event| event.commission_voided)
                     .filter(|voided| !voided.is_zero())
                     .map_or(commission, |voided| commission - voided);
+
                 if !surviving.is_zero() {
                     commissions
                         .entry(surviving.currency)

--- a/crates/trading/src/examples/strategies/hurst_vpin_directional/strategy.rs
+++ b/crates/trading/src/examples/strategies/hurst_vpin_directional/strategy.rs
@@ -355,6 +355,7 @@ nautilus_strategy!(HurstVpinDirectional, {
             .cache()
             .order(&event.client_order_id)
             .is_some_and(|o| o.is_closed());
+
         if closed {
             self.clear_latch_for(event.client_order_id);
         }


### PR DESCRIPTION
A follow-up to the time-event callback registry added in #4496, whose thread-local callback map is read infallibly from two `Drop`-reachable paths.

## Infallible registry access from a destructor aborts on thread-local teardown

`TimeEventCallbackToken::remove_on_owner_thread` and `TimeEventCallbackLease::drop` (both `crates/common/src/runner.rs`) reach `TIME_EVENT_CALLBACKS.with(...)`, which panics with `AccessError` once that thread-local has been destroyed. Both are reachable from a destructor: `LiveTimer::drop` -> `close_registered_callback` -> `TimeEventCallbackToken::close` -> `remove_on_owner_thread`, and the final-lease arm of `TimeEventCallbackLease::drop`. The `owner == thread::current().id()` guard does not defend against this - the destructor runs on the owner thread, so the guard passes and the call then touches an already-freed thread-local. A panic inside a TLS destructor aborts the process.

The window is a `LiveTimer` (or a still-queued `TimeEventCallbackLease`) outliving the registry thread-local at thread exit. It is observable when a node is dropped without a graceful stop: a `RustLocal` equity/aggregation timer armed on a `LiveClock` is kept alive by a strong `Rc` held in `MESSAGE_BUS`-owned handlers, so the clock - and its timers - drop during thread teardown, after `TIME_EVENT_CALLBACKS` has been destroyed. The failure surfaces as `cannot access a Thread Local Storage value during or after destruction: AccessError` -> `thread local panicked on drop` -> SIGABRT.

Both sites now use `try_with` and discard the `AccessError`: if the thread-local is already gone the entry cannot be removed and need not be, since the map is being torn down. The removed entry is returned out of the closure so it drops after the `RefCell` borrow is released, and the teardown path does not log (the logging thread-local may itself be in teardown). On a live owner thread `try_with` resolves the same instance and performs the identical removal, so the non-teardown path is unchanged; `RefCell` borrow panics still propagate.

## Testing

Two `#[rstest]` cases in `crates/common/src/runner.rs`, each reproducing the teardown ordering by initializing a holder thread-local before `TIME_EVENT_CALLBACKS`, so the registry is torn down first and the held value's destructor runs against gone TLS:

- `test_final_lease_drop_survives_registry_tls_teardown` pins the `TimeEventCallbackLease::drop` path: a final, closed lease is parked in the holder and drops after the registry.
- `test_owner_close_survives_registry_tls_teardown` pins the `remove_on_owner_thread` path via a `CloseOnDrop` wrapper that calls `token.close()` from its own `Drop`, standing in for `LiveTimer::drop` without dragging in the global runtime, a task, or a sender.

Each runs the drop inside a spawned thread and asserts the thread joins - an abort would take the whole test binary down with SIGABRT, not fail an assertion. Both were verified to abort with `AccessError` / SIGABRT against the unfixed `.with` code across the default, ffi, and live sweeps, and to pass with `try_with`. No wall-clock waits.

The reproduction relies on the platform's thread-local destruction order (holder initialized before the registry, destroyed after it), which matches the reported Linux abort; the fix itself makes the destructor order-independent.

## Restore the blank line before control-flow constructs

The repository style requires a blank line above a control-flow construct (`if`, `match`, ...) unless the preceding line opens a block, is a comment or attribute, or shares an identifier with the condition. Thirty-one sites across twenty files had drifted from it. Each gets a single blank line inserted - whitespace-only, no behavior change, no tests - bundled here so the branch is clean under the style gate.
