### PR TITLE
Fix inflight coverage and bookkeeping-map retention in live reconciliation

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -1059,6 +1059,7 @@ impl ExecutionManager {
                 .filtered_client_order_ids
                 .contains(&client_order_id)
             {
+                self.clear_recon_tracking(&client_order_id, true);
                 continue;
             }
 
@@ -1995,6 +1996,14 @@ impl ExecutionManager {
 
     /// Registers an order as inflight for tracking.
     pub fn register_inflight(&mut self, client_order_id: ClientOrderId) {
+        if self
+            .config
+            .filtered_client_order_ids
+            .contains(&client_order_id)
+        {
+            return;
+        }
+
         self.inflight_checks.insert(
             client_order_id,
             InflightCheck {
@@ -2143,30 +2152,15 @@ impl ExecutionManager {
     /// engine, so that the manager's state is current when periodic checks run.
     ///
     /// Updates performed per report variant:
-    /// - `Order`: clears inflight tracking and records local activity
+    /// - `Order`: updates reconciliation tracking based on order status
     /// - `Fill`: records order and position activity without marking the fill as processed
-    /// - `OrderWithFills`: clears inflight tracking, records local activity, records position activity per fill
+    /// - `OrderWithFills`: updates order tracking and records position activity per fill
     /// - `Position`: records position activity
     /// - `MassStatus`: no-op (handled separately via startup reconciliation)
     pub fn observe_execution_report(&mut self, report: &ExecutionReport) {
         match report {
             ExecutionReport::Order(order_report) => {
-                if let Some(client_order_id) = &order_report.client_order_id {
-                    // Only clear inflight tracking for non-pending states.
-                    // Pending reports (PendingUpdate, PendingCancel) are interim
-                    // acknowledgements; the order is still inflight until the
-                    // venue confirms the final state.
-                    if !matches!(
-                        order_report.order_status,
-                        OrderStatus::PendingUpdate | OrderStatus::PendingCancel
-                    ) {
-                        self.clear_recon_tracking(
-                            client_order_id,
-                            order_report.order_status.is_closed(),
-                        );
-                    }
-                    self.record_local_activity(*client_order_id);
-                }
+                self.observe_order_status_report(order_report);
             }
             ExecutionReport::Fill(fill_report) => {
                 let client_order_id = fill_report.client_order_id.or_else(|| {
@@ -2182,18 +2176,7 @@ impl ExecutionManager {
                 self.record_position_activity(fill_report.instrument_id, fill_report.account_id);
             }
             ExecutionReport::OrderWithFills(order_report, fills) => {
-                if let Some(client_order_id) = &order_report.client_order_id
-                    && !matches!(
-                        order_report.order_status,
-                        OrderStatus::PendingUpdate | OrderStatus::PendingCancel
-                    )
-                {
-                    self.clear_recon_tracking(
-                        client_order_id,
-                        order_report.order_status.is_closed(),
-                    );
-                    self.record_local_activity(*client_order_id);
-                }
+                self.observe_order_status_report(order_report);
 
                 for fill_report in fills {
                     self.record_position_activity(
@@ -2211,6 +2194,24 @@ impl ExecutionManager {
             ExecutionReport::MassStatus(_) => {
                 // Handled separately via reconcile_execution_mass_status
             }
+        }
+    }
+
+    fn observe_order_status_report(&mut self, report: &OrderStatusReport) {
+        let Some(client_order_id) = report.client_order_id else {
+            return;
+        };
+
+        if matches!(
+            report.order_status,
+            OrderStatus::PendingUpdate | OrderStatus::PendingCancel
+        ) {
+            self.record_local_activity(client_order_id);
+        } else if report.order_status.is_closed() {
+            self.clear_recon_tracking(&client_order_id, true);
+        } else {
+            self.clear_recon_tracking(&client_order_id, false);
+            self.record_local_activity(client_order_id);
         }
     }
 
@@ -2268,6 +2269,12 @@ impl ExecutionManager {
 
         let ttl = Duration::from_mins(lookback_mins).max(Duration::from_mins(1));
         self.processed_fills.prune_older_than(ttl);
+    }
+
+    /// Prunes order activity outside the continuous reconciliation settling window.
+    pub fn prune_order_local_activity(&mut self) {
+        self.order_local_activity
+            .prune_older_than(Duration::from_nanos(self.config.open_check_threshold_ns));
     }
 
     /// Purges closed orders from the cache that are older than the configured buffer.
@@ -3890,6 +3897,175 @@ mod tests {
         manager.clear_recon_tracking(&client_order_id, true);
 
         assert!(manager.targeted_order_queries.is_empty());
+    }
+
+    #[rstest]
+    fn test_register_inflight_skips_filtered_order() {
+        let client_order_id = ClientOrderId::from("O-FILTERED-REGISTER");
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let mut manager = ExecutionManager::new(
+            clock,
+            cache,
+            ExecutionManagerConfig {
+                filtered_client_order_ids: IndexSet::from([client_order_id]),
+                ..Default::default()
+            },
+        );
+
+        manager.register_inflight(client_order_id);
+
+        assert!(!manager.inflight_checks.contains_key(&client_order_id));
+        assert!(!manager.recon_check_retries.contains_key(&client_order_id));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_inflight_check_retires_order_filtered_after_registration() {
+        let client_order_id = ClientOrderId::from("O-FILTERED-LATE");
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let mut manager = ExecutionManager::new(
+            clock,
+            cache,
+            ExecutionManagerConfig {
+                inflight_threshold_ms: 100,
+                ..Default::default()
+            },
+        );
+        manager.register_inflight(client_order_id);
+        manager
+            .config
+            .filtered_client_order_ids
+            .insert(client_order_id);
+        dst::time::sleep(Duration::from_millis(101)).await;
+
+        let first = manager.check_inflight_orders();
+
+        assert!(first.events.is_empty());
+        assert!(first.queries.is_empty());
+        assert!(!manager.inflight_checks.contains_key(&client_order_id));
+        assert!(!manager.recon_check_retries.contains_key(&client_order_id));
+
+        dst::time::sleep(Duration::from_millis(101)).await;
+        let second = manager.check_inflight_orders();
+        assert!(second.events.is_empty());
+        assert!(second.queries.is_empty());
+        assert!(!manager.inflight_checks.contains_key(&client_order_id));
+    }
+
+    #[rstest]
+    #[case(false, OrderStatus::PendingUpdate, true, true, true)]
+    #[case(false, OrderStatus::Accepted, false, true, true)]
+    #[case(false, OrderStatus::Canceled, false, false, false)]
+    #[case(true, OrderStatus::PendingCancel, true, true, true)]
+    #[case(true, OrderStatus::Accepted, false, true, true)]
+    #[case(true, OrderStatus::Filled, false, false, false)]
+    fn test_observe_order_status_report_tracking_matrix(
+        #[case] with_fills: bool,
+        #[case] status: OrderStatus,
+        #[case] expect_inflight: bool,
+        #[case] expect_activity: bool,
+        #[case] expect_last_query: bool,
+    ) {
+        let client_order_id = ClientOrderId::from("O-STATUS-MATRIX");
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let mut manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default());
+        manager.register_inflight(client_order_id);
+        manager.order_query_recency.mark(client_order_id);
+        manager
+            .missing_order_coverage_warnings
+            .insert(client_order_id);
+        manager.unresolved_order_coverage.insert(client_order_id);
+        manager.targeted_order_queries.insert(client_order_id);
+        let order_report = OrderStatusReport::new(
+            AccountId::from("TEST-001"),
+            crypto_perpetual_ethusdt().id(),
+            Some(client_order_id),
+            VenueOrderId::from("V-STATUS-MATRIX"),
+            OrderSide::Buy,
+            OrderType::Limit,
+            TimeInForce::Gtc,
+            status,
+            Quantity::from("10.0"),
+            Quantity::from("0.0"),
+            UnixNanos::from(1_000),
+            UnixNanos::from(1_000),
+            UnixNanos::from(1_000),
+            None,
+        );
+        let report = if with_fills {
+            ExecutionReport::OrderWithFills(Box::new(order_report), Vec::new())
+        } else {
+            ExecutionReport::Order(Box::new(order_report))
+        };
+
+        manager.observe_execution_report(&report);
+
+        assert_eq!(
+            manager.inflight_checks.contains_key(&client_order_id),
+            expect_inflight,
+        );
+        assert_eq!(
+            manager.recon_check_retries.contains_key(&client_order_id),
+            expect_inflight,
+        );
+        assert_eq!(
+            manager.order_local_activity.contains_key(&client_order_id),
+            expect_activity,
+        );
+        assert_eq!(
+            manager.order_query_recency.contains_key(&client_order_id),
+            expect_last_query,
+        );
+        assert_eq!(
+            manager
+                .missing_order_coverage_warnings
+                .contains(&client_order_id),
+            expect_inflight,
+        );
+        assert_eq!(
+            manager.unresolved_order_coverage.contains(&client_order_id),
+            expect_inflight,
+        );
+        assert_eq!(
+            manager.targeted_order_queries.contains(&client_order_id),
+            expect_inflight,
+        );
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_prune_order_local_activity_uses_open_check_threshold() {
+        let old_id = ClientOrderId::from("O-ACTIVITY-OLD");
+        let fresh_id = ClientOrderId::from("O-ACTIVITY-FRESH");
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let mut manager = ExecutionManager::new(
+            clock,
+            cache,
+            ExecutionManagerConfig {
+                open_check_threshold_ns: 100_000_000,
+                ..Default::default()
+            },
+        );
+        manager.record_local_activity(old_id);
+        dst::time::sleep(Duration::from_millis(101)).await;
+        manager.record_local_activity(fresh_id);
+
+        manager.prune_order_local_activity();
+
+        assert!(!manager.order_local_activity.contains_key(&old_id));
+        assert!(manager.order_local_activity.contains_key(&fresh_id));
     }
 
     #[rstest]

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -1241,6 +1241,7 @@ impl LiveNode {
                     if now >= prune_fills_next {
                         self.exec_manager.prune_recent_fills_cache(60.0);
                         self.exec_manager.prune_processed_fills();
+                        self.exec_manager.prune_order_local_activity();
                         prune_fills_next = now + prune_fills_interval;
                     }
 
@@ -1312,28 +1313,7 @@ impl LiveNode {
                         residual_events += 1;
                     }
 
-                    match &cmd {
-                        TradingCommand::SubmitOrder(submit) => {
-                            self.exec_manager.register_inflight(submit.client_order_id);
-                        }
-                        TradingCommand::SubmitOrderList(submit) => {
-                            for order_init in &submit.order_inits {
-                                self.exec_manager.register_inflight(order_init.client_order_id);
-                            }
-                        }
-                        TradingCommand::ModifyOrder(modify) => {
-                            self.exec_manager.register_inflight(modify.client_order_id);
-                        }
-                        TradingCommand::ModifyOrders(modify) => {
-                            for child in &modify.modifies {
-                                self.exec_manager.register_inflight(child.client_order_id);
-                            }
-                        }
-                        TradingCommand::CancelOrder(cancel) => {
-                            self.exec_manager.register_inflight(cancel.client_order_id);
-                        }
-                        _ => {}
-                    }
+                    self.observe_exec_command_before_dispatch(&cmd);
                     AsyncRunner::handle_exec_command(cmd);
                     record_runner_dispatch(
                         &metrics,
@@ -1683,6 +1663,37 @@ impl LiveNode {
         }
 
         Some(close_ids)
+    }
+
+    fn observe_exec_command_before_dispatch(&mut self, cmd: &TradingCommand) {
+        match cmd {
+            TradingCommand::SubmitOrder(submit) => {
+                self.exec_manager.register_inflight(submit.client_order_id);
+            }
+            TradingCommand::SubmitOrderList(submit) => {
+                for order_init in &submit.order_inits {
+                    self.exec_manager
+                        .register_inflight(order_init.client_order_id);
+                }
+            }
+            TradingCommand::ModifyOrder(modify) => {
+                self.exec_manager.register_inflight(modify.client_order_id);
+            }
+            TradingCommand::ModifyOrders(modify) => {
+                for child in &modify.modifies {
+                    self.exec_manager.register_inflight(child.client_order_id);
+                }
+            }
+            TradingCommand::CancelOrder(cancel) => {
+                self.exec_manager.register_inflight(cancel.client_order_id);
+            }
+            TradingCommand::CancelOrders(cancel) => {
+                for child in &cancel.cancels {
+                    self.exec_manager.register_inflight(child.client_order_id);
+                }
+            }
+            _ => {}
+        }
     }
 
     /// Gets the node's environment.
@@ -2690,6 +2701,123 @@ mod tests {
 
         assert_eq!(close_ids, Some(Vec::new()));
         assert!(node.exec_manager.check_open_order_queries().is_empty());
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_batch_cancel_command_registers_each_child_for_inflight_timeout() {
+        use nautilus_common::messages::execution::{BatchCancelOrders, CancelOrder};
+        use nautilus_model::{events::OrderPendingCancel, identifiers::ClientOrderId};
+
+        let config = LiveNodeConfig {
+            exec_engine: crate::config::LiveExecEngineConfig {
+                reconciliation: true,
+                inflight_check_threshold_ms: 100,
+                inflight_check_retries: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut node = LiveNode::build("BatchCancelNode".to_string(), Some(config)).unwrap();
+        let trader_id = TraderId::from("TESTER-001");
+        let strategy_id = StrategyId::from("S-BATCH-CANCEL");
+        let account_id = AccountId::from("TEST-001");
+        let instrument = crypto_perpetual_ethusdt();
+        let instrument_id = instrument.id();
+        let child_ids = [
+            ClientOrderId::from("O-BATCH-CANCEL-1"),
+            ClientOrderId::from("O-BATCH-CANCEL-2"),
+        ];
+        node.kernel
+            .cache
+            .borrow_mut()
+            .add_instrument(InstrumentAny::CryptoPerpetual(instrument))
+            .unwrap();
+
+        for client_order_id in child_ids {
+            let order = OrderTestBuilder::new(OrderType::Limit)
+                .trader_id(trader_id)
+                .strategy_id(strategy_id)
+                .client_order_id(client_order_id)
+                .instrument_id(instrument_id)
+                .quantity(Quantity::from("10.0"))
+                .price(Price::from("100.0"))
+                .build();
+            let venue_order_id = VenueOrderId::from(format!("V-{client_order_id}").as_str());
+            // Model the production batch-cancel path: each child is accepted, then
+            // moved to PendingCancel, so an inflight timeout must emit a Canceled
+            // event (not a Submitted-order rejection).
+            let submitted = TestOrderEventStubs::submitted(&order, account_id);
+            let accepted = TestOrderEventStubs::accepted(&order, account_id, venue_order_id);
+            let pending_cancel = OrderEventAny::PendingCancel(OrderPendingCancel::new(
+                trader_id,
+                strategy_id,
+                instrument_id,
+                client_order_id,
+                Some(account_id),
+                UUID4::new(),
+                UnixNanos::default(),
+                UnixNanos::default(),
+                false,
+                Some(venue_order_id),
+            ));
+            let mut cache = node.kernel.cache.borrow_mut();
+            cache.add_order(order, None, None, false).unwrap();
+            cache.update_order(&submitted).unwrap();
+            cache.update_order(&accepted).unwrap();
+            cache.update_order(&pending_cancel).unwrap();
+        }
+        let cancels = child_ids
+            .into_iter()
+            .map(|client_order_id| {
+                CancelOrder::new(
+                    trader_id,
+                    None,
+                    strategy_id,
+                    instrument_id,
+                    client_order_id,
+                    None,
+                    UUID4::new(),
+                    UnixNanos::default(),
+                    None,
+                    None,
+                )
+            })
+            .collect();
+        let command = TradingCommand::CancelOrders(BatchCancelOrders::new(
+            trader_id,
+            None,
+            strategy_id,
+            instrument_id,
+            cancels,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ));
+
+        node.observe_exec_command_before_dispatch(&command);
+        advance_clock(Duration::from_millis(101)).await;
+        let result = node.exec_manager.check_inflight_orders();
+        let timed_out_ids = result
+            .events
+            .iter()
+            .map(OrderEventAny::client_order_id)
+            .collect::<IndexSet<_>>();
+
+        assert_eq!(timed_out_ids, IndexSet::from(child_ids));
+        assert_eq!(result.events.len(), child_ids.len());
+        assert!(
+            result
+                .events
+                .iter()
+                .all(|event| matches!(event, OrderEventAny::Canceled(_))),
+            "batch-cancel children must time out as Canceled events",
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
A follow-up to the live reconciliation series (#4479, #4490, #4517, #4518, #4521), covering three defects in the manager's inflight-check and local-activity bookkeeping maps: a coverage gap and two unbounded-growth leaks.

## Batch cancels never register for inflight timeout coverage

The exec-command dispatch registers orders for inflight tracking as each `TradingCommand` is handled: `SubmitOrder`, `SubmitOrderList`, `ModifyOrder`, `ModifyOrders`, and single `CancelOrder` all call `register_inflight`, but `TradingCommand::CancelOrders` (the batch) fell through the wildcard arm. The execution engine forwards a batch cancel to the client directly without emitting per-order `CancelOrder` commands, and the strategy has already moved each included order to `PendingCancel`, so without registration `check_inflight_orders` never observes the children. A batch cancel the venue silently drops therefore leaves each child stuck in `PendingCancel` indefinitely with no timeout to resolve it.

The fix adds a `CancelOrders` arm that iterates `cancels` and registers every child `client_order_id`, mirroring the existing `ModifyOrders` arm. `CancelAllOrders` is deliberately left out: it carries no per-order ids and does not move individual orders to `PendingCancel`, so per-order timeout coverage there would need the command to carry a captured target set - a separate change.

## Filtered inflight orders are never retired from the check map

`check_inflight_orders` first snapshots every past-threshold `inflight_checks` key, then for any id in `filtered_client_order_ids` performs a bare `continue` that mutates nothing. The entry's `submitted_at` stays beyond the threshold, so the id is re-selected and re-skipped on every subsequent cycle - it is never retired, and `inflight_checks` grows without bound for the process lifetime.

The fix retires a filtered entry via `clear_recon_tracking` when the checker encounters it, and adds an early guard in `register_inflight` so a filtered id is never inserted in the first place. The checker-path cleanup remains as the retirement route for an id that is filtered after it was already registered.

## Closed-order reports re-mark local activity that nothing prunes

`observe_execution_report` records `order_local_activity` as the real-time settling window that defers reconciliation while a local order interaction is still in flight. For a non-pending order report it called `clear_recon_tracking` (which removes the activity entry) and then unconditionally re-marked `order_local_activity`. For a terminal report the re-mark re-inserts an entry that nothing subsequently removes: report ingress contributes no id to the post-dispatch closed-order cleanup, and unlike the fill recency maps `order_local_activity` was never age-pruned. Every closed order thus left a permanent entry, and the map grew unbounded.

The `Order` and `OrderWithFills` arms now share one `observe_order_status_report` helper implementing the status matrix: `PendingUpdate`/`PendingCancel` retain inflight tracking and mark activity, an open non-pending status clears inflight bookkeeping and marks activity for the settling grace, and a closed status clears all tracking and does not re-mark. This also removes an inconsistency where a pending `OrderWithFills` report previously recorded no activity while a pending `Order` report did. Independently, `prune_order_local_activity` runs on the existing periodic maintenance tick (beside the fill-cache prunes) and drops entries older than `open_check_threshold_ns`. That window is exactly what all four `order_local_activity` consumers already gate on, so an entry older than it is already treated as no activity - pruning it changes no decision - and the periodic bound also covers the fill-report-close and orphaned-order paths that the per-report matrix does not reach.

## Testing

`test_batch_cancel_command_registers_each_child_for_inflight_timeout`: a `CancelOrders` batch whose children are transitioned `Accepted -> PendingCancel` via cache-applied events; after the inflight threshold elapses, `check_inflight_orders` emits one `OrderCanceled` event per child and nothing else. Verified to fail against the unfixed code, where the batch falls through the wildcard arm, no child is registered, and the timeout set is empty.

`test_register_inflight_skips_filtered_order` and `test_inflight_check_retires_order_filtered_after_registration`: a filtered id is never inserted into `inflight_checks`, and an id filtered after registration is removed on the next check and stays absent across a second cycle. The retirement test fails against the unfixed code, which leaves the entry to be revisited every cycle.

`test_observe_order_status_report_tracking_matrix`: parametrized over `Order` and `OrderWithFills` crossed with pending, accepted, and terminal statuses, asserting the resulting `inflight_checks`, retry-count, `order_local_activity`, query-recency, and coverage-set state. The terminal cases fail against the unfixed code, which re-marks local activity immediately after clearing it.

`test_prune_order_local_activity_uses_open_check_threshold`: an entry older than `open_check_threshold_ns` is pruned while a fresher one is retained.

All four use paused virtual time with no wall-clock waits.
