### PR TITLE
Fix Interactive Brokers startup instrument loading

### DIFF
--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -643,7 +643,7 @@ impl DataClient for InteractiveBrokersDataClient {
         .await
         .context("Failed to connect to IB Gateway/TWS")?;
 
-        let client = handle.as_arc();
+        let client = Arc::clone(handle.as_arc());
 
         tracing::info!(
             "Connected to IB Gateway/TWS at {}:{} (client_id: {})",
@@ -663,29 +663,12 @@ impl DataClient for InteractiveBrokersDataClient {
             tracing::info!("Set market data type to {:?}", self.config.market_data_type);
         }
 
-        let notice_client = Arc::clone(client);
-        self.ib_client = Some(handle);
-        self.is_connected.store(true, Ordering::Relaxed);
-
-        let data_farm_state = Arc::clone(&self.data_farm_state);
-        let cancellation_token = self.cancellation_token.child_token();
-        let clock = self.clock;
-
-        self.tasks.push(get_runtime().spawn(async move {
-            if let Err(e) =
-                monitor_data_farm_notices(notice_client, data_farm_state, clock, cancellation_token)
-                    .await
-            {
-                tracing::warn!("IB data farm notice monitor stopped: {e:?}");
-            }
-        }));
-
         // Initialize provider and load instruments from cache/config if configured
         tracing::debug!("Initializing IB data instrument provider");
 
         if let Err(e) = self
             .instrument_provider
-            .initialize_with_client(self.ib_client.as_ref().unwrap().as_arc().as_ref())
+            .initialize_with_client(client.as_ref())
             .await
         {
             if !self.config.instrument_provider.load_ids.is_empty()
@@ -696,6 +679,21 @@ impl DataClient for InteractiveBrokersDataClient {
 
             tracing::warn!("Failed to load instruments on startup: {}", e);
         }
+
+        self.ib_client = Some(handle);
+
+        let data_farm_state = Arc::clone(&self.data_farm_state);
+        let cancellation_token = self.cancellation_token.child_token();
+        let clock = self.clock;
+
+        self.tasks.push(get_runtime().spawn(async move {
+            if let Err(e) =
+                monitor_data_farm_notices(client, data_farm_state, clock, cancellation_token).await
+            {
+                tracing::warn!("IB data farm notice monitor stopped: {e:?}");
+            }
+        }));
+        self.is_connected.store(true, Ordering::Relaxed);
 
         let instrument_count = self.instrument_provider.count();
         if instrument_count > 0 {

--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -620,6 +620,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         )
         .await
         .context("Failed to connect to IB Gateway/TWS")?;
+        let client = Arc::clone(handle.as_arc());
 
         tracing::info!(
             "Connected to IB Gateway/TWS at {}:{} (client_id: {})",
@@ -628,14 +629,12 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
             self.config.client_id
         );
 
-        self.ib_client = Some(handle);
-
         // Initialize provider and load instruments from cache/config if configured
         log::debug!("Initializing IB execution instrument provider");
 
         if let Err(e) = self
             .instrument_provider
-            .initialize_with_client(self.ib_client.as_ref().unwrap().as_arc().as_ref())
+            .initialize_with_client(client.as_ref())
             .await
         {
             if !self.config.instrument_provider.load_ids.is_empty()
@@ -647,7 +646,8 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
             tracing::warn!("Failed to load instruments on startup: {}", e);
         }
 
-        let client = self.ib_client.as_ref().unwrap().as_arc();
+        self.ib_client = Some(handle);
+
         log::debug!("Preloading cached spread instruments for execution client");
         self.preload_cached_spread_instruments(client.as_ref())
             .await?;
@@ -690,7 +690,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
 
         // Subscribe to account summary and generate initial account state
         // Wait for initial account summary to load before proceeding
-        let client_for_account = Arc::clone(client);
+        let client_for_account = Arc::clone(&client);
         let account_id = self.core.account_id;
         let _exec_client_core = self.core.clone(); // Clone core to generate account state
         log::debug!("Subscribing to IB account summary for {}", account_id);
@@ -720,7 +720,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
 
         // Initialize position tracking with existing positions
         // This avoids processing duplicates from execDetails
-        let client_for_positions_init = Arc::clone(client);
+        let client_for_positions_init = Arc::clone(&client);
         let position_tracker_init = Arc::clone(&self.position_tracker);
 
         log::debug!("Initializing IB execution position tracking");
@@ -735,7 +735,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         }
 
         // Subscribe to PnL updates
-        let client_for_pnl = Arc::clone(client); // Clone Arc
+        let client_for_pnl = Arc::clone(&client); // Clone Arc
 
         log::debug!("Subscribing to IB PnL updates");
 
@@ -747,7 +747,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
 
         // Subscribe to position updates for option exercise tracking if enabled
         if self.config.track_option_exercise_from_position_update {
-            let client_for_positions = Arc::clone(client);
+            let client_for_positions = Arc::clone(&client);
             let position_tracker_clone = Arc::clone(&self.position_tracker);
             let instrument_provider_clone = Arc::clone(&self.instrument_provider);
 

--- a/crates/adapters/interactive_brokers/src/providers/instruments.rs
+++ b/crates/adapters/interactive_brokers/src/providers/instruments.rs
@@ -97,6 +97,47 @@ pub struct InteractiveBrokersInstrumentProvider {
     contracts: Arc<DashMap<InstrumentId, Contract>>,
     /// Dedicated cache for price magnifiers for fast lookups.
     price_magnifiers: Arc<DashMap<InstrumentId, i32>>,
+    /// Guards startup loading and records whether every configured input resolved.
+    startup_initialized: Arc<tokio::sync::Mutex<bool>>,
+}
+
+trait StartupInstrumentLoader {
+    async fn load_instrument_id(
+        &self,
+        instrument_id: InstrumentId,
+    ) -> anyhow::Result<Option<InstrumentId>>;
+
+    async fn load_contract(
+        &self,
+        contract_spec: &serde_json::Value,
+    ) -> anyhow::Result<Vec<InstrumentId>>;
+}
+
+struct IbStartupInstrumentLoader<'a> {
+    provider: &'a InteractiveBrokersInstrumentProvider,
+    client: &'a ibapi::Client,
+}
+
+impl StartupInstrumentLoader for IbStartupInstrumentLoader<'_> {
+    async fn load_instrument_id(
+        &self,
+        instrument_id: InstrumentId,
+    ) -> anyhow::Result<Option<InstrumentId>> {
+        self.provider
+            .load_with_return_async(self.client, instrument_id, None)
+            .await
+    }
+
+    async fn load_contract(
+        &self,
+        contract_spec: &serde_json::Value,
+    ) -> anyhow::Result<Vec<InstrumentId>> {
+        let contract = parse_contract_from_json(contract_spec)
+            .context("Failed to parse configured IB contract")?;
+        self.provider
+            .load_contract_spec(self.client, &contract, Some(contract_spec))
+            .await
+    }
 }
 
 impl InteractiveBrokersInstrumentProvider {
@@ -113,6 +154,7 @@ impl InteractiveBrokersInstrumentProvider {
             contract_details: Arc::new(DashMap::new()),
             contracts: Arc::new(DashMap::new()),
             price_magnifiers: Arc::new(DashMap::new()),
+            startup_initialized: Arc::new(tokio::sync::Mutex::new(false)),
         }
     }
 
@@ -178,12 +220,85 @@ impl InteractiveBrokersInstrumentProvider {
         Ok(())
     }
 
+    /// Initializes the provider and resolves every configured startup input.
+    ///
+    /// Successful initialization is idempotent. A failed attempt remains retryable.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if initialization fails or any configured input cannot be loaded.
     pub async fn initialize_with_client(
         &self,
         client: &ibapi::Client,
     ) -> anyhow::Result<Vec<InstrumentId>> {
+        let loader = IbStartupInstrumentLoader {
+            provider: self,
+            client,
+        };
+        self.initialize_with_loader(&loader).await
+    }
+
+    async fn initialize_with_loader<L>(&self, loader: &L) -> anyhow::Result<Vec<InstrumentId>>
+    where
+        L: StartupInstrumentLoader + Sync,
+    {
+        let mut initialized = self.startup_initialized.lock().await;
+        if *initialized {
+            return Ok(Vec::new());
+        }
+
         self.initialize().await?;
-        self.load_all_async(client, None, None, false).await
+        let loaded_ids = self.load_configured_instruments(loader).await?;
+        *initialized = true;
+        Ok(loaded_ids)
+    }
+
+    async fn load_configured_instruments<L>(&self, loader: &L) -> anyhow::Result<Vec<InstrumentId>>
+    where
+        L: StartupInstrumentLoader + Sync,
+    {
+        let mut loaded_ids = Vec::new();
+        let mut unresolved = Vec::new();
+        let mut configured_ids: Vec<_> = self.config.load_ids.iter().copied().collect();
+        configured_ids.sort_unstable();
+
+        for instrument_id in configured_ids {
+            match loader
+                .load_instrument_id(instrument_id)
+                .await
+                .with_context(|| {
+                    format!("Failed to load configured IB instrument ID {instrument_id}")
+                })? {
+                Some(loaded_id) => loaded_ids.push(loaded_id),
+                None => unresolved.push(format!("instrument ID {instrument_id}")),
+            }
+        }
+
+        for (index, contract_spec) in self.config.load_contracts.iter().enumerate() {
+            let mut contract_ids =
+                loader.load_contract(contract_spec).await.with_context(|| {
+                    format!(
+                        "Failed to load configured IB contract at index {index}: {contract_spec}"
+                    )
+                })?;
+
+            if contract_ids.is_empty() {
+                unresolved.push(format!("contract at index {index}: {contract_spec}"));
+            } else {
+                loaded_ids.append(&mut contract_ids);
+            }
+        }
+
+        if !unresolved.is_empty() {
+            anyhow::bail!(
+                "Unable to resolve configured Interactive Brokers instruments: {}",
+                unresolved.join(", ")
+            );
+        }
+
+        loaded_ids.sort_unstable();
+        loaded_ids.dedup();
+        Ok(loaded_ids)
     }
 
     /// Adds instruments already held by the Nautilus cache into the provider cache.
@@ -657,6 +772,9 @@ impl InteractiveBrokersInstrumentProvider {
                         details.contract
                     })
                     .unwrap_or_else(|| contract.clone()),
+                Err(e) if e.is_connection_lost() => {
+                    return Err(e).context("Failed to qualify continuous future contract");
+                }
                 Err(e) => {
                     tracing::warn!(
                         "Failed to qualify continuous future contract {:?}: {}",
@@ -1474,19 +1592,18 @@ impl InteractiveBrokersInstrumentProvider {
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    last_error = Some((candidate_exchange.clone(), e.to_string()));
+                    last_error = Some((candidate_exchange.clone(), e));
                 }
             }
         }
 
         if details_vec.is_empty() {
-            if let Some((candidate_exchange, error)) = last_error {
-                tracing::warn!(
-                    "Failed to fetch contract details for {} on {}: {}",
-                    instrument_id,
-                    candidate_exchange,
-                    error
-                );
+            if let Some((candidate_exchange, e)) = last_error {
+                return Err(e).with_context(|| {
+                    format!(
+                        "Failed to fetch contract details for {instrument_id} on {candidate_exchange}"
+                    )
+                });
             } else {
                 tracing::warn!(
                     "No contract details returned for {} - instrument may not exist in IB or contract specification is incomplete",
@@ -2595,7 +2712,10 @@ impl InteractiveBrokersInstrumentProvider {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{
+        fs,
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
 
     use nautilus_core::{Params, UnixNanos};
     use nautilus_model::{
@@ -2608,6 +2728,68 @@ mod tests {
 
     use super::*;
     use crate::common::contract_to_json_value;
+
+    struct TestStartupLoader {
+        id_calls: AtomicUsize,
+        contract_calls: AtomicUsize,
+        fail_next_id: AtomicBool,
+        resolve_ids: AtomicBool,
+        resolve_contracts: AtomicBool,
+        yield_on_load: bool,
+    }
+
+    impl TestStartupLoader {
+        fn new(resolve_ids: bool, resolve_contracts: bool) -> Self {
+            Self {
+                id_calls: AtomicUsize::new(0),
+                contract_calls: AtomicUsize::new(0),
+                fail_next_id: AtomicBool::new(false),
+                resolve_ids: AtomicBool::new(resolve_ids),
+                resolve_contracts: AtomicBool::new(resolve_contracts),
+                yield_on_load: false,
+            }
+        }
+    }
+
+    impl StartupInstrumentLoader for TestStartupLoader {
+        async fn load_instrument_id(
+            &self,
+            instrument_id: InstrumentId,
+        ) -> anyhow::Result<Option<InstrumentId>> {
+            self.id_calls.fetch_add(1, Ordering::SeqCst);
+
+            if self.yield_on_load {
+                tokio::task::yield_now().await;
+            }
+
+            if self.fail_next_id.swap(false, Ordering::SeqCst) {
+                anyhow::bail!("Socket disconnected");
+            }
+            Ok(self
+                .resolve_ids
+                .load(Ordering::SeqCst)
+                .then_some(instrument_id))
+        }
+
+        async fn load_contract(
+            &self,
+            _contract_spec: &serde_json::Value,
+        ) -> anyhow::Result<Vec<InstrumentId>> {
+            self.contract_calls.fetch_add(1, Ordering::SeqCst);
+
+            if self.yield_on_load {
+                tokio::task::yield_now().await;
+            }
+            Ok(if self.resolve_contracts.load(Ordering::SeqCst) {
+                vec![InstrumentId::new(
+                    Symbol::from("MSFT"),
+                    Venue::from("NASDAQ"),
+                )]
+            } else {
+                Vec::new()
+            })
+        }
+    }
 
     fn create_test_provider_with_cache() -> (InteractiveBrokersInstrumentProvider, TempDir) {
         let temp_dir = TempDir::new().unwrap();
@@ -2674,6 +2856,112 @@ mod tests {
             );
         }
         info
+    }
+
+    #[tokio::test]
+    async fn test_initialize_loads_all_configured_inputs_once() {
+        let instrument_id = InstrumentId::new(Symbol::from("AAPL"), Venue::from("NASDAQ"));
+        let contract_spec = serde_json::json!({
+            "secType": "STK",
+            "symbol": "MSFT",
+            "exchange": "NASDAQ",
+        });
+        let config = InteractiveBrokersInstrumentProviderConfig {
+            load_ids: [instrument_id].into_iter().collect(),
+            load_contracts: vec![contract_spec],
+            ..Default::default()
+        };
+        let provider = InteractiveBrokersInstrumentProvider::new(config);
+        let loader = TestStartupLoader::new(true, true);
+
+        let loaded_ids = provider.initialize_with_loader(&loader).await.unwrap();
+        let second_result = provider.initialize_with_loader(&loader).await.unwrap();
+
+        assert_eq!(
+            loaded_ids,
+            vec![
+                instrument_id,
+                InstrumentId::new(Symbol::from("MSFT"), Venue::from("NASDAQ")),
+            ]
+        );
+        assert!(second_result.is_empty());
+        assert_eq!(loader.id_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(loader.contract_calls.load(Ordering::SeqCst), 1);
+        assert!(*provider.startup_initialized.lock().await);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_fails_closed_and_retries_unresolved_input() {
+        let instrument_id = InstrumentId::new(Symbol::from("AAPL"), Venue::from("NASDAQ"));
+        let contract_spec = serde_json::json!({
+            "secType": "STK",
+            "symbol": "MSFT",
+            "exchange": "NASDAQ",
+        });
+        let config = InteractiveBrokersInstrumentProviderConfig {
+            load_ids: [instrument_id].into_iter().collect(),
+            load_contracts: vec![contract_spec],
+            ..Default::default()
+        };
+        let provider = InteractiveBrokersInstrumentProvider::new(config);
+        let loader = TestStartupLoader::new(true, false);
+
+        let error = provider.initialize_with_loader(&loader).await.unwrap_err();
+
+        assert!(error.to_string().contains("contract at index 0"));
+        assert!(!*provider.startup_initialized.lock().await);
+
+        loader.resolve_contracts.store(true, Ordering::SeqCst);
+        provider.initialize_with_loader(&loader).await.unwrap();
+
+        assert_eq!(loader.id_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(loader.contract_calls.load(Ordering::SeqCst), 2);
+        assert!(*provider.startup_initialized.lock().await);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_preserves_load_error_and_allows_retry() {
+        let instrument_id = InstrumentId::new(Symbol::from("AAPL"), Venue::from("NASDAQ"));
+        let config = InteractiveBrokersInstrumentProviderConfig {
+            load_ids: [instrument_id].into_iter().collect(),
+            ..Default::default()
+        };
+        let provider = InteractiveBrokersInstrumentProvider::new(config);
+        let loader = TestStartupLoader::new(true, true);
+        loader.fail_next_id.store(true, Ordering::SeqCst);
+
+        let error = provider.initialize_with_loader(&loader).await.unwrap_err();
+
+        let error_chain = format!("{error:#}");
+        assert!(error_chain.contains("Failed to load configured IB instrument ID AAPL.NASDAQ"));
+        assert!(error_chain.contains("Socket disconnected"));
+        assert!(!*provider.startup_initialized.lock().await);
+
+        provider.initialize_with_loader(&loader).await.unwrap();
+
+        assert_eq!(loader.id_calls.load(Ordering::SeqCst), 2);
+        assert!(*provider.startup_initialized.lock().await);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_serializes_concurrent_calls() {
+        let instrument_id = InstrumentId::new(Symbol::from("AAPL"), Venue::from("NASDAQ"));
+        let config = InteractiveBrokersInstrumentProviderConfig {
+            load_ids: [instrument_id].into_iter().collect(),
+            ..Default::default()
+        };
+        let provider = InteractiveBrokersInstrumentProvider::new(config);
+        let mut loader = TestStartupLoader::new(true, true);
+        loader.yield_on_load = true;
+
+        let (first, second) = tokio::join!(
+            provider.initialize_with_loader(&loader),
+            provider.initialize_with_loader(&loader),
+        );
+
+        assert_eq!(first.unwrap().len() + second.unwrap().len(), 1);
+        assert_eq!(loader.id_calls.load(Ordering::SeqCst), 1);
+        assert!(*provider.startup_initialized.lock().await);
     }
 
     #[tokio::test]

--- a/docs/integrations/ib.md
+++ b/docs/integrations/ib.md
@@ -411,7 +411,9 @@ There are two primary methods for loading instruments:
 Interactive Brokers does not support loading the full IB instrument universe with
 `load_all=True`. Configure `load_ids` or `load_contracts` for the instruments a node
 needs at startup, or request an instrument explicitly before subscribing to its market
-data.
+data. Startup entries are treated as required. If any configured ID or contract cannot
+be resolved, client initialization fails instead of starting with an incomplete
+instrument cache.
 
 #### 1. Using `load_ids` (recommended)
 

--- a/nautilus_trader/adapters/interactive_brokers/client/client.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/client.py
@@ -644,6 +644,7 @@ class InteractiveBrokersClient(
         timeout: int,
         default_value: Any | None = None,
         suppress_timeout_warning: bool = False,
+        raise_on_error: bool = False,
     ) -> Any:
         """
         Await the completion of a request within a specified timeout.
@@ -658,6 +659,9 @@ class InteractiveBrokersClient(
             The default value to return if the request times out or fails. Defaults to None.
         suppress_timeout_warning: bool, optional
             Suppress the timeout warning. Defaults to False.
+        raise_on_error : bool, optional
+            If True, re-raise timeout and connection errors after ending the request.
+            Defaults to False.
 
         Returns
         -------
@@ -672,10 +676,16 @@ class InteractiveBrokersClient(
             self._log.debug(msg) if suppress_timeout_warning else self._log.warning(msg)
             self._end_request(request.req_id, success=False, exception=e)
 
+            if raise_on_error:
+                raise
+
             return default_value
         except ConnectionError as e:
             self._log.error(f"Connection error during {request}; ending request")
             self._end_request(request.req_id, success=False, exception=e)
+
+            if raise_on_error:
+                raise
 
             return default_value
 

--- a/nautilus_trader/adapters/interactive_brokers/client/contract.py
+++ b/nautilus_trader/adapters/interactive_brokers/client/contract.py
@@ -72,12 +72,14 @@ class InteractiveBrokersClientContractMixin(BaseMixin):
                 request,
                 self._request_timeout_secs,
                 suppress_timeout_warning=True,
+                raise_on_error=True,
             )
         else:
             return await self._await_request(
                 request,
                 self._request_timeout_secs,
                 suppress_timeout_warning=True,
+                raise_on_error=True,
             )
 
     async def get_matching_contracts(self, pattern: str) -> list[IBContract] | None:

--- a/nautilus_trader/adapters/interactive_brokers/data.py
+++ b/nautilus_trader/adapters/interactive_brokers/data.py
@@ -136,7 +136,6 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
     async def _connect(self):
         # Connect client
         await self._client.wait_until_ready(self._connection_timeout)
-        self._client.registered_nautilus_clients.add(self.id)
 
         # Set instrument provider on client for price magnifier access
         self._client._instrument_provider = self._instrument_provider
@@ -148,6 +147,8 @@ class InteractiveBrokersDataClient(LiveMarketDataClient):
         await self.instrument_provider.initialize()
         for instrument in self._instrument_provider.list_all():
             self._handle_data(instrument)
+
+        self._client.registered_nautilus_clients.add(self.id)
 
     async def _disconnect(self):
         self._client.registered_nautilus_clients.discard(self.id)

--- a/nautilus_trader/adapters/interactive_brokers/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers/providers.py
@@ -98,15 +98,51 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
         self.contract: dict[InstrumentId, IBContract] = {}
 
     async def initialize(self, reload: bool = False) -> None:
-        await super().initialize(reload)
+        async with self._init_lock:
+            if not reload and self._loaded:
+                return
 
-        # Trigger contract loading only if `load_ids_on_start` is False and `load_contracts_on_start` is True
-        if not self._load_ids_on_start and self._load_contracts_on_start:
             self._loaded = False
-            self._loading = True
-            await self.load_all_async()  # Load all instruments passed as config at startup
-            self._loading = False
+            load_ids = sorted(
+                (
+                    item if isinstance(item, InstrumentId) else InstrumentId.from_str(item)
+                    for item in (self._load_ids_on_start or [])
+                ),
+                key=str,
+            )
+            load_contracts = sorted(
+                (
+                    item if isinstance(item, IBContract) else IBContract(**item)
+                    for item in (self._load_contracts_on_start or [])
+                ),
+                key=repr,
+            )
+            startup_inputs = [*load_ids, *load_contracts]
+
+            if not startup_inputs:
+                self._log.warning(
+                    "No loading configured: ensure there are `load_ids` or `load_contracts`",
+                )
+                return
+
+            self._log.info("Initializing instruments...")
+
+            unresolved = []
+
+            for item in startup_inputs:
+                loaded_ids = await self.load_with_return_async(item, self._filters)
+                if not loaded_ids:
+                    unresolved.append(item)
+
+            if unresolved:
+                unresolved_str = ", ".join(repr(item) for item in unresolved)
+                raise RuntimeError(
+                    "Unable to resolve configured Interactive Brokers instruments: "
+                    f"{unresolved_str}",
+                )
+
             self._loaded = True
+            self._log.info(f"Initialized {self.count} instruments")
 
     def _is_filtered_sec_type(self, sec_type: str | None) -> bool:
         return bool(sec_type and sec_type in self._filter_sec_types)
@@ -450,6 +486,8 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
             )
 
             return True
+        except (ConnectionError, TimeoutError):
+            raise
         except Exception as e:
             self._log.error(f"Failed to fetch spread instrument {spread_instrument_id}: {e}")
             return False

--- a/nautilus_trader/adapters/interactive_brokers_pyo3/providers.py
+++ b/nautilus_trader/adapters/interactive_brokers_pyo3/providers.py
@@ -237,23 +237,42 @@ class InteractiveBrokersInstrumentProvider(InstrumentProvider):
             self.contract_id_to_instrument_id[details.contract.conId] = instrument_id
 
     async def initialize(self, reload: bool = False) -> None:
-        self._sync_from_rust()
+        async with self._init_lock:
+            if not reload and self._loaded:
+                return
 
-        if reload:
             self._loaded = False
+            self._sync_from_rust()
 
-        if not reload and self._loaded:
-            return
+            load_ids = sorted(
+                (_normalize_instrument_id(item) for item in (self._load_ids_on_start or [])),
+                key=str,
+            )
+            load_contracts = sorted(
+                (getattr(self._config, "load_contracts", None) or []),
+                key=repr,
+            )
+            startup_inputs = [*load_ids, *load_contracts]
 
-        if self._instruments:
+            if not startup_inputs:
+                self._loaded = True
+                return
+
+            unresolved = []
+
+            for item in startup_inputs:
+                loaded_ids = await self.load_with_return_async(item, self._filters)
+                if not loaded_ids:
+                    unresolved.append(item)
+
+            if unresolved:
+                unresolved_str = ", ".join(repr(item) for item in unresolved)
+                raise RuntimeError(
+                    "Unable to resolve configured Interactive Brokers instruments: "
+                    f"{unresolved_str}",
+                )
+
             self._loaded = True
-            return
-
-        load_contracts = getattr(self._config, "load_contracts", None)
-        if self._load_ids_on_start or load_contracts:
-            await self.load_all_async(self._filters)
-
-        self._loaded = True
 
     def find(self, instrument_id: InstrumentId) -> Instrument | None:
         instrument = super().find(instrument_id)

--- a/tests/integration_tests/adapters/interactive_brokers/client/test_client_contract.py
+++ b/tests/integration_tests/adapters/interactive_brokers/client/test_client_contract.py
@@ -40,6 +40,25 @@ async def test_get_contract_details(ib_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("error", [ConnectionError("Socket disconnected"), TimeoutError()])
+async def test_get_contract_details_propagates_transport_errors(ib_client, error):
+    # Arrange
+    ib_client._request_id_seq = 1
+    contract = IBTestContractStubs.aapl_equity_contract()
+    ib_client._eclient.reqContractDetails = Mock()
+
+    # Act
+    with (
+        patch("asyncio.wait_for", side_effect=error),
+        pytest.raises(type(error)),
+    ):
+        await ib_client.get_contract_details(contract)
+
+    # Assert
+    assert ib_client._requests.get(req_id=1) is None
+
+
+@pytest.mark.asyncio
 async def test_get_option_chains(ib_client):
     # Arrange
     ib_client._request_id_seq = 1

--- a/tests/integration_tests/adapters/interactive_brokers/test_ib_pyo3_provider.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_ib_pyo3_provider.py
@@ -15,11 +15,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 from datetime import timedelta
 from datetime import timezone
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -88,6 +90,10 @@ class _FakeRustProvider:
 class _FakeRustDataClient:
     def __init__(self, rust_provider: _FakeRustProvider) -> None:
         self._provider = rust_provider
+        self.load_one_calls: list[InstrumentId] = []
+        self.load_all_calls: list[
+            tuple[list[InstrumentId] | None, list[Mapping[str, Any]] | None, bool]
+        ] = []
         self.option_chain_calls: list[tuple[dict[str, Any], str | None, str | None]] = []
         self.futures_chain_calls: list[
             tuple[str, str | None, str | None, int | None, int | None]
@@ -98,6 +104,7 @@ class _FakeRustDataClient:
         instrument_id: InstrumentId,
         _filters: Any,
     ) -> InstrumentId:
+        self.load_one_calls.append(instrument_id)
         self._store_instrument(instrument_id, 101)
         return instrument_id
 
@@ -114,8 +121,9 @@ class _FakeRustDataClient:
         self,
         instrument_ids: list[InstrumentId] | None,
         contracts: list[Mapping[str, Any]] | None,
-        _force_instrument_update: bool,
+        force_instrument_update: bool,
     ) -> list[InstrumentId]:
+        self.load_all_calls.append((instrument_ids, contracts, force_instrument_update))
         loaded_ids: list[InstrumentId] = []
 
         for index, instrument_id in enumerate(instrument_ids or [], start=1):
@@ -256,6 +264,132 @@ async def test_pyo3_provider_behaves_like_standard_instrument_provider(monkeypat
     assert provider.contract[instrument_id].conId == 101
     assert provider.contract_details[instrument_id].priceMagnifier == 10
     assert provider.contract_id_to_instrument_id[101] == instrument_id
+
+
+@pytest.mark.asyncio
+async def test_pyo3_provider_initialize_loads_configured_ids_and_contracts(monkeypatch):
+    from nautilus_trader.adapters.interactive_brokers_pyo3 import providers as providers_module
+
+    monkeypatch.setattr(
+        providers_module,
+        "RustInteractiveBrokersInstrumentProvider",
+        _FakeRustProvider,
+    )
+
+    instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+    contract = IBContract(secType="STK", symbol="MSFT", exchange="NASDAQ")
+    provider = providers_module.InteractiveBrokersInstrumentProvider(
+        config=_StubConfig(load_ids=[instrument_id], load_contracts=[contract]),
+    )
+    loader = _FakeRustDataClient(provider._rust_provider)
+    provider._attach_loader(loader)
+
+    await provider.initialize()
+
+    assert provider._loaded is True
+    assert [str(item) for item in loader.load_one_calls] == [str(instrument_id)]
+    assert len(loader.load_all_calls) == 1
+    assert loader.load_all_calls[0][0] is None
+    contracts = loader.load_all_calls[0][1]
+    assert contracts is not None
+    [contract_payload] = contracts
+    assert contract_payload["secType"] == "STK"
+    assert contract_payload["symbol"] == "MSFT"
+    assert contract_payload["exchange"] == "NASDAQ"
+
+
+@pytest.mark.asyncio
+async def test_pyo3_provider_initialize_can_retry_after_unresolved_load(monkeypatch):
+    from nautilus_trader.adapters.interactive_brokers_pyo3 import providers as providers_module
+
+    monkeypatch.setattr(
+        providers_module,
+        "RustInteractiveBrokersInstrumentProvider",
+        _FakeRustProvider,
+    )
+
+    instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+    provider = providers_module.InteractiveBrokersInstrumentProvider(
+        config=_StubConfig(load_ids=[instrument_id]),
+    )
+    loader = _FakeRustDataClient(provider._rust_provider)
+    original_load = loader.load_with_return_async
+    attempts = 0
+
+    async def load(item, filters):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return None
+        return await original_load(item, filters)
+
+    loader.load_with_return_async = AsyncMock(side_effect=load)
+    provider._attach_loader(loader)
+
+    with pytest.raises(RuntimeError, match=r"AAPL\.NASDAQ"):
+        await provider.initialize()
+
+    await provider.initialize()
+
+    assert provider._loaded is True
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_pyo3_provider_initialize_preserves_loader_error(monkeypatch):
+    from nautilus_trader.adapters.interactive_brokers_pyo3 import providers as providers_module
+
+    monkeypatch.setattr(
+        providers_module,
+        "RustInteractiveBrokersInstrumentProvider",
+        _FakeRustProvider,
+    )
+
+    instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+    provider = providers_module.InteractiveBrokersInstrumentProvider(
+        config=_StubConfig(load_ids=[instrument_id]),
+    )
+    loader = _FakeRustDataClient(provider._rust_provider)
+    loader.load_with_return_async = AsyncMock(
+        side_effect=RuntimeError("Socket disconnected"),
+    )
+    provider._attach_loader(loader)
+
+    with pytest.raises(RuntimeError, match="Socket disconnected"):
+        await provider.initialize()
+
+    assert provider._loaded is False
+
+
+@pytest.mark.asyncio
+async def test_pyo3_provider_initialize_serializes_concurrent_calls(monkeypatch):
+    from nautilus_trader.adapters.interactive_brokers_pyo3 import providers as providers_module
+
+    monkeypatch.setattr(
+        providers_module,
+        "RustInteractiveBrokersInstrumentProvider",
+        _FakeRustProvider,
+    )
+
+    instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+    provider = providers_module.InteractiveBrokersInstrumentProvider(
+        config=_StubConfig(load_ids=[instrument_id]),
+    )
+    loader = _FakeRustDataClient(provider._rust_provider)
+    original_load = loader.load_with_return_async
+
+    async def load(item, filters):
+        await asyncio.sleep(0)
+        return await original_load(item, filters)
+
+    loader.load_with_return_async = AsyncMock(side_effect=load)
+    provider._attach_loader(loader)
+
+    await asyncio.gather(provider.initialize(), provider.initialize())
+    await provider.initialize()
+
+    assert provider._loaded is True
+    assert loader.load_with_return_async.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/integration_tests/adapters/interactive_brokers/test_providers.py
+++ b/tests/integration_tests/adapters/interactive_brokers/test_providers.py
@@ -13,7 +13,10 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
+import asyncio
 from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 from ibapi.contract import ContractDetails
@@ -26,6 +29,7 @@ from nautilus_trader.adapters.interactive_brokers.config import (
 from nautilus_trader.adapters.interactive_brokers.providers import (
     InteractiveBrokersInstrumentProvider,
 )
+from nautilus_trader.common.component import LiveClock
 from nautilus_trader.model.enums import AssetClass
 from nautilus_trader.model.enums import InstrumentClass
 from nautilus_trader.model.enums import OptionKind
@@ -42,6 +46,149 @@ def mock_ib_contract_calls(mocker, instrument_provider, contract_details: Contra
         "get_contract_details",
         side_effect=AsyncMock(return_value=[contract_details]),
     )
+
+
+def make_instrument_provider(ib_client, *, load_ids=None, load_contracts=None):
+    return InteractiveBrokersInstrumentProvider(
+        client=ib_client,
+        clock=LiveClock(),
+        config=InteractiveBrokersInstrumentProviderConfig(
+            load_ids=frozenset(load_ids or []),
+            load_contracts=frozenset(load_contracts or []),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_loads_configured_ids_and_contracts(ib_client):
+    # Arrange
+    instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+    contract = IBContract(secType="STK", symbol="MSFT", exchange="NASDAQ")
+    provider = make_instrument_provider(
+        ib_client,
+        load_ids=[instrument_id],
+        load_contracts=[contract],
+    )
+
+    async def load(item, _filters):
+        if isinstance(item, InstrumentId):
+            return [item]
+        return [InstrumentId.from_str("MSFT.NASDAQ")]
+
+    provider.load_with_return_async = AsyncMock(side_effect=load)
+
+    # Act
+    await provider.initialize()
+
+    # Assert
+    assert provider._loaded is True
+    assert {call.args[0] for call in provider.load_with_return_async.await_args_list} == {
+        instrument_id,
+        contract,
+    }
+
+
+@pytest.mark.asyncio
+async def test_initialize_fails_closed_for_partial_load(ib_client):
+    # Arrange
+    loaded_id = InstrumentId.from_str("AAPL.NASDAQ")
+    unresolved_id = InstrumentId.from_str("MSFT.NASDAQ")
+    provider = make_instrument_provider(
+        ib_client,
+        load_ids=[loaded_id, unresolved_id],
+    )
+
+    async def load(item, _filters):
+        return [item] if item == loaded_id else None
+
+    provider.load_with_return_async = AsyncMock(side_effect=load)
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match=r"MSFT\.NASDAQ"):
+        await provider.initialize()
+
+    assert provider._loaded is False
+    assert provider.load_with_return_async.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_initialize_can_retry_after_failed_required_load(ib_client):
+    # Arrange
+    instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+    provider = make_instrument_provider(ib_client, load_ids=[instrument_id])
+    provider.load_with_return_async = AsyncMock(side_effect=[None, [instrument_id]])
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match=r"AAPL\.NASDAQ"):
+        await provider.initialize()
+
+    await provider.initialize()
+
+    assert provider._loaded is True
+    assert provider.load_with_return_async.await_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [ConnectionError("Socket disconnected"), TimeoutError()])
+async def test_initialize_propagates_client_transport_errors(ib_client, error):
+    # Arrange
+    ib_client._request_id_seq = 1
+    ib_client._eclient.reqContractDetails = Mock()
+    contract = IBContract(secType="STK", symbol="AAPL", exchange="NASDAQ")
+    provider = make_instrument_provider(ib_client, load_contracts=[contract])
+
+    # Act / Assert
+    with (
+        patch("asyncio.wait_for", side_effect=error),
+        pytest.raises(type(error)),
+    ):
+        await provider.initialize()
+
+    assert provider._loaded is False
+    assert ib_client._requests.get(req_id=1) is None
+
+
+@pytest.mark.asyncio
+async def test_initialize_is_idempotent_and_serializes_concurrent_calls(ib_client):
+    # Arrange
+    instrument_id = InstrumentId.from_str("AAPL.NASDAQ")
+    provider = make_instrument_provider(ib_client, load_ids=[instrument_id])
+
+    async def load(item, _filters):
+        await asyncio.sleep(0)
+        return [item]
+
+    provider.load_with_return_async = AsyncMock(side_effect=load)
+
+    # Act
+    await asyncio.gather(provider.initialize(), provider.initialize())
+    await provider.initialize()
+
+    # Assert
+    assert provider._loaded is True
+    provider.load_with_return_async.assert_awaited_once_with(instrument_id, None)
+
+
+@pytest.mark.asyncio
+async def test_data_client_registers_only_after_instrument_initialization(data_client):
+    # Arrange
+    data_client._client.wait_until_ready = AsyncMock()
+    data_client._client.set_market_data_type = AsyncMock()
+    data_client.instrument_provider.initialize = AsyncMock(
+        side_effect=RuntimeError("Required instrument did not load"),
+    )
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="Required instrument did not load"):
+        await data_client._connect()
+
+    assert data_client.id not in data_client._client.registered_nautilus_clients
+
+    data_client.instrument_provider.initialize = AsyncMock()
+    await data_client._connect()
+
+    assert data_client.id in data_client._client.registered_nautilus_clients
+    data_client._client.registered_nautilus_clients.discard(data_client.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- load every configured instrument ID and contract during startup in both the v1 and v2 IB adapters
- fail startup when any configured instrument cannot be resolved
- keep failed initialization retryable and preserve timeout and connection errors
- avoid registering or marking clients connected until startup loading succeeds
- add coverage for partial failures, retries, and concurrent initialization

Closes #4455

## Tests

- 496 passed with 2 existing flaky-mock skips in the Python IB integration suite
- 374 passed in the native Rust suite
- 386 passed with all Rust features enabled
- strict all-feature Clippy passed
- full pre-commit suite passed
- verified the v1 success and forced socket-disconnect paths against IB Gateway without placing or cancelling orders

The running Gateway reports protocol 203, while the current Rust client requires 213 or newer, so the v2 live connection could not be exercised against it.