### PR TITLE
Stop dYdX error-path tests waiting out the production retry ladder

### DIFF
--- a/crates/adapters/dydx/tests/data_client.rs
+++ b/crates/adapters/dydx/tests/data_client.rs
@@ -82,6 +82,17 @@ struct TestServerState {
     last_trades_params: Arc<tokio::sync::Mutex<Option<HashMap<String, String>>>>,
 }
 
+fn fast_test_retry_config(max_retries: u32) -> RetryConfig {
+    RetryConfig {
+        max_retries,
+        initial_delay_ms: 1,
+        max_delay_ms: 1,
+        backoff_factor: 1.0,
+        jitter_ms: 0,
+        ..Default::default()
+    }
+}
+
 static DATA_CLIENT_CREATION_LOCK: Mutex<()> = Mutex::new(());
 
 async fn wait_for_server(addr: SocketAddr, path: &str) {
@@ -671,7 +682,7 @@ async fn test_network_error() {
         1,
         None,
         DydxNetwork::Mainnet,
-        None,
+        Some(fast_test_retry_config(0)),
     )
     .unwrap();
 
@@ -703,7 +714,14 @@ async fn test_server_error_500() {
     wait_for_server(addr, "/v4/perpetualMarkets").await;
 
     let base_url = format!("http://{addr}");
-    let client = DydxHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap();
+    let client = DydxHttpClient::new(
+        Some(base_url),
+        5,
+        None,
+        DydxNetwork::Mainnet,
+        Some(fast_test_retry_config(0)),
+    )
+    .unwrap();
 
     let result = client.request_instruments(None, None, None).await;
     assert!(result.is_err());
@@ -733,7 +751,14 @@ async fn test_server_error_429_rate_limit() {
     wait_for_server(addr, "/v4/perpetualMarkets").await;
 
     let base_url = format!("http://{addr}");
-    let client = DydxHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap();
+    let client = DydxHttpClient::new(
+        Some(base_url),
+        5,
+        None,
+        DydxNetwork::Mainnet,
+        Some(fast_test_retry_config(0)),
+    )
+    .unwrap();
 
     let result = client.request_instruments(None, None, None).await;
     assert!(result.is_err());

--- a/crates/adapters/dydx/tests/exec_client.rs
+++ b/crates/adapters/dydx/tests/exec_client.rs
@@ -42,7 +42,7 @@ use nautilus_model::{
     identifiers::AccountId,
     instruments::{Instrument, InstrumentAny},
 };
-use nautilus_network::http::HttpClient;
+use nautilus_network::{http::HttpClient, retry::RetryConfig};
 use rstest::rstest;
 use rust_decimal_macros::dec;
 use serde_json::{Value, json};
@@ -71,6 +71,17 @@ struct TestServerState {}
 struct QueryCaptureState {
     orders_params: Arc<tokio::sync::Mutex<Option<HashMap<String, String>>>>,
     fills_params: Arc<tokio::sync::Mutex<Option<HashMap<String, String>>>>,
+}
+
+fn fast_test_retry_config(max_retries: u32) -> RetryConfig {
+    RetryConfig {
+        max_retries,
+        initial_delay_ms: 1,
+        max_delay_ms: 1,
+        backoff_factor: 1.0,
+        jitter_ms: 0,
+        ..Default::default()
+    }
 }
 
 async fn wait_for_server(addr: SocketAddr, path: &str) {
@@ -571,8 +582,14 @@ async fn test_http_error_handling_500() {
     wait_for_server(addr, "/v4/orders").await;
 
     let base_url = format!("http://{addr}");
-    let client =
-        DydxRawHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap();
+    let client = DydxRawHttpClient::new(
+        Some(base_url),
+        5,
+        None,
+        DydxNetwork::Mainnet,
+        Some(fast_test_retry_config(0)),
+    )
+    .unwrap();
 
     let result = client.get_orders("dydx1test", 0, None, None).await;
     assert!(result.is_err());

--- a/crates/adapters/dydx/tests/http.rs
+++ b/crates/adapters/dydx/tests/http.rs
@@ -46,6 +46,17 @@ struct TestServerState {
     request_count: Arc<tokio::sync::Mutex<usize>>,
 }
 
+fn fast_test_retry_config(max_retries: u32) -> RetryConfig {
+    RetryConfig {
+        max_retries,
+        initial_delay_ms: 1,
+        max_delay_ms: 1,
+        backoff_factor: 1.0,
+        jitter_ms: 0,
+        ..Default::default()
+    }
+}
+
 /// Wait for the test server to be ready by polling a health endpoint.
 async fn wait_for_server(addr: SocketAddr, path: &str) {
     let health_url = format!("http://{addr}{path}");
@@ -439,7 +450,7 @@ async fn test_network_error_handling() {
         1,
         None,
         DydxNetwork::Mainnet,
-        None,
+        Some(fast_test_retry_config(0)),
     )
     .unwrap();
 
@@ -488,7 +499,14 @@ async fn test_server_error_500() {
     wait_for_server(addr, "/v4/perpetualMarkets").await;
 
     let base_url = format!("http://{addr}");
-    let client = DydxHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap();
+    let client = DydxHttpClient::new(
+        Some(base_url),
+        5,
+        None,
+        DydxNetwork::Mainnet,
+        Some(fast_test_retry_config(0)),
+    )
+    .unwrap();
 
     let result = client.request_instruments(None, None, None).await;
     assert!(result.is_err());
@@ -618,7 +636,14 @@ async fn test_server_error_503() {
     wait_for_server(addr, "/v4/perpetualMarkets").await;
 
     let base_url = format!("http://{addr}");
-    let client = DydxHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap();
+    let client = DydxHttpClient::new(
+        Some(base_url),
+        5,
+        None,
+        DydxNetwork::Mainnet,
+        Some(fast_test_retry_config(0)),
+    )
+    .unwrap();
 
     let result = client.request_instruments(None, None, None).await;
     assert!(result.is_err());
@@ -1130,8 +1155,14 @@ async fn test_http_502_bad_gateway() {
     wait_for_server(addr, "/v4/perpetualMarkets").await;
 
     let base_url = format!("http://{addr}");
-    let client =
-        DydxRawHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap();
+    let client = DydxRawHttpClient::new(
+        Some(base_url),
+        5,
+        None,
+        DydxNetwork::Mainnet,
+        Some(fast_test_retry_config(0)),
+    )
+    .unwrap();
 
     let result = client.get_height().await;
     assert!(result.is_err());
@@ -1602,14 +1633,23 @@ async fn test_retry_exhaustion() {
     wait_for_server(addr, "/v4/perpetualMarkets").await;
 
     let base_url = format!("http://{addr}");
-    let client =
-        DydxRawHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap();
+    let client = DydxRawHttpClient::new(
+        Some(base_url),
+        5,
+        None,
+        DydxNetwork::Mainnet,
+        Some(fast_test_retry_config(1)),
+    )
+    .unwrap();
 
     let result = client.get_time().await;
     assert!(result.is_err());
 
     let final_count = *state.request_count.lock().await;
-    assert!(final_count > 1, "Should have retried multiple times");
+    assert_eq!(
+        final_count, 2,
+        "Should make one initial request and one retry"
+    );
 }
 
 #[rstest]
@@ -1654,7 +1694,14 @@ async fn test_mixed_success_and_error_responses() {
 
     let base_url = format!("http://{addr}");
     let client = Arc::new(
-        DydxRawHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap(),
+        DydxRawHttpClient::new(
+            Some(base_url),
+            5,
+            None,
+            DydxNetwork::Mainnet,
+            Some(fast_test_retry_config(0)),
+        )
+        .unwrap(),
     );
 
     let mut handles = vec![];


### PR DESCRIPTION
Ten dYdX error-path tests inherit the production retry ladder and then wait it out in real time, which is half the package's test runtime. Same class as #4531.

## The tests pass no retry config, so they get the production one

The error-path tests construct their client with the retry-config parameter set to `None`:

```rust
let client = DydxHttpClient::new(Some(base_url), 5, None, DydxNetwork::Mainnet, None).unwrap();
```

so they inherit `RetryConfig::default()` - `max_retries: 3`, `initial_delay_ms: 1_000`, `max_delay_ms: 10_000`, `backoff_factor: 2.0`, `jitter_ms: 100`. Each then asks a mock `axum` server for an endpoint that always answers 500, 502, 503 or 429, and the client dutifully retries on a 1s, 2s, 4s ladder before surfacing the error. That is 7 seconds of sleeping per test, plus up to 300ms of jitter, and it matches the measured per-test times to the millisecond.

None of these tests are about retrying. Nine of them assert only that an error surfaces. The tenth, `test_retry_exhaustion`, is about retrying, but it asserts on the request count rather than on elapsed time, so it does not need the production delays either.

## Injecting a fast config where the tests already pass `None`

Each of the three test files gains a local helper:

```rust
fn fast_test_retry_config(max_retries: u32) -> RetryConfig {
    RetryConfig {
        max_retries,
        initial_delay_ms: 1,
        max_delay_ms: 1,
        backoff_factor: 1.0,
        jitter_ms: 0,
        ..Default::default()
    }
}
```

The nine error-surfacing tests use `fast_test_retry_config(0)`, and `test_retry_exhaustion` uses `fast_test_retry_config(1)`. Everything else - the operation timeout, `immediate_first`, `max_elapsed_ms` - is inherited from the default, so the only behaviour that changes is how long the client waits between attempts.

The 1ms is deliberate rather than cosmetic. `ExponentialBackoff::new` rejects a zero initial delay, and `RetryManager` builds and validates the backoff before the first operation even when `max_retries` is zero, so a zero-delay config fails construction rather than producing a fast client. With 1ms initial and max, a factor of 1.0 and no jitter, the computed delay is exactly 1ms.

The helper is duplicated in all three files because each `tests/*.rs` is its own integration-test crate and the package has no shared test module; `wait_for_server` is already duplicated the same way.

## Making `test_retry_exhaustion` assert what it claims

Since this test's retry count is now explicit, its assertion is worth tightening. It previously read:

```rust
assert!(final_count > 1, "Should have retried multiple times");
```

which is satisfied by any number of requests greater than one - it cannot distinguish one retry from forty, and would not catch a change that made the client retry far more than intended. With `max_retries: 1` the expected count is exact, so it now reads:

```rust
assert_eq!(final_count, 2, "Should make one initial request and one retry");
```

one initial request plus one retry, then exhaustion. This binds the test to its own explicit config rather than to the production default, which it never asserted in the first place.

## Testing

No new tests; the change is to test configuration, and every existing assertion other than the one tightened above is unchanged.

The strengthened assertion was verified to bite. Against a two-retry config the request count is 3, where the old `final_count > 1` passes and the new `final_count == 2` fails - so the new assertion detects an over-retrying client that the old one admitted. A zero-retry control does not demonstrate this, since a count of 1 fails both forms.

Runtime for the `nautilus-dydx` package drops from 1m54s to 56.5s, measured back to back on the same machine.
