### PR TITLE
Defer recent-fill dedup marking until the fill applies to its order

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -2063,7 +2063,7 @@ impl ExecutionManager {
     /// Observes a local order event and updates tracking state.
     ///
     /// This is the `LiveNode` dispatch path for order events: acknowledgement
-    /// events clear reconciliation tracking, fills record fill/position
+    /// events clear reconciliation tracking, fills record position
     /// activity, and every event stamps local activity. The stamp must come
     /// AFTER any [`Self::clear_recon_tracking`] call - that call drops the
     /// local-activity mark, which is the sole grace gate protecting a
@@ -2073,7 +2073,6 @@ impl ExecutionManager {
         match event {
             OrderEventAny::Filled(fill) => {
                 self.record_position_activity(fill.instrument_id, fill.account_id);
-                self.mark_fill_processed(fill.account_id, fill.instrument_id, fill.trade_id);
             }
             OrderEventAny::Accepted(_)
             | OrderEventAny::Rejected(_)
@@ -2189,6 +2188,14 @@ impl ExecutionManager {
     ) {
         self.recent_fills_cache
             .mark((account_id, instrument_id, trade_id));
+    }
+
+    /// Marks a fill as recently processed when it is present on its canonical order.
+    pub fn commit_recent_fill_if_applied(&mut self, fill: &OrderFilled) {
+        let fill_key = (fill.account_id, fill.instrument_id, fill.trade_id);
+        if self.is_fill_applied(fill, fill_key) {
+            self.mark_fill_processed(fill_key.0, fill_key.1, fill_key.2);
+        }
     }
 
     /// Prunes expired fills from the recent fills cache.

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -1287,7 +1287,7 @@ impl LiveNode {
                         continue;
                     };
 
-                    AsyncRunner::handle_exec_event(evt);
+                    self.dispatch_exec_event_and_commit_fill(evt);
 
                     // Post-dispatch: clear tracking when order closes
                     for coid in &close_ids {
@@ -1500,13 +1500,32 @@ impl LiveNode {
             if let OrderEventAny::Filled(fill) = event {
                 self.exec_manager
                     .record_position_activity(fill.instrument_id, fill.account_id);
-                self.exec_manager.mark_fill_processed(
-                    fill.account_id,
-                    fill.instrument_id,
-                    fill.trade_id,
-                );
             }
             self.kernel.exec_engine.borrow_mut().process(event);
+            if let OrderEventAny::Filled(fill) = event {
+                self.exec_manager.commit_recent_fill_if_applied(fill);
+            }
+        }
+    }
+
+    /// Dispatches a normal-ingress execution event, then commits a direct
+    /// `OrderFilled` to the recent-fills dedup cache only once it is present on
+    /// its canonical order.
+    ///
+    /// The fill candidate is captured from `&evt` BEFORE the value is moved into
+    /// [`AsyncRunner::handle_exec_event`]; the gated commit runs AFTER dispatch,
+    /// so a fill the execution engine rejects (unknown order, invalid
+    /// transition) is never marked and its later `Fill` report stays eligible.
+    fn dispatch_exec_event_and_commit_fill(&mut self, evt: ExecutionEvent) {
+        let recent_fill_candidate = match &evt {
+            ExecutionEvent::Order(OrderEventAny::Filled(fill)) => Some(fill.clone()),
+            _ => None,
+        };
+
+        AsyncRunner::handle_exec_event(evt);
+
+        if let Some(fill) = &recent_fill_candidate {
+            self.exec_manager.commit_recent_fill_if_applied(fill);
         }
     }
 
@@ -2563,20 +2582,22 @@ mod tests {
         },
     };
     use nautilus_core::{UUID4, UnixNanos};
-    use nautilus_execution::engine::{
-        ExecutionEngine, SnapshotAnchorer, stubs::StubExecutionClient,
+    use nautilus_execution::{
+        engine::{ExecutionEngine, SnapshotAnchorer, stubs::StubExecutionClient},
+        reconciliation::create_inferred_fill_for_qty,
     };
     use nautilus_model::{
         data::QuoteTick,
-        enums::{OmsType, OrderStatus, OrderType},
-        events::{OrderAcceptedBatch, order::spec::OrderAcceptedSpec},
+        enums::{LiquiditySide, OmsType, OrderSide, OrderStatus, OrderType, TimeInForce},
+        events::{OrderAcceptedBatch, OrderFilled, order::spec::OrderAcceptedSpec},
         identifiers::{
             AccountId, ClientId, InstrumentId, PositionId, StrategyId, TradeId, TraderId,
             VenueOrderId,
         },
         instruments::{Instrument, InstrumentAny, stubs::crypto_perpetual_ethusdt},
         orders::{OrderTestBuilder, stubs::TestOrderEventStubs},
-        types::{Price, Quantity},
+        reports::FillReport,
+        types::{Money, Price, Quantity},
     };
     use nautilus_system::{KernelEventStore, RegisteredComponents, event_store::EventStoreConfig};
     use nautilus_trading::{
@@ -2641,6 +2662,178 @@ mod tests {
 
         let close_ids = node.observe_exec_event_before_dispatch(&event);
         assert_eq!(close_ids, None);
+    }
+
+    #[rstest]
+    fn test_rejected_direct_fill_stays_eligible_for_later_report() {
+        let (mut node, mut fill_event, _) = recent_fill_test_fixture("RejectedDirectFillNode");
+        let OrderEventAny::Filled(fill) = &mut fill_event else {
+            unreachable!();
+        };
+        fill.client_order_id = ClientOrderId::from("O-UNKNOWN");
+        fill.venue_order_id = VenueOrderId::from("V-UNKNOWN");
+        let fill = fill.clone();
+        let report_event = fill_report_event(&fill);
+        let event = ExecutionEvent::Order(OrderEventAny::Filled(fill.clone()));
+
+        assert!(node.observe_exec_event_before_dispatch(&event).is_some());
+        let marked_before_dispatch = is_recent_fill(&node, &fill);
+
+        node.dispatch_exec_event_and_commit_fill(event);
+
+        let marked_after_dispatch = is_recent_fill(&node, &fill);
+        let later_report_is_eligible = node
+            .observe_exec_event_before_dispatch(&report_event)
+            .is_some();
+        assert_eq!(
+            (
+                marked_before_dispatch,
+                marked_after_dispatch,
+                later_report_is_eligible,
+            ),
+            (false, false, true),
+        );
+    }
+
+    #[rstest]
+    fn test_applied_direct_fill_commits_and_skips_later_report() {
+        let (mut node, fill_event, _) = recent_fill_test_fixture("AppliedDirectFillNode");
+        let OrderEventAny::Filled(fill) = &fill_event else {
+            unreachable!();
+        };
+        let fill = fill.clone();
+        let report_event = fill_report_event(&fill);
+        let event = ExecutionEvent::Order(fill_event);
+
+        assert!(node.observe_exec_event_before_dispatch(&event).is_some());
+        assert!(!is_recent_fill(&node, &fill));
+
+        node.dispatch_exec_event_and_commit_fill(event);
+
+        assert!(is_recent_fill(&node, &fill));
+        assert_eq!(node.observe_exec_event_before_dispatch(&report_event), None);
+    }
+
+    #[rstest]
+    fn test_canonical_duplicate_fill_counts_as_applied() {
+        let (mut node, fill_event, _) = recent_fill_test_fixture("DuplicateDirectFillNode");
+        let OrderEventAny::Filled(fill) = &fill_event else {
+            unreachable!();
+        };
+        let mut fill = fill.clone();
+        node.kernel
+            .cache
+            .borrow_mut()
+            .update_order(&fill_event)
+            .unwrap();
+        fill.client_order_id = ClientOrderId::from("O-DUPLICATE-UNKNOWN");
+
+        node.exec_manager.commit_recent_fill_if_applied(&fill);
+
+        assert!(is_recent_fill(&node, &fill));
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn test_continuous_reconciliation_commits_only_applied_fill(#[case] applied: bool) {
+        let (mut node, mut fill_event, _) = recent_fill_test_fixture(if applied {
+            "AppliedContinuousFillNode"
+        } else {
+            "RejectedContinuousFillNode"
+        });
+
+        if !applied {
+            let OrderEventAny::Filled(fill) = &mut fill_event else {
+                unreachable!();
+            };
+            fill.client_order_id = ClientOrderId::from("O-CONTINUOUS-UNKNOWN");
+            fill.venue_order_id = VenueOrderId::from("V-CONTINUOUS-UNKNOWN");
+        }
+        let OrderEventAny::Filled(fill) = &fill_event else {
+            unreachable!();
+        };
+        let fill = fill.clone();
+
+        node.process_reconciliation_events(&[fill_event]);
+
+        assert_eq!(is_recent_fill(&node, &fill), applied);
+    }
+
+    #[rstest]
+    fn test_recent_fill_commit_requires_account_and_instrument_match() {
+        let (mut node, fill_event, _) = recent_fill_test_fixture("MismatchedDirectFillNode");
+        node.kernel
+            .cache
+            .borrow_mut()
+            .update_order(&fill_event)
+            .unwrap();
+        let OrderEventAny::Filled(fill) = fill_event else {
+            unreachable!();
+        };
+        let mut account_mismatch = fill.clone();
+        account_mismatch.account_id = AccountId::from("OTHER-001");
+        let mut instrument_mismatch = fill;
+        instrument_mismatch.instrument_id = InstrumentId::from("OTHER.VENUE");
+
+        node.exec_manager
+            .commit_recent_fill_if_applied(&account_mismatch);
+        node.exec_manager
+            .commit_recent_fill_if_applied(&instrument_mismatch);
+
+        assert!(!is_recent_fill(&node, &account_mismatch));
+        assert!(!is_recent_fill(&node, &instrument_mismatch));
+    }
+
+    #[rstest]
+    fn test_applied_inferred_fill_remains_recently_processed() {
+        let (mut node, _, instrument) = recent_fill_test_fixture("InferredFillNode");
+        let client_order_id = ClientOrderId::from("O-RECENT-FILL");
+        let venue_order_id = VenueOrderId::from("V-RECENT-FILL");
+        let account_id = AccountId::from("TEST-001");
+        let order = node
+            .kernel
+            .cache
+            .borrow()
+            .order_owned(&client_order_id)
+            .unwrap();
+        let report = OrderStatusReport::new(
+            account_id,
+            instrument.id(),
+            Some(client_order_id),
+            venue_order_id,
+            OrderSide::Buy,
+            OrderType::Limit,
+            TimeInForce::Gtc,
+            OrderStatus::PartiallyFilled,
+            Quantity::from("10.0"),
+            Quantity::from("1.0"),
+            UnixNanos::from(1_000),
+            UnixNanos::from(1_000),
+            UnixNanos::from(1_000),
+            None,
+        )
+        .with_avg_px(100.0)
+        .unwrap();
+        let inferred = create_inferred_fill_for_qty(
+            &order,
+            &report,
+            &account_id,
+            &instrument,
+            Quantity::from("1.0"),
+            UnixNanos::from(1_000),
+            None,
+        )
+        .unwrap();
+        let OrderEventAny::Filled(fill) = &inferred else {
+            unreachable!();
+        };
+        let fill = fill.clone();
+
+        node.process_reconciliation_events(&[inferred]);
+
+        assert!(fill.reconciliation);
+        assert!(is_recent_fill(&node, &fill));
     }
 
     #[rstest]
@@ -3155,6 +3348,83 @@ mod tests {
             .borrow_mut()
             .update_order(&accepted)
             .unwrap();
+    }
+
+    fn recent_fill_test_fixture(name: &str) -> (LiveNode, OrderEventAny, InstrumentAny) {
+        let config = LiveNodeConfig {
+            exec_engine: crate::config::LiveExecEngineConfig {
+                reconciliation: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let node = LiveNode::build(name.to_string(), Some(config)).unwrap();
+        let account_id = AccountId::from("TEST-001");
+        let client_id = ClientId::from("TEST-RECENT-FILL");
+        let client_order_id = ClientOrderId::from("O-RECENT-FILL");
+        let venue_order_id = VenueOrderId::from("V-RECENT-FILL");
+        let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        node.kernel
+            .cache
+            .borrow_mut()
+            .add_instrument(instrument.clone())
+            .unwrap();
+        insert_accepted_limit_order_in_node(
+            &node,
+            account_id,
+            client_id,
+            instrument.id(),
+            client_order_id,
+            venue_order_id,
+        );
+        let order = node
+            .kernel
+            .cache
+            .borrow()
+            .order_owned(&client_order_id)
+            .unwrap();
+        let fill = TestOrderEventStubs::filled(
+            &order,
+            &instrument,
+            Some(TradeId::from("T-RECENT-FILL")),
+            None,
+            Some(Price::from("100.0")),
+            Some(Quantity::from("1.0")),
+            Some(LiquiditySide::Taker),
+            None,
+            None,
+            Some(account_id),
+        );
+
+        (node, fill, instrument)
+    }
+
+    fn fill_report_event(fill: &OrderFilled) -> ExecutionEvent {
+        ExecutionEvent::Report(ExecutionReport::Fill(Box::new(FillReport::new(
+            fill.account_id,
+            fill.instrument_id,
+            fill.venue_order_id,
+            fill.trade_id,
+            fill.order_side,
+            fill.last_qty,
+            fill.last_px,
+            fill.commission
+                .unwrap_or_else(|| Money::zero(fill.currency)),
+            fill.liquidity_side,
+            Some(fill.client_order_id),
+            fill.position_id,
+            fill.ts_event,
+            fill.ts_init,
+            None,
+        ))))
+    }
+
+    fn is_recent_fill(node: &LiveNode, fill: &OrderFilled) -> bool {
+        node.exec_manager.is_fill_recently_processed(
+            fill.account_id,
+            fill.instrument_id,
+            fill.trade_id,
+        )
     }
 
     #[rstest]


### PR DESCRIPTION
A follow-up to the reconciliation fill-dedup work in #4518, which closed a premature-commit window on the mass-status `processed_fills` map; the same pattern remained on the normal-live `recent_fills_cache`.

## recent_fills_cache is marked before the fill applies to its canonical order

The live node dedups repeated venue fills through `recent_fills_cache`, keyed by `(account_id, instrument_id, trade_id)`: a direct `OrderFilled` marks the key, and a later matching `ExecutionReport::Fill` carrying the same key is skipped (`observe_exec_event_before_dispatch`). The mark was committed before the event reached the canonical order cache - `observe_order_event` marked every direct `OrderFilled` while the node called it in the pre-dispatch hook, and `process_reconciliation_events` marked before `ExecutionEngine::process`. Both dispatch paths are synchronous and neither reports application success, so a fill the engine rejected (unknown order, invalid transition) was still marked, and its later report - the venue's authoritative record - was suppressed for the recency window (~60-120s). This is the same class #4518 fixed on the mass-status map.

The fix defers the mark to after dispatch, gated on the canonical order. `commit_recent_fill_if_applied` resolves the order (by `client_order_id`, venue-order-id fallback), requires the account, instrument, and a `trade_ids` containment match, and only then marks - reusing the `is_fill_applied` postcondition introduced in #4518. An already-present trade id counts as applied (correct replay); an unresolved or unapplied fill is not marked, so its later report stays eligible. The mark is removed from the pre-dispatch `observe_order_event` (its position and local activity recording stay); the normal-ingress path captures the `OrderFilled` before the event is moved into dispatch and commits after; `process_reconciliation_events` processes then commits. The skip and prune sites are unchanged.

One intentional behavior change: an orderless leg fill (one the engine applies to a position with no canonical order) is no longer marked, since it has no order to satisfy the postcondition. It stays eligible for a later report - the honest result under an order-cache postcondition; a position-cache postcondition would be separate scope.

## Testing

- `test_rejected_direct_fill_stays_eligible_for_later_report`: a direct fill whose order is absent from the cache is not marked (before or after dispatch) and its later `Fill` report stays eligible.
- `test_applied_direct_fill_commits_and_skips_later_report`: a fill applied to its canonical order is marked only after dispatch, and its later report is skipped. Drives the production dispatch-and-commit path.
- `test_canonical_duplicate_fill_counts_as_applied`: a fill already present on the order (resolved via the venue-order-id fallback) commits.
- `test_continuous_reconciliation_commits_only_applied_fill` (applied/rejected): the reconciliation path marks only when the fill applied.
- `test_recent_fill_commit_requires_account_and_instrument_match`: an account or instrument mismatch does not commit.
- `test_applied_inferred_fill_remains_recently_processed`: an applied inferred reconciliation fill retains the existing recent-cache behavior.

The correctness assertions were verified to fail against the pre-change premature-mark code (a rejected fill was marked before dispatch and its report suppressed). Tests use paused virtual time with no wall-clock waits; the existing recency-TTL tests remain green.
