### PR TITLE
Run architect-ax connection-failure tests in paused time

### DIFF
--- a/crates/adapters/architect_ax/Cargo.toml
+++ b/crates/adapters/architect_ax/Cargo.toml
@@ -100,6 +100,7 @@ axum = { workspace = true }
 criterion = { workspace = true }
 rstest = { workspace = true }
 rust_decimal_macros = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 toml = { workspace = true }
 
 # cargo bench -p nautilus-architect-ax --bench deserialization

--- a/crates/adapters/architect_ax/tests/websocket.rs
+++ b/crates/adapters/architect_ax/tests/websocket.rs
@@ -93,7 +93,7 @@ async fn test_md_client_not_active_before_connect() {
 }
 
 #[rstest]
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn test_md_connection_failure_to_invalid_url() {
     let mut client = AxMdWebSocketClient::new(
         "ws://127.0.0.1:9999/invalid".to_string(),
@@ -1058,7 +1058,7 @@ async fn test_orders_client_not_active_before_connect() {
 }
 
 #[rstest]
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn test_orders_connection_failure_to_invalid_url() {
     let account_id = AccountId::from("AX-001");
     let trader_id = TraderId::from("TESTER-001");


### PR DESCRIPTION
## Neutralise the initial-connect backoff ladder in the two connection-failure tests

`test_orders_connection_failure_to_invalid_url` and `test_md_connection_failure_to_invalid_url` each construct a WebSocket client pointed at an unreachable port and assert that `connect()` returns an error. Both `AxOrdersWebSocketClient::connect` and `AxMdWebSocketClient::connect` retry the initial dial five times with a 500ms/5000ms exponential backoff, sleeping after each of the first four failures on the real clock. Against `ws://127.0.0.1:9999/invalid` every dial is refused near-instantly, so the tests spend essentially all of their ~8s (measured 8.179s and 7.757s) parked in those four `tokio::time::sleep` calls - by far the two slowest tests in the package.

Run both under `#[tokio::test(start_paused = true)]`. The five real dials still happen and still fail, so `connect()` reaches retry exhaustion and returns the same transport error the tests assert on; only the four backoff timers advance in virtual time. The shared connector returns before spawning any reader/writer/heartbeat tasks on a failed dial, so nothing keeps the runtime busy and Tokio auto-advances to each pending backoff timer. Tokio's `test-util` feature is enabled as a dev-dependency for the paused clock.

## Testing

Both changes are test-only; no adapter runtime code is touched. `test_orders_connection_failure_to_invalid_url` drops from 8.179s to 0.06s and `test_md_connection_failure_to_invalid_url` from 7.757s to 0.06s. Each still invokes the real `connect()`, still performs five dial attempts, and still asserts the returned `Result` is `Err`, so the assertions remain non-vacuous - paused time neither manufactures the error nor bypasses the dial. `cargo clippy` and the full `nautilus-architect-ax` test suite pass.
