### PR TITLE
Fix stale live position reconciliation snapshots

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -151,11 +151,10 @@ pub(crate) struct OpenOrderReportCheck {
     pub start: Option<UnixNanos>,
 }
 
-/// Snapshot and command for one continuous position reconciliation check.
+/// Prepare-time client coverage and command for one continuous position reconciliation check.
 #[derive(Debug, Clone)]
 pub(crate) struct PositionReportCheck {
     pub command: GeneratePositionStatusReports,
-    pub positions_by_key: IndexMap<InstrumentAccountKey, Vec<Position>>,
     pub client_coverage: IndexMap<InstrumentAccountKey, ReportClientCoverage>,
 }
 
@@ -1083,25 +1082,20 @@ impl ExecutionManager {
         }
     }
 
-    fn open_positions_by_key_for_reconciliation(
-        &self,
-    ) -> IndexMap<InstrumentAccountKey, Vec<Position>> {
+    fn open_position_keys_for_reconciliation(&self) -> IndexSet<InstrumentAccountKey> {
         let cache = self.cache.borrow();
         let positions = cache.positions_open(None, None, None, None, None);
-        let mut positions_by_key: IndexMap<InstrumentAccountKey, Vec<Position>> = IndexMap::new();
+        let mut position_keys = IndexSet::new();
 
         for position in positions {
             if !self.should_reconcile_instrument(&position.instrument_id) {
                 continue;
             }
 
-            positions_by_key
-                .entry((position.instrument_id, position.account_id))
-                .or_default()
-                .push(position.clone());
+            position_keys.insert((position.instrument_id, position.account_id));
         }
 
-        positions_by_key
+        position_keys
     }
 
     /// Prepares a bulk open-order report request and snapshots cached open orders.
@@ -1636,16 +1630,16 @@ impl ExecutionManager {
         events
     }
 
-    /// Prepares a bulk position report request and snapshots cached positions.
+    /// Prepares a bulk position report request and records client coverage.
     #[must_use]
     pub(crate) fn prepare_position_report_check(
         &self,
         command_id: UUID4,
         clients: &[&dyn ExecutionClient],
     ) -> PositionReportCheck {
-        let positions_by_key = self.open_positions_by_key_for_reconciliation();
-        let client_coverage = positions_by_key
-            .keys()
+        let position_keys = self.open_position_keys_for_reconciliation();
+        let client_coverage = position_keys
+            .iter()
             .map(|key| {
                 (
                     *key,
@@ -1656,8 +1650,8 @@ impl ExecutionManager {
 
         log::debug!(
             "Found {} unique instrument/account combination{} with open positions",
-            positions_by_key.len(),
-            if positions_by_key.len() == 1 { "" } else { "s" }
+            position_keys.len(),
+            if position_keys.len() == 1 { "" } else { "s" }
         );
 
         let mut command = GeneratePositionStatusReports::new(
@@ -1673,7 +1667,6 @@ impl ExecutionManager {
 
         PositionReportCheck {
             command,
-            positions_by_key,
             client_coverage,
         }
     }
@@ -1774,7 +1767,7 @@ impl ExecutionManager {
 
         let mut events = Vec::new();
 
-        for (key, cached_positions) in &check.positions_by_key {
+        for key in check.client_coverage.keys() {
             let venue_report = venue_positions.get(key);
 
             if venue_report.is_none() {
@@ -1826,22 +1819,31 @@ impl ExecutionManager {
                 }
             }
 
-            if let Some(discrepancy_events) =
-                self.check_position_discrepancy(*key, cached_positions, venue_report)
-            {
+            if let Some(discrepancy_events) = self.check_position_discrepancy(*key, venue_report) {
                 events.extend(discrepancy_events);
             }
         }
 
+        let current_position_keys = self.open_position_keys_for_reconciliation();
+
         for (key, venue_report) in &venue_positions {
-            if check.positions_by_key.contains_key(key)
+            if check.client_coverage.contains_key(key)
                 || venue_report.signed_decimal_qty == Decimal::ZERO
             {
                 continue;
             }
 
+            if current_position_keys.contains(key) {
+                log::debug!(
+                    "Deferring position reconciliation for {}/{}: position opened after client coverage was recorded",
+                    key.0,
+                    key.1,
+                );
+                continue;
+            }
+
             if let Some(discrepancy_events) =
-                self.check_position_discrepancy(*key, &[], Some(venue_report))
+                self.check_position_discrepancy(*key, Some(venue_report))
             {
                 events.extend(discrepancy_events);
             }
@@ -1849,10 +1851,8 @@ impl ExecutionManager {
 
         // Prune retry counters for (instrument, account) pairs no longer actively
         // tracked, excluding flat venue reports which shouldn't protect stale counters
-        let active_keys: IndexSet<InstrumentAccountKey> = check
-            .positions_by_key
-            .keys()
-            .copied()
+        let active_keys: IndexSet<InstrumentAccountKey> = current_position_keys
+            .into_iter()
             .chain(
                 venue_positions
                     .iter()
@@ -1866,7 +1866,7 @@ impl ExecutionManager {
         events
     }
 
-    fn position_snapshot_avg_px(cached_positions: &[Position]) -> Option<Decimal> {
+    fn positions_avg_px(cached_positions: &[Position]) -> Option<Decimal> {
         let mut total_value = Decimal::ZERO;
         let mut total_qty = Decimal::ZERO;
 
@@ -2372,15 +2372,22 @@ impl ExecutionManager {
     fn check_position_discrepancy(
         &mut self,
         key: InstrumentAccountKey,
-        cached_positions: &[Position],
         venue_report: Option<&PositionStatusReport>,
     ) -> Option<Vec<OrderEventAny>> {
         let (instrument_id, account_id) = key;
 
-        let mut cached_signed_qty = Decimal::ZERO;
-        for position in cached_positions {
-            cached_signed_qty += position.signed_decimal_qty();
-        }
+        let cached_positions = {
+            let cache = self.cache.borrow();
+            cache
+                .positions_open(None, Some(&instrument_id), None, Some(&account_id), None)
+                .into_iter()
+                .map(|position| (*position).clone())
+                .collect::<Vec<_>>()
+        };
+        let cached_signed_qty: Decimal = cached_positions
+            .iter()
+            .map(Position::signed_decimal_qty)
+            .sum();
         let venue_signed_qty = venue_report.map_or(Decimal::ZERO, |r| r.signed_decimal_qty);
 
         let tolerance = self.position_reconciliation_tolerance(account_id);
@@ -2427,7 +2434,7 @@ impl ExecutionManager {
             return None;
         };
 
-        let cached_avg_px = Self::position_snapshot_avg_px(cached_positions);
+        let cached_avg_px = Self::positions_avg_px(&cached_positions);
         let venue_avg_px = venue_report.and_then(|r| r.avg_px_open);
 
         let crosses_zero = (cached_signed_qty > Decimal::ZERO && venue_signed_qty < Decimal::ZERO)
@@ -3840,7 +3847,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_prepare_position_report_check_builds_bulk_command_with_snapshot() {
+    fn test_prepare_position_report_check_builds_bulk_command_with_coverage() {
         let clock = Rc::new(RefCell::new(TestClock::new()));
         let cache = Rc::new(RefCell::new(Cache::default()));
         let manager = ExecutionManager::new(
@@ -3886,7 +3893,6 @@ mod tests {
             included_position.instrument_id,
             included_position.account_id,
         );
-        let positions = check.positions_by_key.get(&key).unwrap();
 
         assert_eq!(check.command.command_id, command_id);
         assert_eq!(check.command.ts_init, ts_now);
@@ -3894,9 +3900,8 @@ mod tests {
         assert_eq!(check.command.start, None);
         assert_eq!(check.command.end, None);
         assert_eq!(check.command.log_receipt_level, LogLevel::Debug);
-        assert_eq!(check.positions_by_key.len(), 1);
-        assert_eq!(positions.len(), 1);
-        assert_eq!(positions[0].id, included_position.id);
+        assert_eq!(check.client_coverage.len(), 1);
+        assert!(check.client_coverage.contains_key(&key));
     }
 
     #[rstest]

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -4835,6 +4835,34 @@ fn create_test_position_for_account(
     Position::new(instrument, order_filled)
 }
 
+fn close_test_long_position(
+    mut position: Position,
+    instrument: &InstrumentAny,
+    qty: &str,
+    trade_id: TradeId,
+) -> Position {
+    let close_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(qty))
+        .build();
+    let close_fill = TestOrderEventStubs::filled(
+        &close_order,
+        instrument,
+        Some(trade_id),
+        Some(position.id),
+        Some(Price::from("3000.00")),
+        Some(Quantity::from(qty)),
+        None,
+        None,
+        None,
+        Some(position.account_id),
+    );
+    let close_filled: OrderFilled = close_fill.into();
+    position.apply(&close_filled);
+    position
+}
+
 #[tokio::test]
 async fn test_reconcile_mass_status_iterates_all_position_reports() {
     // Tests that we iterate ALL position reports, not just the first one
@@ -9759,6 +9787,246 @@ async fn test_position_check_reconciles_venue_only_nonflat_report() {
     );
 }
 
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_position_check_rereads_position_closed_during_request() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let position = create_test_position(
+        &instrument,
+        PositionId::from("P-CLOSE-DURING-REQUEST"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    );
+    let closed_position = close_test_long_position(
+        position.clone(),
+        &instrument,
+        "5.0",
+        TradeId::from("T-CLOSE-DURING-REQUEST"),
+    );
+    ctx.add_instrument(instrument);
+    ctx.add_position(&position);
+
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![])
+        .with_position_request_mutation(PositionRequestMutation::Update {
+            cache: ctx.cache.clone(),
+            position: closed_position,
+        });
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+    for event in &events {
+        ctx.exec_engine.borrow_mut().process(event);
+    }
+
+    let open_positions = ctx
+        .cache
+        .borrow()
+        .positions_open(None, Some(&test_instrument_id()), None, None, None)
+        .len();
+    assert!(events.is_empty());
+    assert_eq!(
+        open_positions, 0,
+        "a synthetic sell from the stale long would open a real short",
+    );
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_position_check_rereads_position_opened_during_request() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let position = create_test_position(
+        &instrument,
+        PositionId::from("P-OPEN-DURING-REQUEST"),
+        OrderSide::Buy,
+        "3.0",
+        "3000.00",
+    );
+    let venue_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    ctx.add_instrument(instrument);
+
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report])
+        .with_position_request_mutation(PositionRequestMutation::Add {
+            cache: ctx.cache.clone(),
+            position,
+        });
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(
+        events.is_empty(),
+        "the matching report must not recreate a position opened during the request",
+    );
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_position_check_uses_current_avg_px_after_request() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let position_id = PositionId::from("P-AVG-PX-DURING-REQUEST");
+    let stale_position =
+        create_test_position(&instrument, position_id, OrderSide::Buy, "5.0", "3000.00");
+    let current_position =
+        create_test_position(&instrument, position_id, OrderSide::Buy, "3.0", "3100.00");
+    let venue_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("6.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3200.00)),
+    );
+    ctx.add_instrument(instrument);
+    ctx.add_position(&stale_position);
+
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report])
+        .with_position_request_mutation(PositionRequestMutation::Update {
+            cache: ctx.cache.clone(),
+            position: current_position,
+        });
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+    let fill = events
+        .iter()
+        .find_map(|event| match event {
+            OrderEventAny::Filled(fill) => Some(fill),
+            _ => None,
+        })
+        .expect("expected a reconciliation fill");
+
+    assert_eq!(fill.last_qty, Quantity::from("3.0"));
+    assert_eq!(fill.last_px, Price::from("3300.00"));
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_position_check_preserves_retry_for_uncovered_position_opened_during_request() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let key = (instrument_id, test_account_id());
+    let old_position = create_test_position(
+        &instrument,
+        PositionId::from("P-RETRY-OLD"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    );
+    ctx.add_position(&old_position);
+
+    let initial_client = MockPositionExecutionClient::new(vec![], vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&initial_client];
+    assert!(
+        ctx.manager
+            .check_positions_consistency(&clients)
+            .await
+            .is_empty()
+    );
+    assert_eq!(ctx.manager.position_recon_retry_count(&key), 1);
+
+    let closed_position = close_test_long_position(
+        old_position,
+        &instrument,
+        "5.0",
+        TradeId::from("T-RETRY-CLOSE"),
+    );
+    ctx.cache
+        .borrow_mut()
+        .update_position(&closed_position)
+        .unwrap();
+    ctx.add_instrument(instrument.clone());
+
+    let new_position = create_test_position(
+        &instrument,
+        PositionId::from("P-RETRY-NEW"),
+        OrderSide::Buy,
+        "3.0",
+        "3100.00",
+    );
+    let venue_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("4.0"),
+        UnixNanos::from(2_000_000),
+        UnixNanos::from(2_000_000),
+        None,
+        None,
+        Some(dec!(3200.00)),
+    );
+    let request_client = MockPositionExecutionClient::new(vec![], vec![venue_report])
+        .with_position_request_mutation(PositionRequestMutation::Add {
+            cache: ctx.cache.clone(),
+            position: new_position,
+        });
+    let clients: Vec<&dyn ExecutionClient> = vec![&request_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(
+        ctx.manager.position_recon_retry_count(&key),
+        1,
+        "the uncovered key must be deferred and remain active for retry pruning",
+    );
+}
+
 #[tokio::test]
 async fn test_position_check_retries_stops_after_max() {
     // When instrument is not in cache, check_position_discrepancy returns None
@@ -9900,6 +10168,17 @@ async fn test_position_check_stale_retries_pruned_when_position_closed() {
     );
 }
 
+enum PositionRequestMutation {
+    Add {
+        cache: Rc<RefCell<Cache>>,
+        position: Position,
+    },
+    Update {
+        cache: Rc<RefCell<Cache>>,
+        position: Position,
+    },
+}
+
 struct MockPositionExecutionClient {
     client_id: ClientId,
     account_id: AccountId,
@@ -9907,6 +10186,7 @@ struct MockPositionExecutionClient {
     handled_venues: Option<IndexSet<Venue>>,
     order_reports: RefCell<Vec<OrderStatusReport>>,
     position_reports: RefCell<Vec<PositionStatusReport>>,
+    position_request_mutation: RefCell<Option<PositionRequestMutation>>,
     fail_position_reports: bool,
     position_reconciliation_tolerance: Decimal,
 }
@@ -9923,6 +10203,7 @@ impl MockPositionExecutionClient {
             handled_venues: None,
             order_reports: RefCell::new(order_reports),
             position_reports: RefCell::new(position_reports),
+            position_request_mutation: RefCell::new(None),
             fail_position_reports: false,
             position_reconciliation_tolerance: dec!(0.00000001),
         }
@@ -9938,6 +10219,11 @@ impl MockPositionExecutionClient {
         self
     }
 
+    fn with_position_request_mutation(mut self, mutation: PositionRequestMutation) -> Self {
+        self.position_request_mutation = RefCell::new(Some(mutation));
+        self
+    }
+
     fn failing_position_reports() -> Self {
         Self {
             client_id: test_client_id(),
@@ -9946,6 +10232,7 @@ impl MockPositionExecutionClient {
             handled_venues: None,
             order_reports: RefCell::new(Vec::new()),
             position_reports: RefCell::new(Vec::new()),
+            position_request_mutation: RefCell::new(None),
             fail_position_reports: true,
             position_reconciliation_tolerance: dec!(0.00000001),
         }
@@ -9965,6 +10252,7 @@ impl MockPositionExecutionClient {
             handled_venues: Some(handled_venues),
             order_reports: RefCell::new(Vec::new()),
             position_reports: RefCell::new(Vec::new()),
+            position_request_mutation: RefCell::new(None),
             fail_position_reports,
             position_reconciliation_tolerance: dec!(0.00000001),
         }
@@ -10068,6 +10356,21 @@ impl ExecutionClient for MockPositionExecutionClient {
         &self,
         _cmd: &GeneratePositionStatusReports,
     ) -> anyhow::Result<Vec<PositionStatusReport>> {
+        let mutation = { self.position_request_mutation.borrow_mut().take() };
+        if let Some(mutation) = mutation {
+            dst::time::sleep(dst::time::Duration::from_secs(1)).await;
+
+            match mutation {
+                PositionRequestMutation::Add { cache, position } => cache
+                    .borrow_mut()
+                    .add_position(&position, OmsType::Hedging)
+                    .unwrap(),
+                PositionRequestMutation::Update { cache, position } => {
+                    cache.borrow_mut().update_position(&position).unwrap();
+                }
+            }
+        }
+
         if self.fail_position_reports {
             anyhow::bail!("position reports unavailable");
         }


### PR DESCRIPTION
A follow-up to the position-reconciliation tolerance fix in #4490, on the same live reconciliation path.

## Position reconciliation acted on a prepare-time snapshot

The continuous position-consistency check captures open positions at prepare time and then reconciles them against venue reports that arrive after an asynchronous round-trip. `start_position_report_check` calls `open_positions_by_key_for_reconciliation`, cloning each open `Position` into `PositionReportCheck.positions_by_key`, and only then awaits `request_position_reports` (sequential over clients). When that future resolves, `reconcile_position_reports` -> `check_position_discrepancy` derives both `cached_signed_qty` and `cached_avg_px` from the frozen vector. The runner keeps draining execution events during the await, so a fill that closes or reduces the position mutates the cache but not the snapshot; the only guard is the `position_local_activity` grace window (`position_check_threshold_ns`, `5s` by default, `0` disables), and retries do not debounce - the first discrepancy acts. A position that goes flat during the request against an empty venue response yields stale `cached_signed_qty=5, venue=0` and a synthetic market sell of `5`, which applied to the now-flat cache opens a real short. The venue-only loop is the same defect in reverse: reports for keys absent at prepare are reconciled against `&[]`, so a position that opened during the request is treated as absent and its full venue quantity is re-synthesized.

The mass-status netting path (`reconcile_position_report_netting`) already reads `cache.positions_open` live inside a single borrow with no intervening await, and is unaffected. The fix brings the continuous path into line: `check_position_discrepancy` re-reads the current open-`Position` vector for the key from the cache at reconciliation time and drives both quantity and average price from it, in the prepare-key loop and the venue-only loop alike, and retry pruning keys on the reconcile-time active set rather than the prepare-time keys. The prepared `client_coverage` snapshot is retained deliberately - it records which clients were actually queried, which is what lets an absent report be read as flat - so a newly opened key that carries no coverage entry is deferred to the next cycle rather than reconciled against a report that was never requested for it.

## Testing

- `test_position_check_rereads_position_closed_during_request` - a position long `5` at prepare time is closed to flat while the report request is pending; an empty venue response generates no reconciliation event and leaves no open position (the stale long would otherwise synthesize a sell that opens a real short).
- `test_position_check_rereads_position_opened_during_request` - a position opened during the request and matched by the venue report generates no event; the venue-only path defers the key that carried no prepare-time coverage.
- `test_position_check_uses_current_avg_px_after_request` - a residual discrepancy prices its synthetic fill from the current position (`3.0` at `avg_px_open` `3100`, reconciliation price `3300.00`), not the stale snapshot (`5.0` at `3000`).
- `test_position_check_preserves_retry_for_uncovered_position_opened_during_request` - a deferred uncovered key stays in the reconcile-time active set, so its retry counter is not pruned.

All tests use paused/virtual time (the in-flight cache mutation is driven by a virtual `dst::time::sleep`, no wall-clock waits). Each assertion was verified to FAIL against the unfixed snapshot-keyed code.
