### PR TITLE
Remove real-time retry ladders from two bybit adapter tests

### DIFF
--- a/crates/adapters/bybit/Cargo.toml
+++ b/crates/adapters/bybit/Cargo.toml
@@ -101,6 +101,7 @@ axum = { workspace = true }
 criterion = { workspace = true }
 rstest = { workspace = true }
 rust_decimal_macros = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 toml = { workspace = true }
 
 # Run with `cargo bench -p nautilus-bybit --bench websocket`

--- a/crates/adapters/bybit/tests/http.rs
+++ b/crates/adapters/bybit/tests/http.rs
@@ -1209,9 +1209,9 @@ async fn test_rate_limiting_returns_error() {
         "test_api_secret".to_string(),
         Some(base_url),
         60,
-        3,
-        1000,
-        10_000,
+        0,
+        1,
+        1,
         5_000,
         None,
     )

--- a/crates/adapters/bybit/tests/websocket.rs
+++ b/crates/adapters/bybit/tests/websocket.rs
@@ -900,10 +900,10 @@ async fn test_multiple_subscriptions() {
 }
 
 #[rstest]
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn test_wait_until_active_timeout() {
     // Create a client but don't start a server
-    let mut client = BybitWebSocketClient::new_public_with(
+    let client = BybitWebSocketClient::new_public_with(
         BybitProductType::Linear,
         BybitEnvironment::Mainnet,
         Some("ws://127.0.0.1:9999/invalid".to_string()),
@@ -911,9 +911,6 @@ async fn test_wait_until_active_timeout() {
         TransportBackend::default(),
         None,
     );
-
-    // Connect will fail, but we won't await it
-    let _result = client.connect().await;
 
     // wait_until_active should timeout
     let result = client.wait_until_active(0.5).await;


### PR DESCRIPTION
## Disable HTTP retries in the rate-limit test

`test_rate_limiting_returns_error` drove a real retry ladder. The mock server answers the sixth request with HTTP 429 (`tests/http.rs`); the client's send path checks the HTTP status before deserializing the body, yielding `UnexpectedStatus { status: 429, .. }`, and the retry predicate treats 429 (and 5xx) as retryable. With the client constructed at `max_retries = 3`, `retry_delay_ms = 1000`, `retry_delay_max_ms = 10_000`, the request was retried four times with ~1s, ~2s and ~4s jittered sleeps before the error surfaced - about 8s per run, on the real clock.

The test asserts only that a rate-limit error (retCode 10006 / "Too many requests") is returned; it does not exercise retry behaviour. Construct its client with `max_retries = 0` (and `1`/`1` for the delays, since the exponential backoff rejects a zero initial delay) so the 429 is surfaced on the first attempt. The error and its message are unchanged.

## Drop the connect ladder from the wait-until-active timeout test

`test_wait_until_active_timeout` verifies that `wait_until_active` returns an error when the client never becomes active. It first called `client.connect().await` against an unreachable port. `connect()` retries the initial dial five times with exponential backoff, so that call blocked for ~8s walking the ladder before the 0.5s wait the test is actually about even began - a comment even claimed the failed connection was "not awaited" while the code awaited it.

A freshly constructed client is already in the closed state, so `wait_until_active(0.5)` on it exercises the intended contract directly. Drop the `connect()` call and run the test under `#[tokio::test(start_paused = true)]` so the 0.5s timeout and the poll loop's 10ms sleeps advance in virtual time. Tokio's `test-util` feature is enabled as a dev-dependency for the paused clock.

## Testing

Both changes are test-only; no adapter runtime code is touched. On the current base the two tests measured 8.485s (`test_wait_until_active_timeout`) and 7.807s (`test_rate_limiting_returns_error`); after the change they run in 0.06s and 0.22s respectively. Every original assertion is retained: the rate-limit test still requires an error containing "10006"/"Too many", and the timeout test still requires `wait_until_active` to return `Err` for a client that never becomes active (a fresh client is closed, so the assertion is not vacuous). Both now run in deterministic virtual/near-zero time with no wall-clock dependence. `cargo clippy` and the full `nautilus-bybit` test suite pass.
