### PR TITLE
Forward high-precision to nautilus-serialization from dependent crates

### DIFF
--- a/crates/adapters/betfair/Cargo.toml
+++ b/crates/adapters/betfair/Cargo.toml
@@ -31,7 +31,10 @@ extension-module = [
   "pyo3/extension-module",
   "python",
 ]
-high-precision = ["nautilus-model/high-precision"]
+high-precision = [
+  "nautilus-model/high-precision",
+  "nautilus-serialization/high-precision",
+]
 python = [
   "dep:nautilus-system",
   "nautilus-core/python",

--- a/crates/adapters/binance/Cargo.toml
+++ b/crates/adapters/binance/Cargo.toml
@@ -23,7 +23,10 @@ crate-type = ["rlib"]
 [features]
 default = ["high-precision"]
 examples = ["nautilus-live/node", "nautilus-network/transport-sockudo"]
-high-precision = ["nautilus-model/high-precision"]
+high-precision = [
+  "nautilus-model/high-precision",
+  "nautilus-serialization/high-precision",
+]
 extension-module = [
   "nautilus-common/extension-module",
   "nautilus-core/extension-module",

--- a/crates/adapters/tardis/Cargo.toml
+++ b/crates/adapters/tardis/Cargo.toml
@@ -47,7 +47,10 @@ python = [
   "replay",
 ]
 replay = []
-high-precision = ["nautilus-model/high-precision"]
+high-precision = [
+  "nautilus-model/high-precision",
+  "nautilus-serialization/high-precision",
+]
 
 [package.metadata.docs.rs]
 # Python docs depend on the local pyo3-stub-gen patch for now, which published crates do not carry

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -30,7 +30,10 @@ ffi = [
   "nautilus-persistence/ffi",
   "streaming",
 ]
-high-precision = ["nautilus-model/high-precision"]
+high-precision = [
+  "nautilus-model/high-precision",
+  "nautilus-serialization/high-precision",
+]
 extension-module = [
   "nautilus-core/extension-module",
   "nautilus-model/extension-module",

--- a/crates/testkit/Cargo.toml
+++ b/crates/testkit/Cargo.toml
@@ -38,7 +38,10 @@ python = [
   "pyo3",
   "pyo3-stub-gen",
 ]
-high-precision = ["nautilus-model/high-precision"]
+high-precision = [
+  "nautilus-model/high-precision",
+  "nautilus-serialization/high-precision",
+]
 
 [package.metadata.docs.rs]
 # Python docs depend on the local pyo3-stub-gen patch for now, which published crates do not carry


### PR DESCRIPTION
Several crates that depend on `nautilus-serialization` enable `nautilus-model/high-precision` without the matching `nautilus-serialization/high-precision`, so a high-precision build pairs a 128-bit model with a 64-bit serializer.

## Width desync between model and serialization

`nautilus-model`'s `high-precision` feature widens `Price`/`Quantity` raws from 64-bit to 128-bit (`FIXED_PRECISION` 9 -> 16). `nautilus-serialization` mirrors that width through its own `high-precision` feature, which simply forwards to `nautilus-model/high-precision`; its SBE and Cap'n Proto decoders choose the narrowing path from serialization's *local* feature, not from the model's resolved raw type.

`nautilus-binance`, `nautilus-betfair`, `nautilus-tardis`, `nautilus-data`, and `nautilus-testkit` each depend on `nautilus-serialization` but declare `high-precision = ["nautilus-model/high-precision"]`, omitting the serialization forward. When any of them activates `high-precision` (binance and tardis do so by default), feature unification turns on 128-bit model raws while `nautilus-serialization` still compiles its `#[cfg(not(feature = "high-precision"))]` decode path. That path narrows via `i64::try_from` / `u64::try_from` and returns `SbeDecodeError::NumericOverflow` (SBE) or an overflow error (Cap'n Proto) for any value beyond the 64-bit range. The encode side already writes the full 128 bits, so it is purely the decode narrowing that fails. Building the workspace with `--features high-precision` hides this, because a workspace-level feature reaches `nautilus-serialization` directly regardless of the dependents' forwarding.

The fix adds `nautilus-serialization/high-precision` to each of the five `high-precision` features, matching the forwarding pattern already used by `nautilus-persistence`, `nautilus-pyo3`, `nautilus-common`, and the deribit/databento/hyperliquid adapters.

## Alternative: track the model width in the serializer

The manifest forwarding completes an existing pattern but only closes these five feature paths - it does not enforce the invariant globally. An external crate can still enable `nautilus-model/high-precision` while depending on a standard-feature `nautilus-serialization`, and the same desync returns.

A stronger fix keeps the width decision in one place: have serialization's five decode blocks (SBE `Price`/`Quantity`, Cap'n Proto `Price`/`Quantity`/`Money`) convert against `nautilus-model`'s resolved `PriceRaw`/`QuantityRaw` aliases via `try_into()` - the existing checked `i128 -> i64` under standard precision, an identity `i128 -> i128` under high precision. Decode would then track the model's actual raw type regardless of serialization's own feature, `nautilus-serialization/high-precision` would become a convenience alias, and this class of omission could not recur. I kept this PR to the manifest forwarding to match the established convention and avoid changing decode behavior unprompted - happy to follow up with the serializer change, or fold it in here, on your call.

## Testing

The existing `nautilus-serialization` round-trip suites (`tests/test_market_data_sbe.rs`, `tests/test_market_data_capnp.rs`) are the regression. In a build that activates a dependent's `high-precision` without the workspace-level feature - e.g. a default `nautilus-binance` build, which pulls `nautilus-serialization` via `sbe` - the SBE round-trips fail with `NumericOverflow`; with the forward they pass (the SBE round-trip binary goes from 10 failures to a full pass). No new tests: the change is manifest-only and the existing suite already exercises the round trip.
