### PR TITLE
Set margin_trading info field on Bybit spot instruments

### DIFF
--- a/crates/adapters/bybit/src/common/parse.rs
+++ b/crates/adapters/bybit/src/common/parse.rs
@@ -152,10 +152,11 @@ use ustr::Ustr;
 use crate::{
     common::{
         enums::{
-            BybitBboSideType, BybitContractType, BybitKlineInterval, BybitMarketUnit,
-            BybitOptionType, BybitOrderSide, BybitOrderStatus, BybitOrderType, BybitPositionIdx,
-            BybitPositionMode, BybitPositionSide, BybitProductType, BybitStopOrderType,
-            BybitTimeInForce, BybitTpSlMode, BybitTriggerDirection, BybitTriggerType,
+            BybitBboSideType, BybitContractType, BybitKlineInterval, BybitMarginTrading,
+            BybitMarketUnit, BybitOptionType, BybitOrderSide, BybitOrderStatus, BybitOrderType,
+            BybitPositionIdx, BybitPositionMode, BybitPositionSide, BybitProductType,
+            BybitStopOrderType, BybitTimeInForce, BybitTpSlMode, BybitTriggerDirection,
+            BybitTriggerType,
         },
         symbol::BybitSymbol,
     },
@@ -326,6 +327,17 @@ pub fn parse_spot_instrument(
     let maker_fee = parse_decimal(&fee_rate.maker_fee_rate, "makerFeeRate")?;
     let taker_fee = parse_decimal(&fee_rate.taker_fee_rate, "takerFeeRate")?;
 
+    let margin_trading_supported = matches!(
+        definition.margin_trading,
+        BybitMarginTrading::Both | BybitMarginTrading::UtaOnly
+    );
+
+    let mut info = Params::new();
+    info.insert(
+        "margin_trading".to_string(),
+        serde_json::Value::Bool(margin_trading_supported),
+    );
+
     let instrument = CurrencyPair::new(
         instrument_id,
         raw_symbol,
@@ -348,7 +360,7 @@ pub fn parse_spot_instrument(
         Some(maker_fee),
         Some(taker_fee),
         None,
-        None,
+        Some(info),
         ts_event,
         ts_init,
     );
@@ -1938,6 +1950,37 @@ mod tests {
                 assert_eq!(
                     pair.min_notional,
                     Some(Money::from_decimal(Decimal::new(10, 0), Currency::USDT()).unwrap()),
+                );
+                assert_eq!(
+                    pair.info.as_ref().unwrap().get_bool("margin_trading"),
+                    Some(true)
+                );
+            }
+            _ => panic!("expected CurrencyPair"),
+        }
+    }
+
+    #[rstest]
+    #[case(BybitMarginTrading::Both, true)]
+    #[case(BybitMarginTrading::UtaOnly, true)]
+    #[case(BybitMarginTrading::None, false)]
+    #[case(BybitMarginTrading::Other, false)]
+    fn parse_spot_instrument_maps_margin_trading(
+        #[case] margin_trading: BybitMarginTrading,
+        #[case] expected: bool,
+    ) {
+        let json = load_test_json("http_get_instruments_spot.json");
+        let response: BybitInstrumentSpotResponse = serde_json::from_str(&json).unwrap();
+        let mut instrument = response.result.list[0].clone();
+        instrument.margin_trading = margin_trading;
+        let fee_rate = sample_fee_rate("BTCUSDT", "0.0006", "0.0001", Some("BTC"));
+
+        let parsed = parse_spot_instrument(&instrument, &fee_rate, TS, TS).unwrap();
+        match parsed {
+            InstrumentAny::CurrencyPair(pair) => {
+                assert_eq!(
+                    pair.info.as_ref().unwrap().get_bool("margin_trading"),
+                    Some(expected)
                 );
             }
             _ => panic!("expected CurrencyPair"),


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

Bybit's spot instrument definitions carry a `marginTrading` field indicating whether a pair supports margin trading (and thus borrowing/shorting). `parse_spot_instrument` now derives a boolean from `marginTrading` (both/utaOnly → true, everything else → false, since this adapter is UTA-only) and stores it on the `CurrencyPair`'s info params under the key `margin_trading`. This is useful to check if shorting of spot instruments is allowed before using Bybit's `is_leverage` order param to do so.

If the concept proves useful, the natural next step is to promote it to a normalized, optional `is_shortable: Option<bool>` accessor on `CurrencyPair` itself. But that is a future concern.

## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
