### PR TITLE
Forward submit params through execution algorithms

### DIFF
--- a/crates/trading/src/algorithm/core.rs
+++ b/crates/trading/src/algorithm/core.rs
@@ -25,6 +25,7 @@ use nautilus_common::{
     clock::Clock,
     msgbus::TypedHandler,
 };
+use nautilus_core::Params;
 use nautilus_model::{
     events::{OrderEventAny, PositionEvent},
     identifiers::{ActorId, ClientOrderId, ExecAlgorithmId, StrategyId, TraderId},
@@ -71,6 +72,8 @@ pub struct ExecutionAlgorithmCore {
     subscribed_strategies: AHashSet<StrategyId>,
     /// Tracks pending spawn reductions for quantity restoration on denial/rejection.
     pending_spawn_reductions: AHashMap<ClientOrderId, Quantity>,
+    /// Maps primary order client IDs to the command params supplied at submission.
+    submit_params: AHashMap<ClientOrderId, Params>,
     /// The portfolio shared by the trader.
     portfolio: Option<Rc<RefCell<Portfolio>>>,
     /// Maps strategies to their event handlers for cleanup on reset.
@@ -120,6 +123,7 @@ impl Debug for ExecutionAlgorithmCore {
                 "pending_spawn_reductions",
                 &self.pending_spawn_reductions.len(),
             )
+            .field("submit_params", &self.submit_params.len())
             .field(
                 "strategy_event_handlers",
                 &self.strategy_event_handlers.len(),
@@ -153,6 +157,7 @@ impl ExecutionAlgorithmCore {
             exec_spawn_ids: AHashMap::new(),
             subscribed_strategies: AHashSet::new(),
             pending_spawn_reductions: AHashMap::new(),
+            submit_params: AHashMap::new(),
             portfolio: None,
             strategy_event_handlers: IndexMap::new(),
         }
@@ -253,6 +258,28 @@ impl ExecutionAlgorithmCore {
         self.pending_spawn_reductions.clear();
     }
 
+    /// Stores the command params supplied with a primary order submission.
+    ///
+    /// A `None` or empty params map is ignored, so no lookup is created for orders without params.
+    pub fn remember_submit_params(&mut self, primary_id: ClientOrderId, params: Option<Params>) {
+        if let Some(params) = params
+            && !params.is_empty()
+        {
+            self.submit_params.insert(primary_id, params);
+        }
+    }
+
+    /// Returns a clone of the submit command params stored for a primary order, if any.
+    #[must_use]
+    pub fn submit_params(&self, primary_id: &ClientOrderId) -> Option<Params> {
+        self.submit_params.get(primary_id).cloned()
+    }
+
+    /// Clears all stored submit command params.
+    pub fn clear_submit_params(&mut self) {
+        self.submit_params.clear();
+    }
+
     /// Resets the core to its initial state.
     ///
     /// Note: This clears handler storage but does NOT unsubscribe from msgbus.
@@ -261,6 +288,7 @@ impl ExecutionAlgorithmCore {
         self.exec_spawn_ids.clear();
         self.subscribed_strategies.clear();
         self.pending_spawn_reductions.clear();
+        self.submit_params.clear();
         self.strategy_event_handlers.clear();
     }
 

--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -125,14 +125,18 @@ pub trait ExecutionAlgorithm: DataActor {
         match command {
             TradingCommand::SubmitOrder(cmd) => {
                 self.subscribe_to_strategy_events(cmd.strategy_id);
-                let order = ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
-                    .get_order(&cmd.client_order_id)?;
+                let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+                core.remember_submit_params(cmd.client_order_id, cmd.params.clone());
+                let order = core.get_order(&cmd.client_order_id)?;
                 self.on_order(order)
             }
             TradingCommand::SubmitOrderList(cmd) => {
                 self.subscribe_to_strategy_events(cmd.strategy_id);
-                let orders = ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
-                    .get_orders_for_list(&cmd.order_list)?;
+                let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+                for client_order_id in &cmd.order_list.client_order_ids {
+                    core.remember_submit_params(*client_order_id, cmd.params.clone());
+                }
+                let orders = core.get_orders_for_list(&cmd.order_list)?;
                 self.on_order_list(cmd.order_list, orders)
             }
             TradingCommand::CancelOrder(cmd) => self.handle_cancel_order(cmd),
@@ -675,6 +679,11 @@ pub trait ExecutionAlgorithm: DataActor {
         // For spawned orders, use the parent's strategy ID
         let strategy_id = order.strategy_id();
 
+        let primary_id = order
+            .exec_spawn_id()
+            .unwrap_or_else(|| order.client_order_id());
+        let params = core.submit_params(&primary_id);
+
         let order_exists = {
             let cache = core.cache_ref();
             cache.order_exists(&order.client_order_id())
@@ -699,7 +708,7 @@ pub trait ExecutionAlgorithm: DataActor {
             order.init_event().clone(),
             order.exec_algorithm_id(),
             position_id,
-            None, // params
+            params,
             UUID4::new(),
             ts_init,
             None, // correlation_id
@@ -2257,6 +2266,185 @@ mod tests {
 
         assert_eq!(spawned.quantity, Quantity::from("0.4"));
         assert_eq!(primary.quantity(), Quantity::from("0.6"));
+    }
+    #[rstest]
+    fn test_algorithm_forwards_captured_params_to_spawned_order() {
+        let mut algo = create_test_algorithm();
+        register_algorithm(&mut algo);
+
+        let strategy_id = StrategyId::from("STRAT-FWD-001");
+        let mut primary = OrderAny::Market(MarketOrder::new(
+            TraderId::from("TRADER-001"),
+            strategy_id,
+            InstrumentId::from("BTC/USDT.BINANCE"),
+            ClientOrderId::from("O-FWD-001"),
+            OrderSide::Buy,
+            Quantity::from("1.0"),
+            TimeInForce::Gtc,
+            UUID4::new(),
+            0.into(),
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ));
+        {
+            let cache_rc = algo.core.cache_rc();
+            let mut cache = cache_rc.borrow_mut();
+            cache.add_order(primary.clone(), None, None, true).unwrap();
+        }
+
+        let mut params = nautilus_core::Params::new();
+        params.insert("is_leverage".to_string(), serde_json::Value::Bool(true));
+        let command = SubmitOrder::new(
+            TraderId::from("TRADER-001"),
+            None,
+            strategy_id,
+            primary.instrument_id(),
+            primary.client_order_id(),
+            primary.init_event().clone(),
+            primary.exec_algorithm_id(),
+            None,
+            Some(params),
+            UUID4::new(),
+            0.into(),
+            None,
+        );
+        algo.execute(TradingCommand::SubmitOrder(command)).unwrap();
+
+        let received = Rc::new(RefCell::new(None::<SubmitOrder>));
+        let handler = msgbus::TypedIntoHandler::from({
+            let captured = received.clone();
+            move |cmd: TradingCommand| {
+                if let TradingCommand::SubmitOrder(cmd) = cmd {
+                    *captured.borrow_mut() = Some(cmd);
+                }
+            }
+        });
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_execute(),
+            handler,
+        );
+
+        let spawned = algo.spawn_market(
+            &mut primary,
+            Quantity::from("0.4"),
+            TimeInForce::Ioc,
+            false,
+            None,
+            false, // reduce_primary
+        );
+        algo.submit_order(OrderAny::Market(spawned), None, None)
+            .unwrap();
+
+        let captured = received.borrow();
+        let cmd = captured.as_ref().expect("expected a forwarded SubmitOrder");
+        assert_eq!(cmd.client_order_id, ClientOrderId::from("O-FWD-001-E1"));
+        assert_eq!(
+            cmd.params.as_ref().and_then(|p| p.get_bool("is_leverage")),
+            Some(true),
+        );
+    }
+
+    #[rstest]
+    fn test_algorithm_submit_order_list_captures_params_per_order() {
+        use nautilus_common::messages::execution::SubmitOrderList;
+        use nautilus_model::identifiers::OrderListId;
+
+        let mut algo = create_test_algorithm();
+        register_algorithm(&mut algo);
+
+        let strategy_id = StrategyId::from("STRAT-LIST-001");
+        let order1 = OrderAny::Market(MarketOrder::new(
+            TraderId::from("TRADER-001"),
+            strategy_id,
+            InstrumentId::from("BTC/USDT.BINANCE"),
+            ClientOrderId::from("O-LIST-001"),
+            OrderSide::Buy,
+            Quantity::from("1.0"),
+            TimeInForce::Gtc,
+            UUID4::new(),
+            0.into(),
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ));
+        let order2 = OrderAny::Market(MarketOrder::new(
+            TraderId::from("TRADER-001"),
+            strategy_id,
+            InstrumentId::from("BTC/USDT.BINANCE"),
+            ClientOrderId::from("O-LIST-002"),
+            OrderSide::Buy,
+            Quantity::from("1.0"),
+            TimeInForce::Gtc,
+            UUID4::new(),
+            0.into(),
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ));
+        {
+            let cache_rc = algo.core.cache_rc();
+            let mut cache = cache_rc.borrow_mut();
+            cache.add_order(order1.clone(), None, None, true).unwrap();
+            cache.add_order(order2.clone(), None, None, true).unwrap();
+        }
+
+        let order_list = OrderList::new(
+            OrderListId::from("OL-001"),
+            order1.instrument_id(),
+            strategy_id,
+            vec![order1.client_order_id(), order2.client_order_id()],
+            0.into(),
+        );
+
+        let mut params = nautilus_core::Params::new();
+        params.insert("is_leverage".to_string(), serde_json::Value::Bool(true));
+        let command = SubmitOrderList::new(
+            TraderId::from("TRADER-001"),
+            None,
+            strategy_id,
+            order_list,
+            vec![order1.init_event().clone(), order2.init_event().clone()],
+            order1.exec_algorithm_id(),
+            None,
+            Some(params),
+            UUID4::new(),
+            0.into(),
+            None,
+        );
+        algo.execute(TradingCommand::SubmitOrderList(command))
+            .unwrap();
+
+        for id in ["O-LIST-001", "O-LIST-002"] {
+            assert_eq!(
+                algo.core
+                    .submit_params(&ClientOrderId::from(id))
+                    .and_then(|p| p.get_bool("is_leverage")),
+                Some(true),
+                "expected forwarded params for {id}",
+            );
+        }
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Execution algorithms previously discarded the original submit command's params map, hardcoding None when resubmitting spawned child orders. This change makes ExecutionAlgorithmCore remember the submit params keyed by the primary order's ClientOrderId (for both SubmitOrder and SubmitOrderList) and forward a clone onto each spawned order's submit command.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
