### PR TITLE
Bound live node startup and shutdown by the lifecycle timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6911,6 +6911,7 @@ dependencies = [
  "async-trait",
  "bon",
  "bytes",
+ "futures",
  "indexmap 2.14.0",
  "log",
  "nautilus-common",

--- a/crates/live/src/node/builder.rs
+++ b/crates/live/src/node/builder.rs
@@ -50,7 +50,7 @@ use super::{
     LiveNode,
     config::{
         LiveDataEngineConfig, LiveExecEngineConfig, LiveNodeConfig, LiveRiskEngineConfig,
-        RoutingConfig,
+        RoutingConfig, validate_live_environment,
     },
 };
 use crate::{
@@ -135,12 +135,7 @@ impl LiveNodeBuilder {
     ///
     /// Returns an error if `environment` is invalid (BACKTEST).
     pub fn new(trader_id: TraderId, environment: Environment) -> anyhow::Result<Self> {
-        match environment {
-            Environment::Sandbox | Environment::Live => {}
-            Environment::Backtest => {
-                anyhow::bail!("LiveNode cannot be used with Backtest environment");
-            }
-        }
+        validate_live_environment(environment)?;
 
         let config = LiveNodeConfig {
             environment,
@@ -171,12 +166,7 @@ impl LiveNodeBuilder {
     ///
     /// Returns an error if the config's environment is invalid (BACKTEST).
     pub fn from_config(config: LiveNodeConfig) -> anyhow::Result<Self> {
-        match config.environment {
-            Environment::Sandbox | Environment::Live => {}
-            Environment::Backtest => {
-                anyhow::bail!("LiveNode cannot be used with Backtest environment");
-            }
-        }
+        validate_live_environment(config.environment)?;
 
         Ok(Self {
             name: "LiveNode".to_string(),

--- a/crates/live/src/node/config.rs
+++ b/crates/live/src/node/config.rs
@@ -59,6 +59,15 @@ const DEFAULT_ORDER_RATE_LIMIT: &str = "100/00:00:01";
 const RUST_RUNTIME_UNSUPPORTED: &str = "not supported by the Rust live runtime yet";
 const RATE_LIMIT_FORMAT: &str = "expected 'limit/HH:MM:SS'";
 
+pub(crate) fn validate_live_environment(environment: Environment) -> anyhow::Result<()> {
+    match environment {
+        Environment::Sandbox | Environment::Live => Ok(()),
+        Environment::Backtest => {
+            anyhow::bail!("LiveNode cannot be used with Backtest environment")
+        }
+    }
+}
+
 /// Configuration for live data engines.
 #[cfg_attr(
     feature = "python",

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -137,7 +137,7 @@ pub mod plugin;
 
 use builder::ExternalMessageBusIngress;
 pub use builder::LiveNodeBuilder;
-use config::{LiveNodeConfig, PluginConfig};
+use config::{LiveNodeConfig, PluginConfig, validate_live_environment};
 pub use metrics::{RunnerChannelMetricsSnapshot, RunnerMetricsDelta, RunnerMetricsSnapshot};
 use metrics::{RunnerChannelQueueDepths, RunnerMetricChannel, RunnerMetrics};
 use state::EngineConnectionStatus;
@@ -218,15 +218,8 @@ impl LiveNode {
     ///
     /// Returns an error if kernel construction fails.
     pub fn build(name: String, config: Option<LiveNodeConfig>) -> anyhow::Result<Self> {
-        let mut config = config.unwrap_or_default();
-        config.environment = Environment::Live;
-
-        match config.environment() {
-            Environment::Sandbox | Environment::Live => {}
-            Environment::Backtest => {
-                anyhow::bail!("LiveNode cannot be used with Backtest environment");
-            }
-        }
+        let config = config.unwrap_or_default();
+        validate_live_environment(config.environment())?;
 
         config.validate_runtime_support()?;
 
@@ -394,26 +387,39 @@ impl LiveNode {
             return Ok(());
         }
 
+        let connection_deadline = dst::time::Instant::now() + self.config.timeout_connection;
+
         // Connect data clients first and flush instrument events into cache
-        self.kernel.connect_data_clients().await;
+        if let Err(e) = self.connect_data_phase(connection_deadline).await {
+            return self
+                .abort_startup_with_error("Data client connection timed out", e)
+                .await;
+        }
 
         if let Some(runner) = self.runner.as_mut() {
             runner.flush_pending_data();
         }
 
-        self.kernel.connect_exec_clients().await;
+        if let Err(e) = self.connect_exec_clients(connection_deadline).await {
+            return self
+                .abort_startup_with_error("Execution client connection timed out", e)
+                .await;
+        }
 
         if let Some(reason) = self.startup_abort_reason() {
             self.abort_startup(reason).await?;
             return Ok(());
         }
 
-        match self.await_engines_connected().await {
+        match self.await_engines_connected(connection_deadline).await {
             EngineConnectionStatus::Connected => {}
             EngineConnectionStatus::TimedOut => {
-                log::error!("Cannot start trader: engine client(s) not connected");
-                self.handle.set_state(NodeState::Running);
-                return Ok(());
+                return self
+                    .abort_startup_with_error(
+                        "Engine readiness timed out",
+                        anyhow::anyhow!("readiness timeout while waiting for engine connections"),
+                    )
+                    .await;
             }
             EngineConnectionStatus::StopRequested => {
                 self.abort_startup("Stop signal received during startup")
@@ -583,14 +589,15 @@ impl LiveNode {
     /// Awaits engine clients to connect with timeout.
     ///
     /// Returns the final connection wait status.
-    async fn await_engines_connected(&self) -> EngineConnectionStatus {
+    async fn await_engines_connected(
+        &self,
+        deadline: dst::time::Instant,
+    ) -> EngineConnectionStatus {
         log::info!(
             "Awaiting engine connections ({:?} timeout)...",
             self.config.timeout_connection
         );
 
-        let start = dst::time::Instant::now();
-        let timeout = self.config.timeout_connection;
         let interval = Duration::from_millis(100);
 
         loop {
@@ -609,11 +616,12 @@ impl LiveNode {
                 return EngineConnectionStatus::Connected;
             }
 
-            if start.elapsed() >= timeout {
+            let now = dst::time::Instant::now();
+            if now >= deadline {
                 break;
             }
 
-            dst::time::sleep(interval).await;
+            dst::time::sleep(interval.min(deadline - now)).await;
         }
 
         self.log_connection_status();
@@ -622,28 +630,28 @@ impl LiveNode {
 
     /// Awaits engine clients to disconnect with timeout.
     ///
-    /// Logs an error with client status on timeout but does not fail.
-    async fn await_engines_disconnected(&self) {
+    /// Returns an error with client status on timeout.
+    async fn await_engines_disconnected(&self, deadline: dst::time::Instant) -> anyhow::Result<()> {
         log::info!(
             "Awaiting engine disconnections ({:?} timeout)...",
             self.config.timeout_disconnection
         );
 
-        let start = dst::time::Instant::now();
         let timeout = self.config.timeout_disconnection;
         let interval = Duration::from_millis(100);
 
         loop {
             if self.kernel.check_engines_disconnected() {
                 log::info!("All engine clients disconnected");
-                return;
+                return Ok(());
             }
 
-            if start.elapsed() >= timeout {
+            let now = dst::time::Instant::now();
+            if now >= deadline {
                 break;
             }
 
-            dst::time::sleep(interval).await;
+            dst::time::sleep(interval.min(deadline - now)).await;
         }
 
         log::error!(
@@ -654,6 +662,7 @@ impl LiveNode {
             self.kernel.data_engine().check_disconnected(),
             self.kernel.exec_engine().borrow().check_disconnected(),
         );
+        anyhow::bail!("disconnect readiness timeout while waiting for engine disconnections")
     }
 
     fn log_connection_status(&self) {
@@ -910,13 +919,12 @@ impl LiveNode {
 
         let stop_handle = self.handle.clone();
         let mut pending = PendingEvents::default();
+        let connection_deadline = dst::time::Instant::now() + self.config.timeout_connection;
 
         // Startup phase 1: Connect data clients and drain instrument events into cache.
         // This ensures the cache is populated before execution clients connect.
-        // TODO: Add ctrl_c, stop_handle, and shutdown monitoring here to
-        // allow aborting a hanging connect future.
-        drive_with_event_buffering(
-            self.kernel.connect_data_clients(),
+        let data_connect_result = drive_with_event_buffering(
+            self.connect_data_phase(connection_deadline),
             &mut pending,
             &mut time_evt_rx,
             &mut data_evt_rx,
@@ -925,6 +933,29 @@ impl LiveNode {
             &mut exec_cmd_rx,
         )
         .await;
+
+        if let Err(e) = data_connect_result {
+            flush_all_pending(
+                &mut pending,
+                &mut time_evt_rx,
+                &mut data_evt_rx,
+                &mut data_cmd_rx,
+                &mut exec_evt_rx,
+                &mut exec_cmd_rx,
+            );
+            let result = self
+                .abort_startup_with_error("Data client connection timed out", e)
+                .await;
+            Self::drain_channels(
+                &mut time_evt_rx,
+                &mut data_evt_rx,
+                &mut data_cmd_rx,
+                &mut exec_evt_rx,
+                &mut exec_cmd_rx,
+            );
+            log::info!("Event loop stopped");
+            return result;
+        }
 
         // Flush any data events still queued in the channel receivers that the
         // select loop did not capture before the connect future resolved, then
@@ -936,8 +967,8 @@ impl LiveNode {
         );
 
         // Startup phase 2: Connect execution clients (instruments now in cache)
-        let engine_connection_status = drive_with_event_buffering(
-            self.connect_exec_phase(),
+        let engine_connection_result = drive_with_event_buffering(
+            self.connect_exec_phase(connection_deadline),
             &mut pending,
             &mut time_evt_rx,
             &mut data_evt_rx,
@@ -945,7 +976,7 @@ impl LiveNode {
             &mut exec_evt_rx,
             &mut exec_cmd_rx,
         )
-        .await?;
+        .await;
 
         // Flush channel receivers and drain all remaining pending events
         flush_all_pending(
@@ -960,6 +991,42 @@ impl LiveNode {
             pending.is_empty(),
             "all startup events must be processed before reconciliation",
         );
+
+        let engine_connection_status = match engine_connection_result {
+            Ok(status) => status,
+            Err(e) => {
+                let result = self
+                    .abort_startup_with_error("Execution client connection timed out", e)
+                    .await;
+                Self::drain_channels(
+                    &mut time_evt_rx,
+                    &mut data_evt_rx,
+                    &mut data_cmd_rx,
+                    &mut exec_evt_rx,
+                    &mut exec_cmd_rx,
+                );
+                log::info!("Event loop stopped");
+                return result;
+            }
+        };
+
+        if engine_connection_status == EngineConnectionStatus::TimedOut {
+            let result = self
+                .abort_startup_with_error(
+                    "Engine readiness timed out",
+                    anyhow::anyhow!("readiness timeout while waiting for engine connections"),
+                )
+                .await;
+            Self::drain_channels(
+                &mut time_evt_rx,
+                &mut data_evt_rx,
+                &mut data_cmd_rx,
+                &mut exec_evt_rx,
+                &mut exec_cmd_rx,
+            );
+            log::info!("Event loop stopped");
+            return result;
+        }
 
         if let Some(reason) = engine_connection_status
             .abort_reason()
@@ -977,55 +1044,53 @@ impl LiveNode {
             return Ok(());
         }
 
-        if engine_connection_status == EngineConnectionStatus::Connected {
-            // Run reconciliation now that instruments are in cache and start trader
-            if let Err(e) = self.perform_startup_reconciliation().await {
-                let result = self.abort_startup("Startup reconciliation failed").await;
-                Self::drain_channels(
-                    &mut time_evt_rx,
-                    &mut data_evt_rx,
-                    &mut data_cmd_rx,
-                    &mut exec_evt_rx,
-                    &mut exec_cmd_rx,
+        debug_assert_eq!(engine_connection_status, EngineConnectionStatus::Connected);
+
+        // Run reconciliation now that instruments are in cache and start trader
+        if let Err(e) = self.perform_startup_reconciliation().await {
+            let result = self.abort_startup("Startup reconciliation failed").await;
+            Self::drain_channels(
+                &mut time_evt_rx,
+                &mut data_evt_rx,
+                &mut data_cmd_rx,
+                &mut exec_evt_rx,
+                &mut exec_cmd_rx,
+            );
+            log::info!("Event loop stopped");
+
+            if let Err(finalize_err) = result {
+                anyhow::bail!(
+                    "startup reconciliation failed: {e}; failed to finalize startup abort: {finalize_err}"
                 );
-                log::info!("Event loop stopped");
-
-                if let Err(finalize_err) = result {
-                    anyhow::bail!(
-                        "startup reconciliation failed: {e}; failed to finalize startup abort: {finalize_err}"
-                    );
-                }
-
-                return Err(e);
             }
 
-            if let Err(e) = self.kernel.start_trader() {
-                let result = self.abort_after_trader_start_failure(e).await;
-                Self::drain_channels(
-                    &mut time_evt_rx,
-                    &mut data_evt_rx,
-                    &mut data_cmd_rx,
-                    &mut exec_evt_rx,
-                    &mut exec_cmd_rx,
-                );
-                log::info!("Event loop stopped");
-                return result;
-            }
-            #[cfg(feature = "plugin")]
-            if let Err(e) = self.plugins.start_controllers() {
-                let result = self.abort_after_trader_start_failure(e).await;
-                Self::drain_channels(
-                    &mut time_evt_rx,
-                    &mut data_evt_rx,
-                    &mut data_cmd_rx,
-                    &mut exec_evt_rx,
-                    &mut exec_cmd_rx,
-                );
-                log::info!("Event loop stopped");
-                return result;
-            }
-        } else {
-            log::error!("Not starting trader: engine client(s) not connected");
+            return Err(e);
+        }
+
+        if let Err(e) = self.kernel.start_trader() {
+            let result = self.abort_after_trader_start_failure(e).await;
+            Self::drain_channels(
+                &mut time_evt_rx,
+                &mut data_evt_rx,
+                &mut data_cmd_rx,
+                &mut exec_evt_rx,
+                &mut exec_cmd_rx,
+            );
+            log::info!("Event loop stopped");
+            return result;
+        }
+        #[cfg(feature = "plugin")]
+        if let Err(e) = self.plugins.start_controllers() {
+            let result = self.abort_after_trader_start_failure(e).await;
+            Self::drain_channels(
+                &mut time_evt_rx,
+                &mut data_evt_rx,
+                &mut data_cmd_rx,
+                &mut exec_evt_rx,
+                &mut exec_cmd_rx,
+            );
+            log::info!("Event loop stopped");
+            return result;
         }
 
         self.handle.set_state(NodeState::Running);
@@ -1601,13 +1666,35 @@ impl LiveNode {
         }
     }
 
+    async fn connect_data_phase(&mut self, deadline: dst::time::Instant) -> anyhow::Result<()> {
+        // A zero remaining budget still admits an immediately-ready connect (an
+        // empty/ready client set completes on the first poll); a pending connect
+        // fails closed on that same poll. This keeps a zero `timeout_connection`
+        // - a supported "do not wait, but allow ready work" configuration -
+        // working, while still bounding a hung connect.
+        let remaining = deadline.saturating_duration_since(dst::time::Instant::now());
+        dst::time::timeout(remaining, self.kernel.connect_data_clients())
+            .await
+            .map_err(|_| anyhow::anyhow!("data-connect timeout"))
+    }
+
+    async fn connect_exec_clients(&mut self, deadline: dst::time::Instant) -> anyhow::Result<()> {
+        let remaining = deadline.saturating_duration_since(dst::time::Instant::now());
+        dst::time::timeout(remaining, self.kernel.connect_exec_clients())
+            .await
+            .map_err(|_| anyhow::anyhow!("exec-connect timeout"))
+    }
+
     /// Connects execution clients and checks all engines are connected.
     ///
     /// Returns the final connection wait status.
     /// Must be called after data clients are connected and instrument events drained.
-    async fn connect_exec_phase(&mut self) -> anyhow::Result<EngineConnectionStatus> {
-        self.kernel.connect_exec_clients().await;
-        Ok(self.await_engines_connected().await)
+    async fn connect_exec_phase(
+        &mut self,
+        deadline: dst::time::Instant,
+    ) -> anyhow::Result<EngineConnectionStatus> {
+        self.connect_exec_clients(deadline).await?;
+        Ok(self.await_engines_connected(deadline).await)
     }
 
     fn startup_abort_reason(&self) -> Option<&'static str> {
@@ -1624,6 +1711,19 @@ impl LiveNode {
         log::info!("{reason}, aborting startup");
         self.handle.set_state(NodeState::ShuttingDown);
         self.finalize_stop().await
+    }
+
+    async fn abort_startup_with_error(
+        &mut self,
+        reason: &str,
+        startup_err: anyhow::Error,
+    ) -> anyhow::Result<()> {
+        match self.abort_startup(reason).await {
+            Ok(()) => Err(startup_err),
+            Err(finalize_err) => {
+                anyhow::bail!("{startup_err}; failed to finalize startup abort: {finalize_err}")
+            }
+        }
     }
 
     async fn abort_after_trader_start_failure(
@@ -1668,17 +1768,33 @@ impl LiveNode {
     async fn finalize_stop(&mut self) -> anyhow::Result<()> {
         self.close_external_ingress();
 
-        let disconnect_result = self.kernel.disconnect_clients().await;
+        let timeout = self.config.timeout_disconnection;
+        let deadline = dst::time::Instant::now() + timeout;
+        let disconnect_result =
+            match dst::time::timeout(timeout, self.kernel.disconnect_clients()).await {
+                Ok(result) => result,
+                Err(_) => Err(anyhow::anyhow!(
+                    "disconnect timeout while disconnecting clients"
+                )),
+            };
+
         if let Err(ref e) = disconnect_result {
             log::error!("Error disconnecting clients: {e}");
         }
 
-        self.await_engines_disconnected().await;
+        let readiness_result = self.await_engines_disconnected(deadline).await;
         self.kernel.finalize_stop().await;
 
         self.handle.set_state(NodeState::Stopped);
 
-        disconnect_result
+        match (disconnect_result, readiness_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(disconnect_err), Ok(())) => Err(disconnect_err),
+            (Ok(()), Err(readiness_err)) => Err(readiness_err),
+            (Err(disconnect_err), Err(readiness_err)) => anyhow::bail!(
+                "{disconnect_err}; failed while awaiting engine disconnection: {readiness_err}"
+            ),
+        }
     }
 
     fn drain_channels(
@@ -3895,7 +4011,8 @@ mod tests {
 
         handle.stop();
 
-        let status = node.await_engines_connected().await;
+        let deadline = dst::time::Instant::now() + Duration::from_secs(1);
+        let status = node.await_engines_connected(deadline).await;
 
         assert_eq!(status, EngineConnectionStatus::StopRequested);
         assert!(handle.should_stop());
@@ -3908,7 +4025,8 @@ mod tests {
 
         node.kernel().shutdown_flag().set(true);
 
-        let status = node.await_engines_connected().await;
+        let deadline = dst::time::Instant::now() + Duration::from_secs(1);
+        let status = node.await_engines_connected(deadline).await;
 
         assert_eq!(status, EngineConnectionStatus::ShutdownRequested);
     }

--- a/crates/live/tests/node.rs
+++ b/crates/live/tests/node.rs
@@ -267,6 +267,23 @@ mod serial_tests {
         disconnect_attempted: Arc<AtomicBool>,
     }
 
+    #[derive(Clone, Debug, Default)]
+    struct LifecycleClientState {
+        connected: Arc<AtomicBool>,
+        connect_attempted: Arc<AtomicBool>,
+        disconnect_attempted: Arc<AtomicBool>,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum LifecycleClientBehavior {
+        Connects,
+        ConnectPending,
+        ReadinessPending,
+        ConnectDelayedReadinessPending,
+        DisconnectPending,
+        DisconnectKeepsConnected,
+    }
+
     #[derive(Clone, Copy, Debug)]
     enum StartupMassStatusBehavior {
         Unavailable,
@@ -281,6 +298,16 @@ mod serial_tests {
 
     struct FailingDisconnectDataClient {
         state: FailingDisconnectDataClientState,
+    }
+
+    struct LifecycleDataClient {
+        state: LifecycleClientState,
+        behavior: LifecycleClientBehavior,
+    }
+
+    struct LifecycleExecutionClient {
+        state: LifecycleClientState,
+        behavior: LifecycleClientBehavior,
     }
 
     impl StartupMassStatusExecutionClient {
@@ -305,6 +332,12 @@ mod serial_tests {
     #[derive(Debug)]
     struct FailingDisconnectDataClientConfig;
 
+    #[derive(Debug)]
+    struct LifecycleDataClientConfig;
+
+    #[derive(Debug)]
+    struct LifecycleExecutionClientConfig;
+
     impl ClientConfig for StartupMassStatusExecutionClientConfig {
         fn as_any(&self) -> &dyn std::any::Any {
             self
@@ -312,6 +345,18 @@ mod serial_tests {
     }
 
     impl ClientConfig for FailingDisconnectDataClientConfig {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl ClientConfig for LifecycleDataClientConfig {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl ClientConfig for LifecycleExecutionClientConfig {
         fn as_any(&self) -> &dyn std::any::Any {
             self
         }
@@ -328,6 +373,18 @@ mod serial_tests {
         state: FailingDisconnectDataClientState,
     }
 
+    #[derive(Debug)]
+    struct LifecycleDataClientFactory {
+        state: LifecycleClientState,
+        behavior: LifecycleClientBehavior,
+    }
+
+    #[derive(Debug)]
+    struct LifecycleExecutionClientFactory {
+        state: LifecycleClientState,
+        behavior: LifecycleClientBehavior,
+    }
+
     impl StartupMassStatusExecutionClientFactory {
         fn new(state: StartupMassStatusClientState, behavior: StartupMassStatusBehavior) -> Self {
             Self { state, behavior }
@@ -337,6 +394,18 @@ mod serial_tests {
     impl FailingDisconnectDataClientFactory {
         fn new(state: FailingDisconnectDataClientState) -> Self {
             Self { state }
+        }
+    }
+
+    impl LifecycleDataClientFactory {
+        fn new(state: LifecycleClientState, behavior: LifecycleClientBehavior) -> Self {
+            Self { state, behavior }
+        }
+    }
+
+    impl LifecycleExecutionClientFactory {
+        fn new(state: LifecycleClientState, behavior: LifecycleClientBehavior) -> Self {
+            Self { state, behavior }
         }
     }
 
@@ -384,6 +453,51 @@ mod serial_tests {
         }
     }
 
+    impl DataClientFactory for LifecycleDataClientFactory {
+        fn create(
+            &self,
+            _name: &str,
+            _config: &dyn ClientConfig,
+            _cache: CacheView,
+            _clock: Rc<RefCell<dyn Clock>>,
+        ) -> anyhow::Result<Box<dyn DataClient>> {
+            Ok(Box::new(LifecycleDataClient {
+                state: self.state.clone(),
+                behavior: self.behavior,
+            }))
+        }
+
+        fn name(&self) -> &'static str {
+            "lifecycle-data"
+        }
+
+        fn config_type(&self) -> &'static str {
+            stringify!(LifecycleDataClientConfig)
+        }
+    }
+
+    impl ExecutionClientFactory for LifecycleExecutionClientFactory {
+        fn create(
+            &self,
+            _name: &str,
+            _config: &dyn ClientConfig,
+            _cache: CacheView,
+        ) -> anyhow::Result<Box<dyn ExecutionClient>> {
+            Ok(Box::new(LifecycleExecutionClient {
+                state: self.state.clone(),
+                behavior: self.behavior,
+            }))
+        }
+
+        fn name(&self) -> &'static str {
+            "lifecycle-exec"
+        }
+
+        fn config_type(&self) -> &'static str {
+            stringify!(LifecycleExecutionClientConfig)
+        }
+    }
+
     #[async_trait(?Send)]
     impl DataClient for FailingDisconnectDataClient {
         fn client_id(&self) -> ClientId {
@@ -423,6 +537,81 @@ mod serial_tests {
                 .disconnect_attempted
                 .store(true, Ordering::Relaxed);
             anyhow::bail!("simulated data client disconnect failure")
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl DataClient for LifecycleDataClient {
+        fn client_id(&self) -> ClientId {
+            ClientId::from("LIFECYCLE-DATA")
+        }
+
+        fn venue(&self) -> Option<Venue> {
+            None
+        }
+
+        fn start(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn reset(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn dispose(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn is_connected(&self) -> bool {
+            self.state.connected.load(Ordering::Relaxed)
+        }
+
+        fn is_disconnected(&self) -> bool {
+            !self.state.connected.load(Ordering::Relaxed)
+        }
+
+        async fn connect(&mut self) -> anyhow::Result<()> {
+            self.state.connect_attempted.store(true, Ordering::Relaxed);
+
+            match self.behavior {
+                LifecycleClientBehavior::ConnectPending => {
+                    std::future::pending::<anyhow::Result<()>>().await
+                }
+                LifecycleClientBehavior::ReadinessPending => Ok(()),
+                LifecycleClientBehavior::ConnectDelayedReadinessPending => {
+                    dst::time::sleep(Duration::from_millis(25)).await;
+                    Ok(())
+                }
+                LifecycleClientBehavior::Connects
+                | LifecycleClientBehavior::DisconnectPending
+                | LifecycleClientBehavior::DisconnectKeepsConnected => {
+                    self.state.connected.store(true, Ordering::Relaxed);
+                    Ok(())
+                }
+            }
+        }
+
+        async fn disconnect(&mut self) -> anyhow::Result<()> {
+            self.state
+                .disconnect_attempted
+                .store(true, Ordering::Relaxed);
+
+            if matches!(self.behavior, LifecycleClientBehavior::DisconnectPending) {
+                return std::future::pending::<anyhow::Result<()>>().await;
+            }
+
+            if matches!(
+                self.behavior,
+                LifecycleClientBehavior::DisconnectKeepsConnected
+            ) {
+                return Ok(());
+            }
+            self.state.connected.store(false, Ordering::Relaxed);
+            Ok(())
         }
     }
 
@@ -522,6 +711,149 @@ mod serial_tests {
                 }
             }
         }
+    }
+
+    #[async_trait(?Send)]
+    impl ExecutionClient for LifecycleExecutionClient {
+        fn is_connected(&self) -> bool {
+            self.state.connected.load(Ordering::Relaxed)
+        }
+
+        fn client_id(&self) -> ClientId {
+            ClientId::from("LIFECYCLE-EXEC")
+        }
+
+        fn account_id(&self) -> AccountId {
+            AccountId::from("LIFECYCLE-EXEC-001")
+        }
+
+        fn venue(&self) -> Venue {
+            crypto_perpetual_ethusdt().id().venue
+        }
+
+        fn oms_type(&self) -> OmsType {
+            OmsType::Hedging
+        }
+
+        fn get_account(&self) -> Option<AccountAny> {
+            None
+        }
+
+        fn generate_account_state(
+            &self,
+            _balances: Vec<AccountBalance>,
+            _margins: Vec<MarginBalance>,
+            _reported: bool,
+            _ts_event: UnixNanos,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn start(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn connect(&mut self) -> anyhow::Result<()> {
+            self.state.connect_attempted.store(true, Ordering::Relaxed);
+
+            match self.behavior {
+                LifecycleClientBehavior::ConnectPending => {
+                    std::future::pending::<anyhow::Result<()>>().await
+                }
+                LifecycleClientBehavior::ReadinessPending => Ok(()),
+                LifecycleClientBehavior::ConnectDelayedReadinessPending => {
+                    dst::time::sleep(Duration::from_millis(25)).await;
+                    Ok(())
+                }
+                LifecycleClientBehavior::Connects
+                | LifecycleClientBehavior::DisconnectPending
+                | LifecycleClientBehavior::DisconnectKeepsConnected => {
+                    self.state.connected.store(true, Ordering::Relaxed);
+                    Ok(())
+                }
+            }
+        }
+
+        async fn disconnect(&mut self) -> anyhow::Result<()> {
+            self.state
+                .disconnect_attempted
+                .store(true, Ordering::Relaxed);
+
+            if matches!(self.behavior, LifecycleClientBehavior::DisconnectPending) {
+                return std::future::pending::<anyhow::Result<()>>().await;
+            }
+
+            if matches!(
+                self.behavior,
+                LifecycleClientBehavior::DisconnectKeepsConnected
+            ) {
+                return Ok(());
+            }
+            self.state.connected.store(false, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    fn live_node_with_lifecycle_clients(
+        name: &str,
+        data_behavior: LifecycleClientBehavior,
+        exec_behavior: LifecycleClientBehavior,
+    ) -> (LiveNode, LifecycleClientState, LifecycleClientState) {
+        live_node_with_lifecycle_clients_timeout(
+            name,
+            data_behavior,
+            exec_behavior,
+            Duration::from_millis(50),
+        )
+    }
+
+    fn live_node_with_lifecycle_clients_timeout(
+        name: &str,
+        data_behavior: LifecycleClientBehavior,
+        exec_behavior: LifecycleClientBehavior,
+        timeout_connection: Duration,
+    ) -> (LiveNode, LifecycleClientState, LifecycleClientState) {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection,
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let data_state = LifecycleClientState::default();
+        let exec_state = LifecycleClientState::default();
+        let node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name(name)
+            .add_data_client(
+                Some("lifecycle-data".to_string()),
+                Box::new(LifecycleDataClientFactory::new(
+                    data_state.clone(),
+                    data_behavior,
+                )),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .unwrap()
+            .add_exec_client(
+                Some("lifecycle-exec".to_string()),
+                Box::new(LifecycleExecutionClientFactory::new(
+                    exec_state.clone(),
+                    exec_behavior,
+                )),
+                Box::new(LifecycleExecutionClientConfig),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+
+        (node, data_state, exec_state)
     }
 
     struct BlockingReportExecutionClient {
@@ -747,7 +1079,7 @@ mod serial_tests {
     }
 
     #[rstest]
-    fn test_live_node_build_overrides_environment_to_live() {
+    fn test_live_node_build_preserves_sandbox_environment() {
         let config = LiveNodeConfig {
             environment: Environment::Sandbox,
             trader_id: TraderId::from("TESTER-001"),
@@ -756,9 +1088,24 @@ mod serial_tests {
 
         let node = LiveNode::build("TestNode".to_string(), Some(config)).unwrap();
 
-        // Environment is overridden to Live when using build()
-        assert_eq!(node.environment(), Environment::Live);
+        assert_eq!(node.environment(), Environment::Sandbox);
         assert_eq!(node.trader_id(), TraderId::from("TESTER-001"));
+    }
+
+    #[rstest]
+    fn test_live_node_build_rejects_backtest_environment() {
+        let config = LiveNodeConfig {
+            environment: Environment::Backtest,
+            ..Default::default()
+        };
+
+        let err = LiveNode::build("TestNode".to_string(), Some(config))
+            .expect_err("build should reject Backtest");
+
+        assert!(
+            err.to_string().contains("Backtest"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[rstest]
@@ -900,6 +1247,364 @@ mod serial_tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Not running"));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_start_hung_data_connect_times_out_fail_closed() {
+        let (mut node, data_state, exec_state) = live_node_with_lifecycle_clients(
+            "StartHungDataConnectNode",
+            LifecycleClientBehavior::ConnectPending,
+            LifecycleClientBehavior::Connects,
+        );
+        let handle = node.handle();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.start())
+            .await
+            .expect("start should finish within the lifecycle timeout");
+        let err = result.expect_err("start should fail on a data-connect timeout");
+
+        assert!(
+            err.to_string().contains("data-connect"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+        assert!(data_state.connect_attempted.load(Ordering::Relaxed));
+        assert!(data_state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(!exec_state.connect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(flavor = "current_thread", start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_run_hung_data_connect_times_out_fail_closed() {
+        let (mut node, data_state, exec_state) = live_node_with_lifecycle_clients(
+            "RunHungDataConnectNode",
+            LifecycleClientBehavior::ConnectPending,
+            LifecycleClientBehavior::Connects,
+        );
+        let handle = node.handle();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.run())
+            .await
+            .expect("run should finish within the lifecycle timeout");
+        let err = result.expect_err("run should fail on a data-connect timeout");
+
+        assert!(
+            err.to_string().contains("data-connect"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+        assert!(data_state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(!exec_state.connect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_start_hung_exec_connect_times_out_fail_closed() {
+        let (mut node, _data_state, exec_state) = live_node_with_lifecycle_clients(
+            "StartHungExecConnectNode",
+            LifecycleClientBehavior::Connects,
+            LifecycleClientBehavior::ConnectPending,
+        );
+        let handle = node.handle();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.start())
+            .await
+            .expect("start should finish within the lifecycle timeout");
+        let err = result.expect_err("start should fail on an exec-connect timeout");
+
+        assert!(
+            err.to_string().contains("exec-connect"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+        assert!(exec_state.connect_attempted.load(Ordering::Relaxed));
+        assert!(exec_state.disconnect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(flavor = "current_thread", start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_run_hung_exec_connect_times_out_fail_closed() {
+        let (mut node, _data_state, exec_state) = live_node_with_lifecycle_clients(
+            "RunHungExecConnectNode",
+            LifecycleClientBehavior::Connects,
+            LifecycleClientBehavior::ConnectPending,
+        );
+        let handle = node.handle();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.run())
+            .await
+            .expect("run should finish within the lifecycle timeout");
+        let err = result.expect_err("run should fail on an exec-connect timeout");
+
+        assert!(
+            err.to_string().contains("exec-connect"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+        assert!(exec_state.disconnect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_start_readiness_timeout_fails_closed() {
+        let (mut node, data_state, exec_state) = live_node_with_lifecycle_clients(
+            "StartReadinessTimeoutNode",
+            LifecycleClientBehavior::ReadinessPending,
+            LifecycleClientBehavior::Connects,
+        );
+        let handle = node.handle();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.start())
+            .await
+            .expect("start should finish within the lifecycle timeout");
+        let err = result.expect_err("start should fail on a readiness timeout");
+
+        assert!(
+            err.to_string().contains("readiness"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+        assert!(data_state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(exec_state.disconnect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(flavor = "current_thread", start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_run_readiness_timeout_fails_closed() {
+        let (mut node, data_state, exec_state) = live_node_with_lifecycle_clients(
+            "RunReadinessTimeoutNode",
+            LifecycleClientBehavior::ReadinessPending,
+            LifecycleClientBehavior::Connects,
+        );
+        let handle = node.handle();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.run())
+            .await
+            .expect("run should finish within the lifecycle timeout");
+        let err = result.expect_err("run should fail on a readiness timeout");
+
+        assert!(
+            err.to_string().contains("readiness"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+        assert!(data_state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(exec_state.disconnect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_zero_timeout_connection_starts_without_clients() {
+        // A zero `timeout_connection` with no clients must still start: the empty
+        // connect completes on the first poll. Regression for the pre-stage bail
+        // that rejected a zero budget before ever attempting the connect.
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::ZERO,
+            timeout_disconnection: Duration::ZERO,
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("ZeroTimeoutNoClientsNode".to_string(), Some(config)).unwrap();
+        let handle = node.handle();
+
+        node.start().await.unwrap();
+        assert_eq!(handle.state(), NodeState::Running);
+
+        node.stop().await.unwrap();
+        assert_eq!(handle.state(), NodeState::Stopped);
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_zero_timeout_connection_still_bounds_hung_data_connect() {
+        // Zero `timeout_connection` must still fail closed on a hung connect: the
+        // bound is not disabled by a zero budget.
+        let (mut node, data_state, _exec_state) = live_node_with_lifecycle_clients_timeout(
+            "ZeroTimeoutHungConnectNode",
+            LifecycleClientBehavior::ConnectPending,
+            LifecycleClientBehavior::Connects,
+            Duration::ZERO,
+        );
+        let handle = node.handle();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.start())
+            .await
+            .expect("start should finish within the lifecycle timeout");
+        let err = result.expect_err("start should fail on a data-connect timeout");
+
+        assert!(
+            err.to_string().contains("data-connect"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+        assert!(data_state.connect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(flavor = "current_thread", start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_run_zero_timeout_connection_still_bounds_hung_data_connect() {
+        let (mut node, data_state, _exec_state) = live_node_with_lifecycle_clients_timeout(
+            "RunZeroTimeoutHungConnectNode",
+            LifecycleClientBehavior::ConnectPending,
+            LifecycleClientBehavior::Connects,
+            Duration::ZERO,
+        );
+        let handle = node.handle();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.run())
+            .await
+            .expect("run should finish within the lifecycle timeout");
+        let err = result.expect_err("run should fail on a data-connect timeout");
+
+        assert!(
+            err.to_string().contains("data-connect"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+        // The connect was polled (attempt marked) before the zero-budget timeout,
+        // distinguishing the fix from the old pre-stage bail that never polled.
+        assert!(data_state.connect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_start_readiness_timeout_uses_shared_connection_budget() {
+        let (mut node, _data_state, _exec_state) = live_node_with_lifecycle_clients(
+            "SharedConnectionBudgetNode",
+            LifecycleClientBehavior::ConnectDelayedReadinessPending,
+            LifecycleClientBehavior::Connects,
+        );
+        let handle = node.handle();
+        let started_at = dst::time::Instant::now();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.start())
+            .await
+            .expect("start should finish within the lifecycle timeout");
+        let elapsed = dst::time::Instant::now() - started_at;
+        let err = result.expect_err("start should fail on a readiness timeout");
+
+        assert!(
+            err.to_string().contains("readiness"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            elapsed <= Duration::from_millis(60),
+            "readiness timeout exceeded the shared 50ms connection budget: {elapsed:?}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(!handle.is_running());
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_stop_fails_when_disconnect_readiness_poll_times_out() {
+        let (mut node, data_state, _exec_state) = live_node_with_lifecycle_clients(
+            "DisconnectReadinessPollNode",
+            LifecycleClientBehavior::DisconnectKeepsConnected,
+            LifecycleClientBehavior::Connects,
+        );
+        let handle = node.handle();
+        node.start().await.unwrap();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.stop())
+            .await
+            .expect("stop should finish within the lifecycle timeout");
+        let err = result.expect_err("stop should fail on a disconnect readiness timeout");
+
+        assert!(
+            err.to_string().contains("disconnect readiness"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(data_state.disconnect_attempted.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[cfg_attr(
+        not(all(feature = "simulation", madsim)),
+        tokio::test(start_paused = true)
+    )]
+    #[cfg_attr(all(feature = "simulation", madsim), madsim::test)]
+    async fn test_hung_data_disconnect_still_attempts_execution_disconnect() {
+        let (mut node, data_state, exec_state) = live_node_with_lifecycle_clients(
+            "HungDataDisconnectNode",
+            LifecycleClientBehavior::DisconnectPending,
+            LifecycleClientBehavior::Connects,
+        );
+        let handle = node.handle();
+        node.start().await.unwrap();
+
+        let result = dst::time::timeout(Duration::from_millis(200), node.stop())
+            .await
+            .expect("stop should finish within the lifecycle timeout");
+        let err = result.expect_err("stop should fail on a disconnect timeout");
+
+        assert!(
+            err.to_string().contains("disconnect"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(handle.state(), NodeState::Stopped);
+        assert!(data_state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(exec_state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(!exec_state.connected.load(Ordering::Relaxed));
     }
 
     #[rstest]

--- a/crates/system/Cargo.toml
+++ b/crates/system/Cargo.toml
@@ -61,6 +61,7 @@ nautilus-persistence = { workspace = true, optional = true }
 ahash = { workspace = true }
 anyhow = { workspace = true }
 bon = { workspace = true }
+futures = { workspace = true }
 indexmap = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }

--- a/crates/system/src/kernel.rs
+++ b/crates/system/src/kernel.rs
@@ -879,8 +879,10 @@ impl NautilusKernel {
     #[expect(clippy::await_holding_refcell_ref)] // Single-threaded runtime, intentional design
     pub async fn disconnect_clients(&mut self) -> anyhow::Result<()> {
         log::info!("Disconnecting clients...");
-        let data_result = self.data_engine.borrow_mut().disconnect().await;
-        let exec_result = self.exec_engine.borrow_mut().disconnect().await;
+        let mut data_engine = self.data_engine.borrow_mut();
+        let mut exec_engine = self.exec_engine.borrow_mut();
+        let (data_result, exec_result) =
+            futures::join!(data_engine.disconnect(), exec_engine.disconnect());
 
         match (data_result, exec_result) {
             (Ok(()), Ok(())) => Ok(()),


### PR DESCRIPTION
A follow-up to the live-node work behind the reconciliation series (#4479, #4517, #4518, #4521, #4522, #4523), hardening the node's startup and shutdown lifecycle against hung adapters and a false-success timeout path.

## Client connect and disconnect are awaited outside the lifecycle timeouts

The kernel `connect_data_clients`, `connect_exec_clients`, and `disconnect_clients` await the underlying engine future with no bound. Only the `check_connected`/`check_disconnected` poll loops (`await_engines_connected`, `await_engines_disconnected`) were bounded, by `timeout_connection` and `timeout_disconnection`. In `start()` the connect calls were bare awaits ahead of that poll; in `run()` they were driven through `drive_with_event_buffering`, which has no timeout arm (an in-code `TODO` acknowledged the gap); `finalize_stop` awaited `disconnect_clients` bare. A pending adapter connect or disconnect future therefore hangs startup or shutdown indefinitely - the poll meant to bound it never runs.

The fix treats `timeout_connection` as a single deadline spanning data connect, instrument flush, execution connect, and the engine-connected poll: each connect future is wrapped in `dst::time::timeout` against the remaining budget, and the readiness poll shares that same deadline rather than restarting a fresh one. `finalize_stop` bounds `disconnect_clients` and the disconnected-readiness poll under one shared `timeout_disconnection` deadline and always finalizes the kernel locally. `disconnect_clients` now disconnects the data and execution engines concurrently, so a hung data disconnect no longer prevents execution teardown from being attempted. This bounds how long the node waits and how it reports the outcome; it does not retrofit cancellation-safety onto the adapter `connect`/`disconnect` contract, so an adapter that records transport state only after setting its connected flag can still retain that state if its connect future is dropped mid-flight - a separate follow-up.

## A connection timeout reports the node as running

On a readiness timeout `await_engines_connected` returns `TimedOut`. `start()` logged an error, set `NodeState::Running`, and returned `Ok(())`; `run()` logged "Not starting trader" and then unconditionally set `Running`. The trader never started, yet the node's externally observable state was `Running` and the call reported success. `EngineConnectionStatus::abort_reason()` also excluded `TimedOut`, so the `run()` path treated the timeout as a benign non-abort.

A connect or readiness timeout now fails closed: it aborts startup, disconnects and finalizes the kernel, sets the local state to `Stopped`, and returns an error naming the stage that timed out (data connect, execution connect, or readiness). The node never publishes `Running` on a timeout. Intentional stop and shutdown requests observed during startup keep their existing behavior (abort and return `Ok`).

## LiveNode::build validates the environment after overwriting it

`LiveNode::build` assigned `config.environment = Environment::Live` before the match that validates it. A caller-supplied `Sandbox` was silently promoted to `Live`, and the `Backtest` rejection branch was unreachable. The builder entry points (`LiveNodeBuilder::new`, `from_config`) already validate the incoming environment without overwriting; only `build` had the ordering wrong.

`build` no longer overwrites the environment; it validates the incoming value through a shared `validate_live_environment` helper that the builder paths also call, so the two cannot drift apart. `LiveNodeConfig::default()` is already `Live`, so a `None` config still yields `Live`, a supplied `Sandbox` is preserved, and a supplied `Backtest` is rejected.

## Testing

`test_start_hung_data_connect_times_out_fail_closed`, `test_run_hung_data_connect_times_out_fail_closed`, `test_start_hung_exec_connect_times_out_fail_closed`, `test_run_hung_exec_connect_times_out_fail_closed`: a data or execution client whose `connect()` never resolves; `start()` and `run()` return an error naming the connect stage within `timeout_connection`, the node ends `Stopped` and never `Running`, and disconnect is attempted. These fail against the unfixed code, where the bare connect await hangs forever.

`test_start_readiness_timeout_fails_closed`, `test_run_readiness_timeout_fails_closed`: `connect()` returns but the engine never reports connected; the readiness poll times out and both entry points fail closed to `Stopped`. These fail against the unfixed code, which set `Running` and returned success.

`test_start_readiness_timeout_uses_shared_connection_budget`: a connect that consumes part of `timeout_connection` followed by a never-ready engine; the total virtual elapsed time stays within the single connection budget rather than the connect delay plus a restarted readiness timeout. This pins the shared-deadline property.

`test_hung_data_disconnect_still_attempts_execution_disconnect`: a data client whose `disconnect()` never resolves; execution disconnect is still attempted, the shutdown is bounded by `timeout_disconnection`, and the node finalizes to `Stopped`. This fails against a sequential disconnect, where the hung data disconnect blocks execution teardown.

`test_stop_fails_when_disconnect_readiness_poll_times_out`: a client whose `disconnect()` returns `Ok` but stays connected; the disconnected-readiness poll times out and `stop()` returns an error while the node still finalizes to `Stopped`. This fails against the unfixed code, where the poll logged a timeout but returned success.

`test_live_node_build_preserves_sandbox_environment`, `test_live_node_build_rejects_backtest_environment`: `build` keeps a `Sandbox` config and rejects `Backtest`; the former replaces an earlier test that asserted the overwrite to `Live`.

All use paused virtual time with no wall-clock waits, and each timeout assertion was verified to fail against the unfixed implementation.
