### PR TITLE
Fix non-atomic order event application

### DIFF
--- a/crates/model/src/orders/any.rs
+++ b/crates/model/src/orders/any.rs
@@ -777,11 +777,11 @@ mod tests {
 
         match &err {
             OrderReplayError::ApplyFailed { source } => {
-                assert!(matches!(source, OrderError::InvalidStateTransition));
+                assert!(matches!(source, OrderError::AlreadyInitialized));
             }
             _ => panic!("expected ApplyFailed, was {err:?}"),
         }
-        assert_eq!(err.to_string(), "Invalid order state transition");
+        assert_eq!(err.to_string(), "Order was already initialized");
     }
 
     #[rstest]

--- a/crates/model/src/orders/limit.rs
+++ b/crates/model/src/orders/limit.rs
@@ -610,7 +610,7 @@ mod tests {
         events::{OrderEventAny, OrderUpdated},
         identifiers::InstrumentId,
         instruments::{CurrencyPair, stubs::*},
-        orders::{Order, OrderTestBuilder, stubs::TestOrderStubs},
+        orders::{Order, OrderError, OrderTestBuilder, stubs::TestOrderStubs},
         types::{Price, Quantity},
     };
 
@@ -768,6 +768,36 @@ mod tests {
 
         assert_eq!(accepted_order.quantity(), updated_quantity);
         assert_eq!(accepted_order.price(), Some(updated_price));
+    }
+
+    #[rstest]
+    fn test_limit_order_rejects_invalid_update_atomically() {
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .instrument_id(InstrumentId::from("BTC-USDT.BINANCE"))
+            .quantity(Quantity::from(10))
+            .price(Price::new(100.0, 2))
+            .build();
+        let mut accepted_order = TestOrderStubs::make_accepted_order(&order);
+        let state = (
+            accepted_order.status(),
+            accepted_order.previous_status(),
+            accepted_order.ts_last(),
+            accepted_order.events().len(),
+        );
+        let event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            trigger_price: Some(Price::new(95.0, 2)),
+            ..Default::default()
+        };
+
+        let result = accepted_order.apply(OrderEventAny::Updated(event));
+
+        assert!(matches!(result, Err(OrderError::InvalidOrderEvent)));
+        assert_eq!(accepted_order.status(), state.0);
+        assert_eq!(accepted_order.previous_status(), state.1);
+        assert_eq!(accepted_order.ts_last(), state.2);
+        assert_eq!(accepted_order.events().len(), state.3);
     }
 
     #[rstest]

--- a/crates/model/src/orders/market.rs
+++ b/crates/model/src/orders/market.rs
@@ -565,7 +565,9 @@ mod tests {
         enums::{OrderSide, OrderType, TimeInForce},
         events::{OrderEventAny, OrderUpdated, order::spec::OrderInitializedSpec},
         instruments::{CurrencyPair, stubs::*},
-        orders::{MarketOrder, Order, builder::OrderTestBuilder, stubs::TestOrderStubs},
+        orders::{
+            MarketOrder, Order, OrderError, builder::OrderTestBuilder, stubs::TestOrderStubs,
+        },
         types::{Price, Quantity},
     };
 
@@ -632,6 +634,43 @@ mod tests {
 
         // Verify updates were applied correctly
         assert_eq!(accepted_order.quantity(), updated_quantity);
+    }
+
+    #[rstest]
+    #[case(Some(Price::new(95.0, 2)), None)]
+    #[case(None, Some(Price::new(95.0, 2)))]
+    fn test_market_order_rejects_invalid_update_atomically(
+        audusd_sim: CurrencyPair,
+        #[case] price: Option<Price>,
+        #[case] trigger_price: Option<Price>,
+    ) {
+        let order = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(audusd_sim.id)
+            .quantity(Quantity::from(10))
+            .side(OrderSide::Buy)
+            .build();
+        let mut accepted_order = TestOrderStubs::make_accepted_order(&order);
+        let state = (
+            accepted_order.status(),
+            accepted_order.previous_status(),
+            accepted_order.ts_last(),
+            accepted_order.events().len(),
+        );
+        let event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            price,
+            trigger_price,
+            ..Default::default()
+        };
+
+        let result = accepted_order.apply(OrderEventAny::Updated(event));
+
+        assert!(matches!(result, Err(OrderError::InvalidOrderEvent)));
+        assert_eq!(accepted_order.status(), state.0);
+        assert_eq!(accepted_order.previous_status(), state.1);
+        assert_eq!(accepted_order.ts_last(), state.2);
+        assert_eq!(accepted_order.events().len(), state.3);
     }
 
     #[rstest]

--- a/crates/model/src/orders/market_if_touched.rs
+++ b/crates/model/src/orders/market_if_touched.rs
@@ -716,6 +716,36 @@ mod tests {
     }
 
     #[rstest]
+    fn test_market_if_touched_order_rejects_invalid_update_atomically() {
+        let order = OrderTestBuilder::new(OrderType::MarketIfTouched)
+            .instrument_id(InstrumentId::from("BTC-USDT.BINANCE"))
+            .quantity(Quantity::from(10))
+            .trigger_price(Price::new(100.0, 2))
+            .build();
+        let mut accepted_order = TestOrderStubs::make_accepted_order(&order);
+        let state = (
+            accepted_order.status(),
+            accepted_order.previous_status(),
+            accepted_order.ts_last(),
+            accepted_order.events().len(),
+        );
+        let event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            price: Some(Price::new(95.0, 2)),
+            ..Default::default()
+        };
+
+        let result = accepted_order.apply(OrderEventAny::Updated(event));
+
+        assert!(matches!(result, Err(OrderError::InvalidOrderEvent)));
+        assert_eq!(accepted_order.status(), state.0);
+        assert_eq!(accepted_order.previous_status(), state.1);
+        assert_eq!(accepted_order.ts_last(), state.2);
+        assert_eq!(accepted_order.events().len(), state.3);
+    }
+
+    #[rstest]
     fn test_market_if_touched_order_from_order_initialized() {
         // Create an OrderInitialized event with all required fields for a MarketIfTouchedOrder
         let order_initialized = OrderInitializedSpec::builder()

--- a/crates/model/src/orders/market_to_limit.rs
+++ b/crates/model/src/orders/market_to_limit.rs
@@ -688,6 +688,35 @@ mod tests {
     }
 
     #[rstest]
+    fn test_market_to_limit_order_rejects_invalid_update_atomically() {
+        let order = OrderTestBuilder::new(OrderType::MarketToLimit)
+            .instrument_id(InstrumentId::from("BTC-USDT.BINANCE"))
+            .quantity(Quantity::from(10))
+            .build();
+        let mut accepted_order = TestOrderStubs::make_accepted_order(&order);
+        let state = (
+            accepted_order.status(),
+            accepted_order.previous_status(),
+            accepted_order.ts_last(),
+            accepted_order.events().len(),
+        );
+        let event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            trigger_price: Some(Price::new(95.0, 2)),
+            ..Default::default()
+        };
+
+        let result = accepted_order.apply(OrderEventAny::Updated(event));
+
+        assert!(matches!(result, Err(OrderError::InvalidOrderEvent)));
+        assert_eq!(accepted_order.status(), state.0);
+        assert_eq!(accepted_order.previous_status(), state.1);
+        assert_eq!(accepted_order.ts_last(), state.2);
+        assert_eq!(accepted_order.events().len(), state.3);
+    }
+
+    #[rstest]
     fn test_market_to_limit_order_expire_time() {
         // Create a new MarketToLimitOrder with an expire time
         let expire_time = UnixNanos::from(1_234_567_890);

--- a/crates/model/src/orders/mod.rs
+++ b/crates/model/src/orders/mod.rs
@@ -351,6 +351,7 @@ pub trait Order: 'static + Send {
     ///
     /// Returns an error if the event is invalid for the current order status.
     fn apply(&mut self, event: OrderEventAny) -> Result<(), OrderError>;
+
     fn update(&mut self, event: &OrderUpdated);
 
     fn events(&self) -> Vec<&OrderEventAny>;
@@ -819,6 +820,55 @@ impl OrderCore {
             self.validate_fill_void(event)?;
         }
 
+        // Check for duplicate fill before state transition to maintain consistency
+        if let OrderEventAny::Filled(fill) = &event
+            && self.events.iter().any(
+                |event| matches!(event, OrderEventAny::Filled(existing) if existing.trade_id == fill.trade_id),
+            )
+        {
+            return Err(OrderError::DuplicateFill(fill.trade_id));
+        }
+
+        if matches!(event, OrderEventAny::Triggered(_))
+            && !TRIGGERABLE_ORDER_TYPES.contains(&self.order_type)
+        {
+            return Err(OrderError::InvalidOrderEvent);
+        }
+
+        if matches!(event, OrderEventAny::Initialized(_)) {
+            return Err(OrderError::AlreadyInitialized);
+        }
+
+        let new_status = self.status.transition(&event)?;
+        let rejection_status = if matches!(
+            event,
+            OrderEventAny::ModifyRejected(_) | OrderEventAny::CancelRejected(_)
+        ) {
+            self.previous_status.ok_or(OrderError::NoPreviousState)?
+        } else {
+            self.status
+        };
+
+        // Reject an update carrying fields the order type cannot hold before any
+        // mutation. Runs after the identity and transition checks so an identity
+        // mismatch or invalid transition is reported ahead of a field violation.
+        if let OrderEventAny::Updated(update) = &event {
+            let invalid_fields = match self.order_type {
+                OrderType::Market => update.price.is_some() || update.trigger_price.is_some(),
+                OrderType::StopMarket
+                | OrderType::MarketIfTouched
+                | OrderType::TrailingStopMarket => update.price.is_some(),
+                OrderType::Limit | OrderType::MarketToLimit => update.trigger_price.is_some(),
+                OrderType::StopLimit | OrderType::LimitIfTouched | OrderType::TrailingStopLimit => {
+                    false
+                }
+            };
+
+            if invalid_fields {
+                return Err(OrderError::InvalidOrderEvent);
+            }
+        }
+
         let source_status = self.status;
 
         // Save current status as previous_status for ALL transitions except:
@@ -837,25 +887,10 @@ impl OrderCore {
             self.previous_status = Some(self.status);
         }
 
-        // Check for duplicate fill before state transition to maintain consistency
-        if let OrderEventAny::Filled(fill) = &event
-            && self.events.iter().any(
-                |event| matches!(event, OrderEventAny::Filled(existing) if existing.trade_id == fill.trade_id),
-            )
-        {
-            return Err(OrderError::DuplicateFill(fill.trade_id));
-        }
-
-        if matches!(event, OrderEventAny::Triggered(_))
-            && !TRIGGERABLE_ORDER_TYPES.contains(&self.order_type)
-        {
-            return Err(OrderError::InvalidOrderEvent);
-        }
-
-        let new_status = self.status.transition(&event)?;
         self.status = new_status;
 
         match &event {
+            // Rejected by the pre-commit check above; kept for exhaustiveness
             OrderEventAny::Initialized(_) => return Err(OrderError::AlreadyInitialized),
             OrderEventAny::Denied(event) => self.denied(event),
             OrderEventAny::Emulated(event) => self.emulated(event),
@@ -865,8 +900,8 @@ impl OrderCore {
             OrderEventAny::Accepted(event) => self.accepted(event),
             OrderEventAny::PendingUpdate(event) => self.pending_update(event),
             OrderEventAny::PendingCancel(event) => self.pending_cancel(event),
-            OrderEventAny::ModifyRejected(event) => self.modify_rejected(event)?,
-            OrderEventAny::CancelRejected(event) => self.cancel_rejected(event)?,
+            OrderEventAny::ModifyRejected(event) => self.modify_rejected(event, rejection_status),
+            OrderEventAny::CancelRejected(event) => self.cancel_rejected(event, rejection_status),
             OrderEventAny::Updated(event) => self.updated(event),
             OrderEventAny::Triggered(event) => self.triggered(event),
             OrderEventAny::Canceled(event) => self.canceled(event),
@@ -916,14 +951,12 @@ impl OrderCore {
         // Do nothing else
     }
 
-    fn modify_rejected(&mut self, _event: &OrderModifyRejected) -> Result<(), OrderError> {
-        self.status = self.previous_status.ok_or(OrderError::NoPreviousState)?;
-        Ok(())
+    fn modify_rejected(&mut self, _event: &OrderModifyRejected, previous_status: OrderStatus) {
+        self.status = previous_status;
     }
 
-    fn cancel_rejected(&mut self, _event: &OrderCancelRejected) -> Result<(), OrderError> {
-        self.status = self.previous_status.ok_or(OrderError::NoPreviousState)?;
-        Ok(())
+    fn cancel_rejected(&mut self, _event: &OrderCancelRejected, previous_status: OrderStatus) {
+        self.status = previous_status;
     }
 
     fn triggered(&self, _event: &OrderTriggered) {}
@@ -1394,10 +1427,10 @@ mod tests {
     use crate::{
         enums::{LiquiditySide, OrderSide, OrderStatus, PositionSide, TriggerType},
         events::order::spec::{
-            OrderAcceptedSpec, OrderCanceledSpec, OrderDeniedSpec, OrderExpiredSpec,
-            OrderFillVoidedSpec, OrderFilledSpec, OrderInitializedSpec, OrderPendingCancelSpec,
-            OrderPendingUpdateSpec, OrderRejectedSpec, OrderSubmittedSpec, OrderTriggeredSpec,
-            OrderUpdatedSpec,
+            OrderAcceptedSpec, OrderCancelRejectedSpec, OrderCanceledSpec, OrderDeniedSpec,
+            OrderExpiredSpec, OrderFillVoidedSpec, OrderFilledSpec, OrderInitializedSpec,
+            OrderModifyRejectedSpec, OrderPendingCancelSpec, OrderPendingUpdateSpec,
+            OrderRejectedSpec, OrderSubmittedSpec, OrderTriggeredSpec, OrderUpdatedSpec,
         },
         identifiers::InstrumentId,
         instruments::{CurrencyPair, Instrument, InstrumentAny, stubs::audusd_sim},
@@ -2574,6 +2607,165 @@ mod tests {
 
         assert_eq!(order.status(), OrderStatus::Accepted);
         assert_eq!(order.quantity(), Quantity::from(50_000));
+    }
+
+    #[rstest]
+    fn test_rejected_event_preserves_status_restoration() {
+        let init = OrderInitializedSpec::builder().build();
+        let submitted = OrderSubmittedSpec::builder().build();
+        let accepted = OrderAcceptedSpec::builder().build();
+        let invalid = OrderSubmittedSpec::builder().build();
+        let pending_update = OrderPendingUpdateSpec::builder().build();
+        let modify_rejected = OrderModifyRejectedSpec::builder().build();
+        let mut order: MarketOrder = init.try_into().unwrap();
+        order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+        order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+        let previous_status = order.previous_status();
+
+        let result = order.apply(OrderEventAny::Submitted(invalid));
+
+        assert!(matches!(result, Err(OrderError::InvalidStateTransition)));
+        assert_eq!(order.previous_status(), previous_status);
+
+        order
+            .apply(OrderEventAny::PendingUpdate(pending_update))
+            .unwrap();
+        order
+            .apply(OrderEventAny::ModifyRejected(modify_rejected))
+            .unwrap();
+        assert_eq!(order.status(), OrderStatus::Accepted);
+    }
+
+    #[rstest]
+    fn test_rejected_event_preserves_cancel_rejected_restoration() {
+        let init = OrderInitializedSpec::builder().build();
+        let submitted = OrderSubmittedSpec::builder().build();
+        let accepted = OrderAcceptedSpec::builder().build();
+        let invalid = OrderSubmittedSpec::builder().build();
+        let pending_cancel = OrderPendingCancelSpec::builder().build();
+        let cancel_rejected = OrderCancelRejectedSpec::builder().build();
+        let mut order: MarketOrder = init.try_into().unwrap();
+        order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+        order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+        let previous_status = order.previous_status();
+
+        let result = order.apply(OrderEventAny::Submitted(invalid));
+
+        assert!(matches!(result, Err(OrderError::InvalidStateTransition)));
+        assert_eq!(order.previous_status(), previous_status);
+
+        order
+            .apply(OrderEventAny::PendingCancel(pending_cancel))
+            .unwrap();
+        order
+            .apply(OrderEventAny::CancelRejected(cancel_rejected))
+            .unwrap();
+        assert_eq!(order.status(), OrderStatus::Accepted);
+    }
+
+    #[rstest]
+    #[case(true, false, "client_order_id")]
+    #[case(false, true, "strategy_id")]
+    fn test_update_identity_mismatch_precedes_field_validation(
+        #[case] wrong_client: bool,
+        #[case] wrong_strategy: bool,
+        #[case] expected_field: &str,
+    ) {
+        let init = OrderInitializedSpec::builder().build();
+        let submitted = OrderSubmittedSpec::builder().build();
+        let accepted = OrderAcceptedSpec::builder().build();
+        let mut order: MarketOrder = init.try_into().unwrap();
+        order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+        order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+        let state = (
+            order.status(),
+            order.previous_status(),
+            order.ts_last(),
+            order.events().len(),
+        );
+        let client_order_id = if wrong_client {
+            ClientOrderId::from("O-INVALID")
+        } else {
+            order.client_order_id()
+        };
+        let strategy_id = if wrong_strategy {
+            StrategyId::from("OTHER-001")
+        } else {
+            order.strategy_id()
+        };
+        // Carry both a mismatched identity and a price a MarketOrder cannot hold:
+        // the identity mismatch must be reported ahead of the field violation.
+        let updated = OrderUpdatedSpec::builder()
+            .client_order_id(client_order_id)
+            .strategy_id(strategy_id)
+            .price(Price::new(95.0, 2))
+            .build();
+
+        let result = order.apply(OrderEventAny::Updated(updated));
+
+        // The specific identity predicate must surface, not the field violation.
+        let Err(OrderError::Invariant(CorrectnessError::PredicateViolation { message })) = result
+        else {
+            panic!("expected an identity predicate violation, was {result:?}");
+        };
+        assert!(
+            message.contains(expected_field),
+            "message did not name {expected_field}: {message}"
+        );
+        assert_eq!(order.status(), state.0);
+        assert_eq!(order.previous_status(), state.1);
+        assert_eq!(order.ts_last(), state.2);
+        assert_eq!(order.events().len(), state.3);
+    }
+
+    #[rstest]
+    fn test_update_invalid_transition_precedes_field_validation() {
+        let init = OrderInitializedSpec::builder().build();
+        let denied = OrderDeniedSpec::builder().build();
+        let mut order: MarketOrder = init.try_into().unwrap();
+        order.apply(OrderEventAny::Denied(denied)).unwrap();
+        let state = (
+            order.status(),
+            order.previous_status(),
+            order.ts_last(),
+            order.events().len(),
+        );
+        // No (Denied, Updated) transition exists, and the price is invalid for a
+        // MarketOrder: the transition check must win over the field violation.
+        let updated = OrderUpdatedSpec::builder()
+            .price(Price::new(95.0, 2))
+            .build();
+
+        let result = order.apply(OrderEventAny::Updated(updated));
+
+        assert!(matches!(result, Err(OrderError::InvalidStateTransition)));
+        assert_eq!(order.status(), state.0);
+        assert_eq!(order.previous_status(), state.1);
+        assert_eq!(order.ts_last(), state.2);
+        assert_eq!(order.events().len(), state.3);
+    }
+
+    #[rstest]
+    fn test_direct_update_panics_on_invalid_field_before_mutation() {
+        let init = OrderInitializedSpec::builder()
+            .quantity(Quantity::from(100_000))
+            .build();
+        let mut order: MarketOrder = init.try_into().unwrap();
+        let original_quantity = order.quantity();
+        // A distinct quantity so any mutation would be observable, alongside a
+        // price the type cannot hold. The low-level mutation path retains a
+        // defensive guard: a direct update() panics on the invalid field before
+        // it reaches the quantity assignment.
+        let updated = OrderUpdatedSpec::builder()
+            .quantity(Quantity::from(50_000))
+            .price(Price::new(95.0, 2))
+            .build();
+
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| order.update(&updated)));
+
+        assert!(result.is_err());
+        assert_eq!(order.quantity(), original_quantity);
     }
 
     #[rstest]

--- a/crates/model/src/orders/stop_market.rs
+++ b/crates/model/src/orders/stop_market.rs
@@ -747,6 +747,36 @@ mod tests {
     }
 
     #[rstest]
+    fn test_stop_market_order_rejects_invalid_update_atomically() {
+        let order = OrderTestBuilder::new(OrderType::StopMarket)
+            .instrument_id(InstrumentId::from("BTC-USDT.BINANCE"))
+            .quantity(Quantity::from(10))
+            .trigger_price(Price::new(100.0, 2))
+            .build();
+        let mut accepted_order = TestOrderStubs::make_accepted_order(&order);
+        let state = (
+            accepted_order.status(),
+            accepted_order.previous_status(),
+            accepted_order.ts_last(),
+            accepted_order.events().len(),
+        );
+        let event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            price: Some(Price::new(95.0, 2)),
+            ..Default::default()
+        };
+
+        let result = accepted_order.apply(OrderEventAny::Updated(event));
+
+        assert!(matches!(result, Err(OrderError::InvalidOrderEvent)));
+        assert_eq!(accepted_order.status(), state.0);
+        assert_eq!(accepted_order.previous_status(), state.1);
+        assert_eq!(accepted_order.ts_last(), state.2);
+        assert_eq!(accepted_order.events().len(), state.3);
+    }
+
+    #[rstest]
     fn test_stop_market_order_expire_time() {
         // Create a stop market order with an expire time
         let expire_time = UnixNanos::from(1_234_567_890);

--- a/crates/model/src/orders/trailing_stop_market.rs
+++ b/crates/model/src/orders/trailing_stop_market.rs
@@ -785,6 +785,38 @@ mod tests {
     }
 
     #[rstest]
+    fn test_trailing_stop_market_order_rejects_invalid_update_atomically() {
+        let order = OrderTestBuilder::new(OrderType::TrailingStopMarket)
+            .instrument_id(InstrumentId::from("BTC-USDT.BINANCE"))
+            .quantity(Quantity::from(10))
+            .trigger_price(Price::new(100.0, 2))
+            .trailing_offset(Decimal::new(5, 1))
+            .trailing_offset_type(TrailingOffsetType::NoTrailingOffset)
+            .build();
+        let mut accepted_order = TestOrderStubs::make_accepted_order(&order);
+        let state = (
+            accepted_order.status(),
+            accepted_order.previous_status(),
+            accepted_order.ts_last(),
+            accepted_order.events().len(),
+        );
+        let event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            price: Some(Price::new(95.0, 2)),
+            ..Default::default()
+        };
+
+        let result = accepted_order.apply(OrderEventAny::Updated(event));
+
+        assert!(matches!(result, Err(OrderError::InvalidOrderEvent)));
+        assert_eq!(accepted_order.status(), state.0);
+        assert_eq!(accepted_order.previous_status(), state.1);
+        assert_eq!(accepted_order.ts_last(), state.2);
+        assert_eq!(accepted_order.events().len(), state.3);
+    }
+
+    #[rstest]
     fn test_trailing_stop_market_order_expire_time() {
         // Create a new TrailingStopMarketOrder with an expire time
         let expire_time = UnixNanos::from(1_234_567_890);


### PR DESCRIPTION
Two defects in the order event-application path, both the same class as the defensive alignment in #4483: an ordinary venue event stream reaching code that mutates before it finishes validating.

## Order updates are validated after the state transition commits

`OrderCore::apply` writes `previous_status`, transitions `status`, runs the per-event handler, sets `ts_last`, and pushes the event onto the history, then returns `Ok`. Only afterwards does each concrete `apply` call `self.update(event)`, and six order types validate the update there with `assert!`: `MarketOrder` rejects both `price` and `trigger_price`, `StopMarketOrder`, `MarketIfTouchedOrder` and `TrailingStopMarketOrder` reject `price`, `LimitOrder` and `MarketToLimitOrder` reject `trigger_price`. An `OrderUpdated` carrying a field the type cannot hold therefore panics with the transition already committed and the event already in history, and never returns `Err(OrderError::InvalidOrderEvent)`. The release profile sets `panic = "abort"`, so this terminates the process; under unwind the order is left with a status and a history entry for an update that was never applied to its subtype fields. The producers are venue adapters, the order emulator, and reconciliation - `reconciliation/orders.rs` already filters spurious venue trigger prices before building the event, handling one call site rather than the boundary that owns the invariant.

The fix moves the field check into `OrderCore::apply`, where the invariant belongs. `OrderCore` already carries `order_type`, so an exhaustive `match` rejects an `OrderUpdated` whose `price`/`trigger_price` the type cannot hold and returns `Err(OrderError::InvalidOrderEvent)` before any field is written. It runs after the existing client-order-id/strategy-id identity checks and the `OrderStatus::transition` check and before the first mutation, so an update that is both mis-addressed and field-invalid still reports the identity mismatch, and one that is field-invalid in a status that rejects updates still reports `InvalidStateTransition` - the field check never masks a more fundamental rejection. The six restrictive `update()` methods keep their `assert!` as a defensive guard on the low-level mutation path, so a direct `update()` call that bypasses `apply` still trips rather than silently mutating.

## Rejected events mutate core state before the FSM rejects them

The same function has the same ordering problem for its own checks, without any panic involved. `previous_status` is assigned before the duplicate-fill check, the triggerable-type check, and `OrderStatus::transition`; `status` is assigned before the `Initialized` rejection and before `modify_rejected` and `cancel_rejected` can fail with `NoPreviousState`. An event the FSM rejects thus returns `Err` but leaves `previous_status` advanced to the current status - a rejected event is supposed to be a no-op on the order. `previous_status` feeds the `OrderModifyRejected`/`OrderCancelRejected` restore path, so this is core state a rejected event has no business touching; the fix restores the invariant that a rejected event leaves order state unchanged rather than relying on a later transition to overwrite the damage.

The fix hoists every fallible check above the first mutation: duplicate fill, triggerable type, duplicate initialization, the transition itself, and the `previous_status` precondition that the two rejection handlers need, which is now read into a local before anything is written. Only once all of them pass does the function assign `previous_status` and `status`, run the handler, and record the event. The existing conditions governing which transitions save a previous status are unchanged. `modify_rejected` and `cancel_rejected` no longer return `Result`, since their only failure mode is now checked up front.

One observable consequence: applying a second `OrderInitialized` to an existing order previously reached `OrderStatus::transition` first and returned `InvalidStateTransition`, leaving the `AlreadyInitialized` arm dead. The pre-commit check makes that variant reachable, so `OrderAny::from_events` now reports `AlreadyInitialized` for a replay stream carrying a duplicate initialization. No production path discriminates on either variant here.

## Testing

`test_market_order_rejects_invalid_update_atomically` (parametrized over `price` and `trigger_price`) and its five siblings on `StopMarketOrder`, `MarketIfTouchedOrder`, `TrailingStopMarketOrder`, `LimitOrder` and `MarketToLimitOrder` cover every condition that was previously an assertion: each asserts `Err(OrderError::InvalidOrderEvent)` and that `status`, `previous_status`, `ts_last` and the event count are all unchanged. Against the unfixed implementation these panic rather than return.

`test_update_identity_mismatch_precedes_field_validation` (parametrized over a wrong client-order-id and a wrong strategy-id) sends an update that is both mis-addressed and carries a `MarketOrder`-invalid `price`, and asserts the surfaced error is the identity `PredicateViolation` whose message names the mismatched field, not `InvalidOrderEvent`. `test_update_invalid_transition_precedes_field_validation` applies such an update to a `Denied` order and asserts `InvalidStateTransition`. Both fail against a validate-first ordering, which reports `InvalidOrderEvent` in each case. `test_direct_update_panics_on_invalid_field_before_mutation` calls `MarketOrder::update` directly, under `catch_unwind`, with an invalid `price` and a quantity distinct from the order's, and asserts the call panics and the quantity is unchanged - the defensive `assert!` fires ahead of the field writes. It fails with the guard removed: the call returns and the quantity moves.

`test_rejected_event_preserves_status_restoration` and `test_rejected_event_preserves_cancel_rejected_restoration` drive an order to `Accepted`, apply an event the FSM rejects, and assert `previous_status` is untouched, then confirm `OrderModifyRejected` and `OrderCancelRejected` restore `Accepted` through `PendingUpdate` and `PendingCancel` respectively. Both were verified to fail against the unfixed ordering, where the rejected event advances `previous_status` from `Submitted` to `Accepted`.

All of these are deterministic unit tests over constructed events with no clock or wall-clock dependency.
