### PR TITLE
Parse min_notional for Bybit spot instruments

### DIFF
--- a/crates/adapters/bybit/src/common/parse.rs
+++ b/crates/adapters/bybit/src/common/parse.rs
@@ -306,6 +306,13 @@ pub fn parse_spot_instrument(
         &definition.lot_size_filter.min_order_qty,
         "lotSizeFilter.minOrderQty",
     )?);
+    let min_notional = Some(Money::from_decimal(
+        parse_decimal(
+            &definition.lot_size_filter.min_order_amt,
+            "lotSizeFilter.minOrderAmt",
+        )?,
+        quote_currency,
+    )?);
 
     let maker_fee = parse_decimal(&fee_rate.maker_fee_rate, "makerFeeRate")?;
     let taker_fee = parse_decimal(&fee_rate.taker_fee_rate, "takerFeeRate")?;
@@ -324,7 +331,7 @@ pub fn parse_spot_instrument(
         max_quantity,
         min_quantity,
         None,
-        None,
+        min_notional,
         None,
         None,
         Some(default_margin()),
@@ -1900,6 +1907,10 @@ mod tests {
                 assert_eq!(pair.size_increment, Quantity::from_str("0.0001").unwrap());
                 assert_eq!(pair.base_currency.code.as_str(), "BTC");
                 assert_eq!(pair.quote_currency.code.as_str(), "USDT");
+                assert_eq!(
+                    pair.min_notional,
+                    Some(Money::from_decimal(Decimal::new(10, 0), Currency::USDT()).unwrap()),
+                );
             }
             _ => panic!("expected CurrencyPair"),
         }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Parse `min_notional` for Bybit spot instruments from the `minOrderAmt` lot-size filter field. Also add the newer lot-size fields returned by the API (`maxLimitOrderQty`, `maxMarketOrderQty`, `postOnlyMaxLimitOrderSize`, and the deprecated `maxOrderAmt`) as optional, following the linear instrument convention.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
