### PR TITLE
fix(polymarket): replace Price::from with fallible path to prevent panic on excess tick precision

### DIFF
--- a/crates/adapters/polymarket/src/http/parse.rs
+++ b/crates/adapters/polymarket/src/http/parse.rs
@@ -186,7 +186,6 @@ pub fn create_instrument_from_def(
     let raw_symbol = Symbol::new(def.token_id);
     let currency = get_currency(PUSD);
 
-    let price_increment = Price::from(def.tick_size.to_string());
     let size_increment = Quantity::from("0.000001");
 
     let activation_ns = def
@@ -204,6 +203,8 @@ pub fn create_instrument_from_def(
     // these bounds land inside the venue's `[tick, 1 - tick]` range; execution-side validation in
     // `PolymarketOrderBuilder::validate_limit_price` remains the source of truth.
     let (min_price, max_price) = tick_relative_price_bounds(def.tick_size)?;
+    let price_increment = Price::from_decimal(def.tick_size)
+        .map_err(|e| anyhow::anyhow!("Invalid tick_size '{}': {e}", def.tick_size))?;
     // Polymarket exposes `orderMinSize` (limit-order minimum shares) and a separate
     // $1 market-order minimum amount; the instrument model can only carry one
     // `min_quantity`, so leave it unset and let the venue reject out-of-bounds orders.
@@ -276,8 +277,9 @@ pub fn rebuild_instrument_with_tick_size(
         .parse()
         .map_err(|e| anyhow::anyhow!("Failed to parse tick size '{new_tick_size}': {e}"))?;
     let price_precision = tick_size.scale() as u8;
-    let price_increment = Price::from(tick_size.to_string());
     let (min_price, max_price) = tick_relative_price_bounds(tick_size)?;
+    let price_increment = Price::from_decimal(tick_size)
+        .map_err(|e| anyhow::anyhow!("Invalid tick_size '{tick_size}': {e}"))?;
 
     let rebuilt = BinaryOption::new_checked(
         bo.id,
@@ -766,5 +768,31 @@ mod tests {
         };
         assert_eq!(new_bo.outcome, orig_bo.outcome);
         assert_eq!(new_bo.currency, orig_bo.currency);
+    }
+    #[rstest]
+    fn test_create_instrument_rejects_excess_tick_precision() {
+        let mut market = load_gamma_market("gamma_market.json");
+        market.order_price_min_tick_size = Some(1e-19_f64);
+        let defs = parse_gamma_market(&market).unwrap();
+        let ts_init = UnixNanos::default();
+
+        let result = create_instrument_from_def(&defs[0], ts_init);
+        assert!(result.is_err(), "expected Err for precision > FIXED_PRECISION");
+    }
+
+    #[rstest]
+    fn test_rebuild_instrument_rejects_excess_tick_precision() {
+        let market = load_gamma_market("gamma_market.json");
+        let defs = parse_gamma_market(&market).unwrap();
+        let ts_init = UnixNanos::default();
+        let instrument = create_instrument_from_def(&defs[0], ts_init).unwrap();
+
+        let result = rebuild_instrument_with_tick_size(
+            &instrument,
+            "0.0000000000000000001",
+            ts_init,
+            ts_init,
+        );
+        assert!(result.is_err(), "expected Err for precision > FIXED_PRECISION");
     }
 }


### PR DESCRIPTION


Price::from calls expect() internally and panics when the decimal precision of the tick size exceeds FIXED_PRECISION (16). Both create_instrument_from_def and rebuild_instrument_with_tick_size called Price::from before tick_relative_price_bounds, so a malformed Gamma tick size with >16 decimal places could terminate the process.

Fix: move tick_relative_price_bounds before price_increment construction and replace Price::from with Price::from_decimal which returns a Result. The existing fail-soft boundary in instruments_from_defs now correctly logs and skips the invalid instrument.

Fixes #4534

# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
