### PR TITLE
Fix O(n^2) NETTING backtest cost (snapshot replay state, account event-log clones)

### DIFF
--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -4748,6 +4748,12 @@ impl Cache {
     /// Creates a snapshot of the `position` by cloning it, assigning a new ID,
     /// serializing it, and storing it in the position snapshots.
     ///
+    /// The snapshot copy excludes replay-only state (`replay_events` and `fill_voids`):
+    /// these vectors exist to service fill-void corrections on the live cached position
+    /// and are never read back from snapshot blobs, while growing with every fill
+    /// applied to the position ID (which would make each blob O(total fills) in both
+    /// serialization time and retained memory).
+    ///
     /// # Errors
     ///
     /// Returns an error if serializing or storing the position snapshot fails.
@@ -4757,6 +4763,8 @@ impl Cache {
         let mut copied_position = position.clone();
         let new_id = format!("{}-{}", position_id.as_str(), UUID4::new());
         copied_position.id = PositionId::new(new_id);
+        copied_position.replay_events.clear();
+        copied_position.fill_voids.clear();
 
         // Serialize the position (TODO: temporarily just to JSON to remove a dependency)
         let position_serialized = serde_json::to_vec(&copied_position)?;

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -59,7 +59,7 @@ use nautilus_model::{
         builder::OrderTestBuilder,
         stubs::{TestOrderEventStubs, TestOrdersGenerator},
     },
-    position::Position,
+    position::{Position, PositionReplayEvent},
     stubs::TestDefault,
     types::{AccountBalance, Currency, Money, Price, Quantity},
 };
@@ -5737,6 +5737,58 @@ fn test_position_snapshots_round_trip(mut cache: Cache) {
             .position_snapshots(None, Some(&AccountId::new("OTHER-000")))
             .is_empty(),
     );
+}
+
+#[rstest]
+fn test_position_snapshot_blobs_exclude_replay_state(mut cache: Cache) {
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim());
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &audusd_sim,
+        Some(TradeId::new("T-1")),
+        Some(PositionId::new("P-1")),
+        Some(Price::from("1.00000")),
+        None,
+        None,
+        None,
+        Some(UnixNanos::from(1_000_000_000)),
+        None,
+    );
+    let fill: OrderFilled = fill.into();
+    let mut position = Position::new(&audusd_sim, fill.clone());
+    let position_id = position.id;
+
+    cache.snapshot_position(&position).unwrap();
+
+    // Grow the replay log as NETTING close/reopen cycles would
+    for _ in 0..1000 {
+        position
+            .replay_events
+            .push(PositionReplayEvent::Filled(fill.clone()));
+    }
+    cache.snapshot_position(&position).unwrap();
+
+    // Blob size is independent of the replay-log length
+    let frames = cache.position_snapshot_bytes(&position_id).unwrap();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0].len(), frames[1].len());
+
+    // Replay-only state is stripped; summary fields round-trip intact
+    let snapshots = cache.position_snapshots(Some(&position_id), None);
+    assert_eq!(snapshots.len(), 2);
+    for snapshot in &snapshots {
+        assert!(snapshot.replay_events.is_empty());
+        assert!(snapshot.fill_voids.is_empty());
+        assert_eq!(snapshot.realized_pnl, position.realized_pnl);
+        assert_eq!(snapshot.account_id, position.account_id);
+        assert_eq!(snapshot.quantity, position.quantity);
+    }
 }
 
 fn snapshot_test_position() -> Position {

--- a/crates/execution/src/engine/config.rs
+++ b/crates/execution/src/engine/config.rs
@@ -56,6 +56,17 @@ pub struct ExecutionEngineConfig {
     /// If `None` then no additional snapshots will be taken.
     #[serde(default)]
     pub snapshot_positions_interval_secs: Option<f64>,
+    /// If replay events and fill voids are carried across position close/reopen cycles
+    /// (NETTING OMS reuses position IDs).
+    ///
+    /// Carrying the full replay log preserves venue fill-void corrections that reference
+    /// fills from prior cycles, at the cost of per-position state growing with every fill
+    /// applied to the position ID. Disable for high order-count backtests against
+    /// simulated venues (where `OrderFillVoided` events cannot occur) to bound position
+    /// state to the current close/reopen cycle.
+    #[serde(default = "default_true")]
+    #[builder(default = true)]
+    pub carry_replay_events_on_reopen: bool,
     /// If order fills exceeding order quantity are allowed (logs warning instead of raising).
     /// Useful when position reconciliation races with exchange fill events.
     #[serde(default)]
@@ -180,6 +191,21 @@ mod tests {
     #[rstest]
     fn test_default_config_is_valid() {
         assert!(ExecutionEngineConfig::builder().build().is_ok());
+    }
+
+    #[rstest]
+    fn test_carry_replay_events_on_reopen_defaults_true() {
+        assert!(ExecutionEngineConfig::default().carry_replay_events_on_reopen);
+
+        let config: ExecutionEngineConfig =
+            serde_json::from_str("{}").expect("empty config should deserialize");
+        assert!(config.carry_replay_events_on_reopen);
+
+        let config = ExecutionEngineConfig::builder()
+            .carry_replay_events_on_reopen(false)
+            .build()
+            .unwrap();
+        assert!(!config.carry_replay_events_on_reopen);
     }
 
     #[rstest]

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -3640,10 +3640,16 @@ impl ExecutionEngine {
             self.reopen_position(position, oms_type)?;
         }
 
-        let prior_position = position.cloned().or_else(|| {
-            fill.position_id
-                .and_then(|position_id| self.cache.borrow().position_owned(&position_id))
-        });
+        // Fetching the prior position (a clone including its replay log) exists solely
+        // to carry replay state across the reopen, so skip it entirely when disabled.
+        let prior_position = if self.config.carry_replay_events_on_reopen {
+            position.cloned().or_else(|| {
+                fill.position_id
+                    .and_then(|position_id| self.cache.borrow().position_owned(&position_id))
+            })
+        } else {
+            None
+        };
         let mut position = Position::new(instrument, fill.clone());
         if let Some(prior) = prior_position
             && prior.id == position.id

--- a/crates/execution/src/python/config.rs
+++ b/crates/execution/src/python/config.rs
@@ -33,6 +33,7 @@ impl ExecutionEngineConfig {
         snapshot_orders = None,
         snapshot_positions = None,
         snapshot_positions_interval_secs = None,
+        carry_replay_events_on_reopen = None,
         allow_overfills = None,
         external_clients = None,
         purge_closed_orders_interval_mins = None,
@@ -50,6 +51,7 @@ impl ExecutionEngineConfig {
         snapshot_orders: Option<bool>,
         snapshot_positions: Option<bool>,
         snapshot_positions_interval_secs: Option<f64>,
+        carry_replay_events_on_reopen: Option<bool>,
         allow_overfills: Option<bool>,
         external_clients: Option<Vec<ClientId>>,
         purge_closed_orders_interval_mins: Option<u32>,
@@ -67,6 +69,7 @@ impl ExecutionEngineConfig {
             .maybe_snapshot_orders(snapshot_orders)
             .maybe_snapshot_positions(snapshot_positions)
             .maybe_snapshot_positions_interval_secs(snapshot_positions_interval_secs)
+            .maybe_carry_replay_events_on_reopen(carry_replay_events_on_reopen)
             .maybe_allow_overfills(allow_overfills)
             .maybe_external_clients(external_clients)
             .maybe_purge_closed_orders_interval_mins(purge_closed_orders_interval_mins)
@@ -109,6 +112,12 @@ impl ExecutionEngineConfig {
     #[pyo3(name = "snapshot_positions_interval_secs")]
     const fn py_snapshot_positions_interval_secs(&self) -> Option<f64> {
         self.snapshot_positions_interval_secs
+    }
+
+    #[getter]
+    #[pyo3(name = "carry_replay_events_on_reopen")]
+    const fn py_carry_replay_events_on_reopen(&self) -> bool {
+        self.carry_replay_events_on_reopen
     }
 
     #[getter]

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -16036,3 +16036,83 @@ fn test_dispose_leaves_unrelated_clock_timers_intact() {
         "engine.dispose should cancel engine-owned purge timers, names={names:?}",
     );
 }
+
+/// Runs a NETTING open -> flip (buy 100k, then sell 150k on the reused position ID)
+/// and returns the reused position's replay-log length and snapshot frame count.
+fn run_netting_flip(execution_engine: &mut ExecutionEngine) -> (usize, usize) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+    let position_id = PositionId::new(format!("{}-{strategy_id}", instrument.id));
+    setup_netting_snapshot_engine(execution_engine, &instrument);
+
+    process_filled_order(
+        execution_engine,
+        trader_id,
+        strategy_id,
+        &instrument,
+        "O-REPLAY-FLIP-1",
+        "V-REPLAY-FLIP-1",
+        "T-REPLAY-FLIP-1",
+        OrderSide::Buy,
+        100_000,
+        position_id,
+    );
+    process_filled_order(
+        execution_engine,
+        trader_id,
+        strategy_id,
+        &instrument,
+        "O-REPLAY-FLIP-2",
+        "V-REPLAY-FLIP-2",
+        "T-REPLAY-FLIP-2",
+        OrderSide::Sell,
+        150_000,
+        position_id,
+    );
+
+    let cache = execution_engine.cache().borrow();
+    let position = cache
+        .position(&position_id)
+        .expect("flipped position should exist under the reused ID");
+    assert!(
+        cache.is_position_open(&position_id),
+        "flipped position should be open"
+    );
+    assert_eq!(position.side, PositionSide::Short);
+    assert_eq!(position.quantity, Quantity::from(50_000));
+
+    (
+        position.replay_events.len(),
+        cache.position_snapshot_count(&position_id),
+    )
+}
+
+#[rstest]
+fn test_netting_flip_carries_replay_events_by_default(mut execution_engine: ExecutionEngine) {
+    let (replay_len, snapshot_count) = run_netting_flip(&mut execution_engine);
+
+    // Prior cycle log (entry fill + closing split fill) carried, plus the current cycle fill
+    assert_eq!(replay_len, 3);
+    // The closed cycle was snapshotted for realized PnL reconstruction
+    assert_eq!(snapshot_count, 1);
+}
+
+#[rstest]
+fn test_netting_flip_bounds_replay_events_when_carry_disabled() {
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let config = ExecutionEngineConfig {
+        carry_replay_events_on_reopen: false,
+        ..Default::default()
+    };
+    let mut execution_engine = ExecutionEngine::new(clock, cache, Some(config));
+
+    let (replay_len, snapshot_count) = run_netting_flip(&mut execution_engine);
+
+    // Position state is bounded to the current cycle (identical fills and position
+    // outcome as the default path, asserted inside the helper)
+    assert_eq!(replay_len, 1);
+    // Realized-PnL snapshots are unaffected by the carry setting
+    assert_eq!(snapshot_count, 1);
+}

--- a/crates/live/src/node/config.rs
+++ b/crates/live/src/node/config.rs
@@ -508,6 +508,9 @@ impl From<LiveExecEngineConfig> for ExecutionEngineConfig {
             snapshot_orders: config.snapshot_orders,
             snapshot_positions: config.snapshot_positions,
             snapshot_positions_interval_secs: config.snapshot_positions_interval_secs,
+            // Live trading must always carry replay state across reopen cycles so
+            // venue fill-void corrections referencing prior cycles keep working.
+            carry_replay_events_on_reopen: true,
             allow_overfills: config.allow_overfills,
             filter_unclaimed_external_orders: config.filter_unclaimed_external_orders,
             external_clients: config.external_clients,

--- a/crates/portfolio/src/manager.rs
+++ b/crates/portfolio/src/manager.rs
@@ -68,7 +68,14 @@ impl AccountsManager {
         instrument: &InstrumentAny,
         fill: &OrderFilled,
     ) -> (AccountAny, AccountState) {
-        let original_account = account.clone();
+        // Snapshot only the state the balance update can mutate (balances and
+        // commissions) for the rollback path: cloning the whole account would
+        // deep-copy its event log, which grows by one entry per fill.
+        let (original_balances, original_commissions) = match &account {
+            AccountAny::Margin(a) => (a.balances.clone(), a.commissions.clone()),
+            AccountAny::Cash(a) => (a.balances.clone(), a.commissions.clone()),
+            AccountAny::Betting(a) => (a.balances.clone(), a.commissions.clone()),
+        };
         let position_id = if let Some(position_id) = fill.position_id {
             position_id
         } else {
@@ -117,8 +124,22 @@ impl AccountsManager {
         };
 
         if !updated {
-            let state = self.generate_account_state(&original_account, fill.ts_event);
-            return (original_account, state);
+            match &mut account {
+                AccountAny::Margin(a) => {
+                    a.balances = original_balances;
+                    a.commissions = original_commissions;
+                }
+                AccountAny::Cash(a) => {
+                    a.balances = original_balances;
+                    a.commissions = original_commissions;
+                }
+                AccountAny::Betting(a) => {
+                    a.balances = original_balances;
+                    a.commissions = original_commissions;
+                }
+            }
+            let state = self.generate_account_state(&account, fill.ts_event);
+            return (account, state);
         }
 
         let state = self.generate_account_state(&account, fill.ts_event);

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -3160,6 +3160,15 @@ fn on_order_event(
     }
 }
 
+/// Result of peeking at the cached account inside [`update_position`]:
+/// only a margin account with `calculate_account_state` set needs the owned
+/// take-out/recompute path; everything else resolves under the borrow.
+enum AccountPeek {
+    MarginRecompute,
+    LastEvent(Option<AccountState>),
+    Missing,
+}
+
 fn update_position(
     cache: &Rc<RefCell<Cache>>,
     clock: &Rc<RefCell<dyn Clock>>,
@@ -3229,49 +3238,87 @@ fn update_position(
             .insert(event.instrument_id());
     }
 
-    let account = { cache.borrow().account_owned(&account_id) };
-    let account_state_to_publish = match account {
-        Some(AccountAny::Margin(margin_account)) => {
-            if margin_account.calculate_account_state {
-                let instrument = { cache.borrow().instrument(&instrument_id).cloned() };
-                if let Some(instrument) = instrument {
-                    let result = {
-                        let cache_ref = cache.borrow();
-                        let refs = cache_ref.positions_open(
-                            None,
-                            Some(&instrument_id),
-                            None,
-                            Some(&account_id),
-                            None,
-                        );
-                        let positions: Vec<&Position> = refs.iter().map(|r| &**r).collect();
-                        inner.borrow_mut().accounts.update_positions(
-                            &margin_account,
-                            &instrument,
-                            positions,
-                            clock.borrow().timestamp_ns(),
-                        )
-                    };
-
-                    if let Some((margin_account, account_state)) = result {
-                        cache
-                            .borrow_mut()
-                            .update_account(&AccountAny::Margin(margin_account))
-                            .unwrap();
-                        Some(account_state)
-                    } else {
-                        margin_account.last_event()
+    // Peek at the account under a scoped borrow rather than taking an owned
+    // clone: the account's event log grows by one entry per fill, so a clone
+    // here made every fill O(total prior fills). Only the margin recompute
+    // path needs ownership; every other path leaves the cache untouched,
+    // matching the previous behavior.
+    let peek = {
+        let cache_ref = cache.borrow();
+        match cache_ref.account(&account_id) {
+            Some(account) => match &*account {
+                AccountAny::Margin(margin_account) if margin_account.calculate_account_state => {
+                    AccountPeek::MarginRecompute
+                }
+                account => AccountPeek::LastEvent(account.last_event()),
+            },
+            None => AccountPeek::Missing,
+        }
+    };
+    let account_state_to_publish = match peek {
+        AccountPeek::MarginRecompute => {
+            let instrument = { cache.borrow().instrument(&instrument_id).cloned() };
+            if let Some(instrument) = instrument {
+                // Move the account out of the cache for the in-place recompute
+                // (no clone), then move it back. `update_positions_in_place`
+                // leaves the account untouched when it returns `None`, so the
+                // fallback put-back restores the exact prior state (and skips
+                // the database write, as before). Bind the taken account first
+                // so the mutable cache borrow drops before the match body.
+                let taken_account = cache.borrow_mut().take_account(&account_id);
+                match taken_account {
+                    Some(AccountAny::Margin(mut margin_account)) => {
+                        let recomputed = {
+                            let cache_ref = cache.borrow();
+                            let refs = cache_ref.positions_open(
+                                None,
+                                Some(&instrument_id),
+                                None,
+                                Some(&account_id),
+                                None,
+                            );
+                            let positions: Vec<&Position> = refs.iter().map(|r| &**r).collect();
+                            inner.borrow_mut().accounts.update_positions_in_place(
+                                &mut margin_account,
+                                &instrument,
+                                positions,
+                                clock.borrow().timestamp_ns(),
+                            )
+                        };
+                        match recomputed {
+                            Some(account_state) => {
+                                cache
+                                    .borrow_mut()
+                                    .update_account_owned(AccountAny::Margin(margin_account))
+                                    .unwrap();
+                                Some(account_state)
+                            }
+                            None => {
+                                let last_event = margin_account.last_event();
+                                cache
+                                    .borrow_mut()
+                                    .cache_account_owned(AccountAny::Margin(margin_account));
+                                last_event
+                            }
+                        }
                     }
-                } else {
-                    log::error!("Cannot update position: no instrument found for {instrument_id}");
-                    margin_account.last_event()
+                    Some(account) => {
+                        let last_event = account.last_event();
+                        cache.borrow_mut().cache_account_owned(account);
+                        last_event
+                    }
+                    None => None,
                 }
             } else {
-                margin_account.last_event()
+                log::error!("Cannot update position: no instrument found for {instrument_id}");
+                let cache_ref = cache.borrow();
+                cache_ref
+                    .account(&account_id)
+                    .and_then(|account| account.last_event())
             }
         }
-        Some(account) => account.last_event(),
-        None => {
+        AccountPeek::LastEvent(last_event) => last_event,
+        AccountPeek::Missing => {
             log::error!(
                 "Cannot update position: no account registered for {}",
                 event.account_id()


### PR DESCRIPTION
Fixes quadratic (O(n²) in total fills) CPU and memory growth on the NETTING backtest path, which currently makes high order-count tick backtests impractical and eventually OOM.

## Problem

Running a simple EMA-cross strategy over raw trade ticks (BacktestEngine, SimulatedExchange, NETTING OMS, MARGIN account, single instrument, standard-precision build) the per-order cost grows roughly linearly with the number of prior orders, so total cost is O(n²):

| Orders in run | Avg order-path cost per order |
|---|---|
| 950 | ~1.0 ms |
| 8,000 | ~9.4 ms |
| 58,459 | did not complete (retained snapshot memory also grows quadratically → OOM) |

The same 58k-order workload completes in 140 s on nautilus_trader v1 (1.230.0), which does not exhibit the quadratic.

## Root cause

Three composing mechanisms:

1. **`Position.replay_events` is carried across every NETTING close/reopen cycle and never trimmed.** Each fill appends one entry (`Position::apply_fill`), and `ExecutionEngine::open_position` re-attaches the prior position's entire log to the reopened position. After n fills the reused-ID position is O(n)-sized, so every prior-position fetch (`position_owned`), `add_position` cache clone, and snapshot clone is O(n).
2. **`Cache::snapshot_position` serializes and retains the full position on every NETTING flip/reopen.** Each blob embeds the ever-growing `replay_events`, so each flip serializes O(n) bytes and all blobs are retained ⇒ O(n²) retained memory (this is what OOMs).
3. **The portfolio's per-fill handlers deep-clone the whole account up to four times per fill.** `BaseAccount.events` grows by one `AccountState` per fill and is never purged during a run, so each clone (`Cache::account_owned`, the `AccountsManager::update_positions` wrapper, `Cache::update_account` into the cell, and the defensive rollback clone in `update_balances`) is O(n). This was the dominant residual cost after fixing (1)–(2).

## Changes (three commits)

1. **Strip replay-only state from position snapshot blobs.** `Cache::snapshot_position` clears `replay_events` and `fill_voids` on the throwaway snapshot copy before serializing. No snapshot consumer reads these vectors back: the portfolio's realized-PnL reconstruction reads `realized_pnl`/`account_id`, the analyzer reads summary fields, and live fill-void fragment discovery reads the *live* cached position, never a snapshot blob. Both fields are `#[serde(default)]`, so existing persisted blobs and `position_snapshots()` round-trips remain compatible. Snapshot blob size becomes independent of run length (regression test added).
2. **Add `carry_replay_events_on_reopen` to `ExecutionEngineConfig` (default `true` — behavior unchanged).** The replay log exists to service venue `OrderFillVoided` corrections that may reference fills from prior cycles; that cannot occur against purely simulated venues. When disabled, the engine skips the prior-position fetch and replay carry on reopen, bounding position state to the current cycle. `LiveExecEngineConfig` conversion pins the option to `true` so live trading always carries replay state. Python bindings expose the new option.
3. **Stop cloning the account event log on the per-fill portfolio path.** `update_position` now peeks at the account under a scoped borrow and, only for the margin recompute path, moves the account out with the existing `take_account`, recalculates with the existing `update_positions_in_place`, and moves it back (`update_account_owned` on success; `cache_account_owned` — no database write, as before — when the recompute returns `None`, which leaves the account untouched). Cash/betting accounts and margin accounts without `calculate_account_state` no longer write the account back at all, matching the previous read-only behavior. `update_balances` snapshots only the state it can mutate (balances and commissions maps) for its rollback path instead of cloning the account.

## Results

Same tick workload as above (BTC perp trade ticks, i64/9dp build, single core). "Before" measured at develop `0cfa1310` (the touched files are unchanged through `ec58b2a`); "after" is this branch with `carry_replay_events_on_reopen: false`:

| Workload | Before | After |
|---|---|---|
| 1 week (1.43M ticks), 8,000 orders / 9,000 fills | 18.7k ticks/s (76.3 s) | **1.04M ticks/s (1.4 s)** |
| 45 days (10.6M ticks), 6,847 orders / 7,728 fills | 168k ticks/s (63.1 s, 16 GiB RSS) | **1.26M ticks/s (8.4 s, 1.4 GB)** |
| 45 days (10.6M ticks), 58,459 orders / 65,466 fills | did not complete (OOM) | **1.02M ticks/s (10.4 s, 1.6 GB)** — ~13× faster than v1's 140 s on the identical workload |
| Null-strategy floor (no orders) | 1.30M ticks/s | unchanged (1.28M ticks/s) |

Per-fill cost is now flat (~30 µs/fill at 9k and at 65k total fills).

Correctness evidence:

- Fills are event-identical (`side`, `px`, `qty`, `ts_event`) with `carry_replay_events_on_reopen` **on vs off** on the same window.
- Fills are event-identical to **nautilus_trader v1 (1.230.0)** running the same mirrored backtest (same venue semantics, hand-rolled EMA mirrored op-for-op on both engines): **7,728/7,728** fills on the 45-day window (EMA 500/2000) and **65,466/65,466** fills (EMA 50/200) — the latter run previously could not complete on v2 at all. Final balances match v1 to ≤2e-5 USDT (currency-precision rounding between the 9dp raw build and the Python wheel, present before and after this change).
- Full test suites pass: `nautilus-execution` (211 + 50), `nautilus-portfolio` (115), `nautilus-common` cache (244), including `test_portfolio_realized_pnl_with_position_snapshots_netting_oms`; two regression tests added (snapshot blob size independent of replay-log length; replay carry bounded when the option is disabled).

For context, v1's Cython engine has none of these costs: it creates a fresh `Position` per NETTING reopen (per-cycle event list), pickles only the bounded just-closed position on flip, and mutates the account in place. These changes bring v2's default cost model in line while preserving the replay-carry capability for live use.

## Out of scope (can file separately)

- HEDGING OMS has a separate quadratic: `Portfolio::update_position` re-scans all open positions per fill (net-position, unrealized-PnL and margin recompute), degrading with thousands of open positions (measured 25.5k ticks/s with 8,000 open positions).
- `snapshot_position` stores each blob twice (`position_snapshots` map and the generic `cache://position-snapshots/...` keys via `Cache::add`), and `purge_position` removes only the former.
- `BaseAccount.events` still grows O(n) in memory over a run (unchanged behavior; only the per-fill time cost is removed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
