### PR TITLE
Allow useless_conversion in two feature-conditional Quantity tests

### DIFF
--- a/crates/model/src/types/quantity.rs
+++ b/crates/model/src/types/quantity.rs
@@ -1165,6 +1165,10 @@ mod tests {
     }
 
     #[rstest]
+    #[allow(
+        clippy::useless_conversion,
+        reason = "try_from is a no-op when QuantityRaw is u64, and narrows when u128 (high-precision)"
+    )]
     fn test_from_u64_exact() {
         let max = u64::try_from(QUANTITY_RAW_MAX / FIXED_SCALAR_RAW).unwrap();
         let values = [0, 1, max];
@@ -1216,6 +1220,10 @@ mod tests {
     #[cfg_attr(
         not(feature = "high-precision"),
         should_panic(expected = "Raw value exceeds QuantityRaw range")
+    )]
+    #[allow(
+        clippy::useless_conversion,
+        reason = "try_from is a no-op when QuantityRaw is u64, and narrows when u128 (high-precision)"
     )]
     fn test_from_u64_overflow_panics() {
         let max = u64::try_from(QUANTITY_RAW_MAX / FIXED_SCALAR_RAW).unwrap();


### PR DESCRIPTION
`test_from_u64_exact` and `test_from_u64_overflow_panics` compute their bound as `u64::try_from(QUANTITY_RAW_MAX / FIXED_SCALAR_RAW)`. The type of that expression depends on the `high-precision` feature: without it `QuantityRaw` is `u64`, so the `try_from` is a conversion to the same type and `clippy::useless_conversion` fires; with `high-precision` it is `u128`, so the `try_from` is a required narrowing and the lint does not fire. Running `cargo clippy` on the default feature set (without `high-precision`) therefore errors on these two tests.

Because the lint fires in only one feature configuration, `#[expect(clippy::useless_conversion)]` cannot be used - it would be unfulfilled, and itself an error, in the `high-precision` build. Add `#[allow(clippy::useless_conversion, reason = ...)]` to the two tests instead, matching the existing `#[allow(clippy::unnecessary_fallible_conversions, reason = ...)]` on `raw_as_decimal` in the same file, which handles the identical feature-conditional `try_from` split. The `try_from` is kept (it is the correct, checked narrowing under `high-precision`); only the lint is suppressed.

## Testing

Test-only, no runtime change. `cargo clippy` is now clean on `nautilus-model` both with and without the `high-precision` feature, and the full `nautilus-model` test suite passes in both configurations.
