### PR TITLE
Fix nested runtime panic in Parquet catalog queries

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -147,6 +147,7 @@ adapter set. The following limits remain deferred:
 - Fixed v2 `Bar` and `BarSpecification` deserialization to validate OHLC ordering and step periodicity
 - Fixed v2 `Bar.from_pyobject` and bar type parsing at the Python boundary to raise `ValueError` instead of panicking
 - Fixed v2 catalog writes re-labeling mixed instruments or bar types; writes now group or reject them
+- Fixed v2 synchronous Parquet catalog queries panicking in the multi-threaded Rust live runtime
 - Fixed v2 bar-type conversion corrupting `-INTERNAL` symbols and composite bar types
 - Fixed v2 SQL bar decoding to reject invalid rows and composite bar inserts without panicking
 - Fixed v2 external bar unsubscribe detaching the venue stream while other actors remained subscribed

--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -3148,8 +3148,7 @@ impl ParquetDataCatalog {
     where
         F: std::future::Future<Output = anyhow::Result<R>>,
     {
-        let rt = get_runtime();
-        rt.block_on(future)
+        super::block_on(get_runtime().handle(), future)
     }
 
     /// Lists directory stems (directory names without path) in a subdirectory.

--- a/crates/persistence/src/backend/kmerge_batch.rs
+++ b/crates/persistence/src/backend/kmerge_batch.rs
@@ -57,7 +57,7 @@ impl<T> Iterator for EagerStream<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.runtime.block_on(self.rx.recv())
+        super::block_on(&self.runtime, self.rx.recv())
     }
 }
 

--- a/crates/persistence/src/backend/mod.rs
+++ b/crates/persistence/src/backend/mod.rs
@@ -15,6 +15,10 @@
 
 //! Provides an Apache Parquet backend powered by [DataFusion](https://arrow.apache.org/datafusion).
 
+use std::future::Future;
+
+use tokio::runtime::Handle;
+
 pub mod binary_heap;
 pub mod catalog;
 pub mod catalog_operations;
@@ -23,3 +27,19 @@ pub mod custom;
 pub mod feather;
 pub mod kmerge_batch;
 pub mod session;
+
+/// Runs an async operation from a synchronous persistence API.
+///
+/// `block_in_place` permits re-entering the shared multi-thread Nautilus runtime and executes the
+/// closure directly when called outside a Tokio runtime.
+///
+/// # Panics
+///
+/// Panics when called from a Tokio `current_thread` runtime. The shared Nautilus runtime is
+/// required to be multi-threaded.
+pub(crate) fn block_on<F>(runtime: &Handle, future: F) -> F::Output
+where
+    F: Future,
+{
+    tokio::task::block_in_place(|| runtime.block_on(future))
+}

--- a/crates/persistence/src/backend/session.rs
+++ b/crates/persistence/src/backend/session.rs
@@ -179,19 +179,19 @@ impl DataBackendSession {
                 }]],
                 ..Default::default()
             };
-            self.runtime.block_on(self.session_ctx.register_parquet(
-                table_name,
-                file_path,
-                parquet_options,
-            ))?;
+            super::block_on(
+                &self.runtime,
+                self.session_ctx
+                    .register_parquet(table_name, file_path, parquet_options),
+            )?;
 
             self.registered_tables.insert(table_name.to_string());
 
             // Only add batch stream for newly registered tables to avoid duplicates
             let default_query = format!("SELECT * FROM {table_name} ORDER BY ts_init");
             let sql_query = sql_query.unwrap_or(&default_query);
-            let query = self.runtime.block_on(self.session_ctx.sql(sql_query))?;
-            let batch_stream = self.runtime.block_on(query.execute_stream())?;
+            let query = super::block_on(&self.runtime, self.session_ctx.sql(sql_query))?;
+            let batch_stream = super::block_on(&self.runtime, query.execute_stream())?;
             self.add_batch_stream::<T>(batch_stream, custom_type_name.map(String::from));
         }
 
@@ -220,21 +220,21 @@ impl DataBackendSession {
                 }]],
                 ..Default::default()
             };
-            self.runtime.block_on(self.session_ctx.register_parquet(
-                table_name,
-                file_path,
-                parquet_options,
-            ))?;
+            super::block_on(
+                &self.runtime,
+                self.session_ctx
+                    .register_parquet(table_name, file_path, parquet_options),
+            )?;
 
             self.registered_tables.insert(table_name.to_string());
         }
 
         let default_query = format!("SELECT * FROM {table_name} ORDER BY ts_init");
         let sql_query = sql_query.unwrap_or(&default_query);
-        let query = self.runtime.block_on(self.session_ctx.sql(sql_query))?;
-        let mut batch_stream = self.runtime.block_on(query.execute_stream())?;
+        let query = super::block_on(&self.runtime, self.session_ctx.sql(sql_query))?;
+        let mut batch_stream = super::block_on(&self.runtime, query.execute_stream())?;
 
-        self.runtime.block_on(async {
+        super::block_on(&self.runtime, async {
             let mut batches = Vec::new();
             while let Some(batch) = batch_stream.next().await {
                 batches.push(batch?);

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -15,6 +15,7 @@
 
 use std::{collections::HashMap, fs, io::Write, str::FromStr, sync::Arc};
 
+use nautilus_common::live::get_runtime;
 use nautilus_core::{Params, UUID4, UnixNanos};
 use nautilus_model::{
     data::{
@@ -473,6 +474,23 @@ fn test_rust_write_2_bars_to_catalog() {
         .unwrap();
 
     assert_eq!(intervals, vec![(1, 2)]);
+    assert_eq!(loaded, bars);
+}
+
+#[rstest]
+fn test_rust_query_bars_inside_nautilus_runtime() {
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+
+    let bars = vec![create_bar(1), create_bar(2)];
+    catalog.write_to_parquet(&bars, None, None, None).unwrap();
+
+    let loaded = get_runtime().block_on(async {
+        tokio::task::yield_now().await;
+        catalog
+            .bars(Some(vec!["AUD/USD.SIM".to_string()]), None, None)
+            .unwrap()
+    });
+
     assert_eq!(loaded, bars);
 }
 


### PR DESCRIPTION
# Pull Request

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Routes synchronous Parquet catalog query operations through Tokio's `block_in_place(|| handle.block_on(...))` bridge. This prevents catalog-backed historical requests from panicking when called from the multi-threaded Rust `LiveNode` runtime, while preserving the existing synchronous catalog API.

## Related Issues/PRs

Closes #4525 

Relates to #3803 

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Release notes

- [x] I added a concise entry to `RELEASES.md` that follows the existing conventions

## Testing

- [x] I added/updated tests to cover new or changed logic

Added `test_rust_query_bars_inside_nautilus_runtime`, which queries a populated `ParquetDataCatalog` from the shared Nautilus runtime. The test reproduces the nested-runtime panic without the fix and passes with it.