### PR TITLE
Fix TWAP child-order sizing and interval validation

### DIFF
--- a/crates/trading/src/algorithm/twap.rs
+++ b/crates/trading/src/algorithm/twap.rs
@@ -42,8 +42,9 @@ use nautilus_model::{
     identifiers::ClientOrderId,
     instruments::Instrument,
     orders::{Order, OrderAny},
-    types::{Quantity, quantity::QuantityRaw},
+    types::Quantity,
 };
+use rust_decimal::{Decimal, RoundingStrategy, prelude::ToPrimitive};
 use ustr::Ustr;
 
 use super::{
@@ -193,11 +194,24 @@ nautilus_execution_algorithm!(TwapAlgorithm, {
         }
 
         let total_qty = order.quantity();
-        let total_raw = total_qty.raw;
-        let precision = total_qty.precision;
-
-        let qty_per_interval_raw = total_raw / (num_intervals as QuantityRaw);
-        let qty_per_interval = Quantity::from_raw(qty_per_interval_raw, precision);
+        let interval_count = Decimal::from(num_intervals);
+        let quotient = total_qty.as_decimal() / interval_count;
+        let floored = quotient.round_dp_with_strategy(
+            u32::from(instrument.size_precision()),
+            RoundingStrategy::ToZero,
+        );
+        let Some(floored_f64) = floored.to_f64() else {
+            log::error!("Cannot execute order: qty_per_interval={floored} is not representable");
+            return Ok(());
+        };
+        let qty_per_interval = match instrument.try_make_qty(floored_f64, None) {
+            Ok(quantity) => quantity,
+            Err(e) => {
+                log::error!("Cannot execute order: invalid qty_per_interval={floored}: {e}");
+                return Ok(());
+            }
+        };
+        let remainder = total_qty.as_decimal() - floored * interval_count;
 
         if qty_per_interval == total_qty || qty_per_interval < instrument.size_increment() {
             log::warn!(
@@ -219,14 +233,68 @@ nautilus_execution_algorithm!(TwapAlgorithm, {
             return Ok(());
         }
 
+        let interval = match Duration::try_from_secs_f64(interval_secs) {
+            Ok(interval) => interval,
+            Err(e) => {
+                log::error!(
+                    "Cannot execute order: interval_secs={interval_secs} is not a valid duration: {e}"
+                );
+                return Ok(());
+            }
+        };
+
+        if interval == Duration::ZERO {
+            log::error!(
+                "Cannot execute order: interval_secs={interval_secs} rounds to a zero duration"
+            );
+            return Ok(());
+        }
+        let Ok(interval_ns) = u64::try_from(interval.as_nanos()) else {
+            log::error!(
+                "Cannot execute order: interval_secs={interval_secs} exceeds the clock nanosecond range"
+            );
+            return Ok(());
+        };
+        let timestamp_ns = ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+            .clock_mut()
+            .timestamp_ns()
+            .as_u64();
+
+        if timestamp_ns.checked_add(interval_ns).is_none() {
+            log::error!(
+                "Cannot execute order: interval_secs={interval_secs} exceeds the clock timestamp headroom"
+            );
+            return Ok(());
+        }
+
         let mut scheduled_sizes: Vec<Quantity> = vec![qty_per_interval; num_intervals as usize];
 
-        // Remainder goes in the last slice
-        let scheduled_total = qty_per_interval_raw * (num_intervals as QuantityRaw);
-        let remainder_raw = total_raw - scheduled_total;
-        if remainder_raw > 0 {
-            let remainder = Quantity::from_raw(remainder_raw, total_qty.precision);
-            scheduled_sizes.push(remainder);
+        if remainder > Decimal::ZERO {
+            let Some(remainder_f64) = remainder.to_f64() else {
+                log::error!("Cannot execute order: qty_remainder={remainder} is not representable");
+                return Ok(());
+            };
+            let remainder_qty = match instrument.try_make_qty(remainder_f64, None) {
+                Ok(quantity) => quantity,
+                Err(e) => {
+                    log::error!("Cannot execute order: invalid qty_remainder={remainder}: {e}");
+                    return Ok(());
+                }
+            };
+            scheduled_sizes.push(remainder_qty);
+        }
+
+        let scheduled_total = scheduled_sizes
+            .iter()
+            .fold(Decimal::ZERO, |total, quantity| {
+                total + quantity.as_decimal()
+            });
+
+        if scheduled_total != total_qty.as_decimal() {
+            log::error!(
+                "Cannot execute order: scheduled quantity {scheduled_total} does not equal order quantity {total_qty}"
+            );
+            return Ok(());
         }
 
         log::info!("Order execution size schedule: {scheduled_sizes:?}");
@@ -274,15 +342,7 @@ nautilus_execution_algorithm!(TwapAlgorithm, {
 
         ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
             .clock_mut()
-            .set_timer(
-                primary_id.as_str(),
-                Duration::from_secs_f64(interval_secs),
-                None,
-                None,
-                None,
-                None,
-                None,
-            )?;
+            .set_timer(primary_id.as_str(), interval, None, None, None, None, None)?;
 
         log::info!(
             "Started TWAP execution for {primary_id}: horizon_secs={horizon_secs}, interval_secs={interval_secs}"
@@ -377,7 +437,7 @@ mod tests {
         messages::execution::{SubmitOrder, TradingCommand},
         msgbus::{self, MessagingSwitchboard},
     };
-    use nautilus_core::{Params, UUID4};
+    use nautilus_core::{Params, UUID4, UnixNanos};
     use nautilus_model::{
         enums::{OrderSide, TimeInForce},
         events::{OrderEventAny, order::spec::OrderCanceledSpec},
@@ -691,9 +751,9 @@ mod tests {
         register_algorithm(&mut algo);
 
         add_instrument_to_cache(&algo);
+        let instrument = nautilus_model::instruments::stubs::crypto_perpetual_ethusdt();
 
         // 1.0 qty over 60s with 20s intervals = 3 intervals
-        // Raw is scaled to FIXED_PRECISION: 9 (standard) or 16 (high-precision)
         let mut params = IndexMap::new();
         params.insert(Ustr::from("horizon_secs"), Ustr::from("60"));
         params.insert(Ustr::from("interval_secs"), Ustr::from("20"));
@@ -706,22 +766,59 @@ mod tests {
         // First slice spawned, 3 remaining (2 regular + 1 remainder)
         let remaining = algo.scheduled_sizes.get(&primary_id).unwrap();
         assert_eq!(remaining.len(), 3);
+        assert_eq!(
+            remaining,
+            &[
+                Quantity::from("0.333"),
+                Quantity::from("0.333"),
+                Quantity::from("0.001"),
+            ]
+        );
 
-        // Expected raw values depend on FIXED_PRECISION
-        // Standard (9):  1_000_000_000 / 3 = 333_333_333, remainder = 1
-        // High (16): 10_000_000_000_000_000 / 3 = 3_333_333_333_333_333, remainder = 1
-        #[cfg(feature = "high-precision")]
-        {
-            assert_eq!(remaining[0].raw, 3_333_333_333_333_333);
-            assert_eq!(remaining[1].raw, 3_333_333_333_333_333);
-            assert_eq!(remaining[2].raw, 1);
+        for quantity in remaining {
+            assert_eq!(quantity.precision, instrument.size_precision());
+            assert_eq!(quantity.raw % instrument.size_increment().raw, 0);
         }
-        #[cfg(not(feature = "high-precision"))]
-        {
-            assert_eq!(remaining[0].raw, 333_333_333);
-            assert_eq!(remaining[1].raw, 333_333_333);
-            assert_eq!(remaining[2].raw, 1);
-        }
+
+        let first = algo
+            .cache()
+            .order(&ClientOrderId::from("O-001-E1"))
+            .unwrap()
+            .quantity();
+        let total = remaining
+            .iter()
+            .fold(first.as_decimal(), |sum, qty| sum + qty.as_decimal());
+        assert_eq!(total, Quantity::from("1.0").as_decimal());
+    }
+
+    #[rstest]
+    fn test_twap_children_use_instrument_size_precision() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+
+        add_instrument_to_cache(&algo);
+        let instrument = nautilus_model::instruments::stubs::crypto_perpetual_ethusdt();
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("60"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("20"));
+
+        let order = create_market_order_with_params_and_qty(params, Quantity::from("1.000000000"));
+        let primary_id = order.client_order_id();
+
+        algo.on_order(order).unwrap();
+
+        let spawned = algo
+            .cache()
+            .order(&ClientOrderId::from("O-001-E1"))
+            .unwrap()
+            .quantity();
+        assert_eq!(spawned.precision, instrument.size_precision());
+        assert!(
+            algo.scheduled_sizes[&primary_id]
+                .iter()
+                .all(|quantity| quantity.precision == instrument.size_precision())
+        );
     }
 
     #[rstest]
@@ -1100,6 +1197,110 @@ mod tests {
         let result = algo.on_order(order);
         assert!(result.is_ok());
         assert!(algo.scheduled_sizes.is_empty());
+    }
+
+    #[rstest]
+    fn test_twap_rejects_huge_finite_interval_before_submission() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+
+        add_instrument_to_cache(&algo);
+
+        let received = Rc::new(RefCell::new(None::<SubmitOrder>));
+        let handler = msgbus::TypedIntoHandler::from({
+            let captured = received.clone();
+            move |cmd: TradingCommand| {
+                if let TradingCommand::SubmitOrder(cmd) = cmd {
+                    *captured.borrow_mut() = Some(cmd);
+                }
+            }
+        });
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_execute(),
+            handler,
+        );
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("2e20"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("1e20"));
+
+        let result = algo.on_order(create_market_order_with_params(params));
+
+        assert!(result.is_ok());
+        assert!(received.borrow().is_none());
+        assert!(algo.scheduled_sizes.is_empty());
+        assert!(algo.clock().timer_names().is_empty());
+    }
+
+    #[rstest]
+    fn test_twap_rejects_subnanosecond_interval_before_submission() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+
+        add_instrument_to_cache(&algo);
+
+        let received = Rc::new(RefCell::new(None::<SubmitOrder>));
+        let handler = msgbus::TypedIntoHandler::from({
+            let captured = received.clone();
+            move |cmd: TradingCommand| {
+                if let TradingCommand::SubmitOrder(cmd) = cmd {
+                    *captured.borrow_mut() = Some(cmd);
+                }
+            }
+        });
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_execute(),
+            handler,
+        );
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("2e-10"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("1e-10"));
+
+        let result = algo.on_order(create_market_order_with_params(params));
+
+        assert!(result.is_ok());
+        assert!(received.borrow().is_none());
+        assert!(algo.scheduled_sizes.is_empty());
+        assert!(algo.clock().timer_names().is_empty());
+    }
+
+    #[rstest]
+    fn test_twap_rejects_interval_exceeding_timestamp_headroom_before_submission() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+
+        add_instrument_to_cache(&algo);
+        DataActorNative::clock_mut(&mut algo)
+            .as_any_mut()
+            .downcast_mut::<TestClock>()
+            .unwrap()
+            .set_time(UnixNanos::new(u64::MAX - 500_000_000));
+
+        let received = Rc::new(RefCell::new(None::<SubmitOrder>));
+        let handler = msgbus::TypedIntoHandler::from({
+            let captured = received.clone();
+            move |cmd: TradingCommand| {
+                if let TradingCommand::SubmitOrder(cmd) = cmd {
+                    *captured.borrow_mut() = Some(cmd);
+                }
+            }
+        });
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_execute(),
+            handler,
+        );
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("2"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("1"));
+
+        let result = algo.on_order(create_market_order_with_params(params));
+
+        assert!(result.is_ok());
+        assert!(received.borrow().is_none());
+        assert!(algo.scheduled_sizes.is_empty());
+        assert!(algo.clock().timer_names().is_empty());
     }
 
     #[rstest]


### PR DESCRIPTION
Two defects in the Rust TWAP execution algorithm's schedule construction, where the child-order split and the interval timer diverge from the `TWAPExecAlgorithm` reference and can, respectively, emit off-grid child orders and panic mid-sequence.

## Child quantities are split at the internal fixed-point scale instead of the instrument size precision

`on_order` computes `qty_per_interval_raw = total_raw / num_intervals` on the raw fixed-point value and rebuilds each child with `total_qty.precision`, so a `1.0` order over three intervals yields children of raw `333333333` (nine-decimal `0.333333333`) and a final remainder slice of raw `1` (`0.000000001`). The children are off the instrument size grid, the dust remainder is orders of magnitude below any size increment, and the child precision is the primary order's rather than the instrument's - a quantity whose raw value carries precision the `precision` field says is unavailable. The reference `TWAPExecAlgorithm` instead divides in `Decimal`, floors the quotient to `instrument.size_precision`, and builds each child through `make_qty`.

The fix mirrors the reference exactly: the quotient is taken in `Decimal`, floored to `instrument.size_precision()` with round-toward-zero, and both the per-interval quantity and the remainder are constructed through `instrument.make_qty`, with the remainder computed from the pre-`make_qty` floored value. The N-plus-remainder slice layout is retained, and a runtime check now rejects the order before any state mutation if the assembled schedule does not sum exactly to the order quantity. For a `1.0` order over three intervals on a three-decimal instrument the schedule becomes `0.333, 0.333, 0.333, 0.001`, on-grid and summing exactly.

## A large interval panics after the first child is already submitted

The interval timer is created with `Duration::from_secs_f64(interval_secs)` only after the first child has been spawned, the primary reduced, and the child submitted. `from_secs_f64` panics on a non-representable value, so a finite but huge `interval_secs` (validated only as finite and positive) terminates the algorithm with a child order already live and no timer installed - a stranded sequence. `Clock::set_timer` additionally narrows the interval's nanoseconds to `u64` with an `as` cast, so intervals above the `u64` nanosecond range would silently install the wrong timer, and the clock's `start + interval` can overflow.

The fix validates the interval before any mutation, immediately after the submit-whole guards (mirroring the reference, which only builds a timer on the multi-slice path): `Duration::try_from_secs_f64`, a non-zero check, a checked `u64` nanosecond conversion, and a checked add against the current clock timestamp. Each failure logs and returns like the existing finite/positive guards, and the validated `Duration` is reused for `set_timer`.

## Parity scope

This aligns the Rust algorithm with the Python `TWAPExecAlgorithm` reference; it does not change the reference. The reference's coarser behavior - a single lopsided remainder slice, no per-slice size-increment alignment for non-power-of-ten increments, and no per-slice maximum - is shared by both implementations and is deliberately left as-is here, since redistributing or capping the remainder in Rust alone would make the two implementations disagree on child count, timing, and per-child quantity. That belongs in a separate, coordinated change across both, which I am not planning to take on; I am flagging the shared limitation here rather than committing to address it.

## Testing

`test_twap_calculates_size_schedule_with_remainder` now pins the on-grid schedule (`0.333, 0.333, 0.001` remaining after the first spawn) and asserts every slice carries `instrument.size_precision()`, lies on the size increment, and that the full schedule sums exactly to the order quantity; against the unfixed split it renders `0.3, 0.3, 0.0` at the wrong precision. `test_twap_children_use_instrument_size_precision` submits a nine-decimal `1.000000000` order and asserts the children carry the instrument's three-decimal precision, not the primary's nine; against the unfixed code they carry precision nine.

`test_twap_rejects_huge_finite_interval_before_submission`, `test_twap_rejects_subnanosecond_interval_before_submission`, and `test_twap_rejects_interval_exceeding_timestamp_headroom_before_submission` each assert that the order is rejected with no submitted command, no scheduled sizes, and no timer installed. Against the unfixed code the first panics in `Duration::from_secs_f64` with the first child already submitted, the second returns an error only after reaching timer setup, and the third overflows the clock timestamp - all after the first child has gone out.

All tests are deterministic over constructed events and a paused test clock with no wall-clock waits.

N.B.: `crates/adapters/polymarket/tests/exec_client.rs` carries a pre-existing deprecation unrelated to this change - `Atomic::fetch_update` was renamed to `try_update` and warns under a deny-warnings clippy on newer toolchains. It is outside the scope of this PR and left untouched.
