### PR TITLE
Make the Binance Spot WS trading setup timeout configurable

### DIFF
--- a/crates/adapters/binance/src/config.rs
+++ b/crates/adapters/binance/src/config.rs
@@ -317,6 +317,9 @@ pub struct BinanceExecClientConfig {
     /// Whether to use the WebSocket trading API for order operations (Spot and USD-M Futures).
     #[builder(default = true)]
     pub use_ws_trading: bool,
+    /// Timeout in milliseconds for each Binance Spot WS trading setup response.
+    #[builder(default = 10_000)]
+    pub ws_trading_setup_timeout_ms: u64,
     /// Instrument loading and fee configuration.
     #[builder(default)]
     pub instrument_provider: BinanceInstrumentProviderConfig,
@@ -396,6 +399,7 @@ nautilus_core::impl_pyo3_config_getters!(BinanceExecClientConfig {
     base_url_ws: Option<String>,
     base_url_ws_trading: Option<String>,
     use_ws_trading: bool,
+    ws_trading_setup_timeout_ms: u64,
     instrument_provider: BinanceInstrumentProviderConfig,
     instrument_refresh_interval_secs: u64,
     use_gtd: bool,
@@ -423,9 +427,15 @@ impl BinanceExecClientConfig {
     ///
     /// # Errors
     ///
-    /// Returns an error for invalid receive-window, provider, or Binance US settings.
+    /// Returns an error for invalid receive-window, WS trading setup timeout, provider, or
+    /// Binance US settings.
     pub fn validate(&self) -> anyhow::Result<()> {
         validate_recv_window(self.recv_window_ms)?;
+        anyhow::ensure!(
+            self.ws_trading_setup_timeout_ms > 0,
+            "ws_trading_setup_timeout_ms must be greater than 0, was {}",
+            self.ws_trading_setup_timeout_ms
+        );
         self.instrument_provider.validate(self.product_type)?;
 
         if self.us {
@@ -515,6 +525,7 @@ product_types = ["SPOT", "USD_M"]
         assert_eq!(config.environment, expected.environment);
         assert_eq!(config.product_type, expected.product_type);
         assert_eq!(config.use_ws_trading, expected.use_ws_trading);
+        assert_eq!(config.ws_trading_setup_timeout_ms, 10_000);
         assert_eq!(config.instrument_provider, expected.instrument_provider);
         assert_eq!(
             config.instrument_refresh_interval_secs,
@@ -555,6 +566,14 @@ oms_type = "Hedging"
     }
 
     #[rstest]
+    fn test_exec_config_toml_ws_trading_setup_timeout_override() {
+        let config: BinanceExecClientConfig =
+            toml::from_str("ws_trading_setup_timeout_ms = 250").unwrap();
+
+        assert_eq!(config.ws_trading_setup_timeout_ms, 250);
+    }
+
+    #[rstest]
     #[case(0)]
     #[case(60_001)]
     fn test_data_config_rejects_recv_window_out_of_bounds(#[case] recv_window_ms: u64) {
@@ -570,6 +589,21 @@ oms_type = "Hedging"
             format!(
                 "recv_window_ms must be in the inclusive range 1..=60000, was {recv_window_ms}"
             )
+        );
+    }
+
+    #[rstest]
+    fn test_exec_config_rejects_zero_ws_trading_setup_timeout() {
+        let config = BinanceExecClientConfig {
+            ws_trading_setup_timeout_ms: 0,
+            ..Default::default()
+        };
+
+        let message = config.validate().unwrap_err().to_string();
+
+        assert_eq!(
+            message,
+            "ws_trading_setup_timeout_ms must be greater than 0, was 0"
         );
     }
 

--- a/crates/adapters/binance/src/python/config.rs
+++ b/crates/adapters/binance/src/python/config.rs
@@ -205,6 +205,7 @@ impl BinanceExecClientConfig {
         base_url_ws = None,
         base_url_ws_trading = None,
         use_ws_trading = true,
+        ws_trading_setup_timeout_ms = None,
         instrument_provider = None,
         instrument_refresh_interval_secs = None,
         use_gtd = true,
@@ -233,6 +234,7 @@ impl BinanceExecClientConfig {
         base_url_ws: Option<String>,
         base_url_ws_trading: Option<String>,
         use_ws_trading: bool,
+        ws_trading_setup_timeout_ms: Option<u64>,
         instrument_provider: Option<BinanceInstrumentProviderConfig>,
         instrument_refresh_interval_secs: Option<u64>,
         use_gtd: bool,
@@ -261,6 +263,8 @@ impl BinanceExecClientConfig {
             base_url_ws: base_url_ws.or(defaults.base_url_ws),
             base_url_ws_trading: base_url_ws_trading.or(defaults.base_url_ws_trading),
             use_ws_trading,
+            ws_trading_setup_timeout_ms: ws_trading_setup_timeout_ms
+                .unwrap_or(defaults.ws_trading_setup_timeout_ms),
             instrument_provider: instrument_provider.unwrap_or(defaults.instrument_provider),
             instrument_refresh_interval_secs: instrument_refresh_interval_secs
                 .unwrap_or(defaults.instrument_refresh_interval_secs),
@@ -379,8 +383,8 @@ mod tests {
         let trader_id = TraderId::from("TRADER-001");
         let account_id = AccountId::from("BINANCE-001");
         let config = BinanceExecClientConfig::py_new(
-            trader_id, account_id, None, None, None, None, None, true, None, None, true, true,
-            None, None, None, None, false, None, None, None, None, false, false, None, None,
+            trader_id, account_id, None, None, None, None, None, true, None, None, None, true,
+            true, None, None, None, None, false, None, None, None, None, false, false, None, None,
         )
         .unwrap();
         let defaults = BinanceExecClientConfig::default();
@@ -393,6 +397,7 @@ mod tests {
         assert_eq!(config.base_url_ws, defaults.base_url_ws);
         assert_eq!(config.base_url_ws_trading, defaults.base_url_ws_trading);
         assert!(config.use_ws_trading);
+        assert_eq!(config.ws_trading_setup_timeout_ms, 10_000);
         assert_eq!(config.instrument_provider, defaults.instrument_provider);
         assert_eq!(
             config.instrument_refresh_interval_secs,
@@ -434,6 +439,7 @@ mod tests {
             Some("wss://stream.example".to_string()),
             Some("wss://trade.example".to_string()),
             false,
+            Some(250),
             None,
             Some(45),
             false,
@@ -466,6 +472,7 @@ mod tests {
             Some("wss://trade.example")
         );
         assert!(!config.use_ws_trading);
+        assert_eq!(config.ws_trading_setup_timeout_ms, 250);
         assert_eq!(config.instrument_refresh_interval_secs, 45);
         assert!(!config.use_gtd);
         assert!(!config.use_position_ids);
@@ -497,6 +504,7 @@ mod tests {
             None,
             None,
             true,
+            None,
             None,
             None,
             true,

--- a/crates/adapters/binance/src/spot/execution.rs
+++ b/crates/adapters/binance/src/spot/execution.rs
@@ -678,6 +678,8 @@ impl ExecutionClient for BinanceSpotExecutionClient {
             return Ok(());
         }
 
+        let ws_setup_timeout = Duration::from_millis(self.config.ws_trading_setup_timeout_ms);
+
         // Load instruments if not already done
         if !self.core.instruments_initialized() {
             let instruments = self
@@ -772,7 +774,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                             .await;
                     } else {
                         let auth_result = wait_for_ws_setup_response(
-                            Duration::from_secs(10),
+                            ws_setup_timeout,
                             self.ws_authenticated.notified(),
                             &mut ws_setup_error_rx,
                             "WS session authentication timed out",
@@ -788,7 +790,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                                 .await;
                         } else {
                             let subscribe_result = wait_for_ws_setup_response(
-                                Duration::from_secs(10),
+                                ws_setup_timeout,
                                 self.ws_user_data_subscribed.notified(),
                                 &mut ws_setup_error_rx,
                                 "WS user data subscription timed out",

--- a/crates/adapters/binance/tests/spot/exec_client.rs
+++ b/crates/adapters/binance/tests/spot/exec_client.rs
@@ -102,6 +102,13 @@ const ORDERS_GROUP_BLOCK_LENGTH: u16 = 162;
 const PRICE_FILTER_TEMPLATE_ID: u16 = 1;
 const LOT_SIZE_FILTER_TEMPLATE_ID: u16 = 4;
 
+/// WS trading setup timeout for the tests that exercise setup expiry.
+///
+/// Sized to expire quickly while leaving room for the request to reach the
+/// loopback server and be recorded: the timer starts when the command is
+/// queued on the handler channel, not when the frame hits the socket.
+const TEST_WS_SETUP_TIMEOUT_MS: u64 = 250;
+
 fn create_sbe_header(block_length: u16, template_id: u16) -> [u8; 8] {
     let mut header = [0u8; 8];
     header[0..2].copy_from_slice(&block_length.to_le_bytes());
@@ -541,6 +548,7 @@ enum WsSetupBehavior {
     RejectSessionLogon,
     IgnoreSessionLogon,
     RejectUserDataSubscribe,
+    IgnoreUserDataSubscribe,
 }
 
 #[derive(Clone)]
@@ -1137,6 +1145,7 @@ async fn handle_ws_setup_socket(mut socket: WebSocket, state: WsSetupState) {
                             break;
                         }
                     }
+                    ("userDataStream.subscribe", WsSetupBehavior::IgnoreUserDataSubscribe) => {}
                     ("userDataStream.subscribe", _) => {
                         match send_ws_setup_result(
                             &mut socket,
@@ -1328,6 +1337,24 @@ fn create_test_execution_client_with_ws_trading(
     create_test_execution_client_with_transport(base_url_http, true, Some(base_url_ws_trading))
 }
 
+fn create_test_execution_client_with_ws_trading_timeout(
+    base_url_http: String,
+    base_url_ws_trading: String,
+    ws_trading_setup_timeout_ms: u64,
+) -> (
+    BinanceSpotExecutionClient,
+    tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    Rc<RefCell<Cache>>,
+) {
+    create_test_execution_client_with_transport_and_gtd_and_ws_setup_timeout(
+        base_url_http,
+        true,
+        Some(base_url_ws_trading),
+        true,
+        ws_trading_setup_timeout_ms,
+    )
+}
+
 fn create_test_execution_client_with_transport(
     base_url_http: String,
     use_ws_trading: bool,
@@ -1350,6 +1377,26 @@ fn create_test_execution_client_with_transport_and_gtd(
     use_ws_trading: bool,
     base_url_ws_trading: Option<String>,
     use_gtd: bool,
+) -> (
+    BinanceSpotExecutionClient,
+    tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    Rc<RefCell<Cache>>,
+) {
+    create_test_execution_client_with_transport_and_gtd_and_ws_setup_timeout(
+        base_url_http,
+        use_ws_trading,
+        base_url_ws_trading,
+        use_gtd,
+        BinanceExecClientConfig::default().ws_trading_setup_timeout_ms,
+    )
+}
+
+fn create_test_execution_client_with_transport_and_gtd_and_ws_setup_timeout(
+    base_url_http: String,
+    use_ws_trading: bool,
+    base_url_ws_trading: Option<String>,
+    use_gtd: bool,
+    ws_trading_setup_timeout_ms: u64,
 ) -> (
     BinanceSpotExecutionClient,
     tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
@@ -1378,6 +1425,7 @@ fn create_test_execution_client_with_transport_and_gtd(
         base_url_http: Some(base_url_http),
         base_url_ws_trading,
         use_ws_trading,
+        ws_trading_setup_timeout_ms,
         use_gtd,
         api_key: Some("test_api_key".to_string()),
         api_secret: Some("test_api_secret".to_string()),
@@ -1852,15 +1900,23 @@ async fn test_ws_trading_reconnect_retries_ws_after_setup_failure() {
 #[rstest]
 #[tokio::test]
 async fn test_ws_trading_session_logon_rejection_uses_http_only_mode() {
-    assert_ws_setup_failure_uses_http(WsSetupBehavior::RejectSessionLogon, &["session.logon"])
-        .await;
+    assert_ws_setup_failure_uses_http(
+        WsSetupBehavior::RejectSessionLogon,
+        &["session.logon"],
+        None,
+    )
+    .await;
 }
 
 #[rstest]
 #[tokio::test]
 async fn test_ws_trading_auth_timeout_uses_http_only_mode() {
-    assert_ws_setup_failure_uses_http(WsSetupBehavior::IgnoreSessionLogon, &["session.logon"])
-        .await;
+    assert_ws_setup_failure_uses_http(
+        WsSetupBehavior::IgnoreSessionLogon,
+        &["session.logon"],
+        Some(TEST_WS_SETUP_TIMEOUT_MS),
+    )
+    .await;
 }
 
 #[rstest]
@@ -1869,6 +1925,18 @@ async fn test_ws_trading_user_data_subscribe_rejection_uses_http_only_mode() {
     assert_ws_setup_failure_uses_http(
         WsSetupBehavior::RejectUserDataSubscribe,
         &["session.logon", "userDataStream.subscribe"],
+        None,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_ws_trading_user_data_subscribe_timeout_uses_http_only_mode() {
+    assert_ws_setup_failure_uses_http(
+        WsSetupBehavior::IgnoreUserDataSubscribe,
+        &["session.logon", "userDataStream.subscribe"],
+        Some(TEST_WS_SETUP_TIMEOUT_MS),
     )
     .await;
 }
@@ -3234,15 +3302,25 @@ async fn wait_for_ws_method(state: &WsSetupState, expected_method: &str) {
     .await;
 }
 
-async fn assert_ws_setup_failure_uses_http(behavior: WsSetupBehavior, expected_methods: &[&str]) {
+async fn assert_ws_setup_failure_uses_http(
+    behavior: WsSetupBehavior,
+    expected_methods: &[&str],
+    ws_trading_setup_timeout_ms: Option<u64>,
+) {
     let (http_addr, request_count) =
         start_exec_test_server_with_command_responses(CommandResponses::default()).await;
     let (ws_addr, ws_state) = start_ws_setup_test_server(behavior).await;
     let base_url_http = format!("http://{http_addr}");
     let base_url_ws_trading = format!("ws://{ws_addr}/ws-api/v3");
 
-    let (mut client, mut rx, cache) =
-        create_test_execution_client_with_ws_trading(base_url_http, base_url_ws_trading);
+    let (mut client, mut rx, cache) = match ws_trading_setup_timeout_ms {
+        Some(timeout_ms) => create_test_execution_client_with_ws_trading_timeout(
+            base_url_http,
+            base_url_ws_trading,
+            timeout_ms,
+        ),
+        None => create_test_execution_client_with_ws_trading(base_url_http, base_url_ws_trading),
+    };
     add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
 
     client.start().unwrap();
@@ -3250,7 +3328,9 @@ async fn assert_ws_setup_failure_uses_http(behavior: WsSetupBehavior, expected_m
         WsSetupBehavior::CompleteSetup | WsSetupBehavior::RejectFirstSessionLogon => {
             unreachable!("complete setup is not a setup failure")
         }
-        WsSetupBehavior::IgnoreSessionLogon => Duration::from_secs(12),
+        WsSetupBehavior::IgnoreSessionLogon | WsSetupBehavior::IgnoreUserDataSubscribe => {
+            Duration::from_secs(2)
+        }
         WsSetupBehavior::RejectSessionLogon | WsSetupBehavior::RejectUserDataSubscribe => {
             Duration::from_secs(5)
         }

--- a/python/nautilus_trader/adapters/binance/__init__.pyi
+++ b/python/nautilus_trader/adapters/binance/__init__.pyi
@@ -128,6 +128,8 @@ class BinanceExecClientConfig:
     @property
     def use_ws_trading(self) -> bool: ...
     @property
+    def ws_trading_setup_timeout_ms(self) -> int: ...
+    @property
     def instrument_provider(self) -> BinanceInstrumentProviderConfig: ...
     @property
     def instrument_refresh_interval_secs(self) -> int: ...
@@ -165,6 +167,7 @@ class BinanceExecClientConfig:
         base_url_ws: str | None = None,
         base_url_ws_trading: str | None = None,
         use_ws_trading: bool = True,
+        ws_trading_setup_timeout_ms: int | None = None,
         instrument_provider: BinanceInstrumentProviderConfig | None = None,
         instrument_refresh_interval_secs: int | None = None,
         use_gtd: bool = True,


### PR DESCRIPTION
A follow-up to the test-timing work in #4532, on the same class of production timing constants that no consumer can reach.

## The WS trading setup deadlines are hardcoded

`BinanceSpotExecutionClient::connect` bounds each WebSocket trading setup phase with a literal `Duration::from_secs(10)`: one for the `session.logon` response, one for `userDataStream.subscribe`. `BinanceSpotWsTradingClient::session_logon` only enqueues the command on the handler channel and returns, so the response arrives asynchronously and is signalled through `ws_authenticated`, `ws_user_data_subscribed`, or the setup-error channel, which `wait_for_ws_setup_response` races against the deadline. A venue that accepts the socket and then never answers holds `connect()` for the full 10 seconds per phase - up to 20 seconds across both - before the client falls back to HTTP-only execution, and no operator can shorten that for a fast-failover deployment or lengthen it for a proxied or high-latency route.

This adds `BinanceExecClientConfig::ws_trading_setup_timeout_ms`, defaulting to 10000 so current behavior is unchanged. `connect()` derives one `Duration` and passes it to both waits independently, preserving the existing per-phase budget rather than collapsing the two into a single deadline. `validate()` rejects zero, which would make setup a scheduler race that almost always enters HTTP-only mode for the process lifetime while logging a timeout. No upper bound is imposed: the `recv_window_ms` ceiling is a Binance protocol constraint rather than a general timeout precedent, and a setup deadline may legitimately exceed a minute on an unusual route.

## The user data subscribe deadline was never exercised

The second deadline had no test that reached it. `WsSetupBehavior` offered `RejectUserDataSubscribe`, which sends an error the receiver wins immediately, but no behavior that leaves the subscribe unanswered, so every existing test left that wait through the error path and the timeout branch was dead in coverage. `IgnoreUserDataSubscribe` records the method and then does nothing, driving the second wait to expiry the way `IgnoreSessionLogon` already did for the first.

## Testing

`test_ws_trading_auth_timeout_uses_http_only_mode` and the new `test_ws_trading_user_data_subscribe_timeout_uses_http_only_mode` pin the same property at each deadline: an unanswered setup phase expires, the client enters HTTP-only mode, and a subsequent order is accepted over HTTP. Both configure `ws_trading_setup_timeout_ms` through the new field, so they exercise the knob rather than asserting around it. Both were verified to fail against the unfixed code - with the call sites restored to `Duration::from_secs(10)`, each exceeds its guard and fails with `Elapsed`. Together they take about 0.7s where the auth test alone previously took 10.1s.

The two rejection tests are unchanged and keep the production default, so the error paths still prove they return without waiting on a deadline.

`test_exec_config_rejects_zero_ws_trading_setup_timeout` pins the validation message, and the TOML and PyO3 construction tests pin both the 10000 default and an explicit override.

The setup tests use a 250 ms timeout rather than a smaller value deliberately. The deadline starts when the command is queued on the handler channel, not when the frame reaches the socket, so the budget must still cover signing, the WebSocket send, and the mock server recording the method; a tighter value can expire before that record under parallel load and fail the received-method assertion. No test waits on wall-clock time beyond its own configured deadline.
