### PR TITLE
Add pending-update to submitted order status transition

### DIFF
--- a/crates/model/src/orders/mod.rs
+++ b/crates/model/src/orders/mod.rs
@@ -242,6 +242,7 @@ impl OrderStatus {
             (Self::PendingUpdate, OrderEventAny::Canceled(_)) => Self::Canceled,
             (Self::PendingUpdate, OrderEventAny::Expired(_)) => Self::Expired,
             (Self::PendingUpdate, OrderEventAny::Triggered(_)) => Self::Triggered,
+            (Self::PendingUpdate, OrderEventAny::Submitted(_)) => Self::PendingUpdate,  // Real world possibility
             (Self::PendingUpdate, OrderEventAny::PendingUpdate(_)) => Self::PendingUpdate,  // Allow multiple requests
             (Self::PendingUpdate, OrderEventAny::PendingCancel(_)) => Self::PendingCancel,
             (Self::PendingUpdate, OrderEventAny::ModifyRejected(_)) => Self::PendingUpdate,  // Handled by modify_rejected to restore previous_status
@@ -2886,6 +2887,60 @@ mod tests {
             .apply(OrderEventAny::PendingUpdate(pending_update))
             .unwrap();
         assert_eq!(order.status(), OrderStatus::PendingUpdate);
+
+        order.apply(OrderEventAny::Updated(updated)).unwrap();
+
+        assert_eq!(order.status(), OrderStatus::Accepted);
+        assert_eq!(order.quantity(), Quantity::from(50_000));
+    }
+
+    #[rstest]
+    fn test_pending_update_accepts_delayed_submitted() {
+        let init = OrderInitializedSpec::builder()
+            .quantity(Quantity::from(100_000))
+            .build();
+        let submitted = OrderSubmittedSpec::builder()
+            .ts_event(UnixNanos::from(1_000))
+            .build();
+        let accepted = OrderAcceptedSpec::builder().build();
+        let pending_update = OrderPendingUpdateSpec::builder().build();
+
+        // A distinct account and timestamp so the `submitted` handler's writes are
+        // observable: with identical specs the assertions below cannot tell whether
+        // the handler ran at all.
+        let delayed_submitted = OrderSubmittedSpec::builder()
+            .account_id(AccountId::from("SIM-002"))
+            .ts_event(UnixNanos::from(3_000))
+            .build();
+        let updated = OrderUpdatedSpec::builder()
+            .quantity(Quantity::from(50_000))
+            .build();
+
+        let mut order: MarketOrder = init.try_into().unwrap();
+        order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+        order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+        order
+            .apply(OrderEventAny::PendingUpdate(pending_update))
+            .unwrap();
+
+        assert_eq!(order.status(), OrderStatus::PendingUpdate);
+        assert_eq!(order.previous_status(), Some(OrderStatus::Accepted));
+        assert_eq!(order.account_id(), Some(AccountId::from("SIM-001")));
+        assert_eq!(order.ts_submitted(), Some(UnixNanos::from(1_000)));
+
+        order
+            .apply(OrderEventAny::Submitted(delayed_submitted))
+            .unwrap();
+
+        // The order holds PendingUpdate and keeps the pre-update status, so the
+        // in-flight modify can still be resolved.
+        assert_eq!(order.status(), OrderStatus::PendingUpdate);
+        assert_eq!(order.previous_status(), Some(OrderStatus::Accepted));
+
+        // The handler applied the delayed event's fields, matching `_submitted` in
+        // the Cython engine (`base.pyx`), which assigns both unconditionally.
+        assert_eq!(order.account_id(), Some(AccountId::from("SIM-002")));
+        assert_eq!(order.ts_submitted(), Some(UnixNanos::from(3_000)));
 
         order.apply(OrderEventAny::Updated(updated)).unwrap();
 


### PR DESCRIPTION
A follow-up to the order-apply atomicity work in #4530, split out at your request on that thread.

## Missing `(PendingUpdate, Submitted)` state-machine transition

`OrderStatus::transition` in `crates/model/src/orders/mod.rs` omits one arm that the Cython `FiniteStateMachine` table carries (`nautilus_trader/model/orders/base.pyx:132`, `(PENDING_UPDATE, SUBMITTED) -> PENDING_UPDATE`). When a submission acknowledgement arrives after an order has already entered `PendingUpdate` - a venue re-emitting, or a submit ack racing an in-flight modify request - the event matches no arm, falls through to the catch-all, and `OrderCore::apply` returns `InvalidStateTransition`. The event is dropped, diverging from the Python engine, which tolerates it and holds `PENDING_UPDATE`.

The fix adds the single arm `(PendingUpdate, Submitted) -> PendingUpdate`. No handler change is needed: `apply` does not overwrite `previous_status` while the current status is `PendingUpdate` or `PendingCancel`, so holding `PendingUpdate` preserves the pre-update status, and a subsequent `OrderUpdated` or `OrderModifyRejected` still restores it. The `submitted` handler only records `account_id` and `ts_submitted`, which is harmless here.

## Testing

`test_pending_update_accepts_submitted_and_restores_status_on_updated` (an extension of the prior `test_pending_update_order_restores_status_on_updated`) drives an order `Initialized -> Submitted -> Accepted -> PendingUpdate`, applies a delayed `OrderSubmitted`, and asserts the order holds `PendingUpdate` with `previous_status` still `Some(Accepted)` on both sides of the event, then applies `OrderUpdated` and asserts restoration to `Accepted` with the updated quantity. The delayed-submission assertions were verified to FAIL against the unfixed table: `apply` returns `InvalidStateTransition` at that step.
