### PR TITLE
Parse Bybit commision currency from WebSocket stream

### DIFF
--- a/crates/adapters/bybit/src/websocket/dispatch.rs
+++ b/crates/adapters/bybit/src/websocket/dispatch.rs
@@ -55,7 +55,7 @@ use crate::{
     common::{
         enums::BybitOrderStatus,
         parse::{
-            bybit_rejection_due_post_only, make_bybit_symbol, parse_millis_timestamp,
+            bybit_rejection_due_post_only, get_currency, make_bybit_symbol, parse_millis_timestamp,
             parse_price_with_precision, parse_quantity_with_precision,
         },
     },
@@ -754,7 +754,7 @@ fn parse_order_filled(
         .exec_fee
         .parse()
         .with_context(|| format!("failed to parse execFee='{}'", exec.exec_fee))?;
-    let commission_currency = instrument.quote_currency();
+    let commission_currency = get_currency(&exec.fee_currency);
     let commission = Money::from_decimal(fee_decimal, commission_currency).with_context(|| {
         format!(
             "failed to create commission from execFee='{}'",

--- a/crates/adapters/bybit/src/websocket/dispatch.rs
+++ b/crates/adapters/bybit/src/websocket/dispatch.rs
@@ -1387,6 +1387,32 @@ mod tests {
     }
 
     #[rstest]
+    fn parse_order_filled_uses_payload_fee_currency() {
+        let instrument = linear_instrument();
+        let (emitter, _rx) = create_emitter();
+
+        let json = load_test_json("ws_account_execution.json");
+        let msg: crate::websocket::messages::BybitWsAccountExecutionMsg =
+            serde_json::from_str(&json).unwrap();
+
+        let mut exec = msg.data[0].clone();
+        exec.fee_currency = Ustr::from("BTC");
+
+        let filled = parse_order_filled(
+            &exec,
+            &instrument,
+            &default_identity(),
+            &emitter,
+            test_account_id(),
+            UnixNanos::default(),
+        )
+        .unwrap();
+
+        let commission = filled.commission.expect("commission present");
+        assert_eq!(commission.currency.code.as_str(), "BTC");
+    }
+
+    #[rstest]
     fn test_dispatch_tracked_execution_preserves_venue_position_id() {
         let instrument = linear_instrument();
         let instruments = build_instruments(std::slice::from_ref(&instrument));

--- a/crates/adapters/bybit/src/websocket/messages.rs
+++ b/crates/adapters/bybit/src/websocket/messages.rs
@@ -828,6 +828,7 @@ pub struct BybitWsAccountExecution {
     pub exec_value: String,
     pub is_maker: bool,
     pub fee_rate: String,
+    pub fee_currency: Ustr,
     pub trade_iv: String,
     pub mark_iv: String,
     pub block_trade_id: Ustr,

--- a/crates/adapters/bybit/src/websocket/parse.rs
+++ b/crates/adapters/bybit/src/websocket/parse.rs
@@ -984,6 +984,7 @@ pub fn parse_ws_fill_report_fast(
         LiquiditySide::Taker
     };
 
+    // execution.fast carries no fee data (no rate or currency)
     let commission_currency = instrument.quote_currency();
     let commission = Money::from_decimal(Decimal::ZERO, commission_currency)
         .with_context(|| format!("Failed to create zero commission for {commission_currency}"))?;
@@ -1500,6 +1501,22 @@ mod tests {
         let report = parse_ws_fill_report(execution, account_id, &instrument, TS).unwrap();
 
         assert_eq!(report.venue_position_id, None);
+    }
+
+    #[rstest]
+    fn parse_ws_fill_report_uses_payload_fee_currency() {
+        let instrument = linear_instrument();
+        let json = load_test_json("ws_account_execution.json");
+        let msg: crate::websocket::messages::BybitWsAccountExecutionMsg =
+            serde_json::from_str(&json).unwrap();
+
+        let mut execution = msg.data[0].clone();
+        execution.fee_currency = Ustr::from("BTC");
+        let account_id = AccountId::new("BYBIT-001");
+
+        let report = parse_ws_fill_report(&execution, account_id, &instrument, TS).unwrap();
+
+        assert_eq!(report.commission.currency.code.as_str(), "BTC");
     }
 
     fn fast_execution(is_maker: bool, order_link_id: &str) -> BybitWsAccountExecutionFast {

--- a/crates/adapters/bybit/src/websocket/parse.rs
+++ b/crates/adapters/bybit/src/websocket/parse.rs
@@ -907,7 +907,7 @@ pub fn parse_ws_fill_report(
         .parse()
         .with_context(|| format!("Failed to parse execFee='{}'", execution.exec_fee))?;
 
-    let commission_currency = instrument.quote_currency();
+    let commission_currency = get_currency(&execution.fee_currency);
     let commission = Money::from_decimal(fee_decimal, commission_currency).with_context(|| {
         format!(
             "Failed to create commission from execFee='{}'",
@@ -1450,6 +1450,7 @@ mod tests {
         assert_eq!(report.last_qty, instrument.make_qty(0.5, None));
         assert_eq!(report.last_px, instrument.make_price(95900.1));
         assert_eq!(report.commission.as_f64(), 26.3725275);
+        assert_eq!(report.commission.currency.code.as_str(), "USDT");
         assert_eq!(report.liquidity_side, LiquiditySide::Taker);
         assert_eq!(
             report.client_order_id.as_ref().unwrap().to_string(),
@@ -1484,6 +1485,7 @@ mod tests {
         assert_eq!(report.last_qty, instrument.make_qty(0.5, None));
         assert_eq!(report.last_px, instrument.make_price(95850.0));
         assert_eq!(report.commission.as_f64(), 0.0);
+        assert_eq!(report.commission.currency.code.as_str(), "USDT");
     }
 
     #[rstest]

--- a/crates/adapters/bybit/test_data/ws_account_execution.json
+++ b/crates/adapters/bybit/test_data/ws_account_execution.json
@@ -31,7 +31,8 @@
       "execTime": "1746270400353",
       "isLeverage": "0",
       "isMaker": false,
-      "seq": 140612148849382
+      "seq": 140612148849382,
+      "feeCurrency": "USDT"
     }
   ]
 }

--- a/crates/adapters/bybit/test_data/ws_account_execution_adl.json
+++ b/crates/adapters/bybit/test_data/ws_account_execution_adl.json
@@ -31,7 +31,8 @@
       "execTime": "1746270400398",
       "isLeverage": "0",
       "isMaker": false,
-      "seq": 140612148849383
+      "seq": 140612148849383,
+      "feeCurrency": "USDT"
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Fixes the hardcoded commission currency (`instrument.quote_currency()`) in the two Bybit WS execution paths (`dispatch.rs` tracked-order OrderFilled and `websocket/parse.rs` fill-report). These now read `feeCurrency` adaptively from the payload, following the already-correct HTTP reconciliation path in `common/parse.rs`. This matters because the fee currency can genuinely differ from the quote currency, e.g. spot fills charge the fee in the received asset (base on a buy, quote on a sell), so the quote-only assumption mislabeled commissions.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Also verified live that Bybit returns this field.
