### PR TITLE
Cut fixed-time waits from four bitmex tests

### DIFF
--- a/crates/adapters/bitmex/src/broadcast/submitter.rs
+++ b/crates/adapters/bitmex/src/broadcast/submitter.rs
@@ -1050,10 +1050,7 @@ mod tests {
     async fn test_broadcast_submit_duplicate_clordid_expected() {
         let transports = vec![
             create_stub_transport("client-0", || async { anyhow::bail!("Duplicate clOrdID") }),
-            create_stub_transport("client-1", || async {
-                tokio::time::sleep(Duration::from_secs(10)).await;
-                anyhow::bail!("Should be aborted")
-            }),
+            create_stub_transport("client-1", || async { anyhow::bail!("Connection timeout") }),
         ];
 
         let config = SubmitBroadcasterConfig::default();
@@ -1638,10 +1635,7 @@ mod tests {
             create_stub_transport("client-0", || async {
                 anyhow::bail!("Duplicate clOrdID: O-123 already exists")
             }),
-            create_stub_transport("client-1", || async {
-                tokio::time::sleep(Duration::from_secs(10)).await;
-                anyhow::bail!("Should be aborted")
-            }),
+            create_stub_transport("client-1", || async { anyhow::bail!("Connection timeout") }),
         ];
 
         let config = SubmitBroadcasterConfig::default();

--- a/crates/adapters/bitmex/tests/http.rs
+++ b/crates/adapters/bitmex/tests/http.rs
@@ -1110,8 +1110,7 @@ async fn test_http_network_error() {
     let base_url = "http://127.0.0.1:1".to_string();
 
     let client =
-        BitmexRawHttpClient::new(Some(base_url), 1, 3, 1_000, 10_000, 10_000, 10, 30, None)
-            .unwrap();
+        BitmexRawHttpClient::new(Some(base_url), 1, 0, 1, 1, 10_000, 10, 30, None).unwrap();
 
     let result = client.get_instruments(false).await;
 
@@ -1153,8 +1152,7 @@ async fn test_http_500_internal_server_error() {
 
     let base_url = format!("http://{addr}");
     let client =
-        BitmexRawHttpClient::new(Some(base_url), 60, 3, 1_000, 10_000, 10_000, 10, 30, None)
-            .unwrap();
+        BitmexRawHttpClient::new(Some(base_url), 60, 0, 1, 1, 10_000, 10, 30, None).unwrap();
 
     let result = client.get_instruments(false).await;
 


### PR DESCRIPTION
## Stop awaiting a 10s stub in the submit-broadcaster tests

`test_broadcast_submit_duplicate_clordid_expected` and `test_expected_reject_pattern_comprehensive` each build two stub transports: one that immediately returns a `Duplicate clOrdID` rejection, and a second that sleeps for 10s before returning an error. The second stub was labelled "Should be aborted", but `SubmitBroadcaster::process_submit_results` aborts the remaining transports only on the first *success* - an expected rejection is not a success, so the loop keeps awaiting every handle. The second stub was therefore never aborted and each test spent a full 10s parked in its sleep. Awaiting all transports is correct (a slow transport can still return the real report, and the all-duplicate check needs every result), so only the test stub is wrong.

Make the second stub fail immediately with an ordinary error. It stays a non-duplicate failure, so the aggregate outcome is unchanged: one expected reject, one failed submit, no success, and an overall error. The 10s sleep and the misleading label are removed. The cancel-broadcaster tests use the same "should be aborted" stub but there the first transport returns a success or an idempotent `AlreadyCanceled`, which does abort the second - those tests are already fast and are left untouched.

## Disable retries in the two HTTP error-path tests

`test_http_network_error` and `test_http_500_internal_server_error` construct their client with `max_retries = 3`, a 1000ms initial delay and a 10000ms cap. A connection failure maps to `NetworkError` and the mock's 500 to `UnexpectedStatus { status: 500 }`, both retryable, so each test made one attempt plus three retries with ~1s, ~2s and ~4s sleeps before surfacing the error. Neither test exercises retry behaviour - each only asserts the error is returned. Construct both with `max_retries = 0` (and 1ms delays, since the backoff rejects a zero initial delay) so the error is surfaced on the first attempt. The other request-construction sites in the file drive success-path tests that return on the first attempt and are unchanged.

## Related mixed-outcome defect (not fixed here)

While reworking the broadcaster stubs I noticed an adjacent correctness defect, left out of this test-only change. `is_definitive_submit_refusal` treats every typed `BitmexHttpError::BitmexError` as a definitive refusal, without excluding a duplicate `clOrdID`. So a mixed result set - one transport returns a typed duplicate-`clOrdID` error and another returns a different typed BitMEX refusal - makes `all_duplicate_clordid` false while `all_definitive_refusals` stays true, and `broadcast_submit` returns `DEFINITIVE_SUBMIT_REJECTION`. `BitmexExecutionClient` then removes the order identity and emits a rejection, even though one transport reported the explicitly ambiguous duplicate outcome. This contradicts the execution client's own duplicate handling, which deliberately excludes a duplicate `clOrdID` from definitive rejection and instead retains the identity and waits for the WebSocket confirmation. The correct fix is to exclude duplicate `clOrdID` from the definitive-refusal classification so a mixed duplicate-plus-refusal set is treated as the ambiguous case, with a regression test for that result set. Happy to send that as a follow-up once this lands, unless you would rather take it directly.

## Testing

All four changes are test-only; no adapter runtime code is touched. Measured on the current base, the tests ran at 10.016s and 10.002s (submit-broadcaster) and 8.922s and 8.702s (HTTP); after the change each completes in milliseconds. Every assertion is preserved: the broadcaster tests still assert one expected reject, one failed submit, no success and an overall error against a genuine duplicate-plus-failure result set; the HTTP tests still assert their `NetworkError` and 500 outcomes. `cargo clippy` and the full `nautilus-bitmex` test suite pass.
