### PR TITLE
Stop backtest order and account queries panicking the simulated exchange

### DIFF
--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -693,6 +693,14 @@ impl SimulatedExchange {
 
     /// Sends a trading command to the exchange for processing.
     pub fn send(&mut self, command: TradingCommand) {
+        if matches!(
+            &command,
+            TradingCommand::QueryOrder(_) | TradingCommand::QueryAccount(_)
+        ) {
+            log::warn!("Simulated exchange does not support queries: {command}");
+            return;
+        }
+
         if !self.use_message_queue {
             self.process_trading_command(command);
         } else if self.latency_model.is_none() {
@@ -1754,5 +1762,111 @@ impl SimulatedExchange {
 
             self.cache.borrow_mut().update_account(&account).unwrap();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_common::messages::execution::{QueryAccount, QueryOrder};
+    use nautilus_execution::models::latency::StaticLatencyModel;
+    use nautilus_model::{
+        enums::{AccountType, BookType},
+        identifiers::{ClientOrderId, StrategyId, TraderId},
+        stubs::TestDefault,
+    };
+    use rstest::rstest;
+
+    use super::*;
+
+    /// The three `send` dispatch modes a query must be intercepted ahead of.
+    #[derive(Clone, Copy)]
+    enum Dispatch {
+        /// `use_message_queue = true` with a latency model: `inflight_queue`.
+        Latency,
+        /// `use_message_queue = true`, no latency: `message_queue`.
+        Queued,
+        /// `use_message_queue = false`: synchronous `process_trading_command`.
+        Immediate,
+    }
+
+    fn setup_exchange(dispatch: Dispatch) -> SimulatedExchange {
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+        let mut config = SimulatedVenueConfig::builder()
+            .venue(Venue::new("SIM"))
+            .oms_type(OmsType::Netting)
+            .account_type(AccountType::Margin)
+            .book_type(BookType::L2_MBP)
+            .starting_balances(vec![Money::new(1_000.0, Currency::USD())])
+            .build()
+            .unwrap();
+
+        match dispatch {
+            Dispatch::Latency => {
+                config.latency_model = Some(Box::new(StaticLatencyModel::new(
+                    UnixNanos::default(),
+                    UnixNanos::default(),
+                    UnixNanos::default(),
+                    UnixNanos::default(),
+                )));
+            }
+            Dispatch::Queued => {} // Defaults: use_message_queue = true, no latency
+            Dispatch::Immediate => config.use_message_queue = false,
+        }
+
+        SimulatedExchange::new(config, cache, clock).unwrap()
+    }
+
+    fn query_order() -> TradingCommand {
+        TradingCommand::QueryOrder(QueryOrder::new(
+            TraderId::test_default(),
+            None,
+            StrategyId::test_default(),
+            InstrumentId::from("AUD/USD.SIM"),
+            ClientOrderId::from("O-001"),
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ))
+    }
+
+    fn query_account() -> TradingCommand {
+        TradingCommand::QueryAccount(QueryAccount::new(
+            TraderId::test_default(),
+            None,
+            AccountId::test_default(),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ))
+    }
+
+    #[rstest]
+    #[case(Dispatch::Latency)]
+    #[case(Dispatch::Queued)]
+    #[case(Dispatch::Immediate)]
+    fn test_send_query_order_is_no_op(#[case] dispatch: Dispatch) {
+        let mut exchange = setup_exchange(dispatch);
+
+        exchange.send(query_order());
+
+        assert!(!exchange.has_pending_commands(UnixNanos::from(u64::MAX)));
+        assert_eq!(exchange.max_inflight_command_ts(), None);
+    }
+
+    #[rstest]
+    #[case(Dispatch::Latency)]
+    #[case(Dispatch::Queued)]
+    #[case(Dispatch::Immediate)]
+    fn test_send_query_account_is_no_op(#[case] dispatch: Dispatch) {
+        let mut exchange = setup_exchange(dispatch);
+
+        exchange.send(query_account());
+
+        assert!(!exchange.has_pending_commands(UnixNanos::from(u64::MAX)));
+        assert_eq!(exchange.max_inflight_command_ts(), None);
     }
 }

--- a/crates/backtest/src/execution_client.rs
+++ b/crates/backtest/src/execution_client.rs
@@ -282,22 +282,118 @@ impl ExecutionClient for BacktestExecutionClient {
     }
 
     fn query_account(&self, cmd: QueryAccount) -> anyhow::Result<()> {
-        if let Some(exchange) = self.exchange.upgrade() {
-            exchange
-                .borrow_mut()
-                .send(TradingCommand::QueryAccount(cmd));
-        } else {
-            log::error!("query_account: SimulatedExchange has been dropped");
-        }
+        log::warn!("Backtest execution client does not support account queries: {cmd}");
         Ok(())
     }
 
     fn query_order(&self, cmd: QueryOrder) -> anyhow::Result<()> {
-        if let Some(exchange) = self.exchange.upgrade() {
-            exchange.borrow_mut().send(TradingCommand::QueryOrder(cmd));
-        } else {
-            log::error!("query_order: SimulatedExchange has been dropped");
-        }
+        log::warn!("Backtest execution client does not support order queries: {cmd}");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_common::{clock::TestClock, messages::execution::QueryOrder};
+    use nautilus_core::UUID4;
+    use nautilus_execution::models::latency::StaticLatencyModel;
+    use nautilus_model::{
+        enums::{AccountType, BookType, OmsType},
+        identifiers::{InstrumentId, StrategyId},
+        stubs::TestDefault,
+        types::{Currency, Money},
+    };
+    use rstest::rstest;
+
+    use super::*;
+    use crate::config::SimulatedVenueConfig;
+
+    fn setup_client_with_latency() -> (BacktestExecutionClient, Rc<RefCell<SimulatedExchange>>) {
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+        let latency_model = StaticLatencyModel::new(
+            UnixNanos::default(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+        );
+        let config = SimulatedVenueConfig::builder()
+            .venue(Venue::new("SIM"))
+            .oms_type(OmsType::Netting)
+            .account_type(AccountType::Margin)
+            .book_type(BookType::L2_MBP)
+            .starting_balances(vec![Money::new(1_000.0, Currency::USD())])
+            .latency_model(Box::new(latency_model))
+            .build()
+            .unwrap();
+        let exchange = Rc::new(RefCell::new(
+            SimulatedExchange::new(config, cache.clone(), clock.clone()).unwrap(),
+        ));
+        let client = BacktestExecutionClient::new(
+            TraderId::test_default(),
+            AccountId::test_default(),
+            &exchange,
+            cache,
+            clock,
+            None,
+            None,
+        );
+
+        (client, exchange)
+    }
+
+    fn query_order() -> QueryOrder {
+        QueryOrder::new(
+            TraderId::test_default(),
+            None,
+            StrategyId::test_default(),
+            InstrumentId::from("AUD/USD.SIM"),
+            ClientOrderId::from("O-001"),
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        )
+    }
+
+    fn query_account() -> QueryAccount {
+        QueryAccount::new(
+            TraderId::test_default(),
+            None,
+            AccountId::test_default(),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        )
+    }
+
+    #[rstest]
+    fn test_query_order_is_not_forwarded_to_exchange() {
+        let (client, exchange) = setup_client_with_latency();
+
+        // Hold an immutable exchange borrow across the call: if the client
+        // forwards, send()'s `exchange.borrow_mut()` panics here. This makes the
+        // test bite on a client-only revert rather than being masked by the
+        // exchange-side query guard.
+        let exchange_ref = exchange.borrow();
+        let result = client.query_order(query_order());
+
+        assert!(result.is_ok());
+        assert_eq!(exchange_ref.max_inflight_command_ts(), None);
+    }
+
+    #[rstest]
+    fn test_query_account_is_not_forwarded_to_exchange() {
+        let (client, exchange) = setup_client_with_latency();
+
+        // See test_query_order_is_not_forwarded_to_exchange: the held borrow
+        // makes a forwarding attempt panic before the exchange guard can mask it.
+        let exchange_ref = exchange.borrow();
+        let result = client.query_account(query_account());
+
+        assert!(result.is_ok());
+        assert_eq!(exchange_ref.max_inflight_command_ts(), None);
     }
 }


### PR DESCRIPTION
A `QueryOrder` or `QueryAccount` reaching the backtest simulated exchange panics rather than being handled as the unsupported operation it is.

## The simulated exchange panics on an order or account status query

`SimulatedExchange::send` dispatches a `TradingCommand` three ways: synchronously via `process_trading_command` when the message queue is disabled, into the plain `message_queue` when there is no latency model, else into the latency `inflight_queue` via `generate_inflight_command`. A query breaks two of those paths. `generate_inflight_command` matches only the submit/modify/cancel variants and ends `_ => panic!("Cannot handle command")`, so any query under a latency model panics. `process_trading_command` opens with `command.instrument_id()`, which is a hard `panic!("No instrument ID for command")` for the account-level `QueryAccount`. So a strategy that polls order or account status aborts the backtest instead of learning the venue does not answer queries.

The backtest venue does not support these queries - the reference execution client leaves `query_order`/`query_account` unimplemented and synthesizes no report. `BacktestExecutionClient::query_order` and `query_account` now log that the query is unsupported and return without forwarding to the exchange, so the normal path no longer reaches the panicking code. As defense for the public exchange entry point, `SimulatedExchange::send` also intercepts both query variants as a logged no-op ahead of the latency and instrument-id dispatch. `TradingCommand::instrument_id()` is left unchanged: its panic for an account-level command is correct, and the exchange was the invalid caller.

## Testing

`test_query_order_is_not_forwarded_to_exchange` and `test_query_account_is_not_forwarded_to_exchange` drive the client methods against a latency-configured exchange while holding an immutable borrow of that exchange across the call, so any forwarding attempt would panic in `send`'s `borrow_mut`; each asserts the call returns and no inflight command was scheduled. `test_send_query_order_is_no_op` and `test_send_query_account_is_no_op` drive `SimulatedExchange::send` with each query variant across all three dispatch configurations - latency, queued, and synchronous - and assert nothing is queued or scheduled. Against the unfixed code every case panics: the latency path in `generate_inflight_command`, the synchronous `QueryAccount` at `instrument_id()`, and the client cases by forwarding into the same paths.
