### PR TITLE
Fail BitMEX WebSocket authentication on rejection instead of waiting out the timeout

### DIFF
--- a/crates/adapters/bitmex/bin/ws_data.rs
+++ b/crates/adapters/bitmex/bin/ws_data.rs
@@ -80,6 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,   // No API secret
         None,   // Account ID
         5,      // 5 second heartbeat
+        None,   // Default authentication timeout
         TransportBackend::default(),
         None,
     )

--- a/crates/adapters/bitmex/bin/ws_exec.rs
+++ b/crates/adapters/bitmex/bin/ws_exec.rs
@@ -59,6 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
         None,
         5, // 5 second heartbeat
+        None,
         TransportBackend::default(),
         None,
     )

--- a/crates/adapters/bitmex/src/data.rs
+++ b/crates/adapters/bitmex/src/data.rs
@@ -650,6 +650,7 @@ impl DataClient for BitmexDataClient {
                 self.config.api_secret.clone(),
                 None,
                 self.config.heartbeat_interval_secs.unwrap_or(5),
+                None,
                 self.config.environment,
                 self.config.transport_backend,
                 self.config.proxy_url.clone(),

--- a/crates/adapters/bitmex/src/execution.rs
+++ b/crates/adapters/bitmex/src/execution.rs
@@ -152,6 +152,7 @@ impl BitmexExecutionClient {
             config.api_secret.clone(),
             Some(account_id),
             config.heartbeat_interval_secs,
+            None,
             config.environment,
             config.transport_backend,
             config.proxy_url.clone(),

--- a/crates/adapters/bitmex/src/python/websocket.rs
+++ b/crates/adapters/bitmex/src/python/websocket.rs
@@ -104,13 +104,15 @@ impl Debug for PyBitmexWebSocketClient {
 #[pyo3_stub_gen::derive::gen_stub_pymethods]
 impl PyBitmexWebSocketClient {
     #[new]
-    #[pyo3(signature = (url=None, api_key=None, api_secret=None, account_id=None, heartbeat=5, environment=BitmexEnvironment::Mainnet, proxy_url=None))]
+    #[pyo3(signature = (url=None, api_key=None, api_secret=None, account_id=None, heartbeat=5, auth_timeout_secs=None, environment=BitmexEnvironment::Mainnet, proxy_url=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_new(
         url: Option<String>,
         api_key: Option<String>,
         api_secret: Option<String>,
         account_id: Option<AccountId>,
         heartbeat: u64,
+        auth_timeout_secs: Option<u64>,
         environment: BitmexEnvironment,
         proxy_url: Option<String>,
     ) -> PyResult<Self> {
@@ -120,6 +122,7 @@ impl PyBitmexWebSocketClient {
             api_secret,
             account_id,
             heartbeat,
+            auth_timeout_secs,
             environment,
             TransportBackend::default(),
             proxy_url,

--- a/crates/adapters/bitmex/src/websocket/client.rs
+++ b/crates/adapters/bitmex/src/websocket/client.rs
@@ -77,6 +77,7 @@ pub struct BitmexWebSocketClient {
     url: String,
     credential: Option<Credential>,
     heartbeat: Option<u64>,
+    auth_timeout_secs: u64,
     account_id: AccountId,
     auth_tracker: AuthTracker,
     signal: Arc<AtomicBool>,
@@ -97,12 +98,14 @@ impl BitmexWebSocketClient {
     /// # Errors
     ///
     /// Returns an error if only one of `api_key` or `api_secret` is provided (both or neither required).
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         url: Option<String>,
         api_key: Option<String>,
         api_secret: Option<String>,
         account_id: Option<AccountId>,
         heartbeat: u64,
+        auth_timeout_secs: Option<u64>,
         transport_backend: TransportBackend,
         proxy_url: Option<String>,
     ) -> anyhow::Result<Self> {
@@ -124,6 +127,7 @@ impl BitmexWebSocketClient {
             url: url.unwrap_or(BITMEX_WS_URL.to_string()),
             credential,
             heartbeat: Some(heartbeat),
+            auth_timeout_secs: auth_timeout_secs.unwrap_or(AUTHENTICATION_TIMEOUT_SECS),
             account_id,
             auth_tracker: AuthTracker::new(),
             signal: Arc::new(AtomicBool::new(false)),
@@ -156,6 +160,7 @@ impl BitmexWebSocketClient {
         api_secret: Option<String>,
         account_id: Option<AccountId>,
         heartbeat: u64,
+        auth_timeout_secs: Option<u64>,
         environment: BitmexEnvironment,
         transport_backend: TransportBackend,
         proxy_url: Option<String>,
@@ -171,6 +176,7 @@ impl BitmexWebSocketClient {
             secret,
             account_id,
             heartbeat,
+            auth_timeout_secs,
             transport_backend,
             proxy_url,
         )
@@ -193,6 +199,7 @@ impl BitmexWebSocketClient {
             Some(api_secret),
             None,
             5,
+            None,
             TransportBackend::default(),
             None,
         )
@@ -605,10 +612,7 @@ impl BitmexWebSocketClient {
             })?;
 
         self.auth_tracker
-            .wait_for_result::<BitmexWsError>(
-                Duration::from_secs(AUTHENTICATION_TIMEOUT_SECS),
-                receiver,
-            )
+            .wait_for_result::<BitmexWsError>(Duration::from_secs(self.auth_timeout_secs), receiver)
             .await
     }
 
@@ -1274,6 +1278,7 @@ mod tests {
             Some("test_secret".to_string()),
             Some(AccountId::new("BITMEX-TEST")),
             5,
+            None,
             TransportBackend::default(),
             None,
         )
@@ -1340,6 +1345,7 @@ mod tests {
             Some("test_secret".to_string()),
             Some(AccountId::new("BITMEX-TEST")),
             5,
+            None,
             TransportBackend::default(),
             None,
         )
@@ -1371,6 +1377,7 @@ mod tests {
             None,
             Some(AccountId::new("BITMEX-TEST")),
             5,
+            None,
             TransportBackend::default(),
             None,
         )
@@ -1387,6 +1394,7 @@ mod tests {
             Some("test_secret".to_string()),
             Some(AccountId::new("BITMEX-TEST")),
             5,
+            None,
             TransportBackend::default(),
             None,
         )
@@ -1457,6 +1465,7 @@ mod tests {
             None,
             Some(AccountId::new("BITMEX-TEST")),
             5,
+            None,
             TransportBackend::default(),
             None,
         )
@@ -1505,6 +1514,7 @@ mod tests {
             None,
             Some(AccountId::new("BITMEX-TEST")),
             5,
+            None,
             TransportBackend::default(),
             None,
         )
@@ -1560,6 +1570,7 @@ mod tests {
             Some("test_secret".to_string()),
             Some(AccountId::new("BITMEX-TEST")),
             5,
+            None,
             TransportBackend::default(),
             None,
         )

--- a/crates/adapters/bitmex/src/websocket/handler.rs
+++ b/crates/adapters/bitmex/src/websocket/handler.rs
@@ -183,7 +183,7 @@ impl BitmexWsFeedHandler {
                         continue;
                     }
 
-                    let event = match Self::parse_raw_message(msg) {
+                    let event = match self.parse_raw_message(msg) {
                         Some(event) => event,
                         None => continue,
                     };
@@ -228,9 +228,9 @@ impl BitmexWsFeedHandler {
         }
     }
 
-    fn parse_raw_message(msg: Message) -> Option<BitmexWsFrame> {
+    fn parse_raw_message(&self, msg: Message) -> Option<BitmexWsFrame> {
         match msg {
-            Message::Text(text) => Self::parse_text_message(&text),
+            Message::Text(text) => self.parse_text_message(&text),
             Message::Binary(msg) => {
                 let Ok(text) = str::from_utf8(&msg) else {
                     log::warn!(
@@ -239,7 +239,7 @@ impl BitmexWsFeedHandler {
                     );
                     return None;
                 };
-                Self::parse_text_message(text)
+                self.parse_text_message(text)
             }
             Message::Close(_) => {
                 log::debug!("Received close message, waiting for reconnection");
@@ -261,7 +261,7 @@ impl BitmexWsFeedHandler {
         }
     }
 
-    fn parse_text_message(text: &str) -> Option<BitmexWsFrame> {
+    fn parse_text_message(&self, text: &str) -> Option<BitmexWsFrame> {
         if text == RECONNECTED {
             log::info!("Received WebSocket reconnected signal");
             return Some(BitmexWsFrame::Reconnected);
@@ -290,7 +290,19 @@ impl BitmexWsFeedHandler {
                     );
                 }
                 BitmexWsFrame::Subscription { .. } => return Some(msg),
-                BitmexWsFrame::Error { status, error, .. } => {
+                BitmexWsFrame::Error {
+                    status,
+                    error,
+                    request,
+                    ..
+                } => {
+                    if request
+                        .op
+                        .eq_ignore_ascii_case(BitmexWsAuthAction::AuthKeyExpires.as_ref())
+                    {
+                        self.auth_tracker.fail(error.clone());
+                    }
+
                     if Self::is_already_subscribed_error(error) {
                         log::debug!(
                             "Ignoring duplicate BitMEX subscription: status={status}, error={error}",
@@ -481,6 +493,21 @@ mod tests {
         },
     };
 
+    fn test_handler() -> BitmexWsFeedHandler {
+        let (_cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_raw_tx, raw_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (out_tx, _out_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        BitmexWsFeedHandler::new(
+            Arc::new(AtomicBool::new(false)),
+            cmd_rx,
+            raw_rx,
+            out_tx,
+            AuthTracker::new(),
+            SubscriptionState::new(':'),
+        )
+    }
+
     #[rstest]
     #[case(false)]
     #[case(true)]
@@ -492,8 +519,9 @@ mod tests {
             Message::Text(json.into())
         };
 
+        let handler = test_handler();
         let Some(BitmexWsFrame::Table(BitmexTableMessage::Order { action, data })) =
-            BitmexWsFeedHandler::parse_raw_message(message)
+            handler.parse_raw_message(message)
         else {
             panic!("expected order table frame");
         };
@@ -509,7 +537,7 @@ mod tests {
     fn test_non_utf8_binary_frame_is_ignored() {
         let message = Message::Binary(vec![0xFF, 0xFE, 0xFD].into());
 
-        assert!(BitmexWsFeedHandler::parse_raw_message(message).is_none());
+        assert!(test_handler().parse_raw_message(message).is_none());
     }
 
     #[rstest]

--- a/crates/adapters/bitmex/tests/websocket.rs
+++ b/crates/adapters/bitmex/tests/websocket.rs
@@ -58,6 +58,8 @@ struct TestServerState {
     last_pong: Arc<tokio::sync::Mutex<Option<Vec<u8>>>>,
     fail_next_subscriptions: Arc<tokio::sync::Mutex<Vec<String>>>,
     auth_response_delay_ms: Arc<tokio::sync::Mutex<Option<u64>>>,
+    auth_response_gate: Arc<tokio::sync::Mutex<Option<Arc<tokio::sync::Semaphore>>>>,
+    ignore_auth_requests: Arc<AtomicBool>,
     subscription_events: Arc<tokio::sync::Mutex<Vec<(String, bool)>>>,
     ping_count: Arc<AtomicUsize>,
     pong_count: Arc<AtomicUsize>,
@@ -74,6 +76,10 @@ impl TestServerState {
 
     async fn set_auth_response_delay_ms(&self, delay_ms: Option<u64>) {
         *self.auth_response_delay_ms.lock().await = delay_ms;
+    }
+
+    async fn set_auth_response_gate(&self, gate: Option<Arc<tokio::sync::Semaphore>>) {
+        *self.auth_response_gate.lock().await = gate;
     }
 
     async fn clear_subscription_events(&self) {
@@ -100,6 +106,8 @@ impl Default for TestServerState {
             last_pong: Arc::new(tokio::sync::Mutex::new(None)),
             fail_next_subscriptions: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             auth_response_delay_ms: Arc::new(tokio::sync::Mutex::new(None)),
+            auth_response_gate: Arc::new(tokio::sync::Mutex::new(None)),
+            ignore_auth_requests: Arc::new(AtomicBool::new(false)),
             subscription_events: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             ping_count: Arc::new(AtomicUsize::new(0)),
             pong_count: Arc::new(AtomicUsize::new(0)),
@@ -119,9 +127,12 @@ async fn handle_websocket(ws: WebSocketUpgrade, State(state): State<TestServerSt
     ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
-async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
+async fn handle_socket(socket: WebSocket, state: TestServerState) {
     #[allow(unused_imports)]
     use futures_util::{SinkExt, StreamExt};
+
+    let (sink, mut stream) = socket.split();
+    let sink = Arc::new(tokio::sync::Mutex::new(sink));
 
     // Increment connection count
     {
@@ -141,7 +152,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
         }
     });
 
-    if socket
+    if sink
+        .lock()
+        .await
         .send(Message::Text(
             serde_json::to_string(&welcome_msg).unwrap().into(),
         ))
@@ -152,7 +165,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
     }
 
     if state.send_initial_ping.load(Ordering::Relaxed)
-        && socket
+        && sink
+            .lock()
+            .await
             .send(Message::Ping(TEST_PING_PAYLOAD.to_vec().into()))
             .await
             .is_err()
@@ -166,18 +181,18 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
             if state.silent_drop.load(Ordering::Relaxed) {
                 break;
             } else {
-                let _ = socket.send(Message::Close(None)).await;
+                let _ = sink.lock().await.send(Message::Close(None)).await;
                 break;
             }
         }
 
         // One-shot drop: auto-resets after dropping one connection
         if state.drop_next_connection.swap(false, Ordering::Relaxed) {
-            let _ = socket.send(Message::Close(None)).await;
+            let _ = sink.lock().await.send(Message::Close(None)).await;
             break;
         }
 
-        let msg_opt = match tokio::time::timeout(Duration::from_millis(50), socket.recv()).await {
+        let msg_opt = match tokio::time::timeout(Duration::from_millis(50), stream.next()).await {
             Ok(opt) => opt,
             Err(_) => continue,
         };
@@ -195,7 +210,7 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
             if state.silent_drop.load(Ordering::Relaxed) {
                 break;
             } else {
-                let _ = socket.send(Message::Close(None)).await;
+                let _ = sink.lock().await.send(Message::Close(None)).await;
                 break;
             }
         }
@@ -214,14 +229,16 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                             *auth_calls += 1;
                         }
 
-                        if let Some(delay) = *state.auth_response_delay_ms.lock().await {
-                            tokio::time::sleep(Duration::from_millis(delay)).await;
+                        if state.ignore_auth_requests.load(Ordering::Relaxed) {
+                            continue;
                         }
 
-                        if state.fail_next_auth.load(Ordering::Relaxed) {
-                            state.fail_next_auth.store(false, Ordering::Relaxed);
-
-                            let response = json!({
+                        let auth_response_gate = state.auth_response_gate.lock().await.clone();
+                        let auth_response_is_gated = auth_response_gate.is_some();
+                        let auth_response_delay_ms = *state.auth_response_delay_ms.lock().await;
+                        let auth_failed = state.fail_next_auth.swap(false, Ordering::Relaxed);
+                        let response = if auth_failed {
+                            json!({
                                 "status": 401,
                                 "error": "Authentication failed",
                                 "meta": {},
@@ -229,38 +246,40 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                     "op": "authKeyExpires",
                                     "args": data.get("args")
                                 }
-                            });
+                            })
+                        } else {
+                            json!({
+                                "success": true,
+                                "request": {
+                                    "op": "authKeyExpires",
+                                    "args": data.get("args")
+                                }
+                            })
+                        };
+                        let response =
+                            Message::Text(serde_json::to_string(&response).unwrap().into());
+                        let send_auth_response = {
+                            let sink = sink.clone();
+                            let state = state.clone();
+                            async move {
+                                if let Some(gate) = auth_response_gate {
+                                    gate.acquire().await.unwrap().forget();
+                                }
 
-                            if socket
-                                .send(Message::Text(
-                                    serde_json::to_string(&response).unwrap().into(),
-                                ))
-                                .await
-                                .is_err()
-                            {
-                                break;
+                                if let Some(delay) = auth_response_delay_ms {
+                                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                                }
+
+                                if !auth_failed {
+                                    state.authenticated.store(true, Ordering::Relaxed);
+                                }
+                                sink.lock().await.send(response).await
                             }
-                            continue;
-                        }
+                        };
 
-                        state.authenticated.store(true, Ordering::Relaxed);
-
-                        // Send auth success response
-                        let response = json!({
-                            "success": true,
-                            "request": {
-                                "op": "authKeyExpires",
-                                "args": data.get("args")
-                            }
-                        });
-
-                        if socket
-                            .send(Message::Text(
-                                serde_json::to_string(&response).unwrap().into(),
-                            ))
-                            .await
-                            .is_err()
-                        {
+                        if auth_response_is_gated {
+                            tokio::spawn(send_auth_response);
+                        } else if send_auth_response.await.is_err() {
                             break;
                         }
                         continue;
@@ -280,6 +299,12 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
 
                                     if requires_auth && !state.authenticated.load(Ordering::Relaxed)
                                     {
+                                        state
+                                            .subscription_events
+                                            .lock()
+                                            .await
+                                            .push((topic.to_string(), false));
+
                                         // Send auth error
                                         let error_response = json!({
                                             "status": 401,
@@ -291,7 +316,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                             }
                                         });
 
-                                        if socket
+                                        if sink
+                                            .lock()
+                                            .await
                                             .send(Message::Text(
                                                 serde_json::to_string(&error_response)
                                                     .unwrap()
@@ -325,7 +352,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                             .await
                                             .push((topic.to_string(), false));
 
-                                        if socket
+                                        if sink
+                                            .lock()
+                                            .await
                                             .send(Message::Text(
                                                 serde_json::to_string(&response).unwrap().into(),
                                             ))
@@ -360,7 +389,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                         }
                                     });
 
-                                    if socket
+                                    if sink
+                                        .lock()
+                                        .await
                                         .send(Message::Text(
                                             serde_json::to_string(&response).unwrap().into(),
                                         ))
@@ -381,7 +412,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                         trade["table"] = json!("trade");
                                         trade["action"] = json!("insert");
 
-                                        if socket
+                                        if sink
+                                            .lock()
+                                            .await
                                             .send(Message::Text(
                                                 serde_json::to_string(&trade).unwrap().into(),
                                             ))
@@ -400,7 +433,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                         book["table"] = json!("orderBookL2");
                                         book["action"] = json!("partial");
 
-                                        if socket
+                                        if sink
+                                            .lock()
+                                            .await
                                             .send(Message::Text(
                                                 serde_json::to_string(&book).unwrap().into(),
                                             ))
@@ -425,7 +460,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                             }
                                         });
 
-                                        if socket
+                                        if sink
+                                            .lock()
+                                            .await
                                             .send(Message::Text(
                                                 serde_json::to_string(&auth_success)
                                                     .unwrap()
@@ -447,7 +484,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                                 position["table"] = json!("position");
                                                 position["action"] = json!("partial");
 
-                                                if socket
+                                                if sink
+                                                    .lock()
+                                                    .await
                                                     .send(Message::Text(
                                                         serde_json::to_string(&position)
                                                             .unwrap()
@@ -466,7 +505,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                                 order["table"] = json!("order");
                                                 order["action"] = json!("partial");
 
-                                                if socket
+                                                if sink
+                                                    .lock()
+                                                    .await
                                                     .send(Message::Text(
                                                         serde_json::to_string(&order)
                                                             .unwrap()
@@ -485,7 +526,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                                 exec["table"] = json!("execution");
                                                 exec["action"] = json!("insert");
 
-                                                if socket
+                                                if sink
+                                                    .lock()
+                                                    .await
                                                     .send(Message::Text(
                                                         serde_json::to_string(&exec)
                                                             .unwrap()
@@ -524,7 +567,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                                         }
                                     });
 
-                                    if socket
+                                    if sink
+                                        .lock()
+                                        .await
                                         .send(Message::Text(
                                             serde_json::to_string(&response).unwrap().into(),
                                         ))
@@ -541,7 +586,9 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
                     else if data.get("op") == Some(&json!("ping")) {
                         let pong = json!({"op": "pong"});
 
-                        if socket
+                        if sink
+                            .lock()
+                            .await
                             .send(Message::Text(serde_json::to_string(&pong).unwrap().into()))
                             .await
                             .is_err()
@@ -560,7 +607,7 @@ async fn handle_socket(mut socket: WebSocket, state: TestServerState) {
             Message::Ping(data) => {
                 state.ping_count.fetch_add(1, Ordering::Relaxed);
                 // Respond with pong
-                if socket.send(Message::Pong(data)).await.is_err() {
+                if sink.lock().await.send(Message::Pong(data)).await.is_err() {
                     break;
                 }
             }
@@ -642,6 +689,7 @@ async fn test_bitmex_websocket_client_creation() {
         Some("test_secret".to_string()), // api_secret
         Some(get_test_account_id()),     // account_id
         5,                               // heartbeat,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -662,6 +710,7 @@ async fn test_websocket_connection() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -708,6 +757,7 @@ async fn test_initial_authenticated_connect_subscribes_instrument_once() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -762,6 +812,7 @@ async fn test_client_replies_to_server_ping() {
         None,
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -798,6 +849,7 @@ async fn test_subscribe_to_public_data() {
         None, // No API secret for public data
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -846,6 +898,7 @@ async fn test_subscribe_to_orderbook() {
         None,
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -896,6 +949,7 @@ async fn test_subscribe_to_private_data() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -956,6 +1010,7 @@ async fn test_reconnection_scenario() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1066,6 +1121,7 @@ async fn test_reconnection_emits_reconnected_message() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1128,6 +1184,7 @@ async fn test_unsubscribe() {
         None,
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1194,6 +1251,7 @@ async fn test_wait_until_active_timeout() {
         Some("test_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1218,6 +1276,7 @@ async fn test_multiple_symbols_subscription() {
         None,
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1279,6 +1338,7 @@ async fn test_true_auto_reconnect_with_verification() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1431,6 +1491,7 @@ async fn test_auth_and_subscription_restoration_order() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1489,6 +1550,7 @@ async fn test_subscription_restoration_tracking() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1573,6 +1635,7 @@ async fn test_reconnection_retries_failed_subscriptions() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1687,6 +1750,7 @@ async fn test_reconnection_waits_for_delayed_auth_ack() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1724,13 +1788,15 @@ async fn test_reconnection_waits_for_delayed_auth_ack() {
     .await;
 
     let baseline_auth_calls = *state.auth_calls.lock().await;
-    state.set_auth_response_delay_ms(Some(3000)).await;
+    let auth_response_gate = Arc::new(tokio::sync::Semaphore::new(0));
+    state
+        .set_auth_response_gate(Some(auth_response_gate.clone()))
+        .await;
 
     // Trigger disconnect using one-shot flag
     trigger_server_disconnect(&state).await;
 
-    // Wait for auth request to be sent (indicates reconnection happened)
-    // The response is delayed by 3s, so auth is pending but not acknowledged
+    // Wait for the server to receive the auth request while its response is gated.
     let state_for_auth = state.clone();
     let expected_calls = baseline_auth_calls + 1;
     wait_until_async(
@@ -1742,11 +1808,7 @@ async fn test_reconnection_waits_for_delayed_auth_ack() {
     )
     .await;
 
-    // Clear events now that reconnection has happened and auth is pending
-    state.clear_subscription_events().await;
-
-    // Auth request sent but response delayed - subscriptions should be waiting
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // The auth request arrived, but subscriptions must not resume before its acknowledgment.
     {
         let events = state.subscription_events().await;
         assert!(
@@ -1754,6 +1816,8 @@ async fn test_reconnection_waits_for_delayed_auth_ack() {
             "subscriptions should wait for the delayed auth acknowledgment; events={events:?}",
         );
     }
+
+    auth_response_gate.add_permits(1);
 
     let events_after_ack = wait_for_subscription_events(&state, Duration::from_secs(8), |events| {
         let instrument_ok = events
@@ -1785,7 +1849,7 @@ async fn test_reconnection_waits_for_delayed_auth_ack() {
         "public subscription should still be included after ack delay; events={events_after_ack:?}",
     );
 
-    state.set_auth_response_delay_ms(None).await;
+    state.set_auth_response_gate(None).await;
     client.close().await.unwrap();
 }
 
@@ -1802,6 +1866,7 @@ async fn test_unauthenticated_private_channel_rejection() {
         None,
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1838,6 +1903,7 @@ async fn test_heartbeat_timeout_reconnection() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         1, // Very short heartbeat interval (1 second),
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1876,6 +1942,7 @@ async fn test_rapid_consecutive_reconnections() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -1991,6 +2058,7 @@ async fn test_multiple_partial_subscription_failures() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -2090,6 +2158,7 @@ async fn test_reconnection_race_condition() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -2180,6 +2249,7 @@ async fn test_subscribe_after_stream_call() {
         None,
         Some(AccountId::from("TEST-001")),
         1,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -2222,6 +2292,7 @@ async fn test_is_active_false_after_close() {
         None,
         Some(AccountId::from("TEST-001")),
         1,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -2259,6 +2330,7 @@ async fn test_is_active_lifecycle() {
         Some("test_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -2304,6 +2376,7 @@ async fn test_is_active_false_during_reconnection() {
         Some("test_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -2354,6 +2427,7 @@ async fn test_unsubscribed_private_channel_not_resubscribed_after_disconnect() {
         Some("test_api_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -2465,12 +2539,17 @@ async fn test_login_failure_emits_error() {
         Some("invalid_secret".to_string()),
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )
     .unwrap();
 
-    let _ = client.connect().await;
+    let error = client.connect().await.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Authentication error: Authentication failed"
+    );
 
     wait_until_async(
         || async { *state.connection_count.lock().await > 0 },
@@ -2491,6 +2570,35 @@ async fn test_login_failure_emits_error() {
 
 #[rstest]
 #[tokio::test]
+async fn test_login_times_out_when_server_is_silent() {
+    let (addr, state) = start_test_server().await.unwrap();
+    state.ignore_auth_requests.store(true, Ordering::Relaxed);
+    let ws_url = format!("ws://{addr}/realtime");
+
+    let mut client = BitmexWebSocketClient::new(
+        Some(ws_url),
+        Some("test_api_key".to_string()),
+        Some("test_api_secret".to_string()),
+        Some(AccountId::new("BITMEX-001")),
+        5,
+        Some(1),
+        TransportBackend::default(),
+        None,
+    )
+    .unwrap();
+
+    let error = client.connect().await.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Authentication error: Authentication timed out"
+    );
+    assert_eq!(*state.auth_calls.lock().await, 1);
+
+    let _ = client.close().await;
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_sends_pong_for_text_ping() {
     let (addr, state) = start_test_server().await.unwrap();
     let ws_url = format!("ws://{addr}/realtime");
@@ -2501,6 +2609,7 @@ async fn test_sends_pong_for_text_ping() {
         None,
         Some(AccountId::new("BITMEX-001")),
         1, // 1 second heartbeat,
+        None,
         TransportBackend::default(),
         None,
     )
@@ -2531,6 +2640,7 @@ async fn test_sends_pong_for_control_ping() {
         None,
         Some(AccountId::new("BITMEX-001")),
         5,
+        None,
         TransportBackend::default(),
         None,
     )


### PR DESCRIPTION
A follow-up to the WebSocket setup-timeout work in #4538, on the same authentication seam in another adapter.

## An authentication rejection is dropped instead of failing the login

BitMEX answers a failed `authKeyExpires` with an error frame that echoes the originating request. `BitmexWsFeedHandler` matches that as `BitmexWsFrame::Error`, logs it, and falls through without returning the message, so it never reaches the event loop. `auth_tracker.fail` is reachable only from `handle_subscription_message`, which requires a subscription-shaped frame whose request `op` is `authKeyExpires`. The rejection therefore never resolves the receiver created in `authenticate`, and `connect` blocks until the authentication timeout expires before returning a generic timeout error. An operator with a revoked or mistyped key sees a ten second hang and no reason, and the client cannot distinguish a rejected key from a venue that has gone silent.

`BitmexWsFrame::Error` already carries `request: BitmexHttpRequest`; the arm was discarding it. It is now bound, and when its `op` is `authKeyExpires` the tracker is failed with the venue's own error text, so `connect` returns that message immediately. The frame is still dropped afterwards: it has been consumed as a control message and should not also surface as data.

This covers the echoed-request rejection. `BitmexWsFrame::Error` requires `status`, `meta` and `request`, so a bare `{"error": ...}` payload, an envelope without `meta`, or an outright connection close does not take this branch and still resolves through the timeout or the reconnect path. The timeout remains the necessary fallback rather than a redundant one.

## The authentication timeout cannot be bounded by the caller

The wait used the shared `AUTHENTICATION_TIMEOUT_SECS` from `nautilus-network` directly, so no consumer could shorten it for a fast-failover deployment or extend it for a slow route, and the genuinely silent-venue case had no way to be exercised quickly in a test.

`BitmexWebSocketClient` now takes `auth_timeout_secs: Option<u64>` and stores `auth_timeout_secs.unwrap_or(AUTHENTICATION_TIMEOUT_SECS)`, matching how `OKXWebSocketClient` already parameterises the same constant. The option is threaded through `new`, `new_with_env` and the PyO3 constructor; existing callers pass `None` and the shared constant is unchanged, so default behaviour is identical.

## Testing

`test_login_failure_emits_error` previously discarded the result of `connect` and asserted only that the session was not authenticated, so it did not verify what its name claimed and passed while the rejection was being dropped. It now asserts that `connect` returns the venue's `Authentication failed` message, and it passes on the fixed code without any shortened timeout. Verified to fail against the unfixed handler, where it falls through to the timeout path and takes ten seconds.

`test_login_times_out_when_server_is_silent` is new and covers the remaining slow path: the server ignores the auth request entirely, the client is constructed with a one second `auth_timeout_secs`, and the timeout error is asserted. It passes against both the fixed and unfixed handler, which is the point, since it exercises a path the rejection fix does not touch.

`test_reconnection_waits_for_delayed_auth_ack` withheld the auth acknowledgement with a fixed three second delay. The mock server now gates the acknowledgement on a semaphore, and because the server previously blocked inside its only receive loop while delaying, its assertion that no subscription had resumed could not have observed a premature one: the frames would have queued unread in the socket. The socket is now split so the receive loop keeps reading while the acknowledgement is held, and any premature subscription is recorded and fails the assertion. Confirmed by making the client subscribe without waiting for the acknowledgement, which the repaired test detects and the original did not.

No test waits on wall-clock time except the deliberate one second silent-server timeout.
