### PR TITLE
Commit reconciliation fill dedup after canonical apply, and bound its retention

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -166,6 +166,24 @@ struct RetainedFillState {
     netting_lifecycle_starts: IndexMap<(AccountId, InstrumentId, StrategyId), UnixNanos>,
 }
 
+#[derive(Default)]
+struct ReconciliationFillQueue {
+    pending_fill_keys: IndexSet<FillKey>,
+    event_fill_keys: IndexMap<UUID4, FillKey>,
+}
+
+impl ReconciliationFillQueue {
+    fn push(&mut self, events: &mut Vec<OrderEventAny>, event: OrderEventAny, fill_key: FillKey) {
+        let OrderEventAny::Filled(fill) = &event else {
+            unreachable!("reported fills always create filled events");
+        };
+
+        self.pending_fill_keys.insert(fill_key);
+        self.event_fill_keys.insert(fill.event_id, fill_key);
+        events.push(event);
+    }
+}
+
 /// Configuration for execution manager.
 #[expect(
     clippy::struct_excessive_bools,
@@ -310,7 +328,7 @@ pub struct ExecutionManager {
     config: ExecutionManagerConfig,
     inflight_checks: IndexMap<ClientOrderId, InflightCheck>,
     external_order_claims: IndexMap<InstrumentId, StrategyId>,
-    processed_fills: IndexMap<FillKey, ClientOrderId>,
+    processed_fills: RecencyMap<FillKey>,
     recon_check_retries: IndexMap<ClientOrderId, u32>,
     order_query_recency: RecencyMap<ClientOrderId>,
     order_local_activity: RecencyMap<ClientOrderId>,
@@ -349,7 +367,7 @@ impl ExecutionManager {
             config,
             inflight_checks: IndexMap::new(),
             external_order_claims: IndexMap::new(),
-            processed_fills: IndexMap::new(),
+            processed_fills: RecencyMap::default(),
             recon_check_retries: IndexMap::new(),
             order_query_recency: RecencyMap::default(),
             order_local_activity: RecencyMap::default(),
@@ -464,6 +482,7 @@ impl ExecutionManager {
         let mut orders_skipped_no_instrument = 0usize;
         let mut orders_skipped_duplicate = 0usize;
         let mut fills_applied = 0usize;
+        let mut fill_queue = ReconciliationFillQueue::default();
 
         let fill_reports = &adjusted_fill_reports;
         let mut seen_fill_keys: IndexSet<FillKey> = IndexSet::new();
@@ -546,6 +565,7 @@ impl ExecutionManager {
                         report,
                         &order_fills,
                         instrument.as_ref(),
+                        &mut fill_queue,
                     );
 
                     if !order_events.is_empty() {
@@ -589,6 +609,7 @@ impl ExecutionManager {
                         report,
                         &order_fills,
                         instrument.as_ref(),
+                        &mut fill_queue,
                     );
 
                     if !order_events.is_empty() {
@@ -619,6 +640,7 @@ impl ExecutionManager {
                             &instrument,
                             &order_fills,
                             false, // Not synthetic (venue order)
+                            Some(&mut fill_queue),
                         );
 
                         if !external_events.is_empty() {
@@ -664,6 +686,7 @@ impl ExecutionManager {
                     report,
                     &order_fills,
                     instrument.as_ref(),
+                    &mut fill_queue,
                 );
 
                 if !order_events.is_empty() {
@@ -696,6 +719,7 @@ impl ExecutionManager {
                     &instrument,
                     &order_fills,
                     is_synthetic,
+                    Some(&mut fill_queue),
                 );
 
                 if !external_events.is_empty() {
@@ -781,9 +805,14 @@ impl ExecutionManager {
                     sorted_fills.sort_by_key(|f| f.ts_event);
 
                     for fill in sorted_fills {
-                        if let Some(event) = self.create_order_fill(&order, fill, &instrument) {
+                        if let Some((event, fill_key)) = self.create_order_fill(
+                            &order,
+                            fill,
+                            &instrument,
+                            &fill_queue.pending_fill_keys,
+                        ) {
                             fills_applied += 1;
-                            events.push(event);
+                            fill_queue.push(&mut events, event, fill_key);
                         }
                     }
                 }
@@ -818,6 +847,22 @@ impl ExecutionManager {
                 exec_engine.borrow_mut().project_reconciliation_fill(fill);
             } else {
                 exec_engine.borrow_mut().process(event);
+            }
+
+            if let OrderEventAny::Filled(fill) = event
+                && let Some(fill_key) = fill_queue.event_fill_keys.get(&fill.event_id).copied()
+            {
+                let order = self
+                    .get_order(fill.client_order_id)
+                    .or_else(|| self.get_order_by_venue_order_id(fill.venue_order_id));
+
+                if order.is_some_and(|order| {
+                    order.account_id() == Some(fill_key.0)
+                        && order.instrument_id() == fill_key.1
+                        && order.trade_ids().contains(&&fill_key.2)
+                }) {
+                    self.processed_fills.mark(fill_key);
+                }
             }
         }
 
@@ -2027,7 +2072,7 @@ impl ExecutionManager {
     ///
     /// Updates performed per report variant:
     /// - `Order`: clears inflight tracking and records local activity
-    /// - `Fill`: marks fill as processed, records order and position activity
+    /// - `Fill`: records order and position activity without marking the fill as processed
     /// - `OrderWithFills`: clears inflight tracking, records local activity, records position activity per fill
     /// - `Position`: records position activity
     /// - `MassStatus`: no-op (handled separately via startup reconciliation)
@@ -2138,6 +2183,19 @@ impl ExecutionManager {
         };
 
         self.recent_fills_cache.prune_older_than(ttl);
+    }
+
+    /// Prunes committed mass-reconciliation fills outside the startup report window.
+    ///
+    /// An unbounded startup lookback requires indefinite retention because no finite
+    /// horizon can safely exclude a replayed fill report.
+    pub fn prune_processed_fills(&mut self) {
+        let Some(lookback_mins) = self.config.lookback_mins else {
+            return;
+        };
+
+        let ttl = Duration::from_mins(lookback_mins).max(Duration::from_mins(1));
+        self.processed_fills.prune_older_than(ttl);
     }
 
     /// Purges closed orders from the cache that are older than the configured buffer.
@@ -2515,6 +2573,7 @@ impl ExecutionManager {
                                 &instrument,
                                 &[],
                                 true,
+                                None,
                             );
                             events
                         })
@@ -2549,7 +2608,7 @@ impl ExecutionManager {
     /// fills: close existing position then open new position in opposite direction.
     #[expect(clippy::too_many_arguments)]
     fn reconcile_cross_zero_position(
-        &mut self,
+        &self,
         instrument: &InstrumentAny,
         account_id: AccountId,
         instrument_id: InstrumentId,
@@ -2617,7 +2676,7 @@ impl ExecutionManager {
             );
 
             let (close_events, _) =
-                self.handle_external_order(&close_report, account_id, instrument, &[], true);
+                self.handle_external_order(&close_report, account_id, instrument, &[], true, None);
             all_events.extend(close_events);
         } else {
             log::warn!("Cannot close position for {instrument_id}: no cached average price");
@@ -2674,7 +2733,7 @@ impl ExecutionManager {
             );
 
             let (open_events, _) =
-                self.handle_external_order(&open_report, account_id, instrument, &[], true);
+                self.handle_external_order(&open_report, account_id, instrument, &[], true, None);
             all_events.extend(open_events);
         } else {
             log::warn!("Cannot open new position for {instrument_id}: no venue average price");
@@ -2689,7 +2748,7 @@ impl ExecutionManager {
     /// This handles the case where the venue reports an open position but there are
     /// no order or fill reports to create it from (e.g., orders are already closed).
     fn create_position_from_report(
-        &mut self,
+        &self,
         report: &PositionStatusReport,
         account_id: AccountId,
         instrument: &InstrumentAny,
@@ -2755,12 +2814,12 @@ impl ExecutionManager {
         );
 
         let (events, _) =
-            self.handle_external_order(&order_report, account_id, instrument, &[], true);
+            self.handle_external_order(&order_report, account_id, instrument, &[], true, None);
         Some(events)
     }
 
     fn reconcile_position_report(
-        &mut self,
+        &self,
         report: &PositionStatusReport,
         account_id: AccountId,
         instruments_with_unattributed_fills: &IndexSet<InstrumentId>,
@@ -2779,7 +2838,7 @@ impl ExecutionManager {
     }
 
     fn reconcile_position_report_hedging(
-        &mut self,
+        &self,
         report: &PositionStatusReport,
         account_id: AccountId,
         instruments_with_unattributed_fills: &IndexSet<InstrumentId>,
@@ -2868,7 +2927,7 @@ impl ExecutionManager {
     }
 
     fn reconcile_hedge_position_discrepancy(
-        &mut self,
+        &self,
         report: &PositionStatusReport,
         account_id: AccountId,
         position: &Position,
@@ -2914,7 +2973,7 @@ impl ExecutionManager {
     }
 
     fn reconcile_missing_hedge_position(
-        &mut self,
+        &self,
         report: &PositionStatusReport,
         account_id: AccountId,
     ) -> Option<Vec<OrderEventAny>> {
@@ -2947,7 +3006,7 @@ impl ExecutionManager {
     }
 
     fn reconcile_position_report_netting(
-        &mut self,
+        &self,
         report: &PositionStatusReport,
         account_id: AccountId,
     ) -> Option<Vec<OrderEventAny>> {
@@ -3053,7 +3112,7 @@ impl ExecutionManager {
     }
 
     fn create_position_reconciliation_order(
-        &mut self,
+        &self,
         report: &PositionStatusReport,
         account_id: AccountId,
         instrument: &InstrumentAny,
@@ -3124,7 +3183,7 @@ impl ExecutionManager {
         );
 
         let (events, _) =
-            self.handle_external_order(&order_report, account_id, instrument, &[], true);
+            self.handle_external_order(&order_report, account_id, instrument, &[], true, None);
         Some(events)
     }
 
@@ -3140,11 +3199,12 @@ impl ExecutionManager {
 
     /// Reconciles an order with its associated fills atomically.
     fn reconcile_order_with_fills(
-        &mut self,
+        &self,
         order: &OrderAny,
         report: &OrderStatusReport,
         fills: &[&FillReport],
         instrument: Option<&InstrumentAny>,
+        fill_queue: &mut ReconciliationFillQueue,
     ) -> Vec<OrderEventAny> {
         let mut events = Vec::new();
         let mut working = order.clone();
@@ -3189,7 +3249,9 @@ impl ExecutionManager {
 
         if let Some(inst) = instrument {
             for fill in sorted_fills {
-                let Some(event) = self.create_order_fill(&working, fill, inst) else {
+                let Some((event, fill_key)) =
+                    self.create_order_fill(&working, fill, inst, &fill_queue.pending_fill_keys)
+                else {
                     continue;
                 };
 
@@ -3200,7 +3262,7 @@ impl ExecutionManager {
                     );
                     return events;
                 }
-                events.push(event);
+                fill_queue.push(&mut events, event, fill_key);
             }
         }
 
@@ -3221,12 +3283,13 @@ impl ExecutionManager {
     }
 
     fn handle_external_order(
-        &mut self,
+        &self,
         report: &OrderStatusReport,
         account_id: AccountId,
         instrument: &InstrumentAny,
         fills: &[&FillReport],
         is_synthetic: bool,
+        mut fill_queue: Option<&mut ReconciliationFillQueue>,
     ) -> (Vec<OrderEventAny>, Option<ExternalOrderMetadata>) {
         let (strategy_id, tags) =
             if let Some(claimed_strategy) = self.external_order_claims.get(&report.instrument_id) {
@@ -3405,11 +3468,18 @@ impl ExecutionManager {
                     let mut real_fill_total = Decimal::ZERO;
 
                     for fill in &sorted_fills {
-                        if let Some(fill_event) =
-                            self.create_order_fill(&cached_order, fill, instrument)
-                        {
+                        let fill_queue = fill_queue
+                            .as_deref_mut()
+                            .expect("real report fills require reconciliation queue state");
+
+                        if let Some((fill_event, fill_key)) = self.create_order_fill(
+                            &cached_order,
+                            fill,
+                            instrument,
+                            &fill_queue.pending_fill_keys,
+                        ) {
                             real_fill_total += fill.last_qty.as_decimal();
-                            order_events.push(fill_event);
+                            fill_queue.push(&mut order_events, fill_event, fill_key);
                         }
                     }
 
@@ -3624,20 +3694,18 @@ impl ExecutionManager {
     }
 
     fn create_order_fill(
-        &mut self,
+        &self,
         order: &OrderAny,
         fill: &FillReport,
         instrument: &InstrumentAny,
-    ) -> Option<OrderEventAny> {
+        pending_fill_keys: &IndexSet<FillKey>,
+    ) -> Option<(OrderEventAny, FillKey)> {
         let fill_key = (fill.account_id, fill.instrument_id, fill.trade_id);
-        if self.processed_fills.contains_key(&fill_key) {
+        if self.processed_fills.contains_key(&fill_key) || pending_fill_keys.contains(&fill_key) {
             return None;
         }
 
-        self.processed_fills
-            .insert(fill_key, order.client_order_id());
-
-        Some(OrderEventAny::Filled(OrderFilled::new(
+        let event = OrderEventAny::Filled(OrderFilled::new(
             order.trader_id(),
             order.strategy_id(),
             order.instrument_id(),
@@ -3658,7 +3726,9 @@ impl ExecutionManager {
             fill.venue_position_id,
             Some(fill.commission),
             None,
-        )))
+        ));
+
+        Some((event, fill_key))
     }
 }
 
@@ -3903,7 +3973,7 @@ mod tests {
     fn test_mass_status_projects_companion_fill_before_void_correction() {
         let clock = Rc::new(RefCell::new(TestClock::new()));
         let cache = Rc::new(RefCell::new(Cache::default()));
-        let mut manager =
+        let manager =
             ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default());
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         let client_order_id = ClientOrderId::from("O-MASS-VOID-001");
@@ -3968,11 +4038,13 @@ mod tests {
             None,
         );
 
+        let mut fill_queue = ReconciliationFillQueue::default();
         let events = manager.reconcile_order_with_fills(
             &order,
             &report,
             &[&companion_fill],
             Some(&instrument),
+            &mut fill_queue,
         );
         let mut projected = order;
         for event in &events {

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -1240,6 +1240,7 @@ impl LiveNode {
 
                     if now >= prune_fills_next {
                         self.exec_manager.prune_recent_fills_cache(60.0);
+                        self.exec_manager.prune_processed_fills();
                         prune_fills_next = now + prune_fills_interval;
                     }
 

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -315,6 +315,47 @@ fn create_order_status_report_for_side(
     .with_price(Price::from("3000.00"))
 }
 
+fn create_fill_report(
+    client_order_id: ClientOrderId,
+    venue_order_id: VenueOrderId,
+    instrument_id: InstrumentId,
+    trade_id: TradeId,
+    quantity: &str,
+) -> FillReport {
+    FillReport::new(
+        test_account_id(),
+        instrument_id,
+        venue_order_id,
+        trade_id,
+        OrderSide::Buy,
+        Quantity::from(quantity),
+        Price::from("3000.00"),
+        Money::from("0.50 USDT"),
+        LiquiditySide::Maker,
+        Some(client_order_id),
+        None,
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )
+}
+
+fn create_mass_status(
+    order_reports: Vec<OrderStatusReport>,
+    fill_reports: Vec<FillReport>,
+) -> ExecutionMassStatus {
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_order_reports(order_reports);
+    mass_status.add_fill_reports(fill_reports);
+    mass_status
+}
+
 #[rstest]
 fn test_fill_deduplication_new_fill_not_processed() {
     let ctx = TestContext::new();
@@ -565,8 +606,8 @@ async fn test_observe_pending_order_report_keeps_inflight_tracking() {
 
 #[rstest]
 fn test_observe_fill_report_does_not_mark_fill_processed() {
-    // Fill dedup marking is deferred to node.rs after dispatch to avoid
-    // permanently losing fills when the execution engine cannot apply them
+    // Incoming fill reports record activity only. Normal-live fill dedup marking
+    // follows the separate order-event observation path.
     let mut ctx = TestContext::new();
     let instrument_id = test_instrument_id();
     let trade_id = TradeId::from("T-001");
@@ -593,8 +634,7 @@ fn test_observe_fill_report_does_not_mark_fill_processed() {
 
     ctx.manager.observe_execution_report(&report);
 
-    // observe_execution_report should NOT mark fills as processed;
-    // that happens post-dispatch in the event loop
+    // observe_execution_report should not mark fills as processed.
     assert!(
         !ctx.manager
             .is_fill_recently_processed(test_account_id(), instrument_id, trade_id)
@@ -1774,6 +1814,536 @@ async fn test_reconcile_mass_status_deduplicates_fills() {
 
     // Only one fill should be processed
     assert_eq!(result.events.len(), 1);
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_rejected_reconciliation_fill_is_retried() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let client_order_id = ClientOrderId::from("O-REJECT-RETRY");
+    let venue_order_id = VenueOrderId::from("V-REJECT-RETRY");
+    let retry_client_order_id = ClientOrderId::from("O-REJECT-RETRY-2");
+    let retry_venue_order_id = VenueOrderId::from("V-REJECT-RETRY-2");
+    let trade_id = TradeId::from("T-REJECT-RETRY");
+
+    let instrument = test_instrument();
+    ctx.add_instrument(instrument.clone());
+    let mut order = create_accepted_order(
+        client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "2.0",
+        "3000.00",
+        venue_order_id,
+    );
+    let existing_fill = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(trade_id),
+        None,
+        Some(Price::from("3000.00")),
+        Some(Quantity::from("1.0")),
+        Some(LiquiditySide::Maker),
+        None,
+        None,
+        Some(test_account_id()),
+    );
+    order.apply(existing_fill).unwrap();
+    ctx.add_order(order);
+
+    let rejected_report = create_order_status_report(
+        Some(client_order_id),
+        venue_order_id,
+        instrument_id,
+        OrderStatus::Filled,
+        Quantity::from("2.0"),
+        Quantity::from("2.0"),
+    );
+    let rejected_fill = create_fill_report(
+        client_order_id,
+        venue_order_id,
+        instrument_id,
+        trade_id,
+        "1.0",
+    );
+    let rejected = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(vec![rejected_report], vec![rejected_fill]),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+    assert!(
+        rejected
+            .events
+            .iter()
+            .all(|event| !matches!(event, OrderEventAny::Filled(_)))
+    );
+
+    ctx.add_order(create_accepted_order(
+        retry_client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+        retry_venue_order_id,
+    ));
+    let retry_fill = create_fill_report(
+        retry_client_order_id,
+        retry_venue_order_id,
+        instrument_id,
+        trade_id,
+        "1.0",
+    );
+    let retry = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(vec![], vec![retry_fill]),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+
+    assert_eq!(
+        retry
+            .events
+            .iter()
+            .filter(|event| matches!(event, OrderEventAny::Filled(_)))
+            .count(),
+        1
+    );
+    assert!(
+        ctx.get_order(&retry_client_order_id)
+            .unwrap()
+            .trade_ids()
+            .contains(&&trade_id)
+    );
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_reconciliation_fill_dispatch_rejection_does_not_commit() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let client_order_id = ClientOrderId::from("O-DISPATCH-RETRY");
+    let venue_order_id = VenueOrderId::from("V-DISPATCH-RETRY");
+    let trade_id = TradeId::from("T-DISPATCH-RETRY");
+
+    ctx.add_instrument(test_instrument());
+    ctx.add_order(create_limit_order(
+        client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+    ));
+
+    let fill = create_fill_report(
+        client_order_id,
+        venue_order_id,
+        instrument_id,
+        trade_id,
+        "1.0",
+    );
+    // An orphan report queues without the order-report working.apply projection.
+    let rejected = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(vec![], vec![fill.clone()]),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+
+    assert_eq!(
+        rejected
+            .events
+            .iter()
+            .filter(|event| matches!(event, OrderEventAny::Filled(_)))
+            .count(),
+        1
+    );
+    assert!(
+        !ctx.get_order(&client_order_id)
+            .unwrap()
+            .trade_ids()
+            .contains(&&trade_id)
+    );
+
+    let order = ctx.get_order(&client_order_id).unwrap();
+    let submitted = TestOrderEventStubs::submitted(&order, test_account_id());
+    let order = ctx.cache.borrow_mut().update_order(&submitted).unwrap();
+    let accepted = TestOrderEventStubs::accepted(&order, test_account_id(), venue_order_id);
+    ctx.cache.borrow_mut().update_order(&accepted).unwrap();
+
+    let retry = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(vec![], vec![fill]),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+
+    assert_eq!(
+        retry
+            .events
+            .iter()
+            .filter(|event| matches!(event, OrderEventAny::Filled(_)))
+            .count(),
+        1
+    );
+    assert!(
+        ctx.get_order(&client_order_id)
+            .unwrap()
+            .trade_ids()
+            .contains(&&trade_id)
+    );
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_applied_reconciliation_fill_is_committed() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let trade_id = TradeId::from("T-COMMITTED");
+    let first_client_order_id = ClientOrderId::from("O-COMMITTED-1");
+    let first_venue_order_id = VenueOrderId::from("V-COMMITTED-1");
+    let second_client_order_id = ClientOrderId::from("O-COMMITTED-2");
+    let second_venue_order_id = VenueOrderId::from("V-COMMITTED-2");
+
+    ctx.add_instrument(test_instrument());
+    ctx.add_order(create_accepted_order(
+        first_client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+        first_venue_order_id,
+    ));
+    ctx.add_order(create_accepted_order(
+        second_client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+        second_venue_order_id,
+    ));
+
+    let first = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(
+                vec![],
+                vec![create_fill_report(
+                    first_client_order_id,
+                    first_venue_order_id,
+                    instrument_id,
+                    trade_id,
+                    "1.0",
+                )],
+            ),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+    assert_eq!(first.events.len(), 1);
+
+    let duplicate = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(
+                vec![],
+                vec![create_fill_report(
+                    second_client_order_id,
+                    second_venue_order_id,
+                    instrument_id,
+                    trade_id,
+                    "1.0",
+                )],
+            ),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+
+    assert!(duplicate.events.is_empty());
+    assert!(
+        ctx.get_order(&second_client_order_id)
+            .unwrap()
+            .trade_ids()
+            .is_empty()
+    );
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_same_cycle_cross_order_fill_is_queued_once() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let trade_id = TradeId::from("T-CROSS-ORDER");
+    let first_client_order_id = ClientOrderId::from("O-CROSS-ORDER-1");
+    let first_venue_order_id = VenueOrderId::from("V-CROSS-ORDER-1");
+    let second_client_order_id = ClientOrderId::from("O-CROSS-ORDER-2");
+    let second_venue_order_id = VenueOrderId::from("V-CROSS-ORDER-2");
+
+    ctx.add_instrument(test_instrument());
+    ctx.add_order(create_accepted_order(
+        first_client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+        first_venue_order_id,
+    ));
+    ctx.add_order(create_accepted_order(
+        second_client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+        second_venue_order_id,
+    ));
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(
+                vec![],
+                vec![
+                    create_fill_report(
+                        first_client_order_id,
+                        first_venue_order_id,
+                        instrument_id,
+                        trade_id,
+                        "1.0",
+                    ),
+                    create_fill_report(
+                        second_client_order_id,
+                        second_venue_order_id,
+                        instrument_id,
+                        trade_id,
+                        "1.0",
+                    ),
+                ],
+            ),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+
+    assert_eq!(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, OrderEventAny::Filled(_)))
+            .count(),
+        1
+    );
+    let applied_orders = [first_client_order_id, second_client_order_id]
+        .iter()
+        .filter(|client_order_id| {
+            ctx.get_order(client_order_id)
+                .unwrap()
+                .trade_ids()
+                .contains(&&trade_id)
+        })
+        .count();
+    assert_eq!(applied_orders, 1);
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_inferred_fill_is_not_committed_as_reported_fill() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let external_venue_order_id = VenueOrderId::from("V-INFERRED-SOURCE");
+    ctx.add_instrument(test_instrument());
+
+    let order_report = create_order_status_report(
+        None,
+        external_venue_order_id,
+        instrument_id,
+        OrderStatus::Filled,
+        Quantity::from("2.0"),
+        Quantity::from("2.0"),
+    )
+    .with_avg_px(3000.0)
+    .unwrap();
+    let real_trade_id = TradeId::from("T-INFERRED-SOURCE");
+    let source = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(
+                vec![order_report],
+                vec![create_fill_report(
+                    ClientOrderId::from(external_venue_order_id.as_str()),
+                    external_venue_order_id,
+                    instrument_id,
+                    real_trade_id,
+                    "1.0",
+                )],
+            ),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+    let inferred_trade_id = source
+        .events
+        .iter()
+        .find_map(|event| match event {
+            OrderEventAny::Filled(fill) if fill.trade_id != real_trade_id => Some(fill.trade_id),
+            _ => None,
+        })
+        .expect("expected inferred fill");
+
+    let client_order_id = ClientOrderId::from("O-INFERRED-REUSE");
+    let venue_order_id = VenueOrderId::from("V-INFERRED-REUSE");
+    ctx.add_order(create_accepted_order(
+        client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+        venue_order_id,
+    ));
+    let reused = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(
+                vec![],
+                vec![create_fill_report(
+                    client_order_id,
+                    venue_order_id,
+                    instrument_id,
+                    inferred_trade_id,
+                    "1.0",
+                )],
+            ),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+
+    assert_eq!(reused.events.len(), 1);
+    assert!(matches!(reused.events[0], OrderEventAny::Filled(_)));
+}
+
+#[rstest]
+#[case(Some(0), 60, true)]
+#[case(Some(2), 120, true)]
+#[case(None, 86_400, false)]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_processed_fill_retention(
+    #[case] lookback_mins: Option<u64>,
+    #[case] horizon_secs: u64,
+    #[case] prunes_past_horizon: bool,
+) {
+    let config = ExecutionManagerConfig {
+        lookback_mins,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument_id = test_instrument_id();
+    let trade_id = TradeId::from("T-RETENTION");
+    let first_client_order_id = ClientOrderId::from("O-RETENTION-1");
+    let first_venue_order_id = VenueOrderId::from("V-RETENTION-1");
+    let second_client_order_id = ClientOrderId::from("O-RETENTION-2");
+    let second_venue_order_id = VenueOrderId::from("V-RETENTION-2");
+
+    ctx.add_instrument(test_instrument());
+    ctx.add_order(create_accepted_order(
+        first_client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+        first_venue_order_id,
+    ));
+    ctx.add_order(create_accepted_order(
+        second_client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+        second_venue_order_id,
+    ));
+
+    let first = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(
+                vec![],
+                vec![create_fill_report(
+                    first_client_order_id,
+                    first_venue_order_id,
+                    instrument_id,
+                    trade_id,
+                    "1.0",
+                )],
+            ),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+    assert_eq!(first.events.len(), 1);
+
+    ctx.advance_both(dst::time::Duration::from_secs(horizon_secs))
+        .await;
+    ctx.manager.prune_processed_fills();
+    let at_horizon = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(
+                vec![],
+                vec![create_fill_report(
+                    second_client_order_id,
+                    second_venue_order_id,
+                    instrument_id,
+                    trade_id,
+                    "1.0",
+                )],
+            ),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+    assert!(at_horizon.events.is_empty());
+
+    ctx.advance_both(dst::time::Duration::from_nanos(1)).await;
+    ctx.manager.prune_processed_fills();
+    let past_horizon = ctx
+        .manager
+        .reconcile_execution_mass_status(
+            create_mass_status(
+                vec![],
+                vec![create_fill_report(
+                    second_client_order_id,
+                    second_venue_order_id,
+                    instrument_id,
+                    trade_id,
+                    "1.0",
+                )],
+            ),
+            ctx.exec_engine.clone(),
+        )
+        .await;
+    assert_eq!(past_horizon.events.len(), usize::from(prunes_past_horizon));
 }
 
 #[rstest]


### PR DESCRIPTION
A follow-up to the live-reconciliation series (#4479, #4490, #4517), on the startup mass-status fill path.

## Mark a reconciliation fill deduplicated only after it applies

`ExecutionManager::create_order_fill` performed the dedup read-guard (`processed_fills.contains_key`) and the commit (`insert`) in one step, then returned the `OrderFilled` event for the caller to dispatch. All three mass-status callers - the orphan-fill path, `reconcile_order_with_fills`, and `handle_external_order` - collect their events and dispatch them later, after a global sort, through `exec_engine.process` / `project_reconciliation_fill`, none of which reports success. So the key was committed before the fill reached the canonical order cache. `reconcile_order_with_fills` projects the fill onto a `working` clone, and if `working.apply` fails it returns without emitting the event - but `processed_fills` already holds the key, so the next reconciliation cycle's `contains_key` short-circuits the fill to `None` and it is never retried, suppressed until the manager is dropped. A fill the canonical engine rejects (unknown order, duplicate, overfill, invalid transition) is lost the same way.

`create_order_fill` now read-guards against the committed `processed_fills` and a per-pass `pending_fill_keys` reservation set, builds the event, and inserts nothing. A real report fill is reserved in `pending_fill_keys` only when its event is actually queued (a failed `working.apply` returns first and reserves nothing), and the dedup key is committed to `processed_fills` inside the dispatch loop, per fill, immediately after that fill's synchronous `process` / `project_reconciliation_fill` returns - gated on a canonical-cache postcondition: the order resolved by `client_order_id` (venue-order-id fallback) must match the `FillKey` account and instrument and already carry the fill's `trade_id`. A trade id already present counts as applied and commits (correct replay); an absent one does not commit and the fill is left for the next cycle. Inferred top-up fills (`create_inferred_fill_for_qty`) keep their plain `order_events.push` and never enter the dedup map. The doc comment on `observe_execution_report` claimed the `Fill` report arm marks the fill processed; it only records activity, and is corrected to say so.

## Bound processed_fills retention to the reconciliation lookback

`processed_fills` was an `IndexMap` with no prune path - it grew for the lifetime of the manager, unlike the sibling `recent_fills_cache`, which `LiveNode` prunes each minute. It becomes a `RecencyMap<FillKey>` pruned in that same per-minute pass, at horizon `max(60s, reconciliation_lookback_mins)` - the startup mass-status lookback (`ExecutionManagerConfig::lookback_mins`), which is what actually bounds how far back a replayed fill report can arrive. When no finite startup lookback is configured (`reconciliation_lookback_mins: None`, the default), pruning is skipped and the map is retained for the manager's lifetime: without a finite lookback there is no horizon past which a replayed fill is provably stale, so no finite TTL is replay-safe. This bounds retention for deployments with a finite startup lookback; it deliberately does not bound the default `None` configuration, which keeps the replay guarantee at the cost of the memory bound (the map is non-persistent and resets on restart).

## Testing

All tests use `#[rstest]` with paused/virtual time and no wall-clock waits.

- `test_rejected_reconciliation_fill_is_retried` - a fill whose duplicate-trade projection fails on the `working` clone is not committed to `processed_fills`, so a later cycle re-emits it and it lands on the canonical order.
- `test_reconciliation_fill_dispatch_rejection_does_not_commit` - a fill whose event reaches the dispatch loop but is rejected by the canonical `process` (applied to an `Initialized` order) is not committed; after the order is promoted to `Accepted` the same fill applies on retry. This pins the canonical-cache commit gate itself, which the case above does not reach (it stops at the clone, before dispatch).
- `test_applied_reconciliation_fill_is_committed` - an applied fill commits its key and a duplicate report in a later cycle is deduped.
- `test_same_cycle_cross_order_fill_is_queued_once` - two orders reporting the same `FillKey` in one mass status emit a single fill; the pending set dedups across orders, which per-order projection alone does not.
- `test_inferred_fill_is_not_committed_as_reported_fill` - an inferred top-up fill does not enter `processed_fills`.
- `test_processed_fill_retention` - a committed key is pruned only past `max(60s, reconciliation_lookback_mins)`, and a `None` lookback retains it.

The two retry assertions - `test_rejected_reconciliation_fill_is_retried` and `test_reconciliation_fill_dispatch_rejection_does_not_commit` - were verified to fail against the unfixed premature-commit implementation; the remaining tests characterize the surrounding behavior.
