### PR TITLE
Replace timer-driven mock stream teardown in Betfair tests

### DIFF
--- a/crates/adapters/betfair/tests/data_client.rs
+++ b/crates/adapters/betfair/tests/data_client.rs
@@ -76,9 +76,11 @@ async fn test_data_client_connect_disconnect() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, _rx) = create_test_data_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -89,7 +91,8 @@ async fn test_data_client_connect_disconnect() {
     client.disconnect().await.unwrap();
     assert!(client.is_disconnected());
 
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -99,9 +102,11 @@ async fn test_data_client_emits_instruments_on_connect() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx) = create_test_data_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -121,7 +126,8 @@ async fn test_data_client_emits_instruments_on_connect() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -134,6 +140,8 @@ async fn test_data_client_subscribe_sends_market_subscription() {
     let sub_received = Arc::new(tokio::sync::Mutex::new(String::new()));
     let sub_received2 = Arc::clone(&sub_received);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, write_half) = accept_and_auth(&listener).await;
 
@@ -145,7 +153,7 @@ async fn test_data_client_subscribe_sends_market_subscription() {
 
         *sub_received2.lock().await = line.trim().to_string();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -185,7 +193,8 @@ async fn test_data_client_subscribe_sends_market_subscription() {
     assert_eq!(json["op"], "marketSubscription");
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -280,6 +289,8 @@ async fn test_mcm_handler_emits_book_deltas() {
 
     let mcm_fixture = load_fixture("stream/mcm_UPDATE.json");
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -293,7 +304,7 @@ async fn test_mcm_handler_emits_book_deltas() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -312,7 +323,8 @@ async fn test_mcm_handler_emits_book_deltas() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -323,6 +335,8 @@ async fn test_mcm_handler_emits_trades() {
     let (mut client, mut rx) = create_test_data_client(addr, stream_port);
 
     let mcm_fixture = load_fixture("stream/mcm_UPDATE_tv.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
@@ -336,7 +350,7 @@ async fn test_mcm_handler_emits_trades() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -360,7 +374,8 @@ async fn test_mcm_handler_emits_trades() {
     assert!(found_trade, "Expected Trade event from MCM with trd field");
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -371,6 +386,8 @@ async fn test_data_client_handles_heartbeat_gracefully() {
     let (mut client, mut rx) = create_test_data_client(addr, stream_port);
 
     let heartbeat_fixture = load_fixture("stream/mcm_HEARTBEAT.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
@@ -384,7 +401,7 @@ async fn test_data_client_handles_heartbeat_gracefully() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -400,7 +417,8 @@ async fn test_data_client_handles_heartbeat_gracefully() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -417,6 +435,8 @@ async fn test_data_client_emits_instrument_before_status_on_market_definition() 
 
     let md_fixture = load_fixture("stream/mcm_UPDATE_md.json");
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -429,7 +449,7 @@ async fn test_data_client_emits_instrument_before_status_on_market_definition() 
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -482,7 +502,8 @@ async fn test_data_client_emits_instrument_before_status_on_market_definition() 
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -493,6 +514,8 @@ async fn test_data_client_handles_sub_image_snapshot() {
     let (mut client, mut rx) = create_test_data_client(addr, stream_port);
 
     let sub_image_fixture = load_fixture("stream/mcm_SUB_IMAGE.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
@@ -506,7 +529,7 @@ async fn test_data_client_handles_sub_image_snapshot() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -548,7 +571,8 @@ async fn test_data_client_handles_sub_image_snapshot() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// `RESUB_DELTA` MCMs arrive when the venue replays buffered changes after a
@@ -563,6 +587,8 @@ async fn test_data_client_handles_resub_delta_emits_deltas() {
 
     let resub_fixture = load_fixture("stream/mcm_RESUB_DELTA.json");
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -575,7 +601,7 @@ async fn test_data_client_handles_resub_delta_emits_deltas() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -621,7 +647,8 @@ async fn test_data_client_handles_resub_delta_emits_deltas() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// Live race-style MCMs reach the parser and emit one Deltas event per runner
@@ -642,6 +669,8 @@ async fn test_data_client_handles_live_race_message_emits_deltas(
 
     let fixture = load_fixture(fixture_path);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -654,7 +683,7 @@ async fn test_data_client_handles_live_race_message_emits_deltas(
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -683,7 +712,8 @@ async fn test_data_client_handles_live_race_message_emits_deltas(
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A BSP-settled MCM (`marketDefinition.status = CLOSED`, `bspReconciled =
@@ -698,6 +728,8 @@ async fn test_data_client_handles_bsp_settled_emits_close_status() {
 
     let settled_fixture = load_fixture("stream/mcm_BSP_settled.json");
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -710,7 +742,7 @@ async fn test_data_client_handles_bsp_settled_emits_close_status() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -739,7 +771,8 @@ async fn test_data_client_handles_bsp_settled_emits_close_status() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A BSP SUB_IMAGE frame carries both a market definition and runner-change
@@ -762,6 +795,8 @@ async fn test_data_client_handles_bsp_sub_image_emits_instrument_and_deltas() {
         .expect("expected at least one BSP frame")
         .to_string();
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -774,7 +809,7 @@ async fn test_data_client_handles_bsp_sub_image_emits_instrument_and_deltas() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -826,7 +861,8 @@ async fn test_data_client_handles_bsp_sub_image_emits_instrument_and_deltas() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// `disconnect()` on a never-connected client is a no-op rather than an
@@ -860,6 +896,8 @@ async fn test_data_client_connect_is_idempotent() {
     // client would open a second connection on the second connect() call.
     let stream_accepts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let stream_accepts_server = Arc::clone(&stream_accepts);
+
+    let (server_done_tx, mut server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         loop {
@@ -897,7 +935,7 @@ async fn test_data_client_connect_is_idempotent() {
                         }
                     });
                 }
-                () = tokio::time::sleep(Duration::from_secs(5)) => break,
+                _ = &mut server_done_rx => break,
             }
         }
     });
@@ -967,7 +1005,8 @@ async fn test_data_client_connect_is_idempotent() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -977,9 +1016,11 @@ async fn test_data_client_reset_clears_state() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, _rx) = create_test_data_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -989,5 +1030,6 @@ async fn test_data_client_reset_clears_state() {
     client.reset().unwrap();
     assert!(client.is_disconnected());
 
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }

--- a/crates/adapters/betfair/tests/exec_client.rs
+++ b/crates/adapters/betfair/tests/exec_client.rs
@@ -153,6 +153,8 @@ async fn test_exec_client_connect_disconnect() {
     let subscription_received = Arc::new(AtomicBool::new(false));
     let subscription_received_server = Arc::clone(&subscription_received);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, write_half) = accept_and_auth(&listener).await;
 
@@ -166,7 +168,7 @@ async fn test_exec_client_connect_disconnect() {
         assert_eq!(json["op"], "orderSubscription");
         subscription_received_server.store(true, Ordering::Relaxed);
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -187,7 +189,8 @@ async fn test_exec_client_connect_disconnect() {
     client.disconnect().await.unwrap();
     assert!(!client.is_connected());
 
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -197,9 +200,11 @@ async fn test_exec_client_connect_emits_account_state() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -220,7 +225,8 @@ async fn test_exec_client_connect_emits_account_state() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -231,6 +237,8 @@ async fn test_ocm_handler_emits_order_status_report() {
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_FILLED.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -248,7 +256,7 @@ async fn test_ocm_handler_emits_order_status_report() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -267,7 +275,8 @@ async fn test_ocm_handler_emits_order_status_report() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -278,6 +287,8 @@ async fn test_ocm_voided_order_emits_data_event() {
     let (mut client, _rx, mut data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_VOIDED.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -294,7 +305,7 @@ async fn test_ocm_voided_order_emits_data_event() {
         )
         .await
         .unwrap();
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -313,7 +324,8 @@ async fn test_ocm_voided_order_emits_data_event() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 fn make_cancel_order(
@@ -351,9 +363,11 @@ async fn test_cancel_order_bet_taken_or_lapsed_treated_as_success() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -396,7 +410,8 @@ async fn test_cancel_order_bet_taken_or_lapsed_treated_as_success() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -417,9 +432,11 @@ async fn test_cancel_order_instruction_failure_emits_rejected() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -452,7 +469,8 @@ async fn test_cancel_order_instruction_failure_emits_rejected() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -471,9 +489,11 @@ async fn test_cancel_order_result_failure_no_instructions_emits_no_rejected() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -516,7 +536,8 @@ async fn test_cancel_order_result_failure_no_instructions_emits_no_rejected() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -532,9 +553,11 @@ async fn test_cancel_order_ambiguous_5xx_emits_no_rejected() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -577,7 +600,8 @@ async fn test_cancel_order_ambiguous_5xx_emits_no_rejected() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -597,9 +621,11 @@ async fn test_cancel_order_timeout_status_emits_no_rejected() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -643,7 +669,8 @@ async fn test_cancel_order_timeout_status_emits_no_rejected() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -662,9 +689,11 @@ async fn test_cancel_order_success_no_rejected_event() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -684,7 +713,8 @@ async fn test_cancel_order_success_no_rejected_event() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 fn make_test_order(
@@ -730,9 +760,11 @@ async fn test_submit_order_success_emits_accepted() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -771,7 +803,8 @@ async fn test_submit_order_success_emits_accepted() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -792,9 +825,11 @@ async fn test_submit_order_error_emits_rejected() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -838,7 +873,8 @@ async fn test_submit_order_error_emits_rejected() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -848,9 +884,11 @@ async fn test_modify_order_price_and_quantity_rejects() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -899,7 +937,8 @@ async fn test_modify_order_price_and_quantity_rejects() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -909,9 +948,11 @@ async fn test_modify_order_no_effective_change_rejects() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -957,7 +998,8 @@ async fn test_modify_order_no_effective_change_rejects() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -967,9 +1009,11 @@ async fn test_cancel_all_orders_sends_request() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1012,7 +1056,8 @@ async fn test_cancel_all_orders_sends_request() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1022,9 +1067,11 @@ async fn test_cancel_all_orders_invalid_instrument_emits_no_rejected_locally() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1063,7 +1110,8 @@ async fn test_cancel_all_orders_invalid_instrument_emits_no_rejected_locally() {
     assert_eq!(state.betting_request_count.load(Ordering::Relaxed), 0);
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1079,9 +1127,11 @@ async fn test_cancel_all_orders_ambiguous_5xx_emits_no_rejected() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1136,7 +1186,8 @@ async fn test_cancel_all_orders_ambiguous_5xx_emits_no_rejected() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1147,6 +1198,8 @@ async fn test_ocm_handler_emits_cancel_event() {
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_CANCEL.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -1163,7 +1216,7 @@ async fn test_ocm_handler_emits_cancel_event() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1182,7 +1235,8 @@ async fn test_ocm_handler_emits_cancel_event() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1193,6 +1247,8 @@ async fn test_ocm_handler_handles_mixed_updates() {
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_MIXED.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -1209,7 +1265,7 @@ async fn test_ocm_handler_handles_mixed_updates() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1235,7 +1291,8 @@ async fn test_ocm_handler_handles_mixed_updates() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1246,6 +1303,8 @@ async fn test_ocm_handler_handles_full_image() {
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_FULL_IMAGE.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -1262,7 +1321,7 @@ async fn test_ocm_handler_handles_full_image() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1286,7 +1345,8 @@ async fn test_ocm_handler_handles_full_image() {
     assert!(found_report, "Expected Report event from FULL_IMAGE OCM");
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1297,6 +1357,8 @@ async fn test_ocm_voided_partial_emits_both_fill_and_void() {
     let (mut client, mut rx, mut data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_VOIDED_partial.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -1313,7 +1375,7 @@ async fn test_ocm_voided_partial_emits_both_fill_and_void() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1352,7 +1414,8 @@ async fn test_ocm_voided_partial_emits_both_fill_and_void() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1363,6 +1426,8 @@ async fn test_ocm_no_void_event_when_sv_zero() {
     let (mut client, mut rx, mut data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_FILLED_sv_zero.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -1379,7 +1444,7 @@ async fn test_ocm_no_void_event_when_sv_zero() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1412,7 +1477,8 @@ async fn test_ocm_no_void_event_when_sv_zero() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1422,9 +1488,11 @@ async fn test_submit_order_registers_customer_order_ref() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1452,7 +1520,8 @@ async fn test_submit_order_registers_customer_order_ref() {
     assert!(has_place_orders, "Expected placeOrders call");
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1463,6 +1532,8 @@ async fn test_ocm_filled_no_avp_uses_order_price() {
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_FILLED_no_avp.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -1479,7 +1550,7 @@ async fn test_ocm_filled_no_avp_uses_order_price() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1507,7 +1578,8 @@ async fn test_ocm_filled_no_avp_uses_order_price() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1527,9 +1599,11 @@ async fn test_generate_order_status_reports() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1556,7 +1630,8 @@ async fn test_generate_order_status_reports() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1576,9 +1651,11 @@ async fn test_generate_fill_reports() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1613,7 +1690,8 @@ async fn test_generate_fill_reports() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1634,9 +1712,11 @@ async fn test_query_order_emits_order_status_report() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1680,7 +1760,8 @@ async fn test_query_order_emits_order_status_report() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -1701,9 +1782,11 @@ async fn test_query_order_no_match_emits_nothing() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1745,7 +1828,8 @@ async fn test_query_order_no_match_emits_nothing() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 fn make_submit_order_list_cmd(
@@ -1795,9 +1879,11 @@ async fn test_submit_order_list_success_emits_accepted_for_each_leg() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1865,7 +1951,8 @@ async fn test_submit_order_list_success_emits_accepted_for_each_leg() {
     assert_eq!(accepted_ids[1].1, VenueOrderId::from("228302937744"));
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// `submit_order_list` with a partial-failure fixture must emit
@@ -1886,9 +1973,11 @@ async fn test_submit_order_list_partial_failure_emits_mixed_events() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -1952,7 +2041,8 @@ async fn test_submit_order_list_partial_failure_emits_mixed_events() {
     assert_eq!(rejected, vec![ClientOrderId::from("O-LIST-FAIL")]);
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 fn make_batch_cancel_cmd(
@@ -2007,9 +2097,11 @@ async fn test_batch_cancel_orders_success_no_rejected_events() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2049,7 +2141,8 @@ async fn test_batch_cancel_orders_success_no_rejected_events() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A mixed per-item batch result must emit CancelRejected for the explicit
@@ -2070,9 +2163,11 @@ async fn test_batch_cancel_orders_partial_failure_emits_rejected_for_failing_leg
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2114,7 +2209,8 @@ async fn test_batch_cancel_orders_partial_failure_emits_rejected_for_failing_leg
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -2133,9 +2229,11 @@ async fn test_batch_cancel_orders_result_failure_without_instruction_reports_emi
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2186,7 +2284,8 @@ async fn test_batch_cancel_orders_result_failure_without_instruction_reports_emi
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -2202,9 +2301,11 @@ async fn test_batch_cancel_orders_ambiguous_5xx_emits_no_rejections() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2257,7 +2358,8 @@ async fn test_batch_cancel_orders_ambiguous_5xx_emits_no_rejections() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -2267,9 +2369,11 @@ async fn test_batch_cancel_orders_missing_venue_id_emits_no_rejected_locally() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2301,7 +2405,8 @@ async fn test_batch_cancel_orders_missing_venue_id_emits_no_rejected_locally() {
     assert_eq!(state.betting_request_count.load(Ordering::Relaxed), 0);
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A modify with quantity reduction (no price change) must succeed without
@@ -2325,9 +2430,11 @@ async fn test_modify_order_quantity_reduction_does_not_reject() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2385,7 +2492,8 @@ async fn test_modify_order_quantity_reduction_does_not_reject() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// Modify cannot proceed without a `venue_order_id`. The command must
@@ -2397,9 +2505,11 @@ async fn test_modify_order_without_venue_id_returns_error() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, _rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2433,7 +2543,8 @@ async fn test_modify_order_without_venue_id_returns_error() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// An empty full-image OCM (no `orc`) must clear state without producing
@@ -2446,6 +2557,8 @@ async fn test_ocm_empty_image_emits_no_report() {
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_EMPTY_IMAGE.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -2462,7 +2575,7 @@ async fn test_ocm_empty_image_emits_no_report() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2485,7 +2598,8 @@ async fn test_ocm_empty_image_emits_no_report() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 fn load_fixture_frames(path: &str) -> Vec<String> {
@@ -2519,6 +2633,8 @@ async fn test_ocm_multiple_incremental_fills_emits_one_report_per_step() {
     let frames = load_fixture_frames("stream/ocm_multiple_fills.json");
     assert_eq!(frames.len(), 3, "expected 3 incremental fill frames");
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -2529,7 +2645,7 @@ async fn test_ocm_multiple_incremental_fills_emits_one_report_per_step() {
 
         write_lines(&mut write_half, &frames).await;
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2558,7 +2674,8 @@ async fn test_ocm_multiple_incremental_fills_emits_one_report_per_step() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// Replaying the same OCM frame twice must emit a single fill report; the
@@ -2574,6 +2691,8 @@ async fn test_ocm_duplicate_frame_dedupes_fill_report() {
     let single = frames.into_iter().next().unwrap();
     let duplicated = vec![single.clone(), single];
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -2584,7 +2703,7 @@ async fn test_ocm_duplicate_frame_dedupes_fill_report() {
 
         write_lines(&mut write_half, &duplicated).await;
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2606,7 +2725,8 @@ async fn test_ocm_duplicate_frame_dedupes_fill_report() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// With `ignore_external_orders=true`, an unmatched order with no `rfo`
@@ -2661,6 +2781,8 @@ async fn test_ocm_ignore_external_orders_skips_orders_without_rfo() {
         .unwrap()
         .to_string();
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -2671,7 +2793,7 @@ async fn test_ocm_ignore_external_orders_skips_orders_without_rfo() {
 
         write_lines(&mut write_half, &[external_line]).await;
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2694,7 +2816,8 @@ async fn test_ocm_ignore_external_orders_skips_orders_without_rfo() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// Regression: an empty `rfo` string must be treated identically to a missing
@@ -2751,6 +2874,8 @@ async fn test_ocm_ignore_external_orders_skips_empty_string_rfo() {
         .unwrap()
         .to_string();
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -2761,7 +2886,7 @@ async fn test_ocm_ignore_external_orders_skips_empty_string_rfo() {
 
         write_lines(&mut write_half, &[external_line]).await;
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2784,7 +2909,8 @@ async fn test_ocm_ignore_external_orders_skips_empty_string_rfo() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// `stream_market_ids_filter` must drop OCMs for markets outside the filter
@@ -2805,6 +2931,8 @@ async fn test_ocm_market_ids_filter_skips_unrelated_markets() {
     // "1.OTHER" the handler must drop every frame.
     let frames = load_fixture_frames("stream/ocm_multiple_fills.json");
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -2815,7 +2943,7 @@ async fn test_ocm_market_ids_filter_skips_unrelated_markets() {
 
         write_lines(&mut write_half, &frames).await;
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2838,7 +2966,8 @@ async fn test_ocm_market_ids_filter_skips_unrelated_markets() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -2848,9 +2977,11 @@ async fn test_cancel_order_without_venue_id_emits_no_rejected_locally() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2895,7 +3026,8 @@ async fn test_cancel_order_without_venue_id_emits_no_rejected_locally() {
     assert_eq!(state.betting_request_count.load(Ordering::Relaxed), 0);
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A modify with a quantity *increase* (not allowed on Betfair) must emit a
@@ -2907,9 +3039,11 @@ async fn test_modify_order_quantity_increase_rejects() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -2955,7 +3089,8 @@ async fn test_modify_order_quantity_increase_rejects() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A handicap-bearing instrument id (e.g. `1.M-S-1.5.BETFAIR`) must round-trip
@@ -2968,9 +3103,11 @@ async fn test_submit_order_with_handicap_includes_handicap_in_instruction() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3014,7 +3151,8 @@ async fn test_submit_order_with_handicap_includes_handicap_in_instruction() {
     assert_eq!(instr["handicap"], "1.5");
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A price modify dispatches `replaceOrders` (Betfair's atomic price update)
@@ -3027,9 +3165,11 @@ async fn test_modify_price_dispatches_replace_orders_with_new_price() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3094,7 +3234,8 @@ async fn test_modify_price_dispatches_replace_orders_with_new_price() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// `generate_order_status_reports` must transparently recover from a stale
@@ -3129,9 +3270,11 @@ async fn test_generate_order_status_reports_recovers_from_no_session() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3177,7 +3320,8 @@ async fn test_generate_order_status_reports_recovers_from_no_session() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// `generate_fill_reports` has its own copy of the NO_SESSION recovery
@@ -3208,9 +3352,11 @@ async fn test_generate_fill_reports_recovers_from_no_session() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3251,7 +3397,8 @@ async fn test_generate_fill_reports_recovers_from_no_session() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// `query_order` runs through `list_current_orders_with_retry`
@@ -3281,9 +3428,11 @@ async fn test_query_order_recovers_from_no_session() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3354,7 +3503,8 @@ async fn test_query_order_recovers_from_no_session() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// Replace-flow reconciliation: after a successful `replaceOrders`, the OCM
@@ -3559,9 +3709,11 @@ async fn test_submit_order_fok_sends_fill_or_kill_payload() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3619,7 +3771,8 @@ async fn test_submit_order_fok_sends_fill_or_kill_payload() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A Market AtTheClose order must serialise as a `marketOnCloseOrder` (BSP)
@@ -3631,9 +3784,11 @@ async fn test_submit_order_market_on_close_sends_bsp_instruction() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3689,7 +3844,8 @@ async fn test_submit_order_market_on_close_sends_bsp_instruction() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A submit failure that is "ambiguous" (5xx, network error, timeout) leaves
@@ -3708,9 +3864,11 @@ async fn test_submit_order_ambiguous_5xx_does_not_emit_rejected() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (_reader, write_half) = accept_and_auth(&listener).await;
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3763,7 +3921,8 @@ async fn test_submit_order_ambiguous_5xx_does_not_emit_rejected() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// `FULL_IMAGE_STRATEGY` OCMs carry only matched-order history (`mb`/`ml`) and
@@ -3777,6 +3936,8 @@ async fn test_ocm_full_image_strategy_emits_no_report() {
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
     let ocm_fixture = load_fixture("stream/ocm_FULL_IMAGE_STRATEGY.json");
+
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
@@ -3793,7 +3954,7 @@ async fn test_ocm_full_image_strategy_emits_no_report() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3820,7 +3981,8 @@ async fn test_ocm_full_image_strategy_emits_no_report() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 /// A second EC (terminal) OCM for the same `bet_id` must be deduped: the first
@@ -3840,6 +4002,8 @@ async fn test_ocm_duplicate_terminal_event_is_deduped() {
     let initial_frame = frames.remove(0);
     let lines = vec![initial_frame, terminal_frame.clone(), terminal_frame];
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -3850,7 +4014,7 @@ async fn test_ocm_duplicate_terminal_event_is_deduped() {
 
         write_lines(&mut write_half, &lines).await;
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3879,7 +4043,8 @@ async fn test_ocm_duplicate_terminal_event_is_deduped() {
     );
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 const RECONNECT_CONNECTION_MSG: &[u8] =
@@ -3901,6 +4066,8 @@ async fn test_post_reconnect_dispatches_mass_status() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
 
@@ -3914,7 +4081,7 @@ async fn test_post_reconnect_dispatches_mass_status() {
             .await
             .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -3946,7 +4113,8 @@ async fn test_post_reconnect_dispatches_mass_status() {
     assert!(!client.is_reconciling());
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -3970,6 +4138,8 @@ async fn test_submit_denied_during_reconciliation() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
         let mut line = String::new();
@@ -3979,7 +4149,7 @@ async fn test_submit_denied_during_reconciliation() {
         tokio::io::AsyncWriteExt::write_all(&mut write_half, RECONNECT_CONNECTION_MSG)
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -4019,7 +4189,8 @@ async fn test_submit_denied_during_reconciliation() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -4045,6 +4216,8 @@ async fn test_queued_reconnect_re_asserts_halt() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
         let mut line = String::new();
@@ -4066,7 +4239,7 @@ async fn test_queued_reconnect_re_asserts_halt() {
         .await
         .unwrap();
 
-        tokio::time::sleep(Duration::from_secs(10)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -4119,7 +4292,8 @@ async fn test_queued_reconnect_re_asserts_halt() {
     assert!(!client.is_reconciling());
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -4143,6 +4317,8 @@ async fn test_submit_order_list_denied_during_reconciliation() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
         let mut line = String::new();
@@ -4152,7 +4328,7 @@ async fn test_submit_order_list_denied_during_reconciliation() {
         tokio::io::AsyncWriteExt::write_all(&mut write_half, RECONNECT_CONNECTION_MSG)
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -4223,7 +4399,8 @@ async fn test_submit_order_list_denied_during_reconciliation() {
     assert!(denied_ids.contains(&ClientOrderId::from("O-HLT-LIST-002")));
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -4250,6 +4427,8 @@ async fn test_disconnect_during_reconciliation_clears_halt() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, _rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
         let mut line = String::new();
@@ -4259,7 +4438,7 @@ async fn test_disconnect_during_reconciliation_clears_halt() {
         tokio::io::AsyncWriteExt::write_all(&mut write_half, RECONNECT_CONNECTION_MSG)
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_secs(15)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -4284,7 +4463,8 @@ async fn test_disconnect_during_reconciliation_clears_halt() {
         "is_reconciling must be cleared on disconnect even when reconnect task is aborted",
     );
 
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }
 
 #[rstest]
@@ -4313,6 +4493,8 @@ async fn test_cancel_allowed_during_reconciliation() {
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, mut rx, _data_rx, _cache) = create_test_execution_client(addr, stream_port);
 
+    let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();
+
     let server = tokio::spawn(async move {
         let (mut reader, mut write_half) = accept_and_auth(&listener).await;
         let mut line = String::new();
@@ -4322,7 +4504,7 @@ async fn test_cancel_allowed_during_reconciliation() {
         tokio::io::AsyncWriteExt::write_all(&mut write_half, RECONNECT_CONNECTION_MSG)
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
+        let _ = server_done_rx.await;
         drop(write_half);
     });
 
@@ -4357,5 +4539,6 @@ async fn test_cancel_allowed_during_reconciliation() {
     }
 
     client.disconnect().await.unwrap();
-    let _ = server.await;
+    let _ = server_done_tx.send(());
+    server.await.unwrap();
 }


### PR DESCRIPTION
The Betfair client test suite spends most of its runtime asleep: 256 of its 307 seconds are mock stream servers waiting out fixed delays that nothing is waiting for.

## Mock stream teardown is driven by a timer instead of by the test

Each test in `tests/exec_client.rs` and `tests/data_client.rs` spawns a mock stream server whose last act is a fixed sleep followed by closing the socket:

```rust
let server = tokio::spawn(async move {
    let (_reader, write_half) = accept_and_auth(&listener).await;
    tokio::time::sleep(Duration::from_secs(5)).await;
    drop(write_half);
});
```

and ends with `let _ = server.await`. The test body performs its work and assertions in well under a second, then blocks on that timer. Nothing observes the socket close: no assertion depends on it, and the four tests that exercise reconnection drive it with a synthetic second `Connection` frame over the still-open socket, which `BetfairExecutionClient` treats as a reconnect regardless of transport state. The delay exists only to keep the peer alive long enough for the test to finish, which is a signal, not a duration.

Because it is a duration, it is also a latent flake. Every test disconnects its client before joining the server, so today the socket closes after the client is gone. A test body that runs longer than its keepalive - under a loaded CI runner, say - instead gets transport EOF mid-test, which the client reads as a dropped connection and can turn into a spurious reconnect. The failure would appear as an unrelated assertion failing intermittently.

`test_cancel_all_orders_sends_request` measures 5.20s unchanged and 0.37s with its keepalive shortened, so the timer accounts for essentially the whole runtime.

## Replacing the timer with an explicit completion signal

The mock server now waits on a `tokio::sync::oneshot` instead of the clock:

```rust
let (server_done_tx, server_done_rx) = tokio::sync::oneshot::channel();

let server = tokio::spawn(async move {
    let (_reader, write_half) = accept_and_auth(&listener).await;
    let _ = server_done_rx.await;
    drop(write_half);
});

// ... test body and assertions ...

client.disconnect().await.unwrap();
let _ = server_done_tx.send(());
server.await.unwrap();
```

The signal is sent after the client's own cleanup and after the final assertion, so the socket still closes with the client already gone - the ordering the timer was approximating - but now by construction rather than by racing a deadline. Sender drop on a failing test releases the receiver, so a panicking test does not leave the mock parked.

The join also becomes `server.await.unwrap()`. Previously `let _ = server.await` discarded the mock task's result, so a panic inside a mock server - an `unwrap` on a malformed frame, a failed write - was swallowed and the test passed anyway. That is now a test failure.

## What is converted, and what is deliberately not

The rule is positional, not by duration: a sleep immediately preceding `drop(write_half)` as the final act of the spawned task is keepalive and is converted, whatever its constant. 75 sites qualify - 61 in `tests/exec_client.rs` (21 at 2s, one at 3s, 37 at 5s, one at 10s, one at 15s), 13 in `tests/data_client.rs`, plus the accept-loop timeout in `test_data_client_connect_is_idempotent`, which is stopped by the same signal.

Sleeps that sit mid-task are observation windows and are untouched: the 150ms gaps between the two synthetic `Connection` frames in the reconnect-queue tests, the fixture-send delays, the three inline one-second negative-event waits, the 200ms second-connect window in the idempotence test, and the `betting_response_delays` entries that make an HTTP method slow on purpose so a reconciliation can be aborted mid-flight. `test_data_client_deduplicates_same_market_subscription` keeps its sleep as well, because its server returns an observed value to the test after the drop and so is not a terminal task; its absence check is the preceding 500ms read timeout.

No production code is touched.

## Testing

The change is to test scaffolding only; every assertion is unchanged, so the existing suite is the regression test and the differential is runtime.

The Betfair suite drops from 307.32s to 51.62s, a reduction of 255.70s. The two slowest tests in the suite, both of which set a floor on their test lane, drop furthest: `test_disconnect_during_reconciliation_clears_halt` from 15.09s to 0.32s, and `test_queued_reconnect_re_asserts_halt` from 10.28s to 1.90s. A full workspace test run is about 45s faster; the gap between that and the 255.70s is parallel overlap, since sleeping tests consume no CPU and interleave - the saving is proportionally larger the narrower the lane, which is the CI case.
