### PR TITLE
Stop okx data-client tests waiting out the event-drain deadline

### DIFF
--- a/crates/adapters/okx/tests/data_client.rs
+++ b/crates/adapters/okx/tests/data_client.rs
@@ -166,6 +166,35 @@ async fn drain_data_events(
     events
 }
 
+async fn collect_data_events_until_response(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
+    request_id: UUID4,
+    timeout: Duration,
+) -> Vec<DataEvent> {
+    let mut events = Vec::new();
+    tokio::time::timeout(timeout, async {
+        loop {
+            let event = rx.recv().await.expect("data event channel closed");
+            let is_correlated_response = matches!(
+                &event,
+                DataEvent::Response(response) if response.correlation_id() == &request_id
+            );
+            events.push(event);
+
+            if is_correlated_response {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for data response {request_id}"));
+
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    events
+}
+
 fn request_instruments() -> RequestInstruments {
     RequestInstruments::new(
         None,
@@ -232,11 +261,14 @@ async fn test_request_instruments_includes_spreads_when_enabled() {
     let addr = start_test_server(state.clone()).await;
     let (client, mut rx) = create_test_data_client(addr, true);
 
+    let request = request_instruments();
+    let request_id = request.request_id;
     client
-        .request_instruments(request_instruments())
+        .request_instruments(request)
         .expect("request_instruments");
 
-    let events = drain_data_events(&mut rx, Duration::from_secs(5)).await;
+    let events =
+        collect_data_events_until_response(&mut rx, request_id, Duration::from_secs(5)).await;
     let response = instruments_response(&events);
     let spread_ids = response
         .data
@@ -274,11 +306,14 @@ async fn test_request_instruments_continues_when_spread_endpoint_fails() {
     let addr = start_test_server(state.clone()).await;
     let (client, mut rx) = create_test_data_client(addr, true);
 
+    let request = request_instruments();
+    let request_id = request.request_id;
     client
-        .request_instruments(request_instruments())
+        .request_instruments(request)
         .expect("request_instruments");
 
-    let events = drain_data_events(&mut rx, Duration::from_secs(5)).await;
+    let events =
+        collect_data_events_until_response(&mut rx, request_id, Duration::from_secs(5)).await;
     let response = instruments_response(&events);
     let spread_count = response
         .data
@@ -304,11 +339,14 @@ async fn test_request_instrument_returns_spread_when_enabled() {
     let addr = start_test_server(state.clone()).await;
     let (client, mut rx) = create_test_data_client(addr, true);
 
+    let request = request_instrument("BTC-USDT_BTC-USDT-SWAP.OKX");
+    let request_id = request.request_id;
     client
-        .request_instrument(request_instrument("BTC-USDT_BTC-USDT-SWAP.OKX"))
+        .request_instrument(request)
         .expect("request_instrument");
 
-    let events = drain_data_events(&mut rx, Duration::from_secs(5)).await;
+    let events =
+        collect_data_events_until_response(&mut rx, request_id, Duration::from_secs(5)).await;
     let response = instrument_response(&events).expect("spread response must be emitted");
     let spread_queries = state.spread_queries.lock().await;
 
@@ -338,6 +376,7 @@ async fn test_request_instrument_emits_no_spread_when_disabled() {
         .request_instrument(request_instrument("BTC-USDT_BTC-USDT-SWAP.OKX"))
         .expect("request_instrument");
 
+    // This path emits no response, so retain a bounded absence window.
     let events = drain_data_events(&mut rx, Duration::from_secs(1)).await;
     let spread_queries = state.spread_queries.lock().await;
 


### PR DESCRIPTION
The okx data-client instrument-request tests each wait out a fixed five-second event-drain deadline, costing five seconds apiece regardless of when the response arrives.

## The event drain cannot return early

`drain_data_events` in `crates/adapters/okx/tests/data_client.rs` collects events with `tokio::time::timeout_at(deadline, rx.recv())` in a loop, so it only returns once the deadline expires. The `OKXDataClient` holds the `UnboundedSender` for the life of the test, so `rx.recv()` never sees a closed channel and blocks the full window after the last event. The three instrument-request tests each pass a five-second window and so cost five seconds apiece even though the response arrives in milliseconds.

The correlated `DataResponse` is a deterministic terminal marker for these requests. `collect_data_events_until_response` receives until it sees the `DataEvent::Response` whose `correlation_id` equals the request's id, then sweeps anything already queued with `try_recv`. The three positive tests capture the request id before submitting and collect through that response; the five-second argument survives only as a failure deadline a passing run never reaches. Every existing assertion is unchanged - the exact spread ids, spread and spot counts, response variants, instrument id and type, and the server-side query counts and parameters - and the response is emitted only after the relevant HTTP queries complete, so returning at the correlated response does not race those checks.

No test can now pass vacuously: a missing correlated response times out and panics, a closed channel panics, and a correlated response of the wrong variant still trips the `instruments_response`/`instrument_response` variant assertions.

`test_request_instrument_emits_no_spread_when_disabled` keeps its one-second window: with spreads disabled that path issues the query but emits no response, so it has no terminal marker to collect through, and the bounded wait is a deliberate absence check.

## Testing

No test cases were added; the existing assertions are the regression and every one is preserved. The three converted tests drop from ~5.005s each to a few milliseconds, so the former five-second members no longer appear among the package's slowest tests, and their five-second arguments are now failure ceilings. The correlation was verified: a request id that never receives its response makes the helper time out and panic rather than pass.
