### PR TITLE
Prepare both cross-zero reconciliation legs before the first cache mutation

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -87,6 +87,52 @@ static TAG_RECONCILIATION: LazyLock<Ustr> = LazyLock::new(|| Ustr::from("RECONCI
 pub type InstrumentAccountKey = (InstrumentId, AccountId);
 type FillKey = (AccountId, InstrumentId, TradeId);
 
+#[expect(clippy::too_many_arguments)]
+fn build_cross_zero_leg_report(
+    instrument: &InstrumentAny,
+    account_id: AccountId,
+    instrument_id: InstrumentId,
+    order_side: OrderSide,
+    quantity: Decimal,
+    avg_px: Decimal,
+    tag: &str,
+    ts_now: UnixNanos,
+    venue_ts_last: UnixNanos,
+) -> Option<OrderStatusReport> {
+    let order_qty = Quantity::from_decimal_dp(quantity, instrument.size_precision()).ok()?;
+    let fill_price = Price::from_decimal_dp(avg_px, instrument.price_precision()).ok();
+    let venue_order_id = create_position_reconciliation_venue_order_id(
+        account_id,
+        instrument_id,
+        order_side,
+        OrderType::Market,
+        order_qty,
+        fill_price,
+        None,
+        Some(tag),
+        venue_ts_last,
+    );
+
+    OrderStatusReport::new(
+        account_id,
+        instrument_id,
+        None,
+        venue_order_id,
+        order_side,
+        OrderType::Market,
+        TimeInForce::Gtc,
+        OrderStatus::Filled,
+        order_qty,
+        order_qty,
+        ts_now,
+        ts_now,
+        ts_now,
+        None,
+    )
+    .with_avg_px(avg_px.to_f64().unwrap_or(0.0))
+    .ok()
+}
+
 /// Execution clients responsible for reporting one cached entity.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ReportClientCoverage {
@@ -2657,66 +2703,12 @@ impl ExecutionManager {
             "Position crosses zero for {instrument_id}: cached={cached_signed_qty}, venue={venue_signed_qty}. Splitting into two fills",
         );
 
-        let mut all_events = Vec::new();
-
-        // Close existing position first
         let close_qty = cached_signed_qty.abs();
         let close_side = if cached_signed_qty < Decimal::ZERO {
             OrderSide::Buy // Close short by buying
         } else {
             OrderSide::Sell // Close long by selling
         };
-
-        if let Some(close_px) = cached_avg_px {
-            let close_order_qty =
-                Quantity::from_decimal_dp(close_qty, instrument.size_precision()).ok()?;
-            let close_fill_price =
-                Price::from_decimal_dp(close_px, instrument.price_precision()).ok();
-            let close_venue_order_id = create_position_reconciliation_venue_order_id(
-                account_id,
-                instrument_id,
-                close_side,
-                OrderType::Market,
-                close_order_qty,
-                close_fill_price,
-                None,
-                Some("CLOSE"),
-                venue_ts_last,
-            );
-
-            let close_report = OrderStatusReport::new(
-                account_id,
-                instrument_id,
-                None,
-                close_venue_order_id,
-                close_side,
-                OrderType::Market,
-                TimeInForce::Gtc,
-                OrderStatus::Filled,
-                close_order_qty,
-                close_order_qty,
-                ts_now,
-                ts_now,
-                ts_now,
-                None,
-            )
-            .with_avg_px(close_px.to_f64().unwrap_or(0.0))
-            .ok()?;
-
-            log::info!(
-                color = LogColor::Blue as u8;
-                "Generating close fill for cross-zero {instrument_id}: side={close_side:?}, qty={close_qty}, px={close_px}",
-            );
-
-            let (close_events, _) =
-                self.handle_external_order(&close_report, account_id, instrument, &[], true, None);
-            all_events.extend(close_events);
-        } else {
-            log::warn!("Cannot close position for {instrument_id}: no cached average price");
-            return None;
-        }
-
-        // Then open new position in opposite direction
         let open_qty = venue_signed_qty.abs();
         let open_side = if venue_signed_qty > Decimal::ZERO {
             OrderSide::Buy // Open long
@@ -2724,42 +2716,51 @@ impl ExecutionManager {
             OrderSide::Sell // Open short
         };
 
-        if let Some(open_px) = venue_avg_px {
-            let open_order_qty =
-                Quantity::from_decimal_dp(open_qty, instrument.size_precision()).ok()?;
-            let open_fill_price =
-                Price::from_decimal_dp(open_px, instrument.price_precision()).ok();
-            let open_venue_order_id = create_position_reconciliation_venue_order_id(
-                account_id,
-                instrument_id,
-                open_side,
-                OrderType::Market,
-                open_order_qty,
-                open_fill_price,
-                None,
-                Some("OPEN"),
-                venue_ts_last,
-            );
+        let Some(close_px) = cached_avg_px else {
+            log::warn!("Cannot close position for {instrument_id}: no cached average price");
+            return None;
+        };
 
-            let open_report = OrderStatusReport::new(
-                account_id,
-                instrument_id,
-                None,
-                open_venue_order_id,
-                open_side,
-                OrderType::Market,
-                TimeInForce::Gtc,
-                OrderStatus::Filled,
-                open_order_qty,
-                open_order_qty,
-                ts_now,
-                ts_now,
-                ts_now,
-                None,
-            )
-            .with_avg_px(open_px.to_f64().unwrap_or(0.0))
-            .ok()?;
+        let open_report = match venue_avg_px {
+            Some(open_px) => Some((
+                build_cross_zero_leg_report(
+                    instrument,
+                    account_id,
+                    instrument_id,
+                    open_side,
+                    open_qty,
+                    open_px,
+                    "OPEN",
+                    ts_now,
+                    venue_ts_last,
+                )?,
+                open_px,
+            )),
+            None => None,
+        };
 
+        let close_report = build_cross_zero_leg_report(
+            instrument,
+            account_id,
+            instrument_id,
+            close_side,
+            close_qty,
+            close_px,
+            "CLOSE",
+            ts_now,
+            venue_ts_last,
+        )?;
+
+        log::info!(
+            color = LogColor::Blue as u8;
+            "Generating close fill for cross-zero {instrument_id}: side={close_side:?}, qty={close_qty}, px={close_px}",
+        );
+
+        let (close_events, _) =
+            self.handle_external_order(&close_report, account_id, instrument, &[], true, None);
+        let mut all_events = close_events;
+
+        if let Some((open_report, open_px)) = open_report {
             log::info!(
                 color = LogColor::Blue as u8;
                 "Generating open fill for cross-zero {instrument_id}: side={open_side:?}, qty={open_qty}, px={open_px}",
@@ -2770,7 +2771,6 @@ impl ExecutionManager {
             all_events.extend(open_events);
         } else {
             log::warn!("Cannot open new position for {instrument_id}: no venue average price");
-            return Some(all_events);
         }
 
         Some(all_events)

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -49,7 +49,10 @@ use nautilus_common::{
 };
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_execution::{
-    engine::ExecutionEngine, reconciliation::process_mass_status_for_reconciliation,
+    engine::ExecutionEngine,
+    reconciliation::{
+        create_position_reconciliation_venue_order_id, process_mass_status_for_reconciliation,
+    },
 };
 use nautilus_live::manager::{ExecutionManager, ExecutionManagerConfig};
 use nautilus_model::{
@@ -6742,6 +6745,198 @@ async fn test_closed_reconciliation_orders_skipped_on_restart() {
         "Should skip closed RECONCILIATION order, but got {} events",
         result.events.len()
     );
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_cross_zero_unbuildable_open_leg_has_no_side_effects() {
+    let config = ExecutionManagerConfig {
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let position_id = PositionId::from("P-CROSS-ZERO-ATOMIC");
+    let position = create_test_position(&instrument, position_id, OrderSide::Buy, "5.0", "3000.00");
+    let strategy_id = StrategyId::from("CROSS-ZERO-ATOMIC");
+    let venue_ts_last = UnixNanos::from(1_000_000);
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&position);
+    ctx.manager
+        .claim_external_orders(instrument_id, strategy_id)
+        .unwrap();
+
+    let topic = switchboard::get_event_order_topic(strategy_id);
+    let (handler, event_messages): (_, TypedMessageSavingHandler<OrderEventAny>) =
+        get_typed_message_saving_handler(None);
+    msgbus::subscribe_order_events(topic.into(), handler.clone(), None);
+
+    let mut report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Short,
+        Quantity::from("3.0"),
+        venue_ts_last,
+        venue_ts_last,
+        None,
+        None,
+        Some(dec!(3100.00)),
+    );
+    report.signed_decimal_qty = -dec!(10000000000000000000);
+    let client = MockPositionExecutionClient::new(vec![], vec![report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&client];
+
+    let order_count_before = ctx
+        .cache
+        .borrow()
+        .orders_total_count(None, None, None, None, None);
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    msgbus::unsubscribe_order_events(topic.into(), &handler);
+
+    let close_venue_order_id = create_position_reconciliation_venue_order_id(
+        test_account_id(),
+        instrument_id,
+        OrderSide::Sell,
+        OrderType::Market,
+        Quantity::from("5.0"),
+        Price::from_decimal_dp(dec!(3000.00), instrument.price_precision()).ok(),
+        None,
+        Some("CLOSE"),
+        venue_ts_last,
+    );
+    let close_client_order_id = ClientOrderId::from(close_venue_order_id.as_str());
+    let cache = ctx.cache.borrow();
+    let cached_qty = cache
+        .position(&position_id)
+        .expect("cached position should remain present")
+        .signed_decimal_qty();
+
+    assert!(events.is_empty());
+    assert_eq!(
+        cache.orders_total_count(None, None, None, None, None),
+        order_count_before,
+        "an unbuildable open leg must not cache the close order",
+    );
+    assert!(
+        cache.client_order_id(&close_venue_order_id).is_none(),
+        "an unbuildable open leg must not add the venue-to-client order index",
+    );
+    assert!(
+        cache.venue_order_id(&close_client_order_id).is_none(),
+        "an unbuildable open leg must not add the client-to-venue order index",
+    );
+    assert_eq!(cached_qty, dec!(5.0));
+    assert!(
+        event_messages.get_messages().is_empty(),
+        "an unbuildable open leg must not publish any order event",
+    );
+}
+
+#[rstest]
+#[cfg_attr(
+    not(all(feature = "simulation", madsim)),
+    tokio::test(start_paused = true)
+)]
+#[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+async fn test_cross_zero_unbuildable_open_leg_retries_without_poisoning_order_id() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let key = (instrument_id, test_account_id());
+    let position = create_test_position(
+        &instrument,
+        PositionId::from("P-CROSS-ZERO-RETRY"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    );
+    let venue_ts_last = UnixNanos::from(1_000_000);
+    ctx.add_instrument(instrument);
+    ctx.add_position(&position);
+
+    let mut unbuildable_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Short,
+        Quantity::from("3.0"),
+        venue_ts_last,
+        venue_ts_last,
+        None,
+        None,
+        Some(dec!(3100.00)),
+    );
+    unbuildable_report.signed_decimal_qty = -dec!(10000000000000000000);
+    let unbuildable_client = MockPositionExecutionClient::new(vec![], vec![unbuildable_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&unbuildable_client];
+
+    let first_events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(first_events.is_empty());
+    assert_eq!(ctx.manager.position_recon_retry_count(&key), 1);
+
+    let valid_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Short,
+        Quantity::from("3.0"),
+        venue_ts_last,
+        venue_ts_last,
+        None,
+        None,
+        Some(dec!(3100.00)),
+    );
+    let valid_client = MockPositionExecutionClient::new(vec![], vec![valid_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&valid_client];
+
+    let second_events = ctx.manager.check_positions_consistency(&clients).await;
+    let fills: Vec<_> = second_events
+        .iter()
+        .filter_map(|event| match event {
+            OrderEventAny::Filled(fill) => Some(fill),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(ctx.manager.position_recon_retry_count(&key), 0);
+    assert_eq!(
+        fills.len(),
+        2,
+        "the retry must rebuild both cross-zero legs"
+    );
+    assert_eq!(fills[0].order_side, OrderSide::Sell);
+    assert_eq!(fills[0].last_qty, Quantity::from("5.0"));
+    assert_eq!(fills[1].order_side, OrderSide::Sell);
+    assert_eq!(fills[1].last_qty, Quantity::from("3.0"));
+
+    for event in &second_events {
+        ctx.exec_engine.borrow_mut().process(event);
+    }
+
+    let cached_signed_qty = ctx
+        .cache
+        .borrow()
+        .positions_open(
+            None,
+            Some(&instrument_id),
+            None,
+            Some(&test_account_id()),
+            None,
+        )
+        .iter()
+        .map(|position| position.signed_decimal_qty())
+        .sum::<Decimal>();
+    assert_eq!(cached_signed_qty, dec!(-3.0));
 }
 
 #[tokio::test]


### PR DESCRIPTION
A follow-up to the live reconciliation series (#4479, #4490, #4517), closing a path where a fallible open-leg construction could strand a synthetic order.

## Cross-zero reconciliation mutates the close leg before the open leg is known-constructible

`ExecutionManager::reconcile_cross_zero_position` splits a sign-flipping position discrepancy into two synthetic fills: close the cached side, then open the venue side. It ran the close leg through `handle_external_order` before constructing the open leg.

`handle_external_order` is not a pure event builder - before returning events it calls `Cache::add_order` (inserting the synthetic order, marking it active-local, updating the order/venue/instrument/strategy indexes, and persisting to the cache database), registers both directions of the client-order-id/venue-order-id index, and publishes `OrderInitialized` on the message bus.

The open leg's fallible conversions ran only after that: `Quantity::from_decimal_dp(...).ok()?` for the open quantity and `OrderStatusReport::new(...).with_avg_px(...).ok()?` for the open report. When either returned `None` the function early-returned and dropped the accumulated events, so no close fill ever reached the position - but the synthetic close order was already cached, indexed, and published. Because the synthetic `client_order_id` is derived deterministically from the venue order id, the next reconciliation cycle regenerates the same id, `Cache::add_order` collides, the "exists in cache in non-terminal state; fill not regenerated" branch returns no events, and the cross-zero reconciliation can never complete - a permanently stranded non-terminal order with the discrepancy left unresolved.

The fix builds and validates both leg reports before the first `handle_external_order` call: when `venue_avg_px` is `Some`, the complete open `OrderStatusReport` is constructed up front, and if it cannot be built the function returns `None` with nothing cached, indexed, or published. The close leg is then applied, followed by the open leg, preserving close-before-open ordering. The `venue_avg_px == None` close-only path (deliberately closes the stale cached side when the venue reports no average price) is unchanged. A small pure `build_cross_zero_leg_report` helper removes the duplicated report construction.

## Testing

`test_cross_zero_unbuildable_open_leg_has_no_side_effects`: a cross-zero discrepancy whose open leg cannot be built (venue signed quantity forced past `QUANTITY_MAX`) leaves the order count, both client/venue order-id index directions, and the cached position quantity unchanged, and publishes no order event. Verified to fail against the unfixed code, which caches and publishes the synthetic close order.

`test_cross_zero_unbuildable_open_leg_retries_without_poisoning_order_id`: the first reconciliation fails the open-leg conversion and increments (does not reset) the position-discrepancy retry counter; a subsequent cycle with a buildable open leg produces both fills in close-then-open order and drives the cache to the venue quantity. Verified to fail against the unfixed code, where the stranded close order collides on the deterministic id and only one leg is regenerated.

Both use paused virtual time with no wall-clock waits. The existing `test_cross_zero_with_missing_venue_avg_px_closes_only` remains green, pinning the unchanged close-only contract.
