### PR TITLE
Add canonical custom data identity and cache histories

### DIFF
--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -65,8 +65,9 @@ use nautilus_model::defi::{Pool, PoolProfiler};
 use nautilus_model::{
     accounts::{Account, AccountAny},
     data::{
-        Bar, BarType, FundingRateUpdate, GreeksData, IndexPriceUpdate, InstrumentStatus,
-        MarkPriceUpdate, QuoteTick, TradeTick, YieldCurveData, option_chain::OptionGreeks,
+        Bar, BarType, CustomData, DataType, FundingRateUpdate, GreeksData, IndexPriceUpdate,
+        InstrumentStatus, MarkPriceUpdate, QuoteTick, TradeTick, YieldCurveData,
+        option_chain::OptionGreeks,
     },
     enums::{
         AggregationSource, ContingencyType, InstrumentClass, OmsType, OrderSide, PositionSide,
@@ -1593,6 +1594,18 @@ impl<'a> CacheApi<'a> {
         self.cache().bar_at_index(bar_type, index).copied()
     }
 
+    /// Returns the custom data at `index` for the `data_type` (if found).
+    ///
+    /// Index 0 is the most recent.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the cache is already mutably borrowed.
+    #[must_use]
+    pub fn custom_data_at_index(&self, data_type: &DataType, index: usize) -> Option<CustomData> {
+        self.cache().custom_data_at_index(data_type, index).cloned()
+    }
+
     /// Returns the order book update count for the `instrument_id`.
     ///
     /// # Panics
@@ -2130,6 +2143,7 @@ pub struct Cache {
     funding_rates: AHashMap<InstrumentId, BoundedVecDeque<FundingRateUpdate>>,
     instrument_statuses: AHashMap<InstrumentId, BoundedVecDeque<InstrumentStatus>>,
     bars: AHashMap<BarType, BoundedVecDeque<Bar>>,
+    custom_data: AHashMap<String, BoundedVecDeque<CustomData>>,
     greeks: AHashMap<InstrumentId, GreeksData>,
     option_greeks: AHashMap<InstrumentId, OptionGreeks>,
     yield_curves: AHashMap<String, YieldCurveData>,
@@ -2161,6 +2175,7 @@ impl Debug for Cache {
             .field("funding_rates", &self.funding_rates)
             .field("instrument_statuses", &self.instrument_statuses)
             .field("bars", &self.bars)
+            .field("custom_data", &self.custom_data)
             .field("greeks", &self.greeks)
             .field("option_greeks", &self.option_greeks)
             .field("yield_curves", &self.yield_curves)
@@ -2215,6 +2230,7 @@ impl Cache {
             funding_rates: AHashMap::new(),
             instrument_statuses: AHashMap::new(),
             bars: AHashMap::new(),
+            custom_data: AHashMap::new(),
             greeks: AHashMap::new(),
             option_greeks: AHashMap::new(),
             yield_curves: AHashMap::new(),
@@ -3585,6 +3601,7 @@ impl Cache {
         self.order_lists.clear();
         self.positions.clear();
         self.position_snapshots.clear();
+        self.custom_data.clear();
         self.greeks.clear();
         self.yield_curves.clear();
 
@@ -3951,6 +3968,28 @@ impl Cache {
         for bar in bars {
             bars_deque.push_front(*bar);
         }
+        Ok(())
+    }
+
+    /// Adds custom data to the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if persisting the custom data to the backing database fails.
+    pub fn add_custom_data(&mut self, data: CustomData) -> anyhow::Result<()> {
+        log::debug!("Adding custom data {}", data.data_type.topic());
+
+        if self.config.save_market_data
+            && let Some(database) = &mut self.database
+        {
+            database.add_custom_data(&data)?;
+        }
+
+        let key = data.data_type.topic().to_string();
+        self.custom_data
+            .entry(key)
+            .or_insert_with(|| BoundedVecDeque::new(self.config.tick_capacity))
+            .push_front(data);
         Ok(())
     }
 
@@ -7219,6 +7258,15 @@ impl Cache {
             .map(|bars| bars.iter().copied().collect())
     }
 
+    /// Gets cached custom data history for the `data_type`, newest first.
+    #[must_use]
+    pub fn custom_data_history(&self, data_type: &DataType) -> Vec<CustomData> {
+        self.custom_data
+            .get(data_type.topic())
+            .map(|data| data.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
     /// Gets a reference to the order book for the `instrument_id`.
     #[must_use]
     pub fn order_book(&self, instrument_id: &InstrumentId) -> Option<&OrderBook> {
@@ -7355,6 +7403,24 @@ impl Cache {
     #[must_use]
     pub fn bar_at_index(&self, bar_type: &BarType, index: usize) -> Option<&Bar> {
         self.bars.get(bar_type).and_then(|bars| bars.get(index))
+    }
+
+    /// Gets the newest custom data for the `data_type`.
+    #[must_use]
+    pub fn custom_data(&self, data_type: &DataType) -> Option<&CustomData> {
+        self.custom_data
+            .get(data_type.topic())
+            .and_then(BoundedVecDeque::front)
+    }
+
+    /// Gets custom data at `index` for the `data_type`.
+    ///
+    /// Index 0 is the most recent.
+    #[must_use]
+    pub fn custom_data_at_index(&self, data_type: &DataType, index: usize) -> Option<&CustomData> {
+        self.custom_data
+            .get(data_type.topic())
+            .and_then(|data| data.get(index))
     }
 
     /// Gets the order book update count for the `instrument_id`.

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -31,6 +31,7 @@ use nautilus_model::{
     data::{
         Bar, BarType, CustomData, DataType, FundingRateUpdate, IndexPriceUpdate, InstrumentStatus,
         MarkPriceUpdate, QuoteTick, TradeTick,
+        stubs::{StubCustomData, stub_custom_data},
     },
     enums::{
         AccountType, AggregationSource, AggressorSide, AssetClass, BookType, ContingencyType,
@@ -7888,4 +7889,100 @@ fn test_view_returns_borrowed_when_unfiltered(mut cache: Cache, audusd_sim: Curr
     check_borrow!(position_ids_view, positions);
     check_borrow!(position_open_ids_view, positions_open);
     check_borrow!(position_closed_ids_view, positions_closed);
+}
+
+#[rstest]
+fn test_custom_data_cache_keeps_topic_histories(mut cache: Cache) {
+    cache
+        .add_custom_data(stub_custom_data(1, 10, None, None))
+        .unwrap();
+    cache
+        .add_custom_data(stub_custom_data(2, 20, None, None))
+        .unwrap();
+    cache
+        .add_custom_data(stub_custom_data(3, 30, None, Some("A".to_string())))
+        .unwrap();
+
+    let data_type = DataType::new("StubCustomData", None, None);
+    let history = cache.custom_data_history(&data_type);
+    let values: Vec<i64> = history
+        .iter()
+        .map(|custom| {
+            custom
+                .data
+                .as_any()
+                .downcast_ref::<StubCustomData>()
+                .unwrap()
+                .value
+        })
+        .collect();
+    assert_eq!(values, vec![20, 10]);
+
+    let identified_data_type = DataType::new("StubCustomData", None, Some("A".to_string()));
+    let identified_history = cache.custom_data_history(&identified_data_type);
+    assert_eq!(identified_history.len(), 1);
+    assert_eq!(
+        identified_history[0]
+            .data
+            .as_any()
+            .downcast_ref::<StubCustomData>()
+            .unwrap()
+            .value,
+        30,
+    );
+}
+
+#[rstest]
+fn test_custom_data_cache_key_uses_topic_only(mut cache: Cache) {
+    cache
+        .add_custom_data(stub_custom_data(1, 10, None, Some("A".to_string())))
+        .unwrap();
+
+    let data_type = DataType::from_parts("StubCustomData", "StubCustomData.identifier=A", None);
+    let history = cache.custom_data_history(&data_type);
+
+    assert_eq!(history.len(), 1);
+    assert_eq!(
+        history[0]
+            .data
+            .as_any()
+            .downcast_ref::<StubCustomData>()
+            .unwrap()
+            .value,
+        10,
+    );
+}
+
+#[rstest]
+fn test_custom_data_at_index_returns_requested_history_item(mut cache: Cache) {
+    cache
+        .add_custom_data(stub_custom_data(1, 10, None, None))
+        .unwrap();
+    cache
+        .add_custom_data(stub_custom_data(2, 20, None, None))
+        .unwrap();
+
+    let data_type = DataType::new("StubCustomData", None, None);
+    let newest = cache.custom_data_at_index(&data_type, 0).unwrap();
+    let previous = cache.custom_data_at_index(&data_type, 1).unwrap();
+
+    assert_eq!(
+        newest
+            .data
+            .as_any()
+            .downcast_ref::<StubCustomData>()
+            .unwrap()
+            .value,
+        20,
+    );
+    assert_eq!(
+        previous
+            .data
+            .as_any()
+            .downcast_ref::<StubCustomData>()
+            .unwrap()
+            .value,
+        10,
+    );
+    assert!(cache.custom_data_at_index(&data_type, 2).is_none());
 }

--- a/crates/model/src/data/mod.rs
+++ b/crates/model/src/data/mod.rs
@@ -599,6 +599,54 @@ fn value_to_topic_string(v: &JsonValue) -> String {
     serde_json::to_string(v).unwrap_or_default()
 }
 
+fn topic_string_to_value(s: &str) -> JsonValue {
+    serde_json::from_str(s).unwrap_or_else(|_| JsonValue::String(s.to_string()))
+}
+
+fn parse_topic_metadata(metadata_topic: &str) -> anyhow::Result<Params> {
+    let mut metadata = Params::new();
+    if metadata_topic.is_empty() {
+        return Ok(metadata);
+    }
+
+    // Values may contain dots: a segment with '=' starts a new pair, otherwise it
+    // extends the current value (or the first key before any pair has started).
+    let mut pending_key: Option<String> = None;
+    let mut current: Option<(String, String)> = None;
+
+    for segment in metadata_topic.split('.') {
+        if let Some((key, value)) = segment.split_once('=') {
+            let key = if let Some(prefix) = pending_key.take() {
+                format!("{prefix}.{key}")
+            } else {
+                if key.is_empty() {
+                    anyhow::bail!("Invalid empty metadata topic key");
+                }
+                key.to_string()
+            };
+
+            if let Some((prev_key, prev_value)) = current.replace((key, value.to_string())) {
+                metadata.insert(prev_key, topic_string_to_value(&prev_value));
+            }
+        } else if let Some((_, value)) = current.as_mut() {
+            value.push('.');
+            value.push_str(segment);
+        } else if let Some(prefix) = pending_key.as_mut() {
+            prefix.push('.');
+            prefix.push_str(segment);
+        } else {
+            pending_key = Some(segment.to_string());
+        }
+    }
+
+    let Some((key, value)) = current else {
+        anyhow::bail!("Invalid metadata topic pair: {metadata_topic}");
+    };
+    metadata.insert(key, topic_string_to_value(&value));
+
+    Ok(metadata)
+}
+
 /// Builds the topic suffix from Params (string-only view: key=value joined by ".").
 fn params_to_topic_suffix(params: &Params) -> String {
     let mut entries = params.iter().collect::<Vec<_>>();
@@ -610,6 +658,8 @@ fn params_to_topic_suffix(params: &Params) -> String {
         .collect::<Vec<_>>()
         .join(".")
 }
+
+const IDENTIFIER_TOPIC_SUFFIX: &str = ".identifier=";
 
 /// Represents a data type including metadata.
 #[derive(Clone, Serialize, Deserialize)]
@@ -629,12 +679,17 @@ pub struct DataType {
     identifier: Option<String>,
 }
 
+fn calculate_hash(topic: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    topic.hash(&mut hasher);
+    hasher.finish()
+}
+
 impl DataType {
     /// Creates a new [`DataType`] instance.
     #[must_use]
     pub fn new(type_name: &str, metadata: Option<Params>, identifier: Option<String>) -> Self {
-        // Precompute topic from type_name + metadata (string-only view for backward compatibility)
-        let topic = if let Some(ref meta) = metadata {
+        let base_topic = if let Some(ref meta) = metadata {
             if meta.is_empty() {
                 type_name.to_string()
             } else {
@@ -643,16 +698,19 @@ impl DataType {
         } else {
             type_name.to_string()
         };
+        let topic = identifier
+            .as_ref()
+            .map_or(base_topic.clone(), |identifier| {
+                format!("{base_topic}{IDENTIFIER_TOPIC_SUFFIX}{identifier}")
+            });
 
-        // Precompute hash
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        topic.hash(&mut hasher);
+        let hash = calculate_hash(&topic);
 
         Self {
             type_name: type_name.to_owned(),
             metadata,
             topic,
-            hash: hasher.finish(),
+            hash,
             identifier,
         }
     }
@@ -662,13 +720,11 @@ impl DataType {
     /// Identifier is set to None.
     #[must_use]
     pub fn from_parts(type_name: &str, topic: &str, metadata: Option<Params>) -> Self {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        topic.hash(&mut hasher);
         Self {
             type_name: type_name.to_owned(),
             metadata,
             topic: topic.to_owned(),
-            hash: hasher.finish(),
+            hash: calculate_hash(topic),
             identifier: None,
         }
     }
@@ -785,7 +841,7 @@ impl DataType {
         self.topic.as_str()
     }
 
-    /// Returns the optional catalog path identifier (can contain subdirs, e.g. `"venue//symbol"`).
+    /// Returns the optional catalog path identifier.
     #[must_use]
     pub fn identifier(&self) -> Option<&str> {
         self.identifier.as_deref()
@@ -886,6 +942,27 @@ impl Ord for DataType {
 impl Hash for DataType {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.hash.hash(state);
+    }
+}
+
+impl FromStr for DataType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (base_topic, identifier) = s
+            .rsplit_once(IDENTIFIER_TOPIC_SUFFIX)
+            .map_or((s, None), |(base, identifier)| {
+                (base, Some(identifier.to_string()))
+            });
+        let (type_name, metadata) = match base_topic.split_once('.') {
+            None => (base_topic, None),
+            Some((type_name, metadata_topic)) => {
+                let metadata = parse_topic_metadata(metadata_topic)?;
+                (type_name, Some(metadata))
+            }
+        };
+
+        Ok(Self::new(type_name, metadata, identifier))
     }
 }
 
@@ -1038,6 +1115,24 @@ mod tests {
     }
 
     #[rstest]
+    fn test_data_type_identifier_is_part_of_topic_identity_and_hash() {
+        let data_type1 = DataType::new("ExampleType", None, Some("A".to_string()));
+        let data_type2 = DataType::new("ExampleType", None, Some("B".to_string()));
+
+        let mut hasher1 = DefaultHasher::new();
+        data_type1.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+        let mut hasher2 = DefaultHasher::new();
+        data_type2.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(data_type1.topic(), "ExampleType.identifier=A");
+        assert_eq!(data_type2.topic(), "ExampleType.identifier=B");
+        assert_ne!(data_type1, data_type2);
+        assert_ne!(hash1, hash2);
+    }
+
+    #[rstest]
     fn test_data_type_display() {
         let metadata = Some(params_from_json(json!({"key1": "value1"})));
         let data_type = DataType::new("ExampleType", metadata, None);
@@ -1118,14 +1213,35 @@ mod tests {
 
     #[rstest]
     fn test_data_type_persistence_json_with_identifier() {
-        let data_type = DataType::new("MyCustomType", None, Some("venue//symbol".to_string()));
+        let data_type = DataType::new("MyCustomType", None, Some("SYMBOL.VENUE".to_string()));
         let json = data_type.to_persistence_json().unwrap();
         assert!(!json.contains("topic"));
-        assert!(json.contains("\"identifier\":\"venue//symbol\""));
+        assert!(json.contains("\"identifier\":\"SYMBOL.VENUE\""));
         let restored = DataType::from_persistence_json(&json).unwrap();
         assert_eq!(restored.type_name(), "MyCustomType");
-        assert_eq!(restored.identifier(), Some("venue//symbol"));
-        assert_eq!(restored.topic(), "MyCustomType");
+        assert_eq!(restored.identifier(), Some("SYMBOL.VENUE"));
+        assert_eq!(restored.topic(), "MyCustomType.identifier=SYMBOL.VENUE");
+    }
+
+    #[rstest]
+    fn test_data_type_from_str_parses_metadata_and_identifier() {
+        let data_type = DataType::from_str(
+            "MyCustomType.instrument_id=SYMBOL.VENUE.strike=1.23.identifier=SYMBOL.VENUE",
+        )
+        .unwrap();
+
+        assert_eq!(data_type.type_name(), "MyCustomType");
+        assert_eq!(
+            data_type.metadata(),
+            Some(&params_from_json(
+                json!({"instrument_id": "SYMBOL.VENUE", "strike": 1.23})
+            ))
+        );
+        assert_eq!(data_type.identifier(), Some("SYMBOL.VENUE"));
+        assert_eq!(
+            data_type.topic(),
+            "MyCustomType.instrument_id=SYMBOL.VENUE.strike=1.23.identifier=SYMBOL.VENUE"
+        );
     }
 
     #[rstest]

--- a/crates/model/src/python/data/mod.rs
+++ b/crates/model/src/python/data/mod.rs
@@ -141,7 +141,7 @@ impl DataType {
         self.topic()
     }
 
-    /// Returns the optional catalog path identifier (can contain subdirs, e.g. `"venue//symbol"`).
+    /// Returns the optional catalog path identifier.
     #[getter]
     #[pyo3(name = "identifier")]
     fn py_identifier(&self) -> Option<&str> {


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

<!-- Provide a brief description of *what* changed, *why* it was changed, and the impact on the system or users (2-3 sentences). -->

This PR adds generic custom-data histories to the common in-memory cache. Each history uses the
canonical `DataType.topic()` as its only key, remains bounded by the configured tick capacity, and
stores the newest value first.

`DataType.topic()` now includes the optional identifier. This makes two instances of the same custom
type and metadata independently addressable without duplicating the identifier in the cache key.
`DataType` also parses canonical topics through `FromStr`, round-trips identifiers through its
persistence JSON, and preserves dotted metadata values such as instrument IDs and decimal strikes.

```mermaid
flowchart LR
    Data["CustomData"] --> Topic["DataType.topic()"]
    Topic --> History["bounded newest-first history"]
    History --> Latest["custom_data"]
    History --> Index["custom_data_at_index"]
    History --> All["custom_data_history"]
```

### Design

- Use the canonical topic string as the complete custom-data identity.
- Keep topic construction, equality, ordering, hashing, display, and parsing on the same canonical
  representation.
- Use current `SYMBOL.VENUE` identifier examples rather than deprecated path-shaped identifiers.
- Persist through the existing `CacheDatabaseAdapter::add_custom_data` boundary when market-data
  saving is enabled.
- Clear custom-data histories with the rest of the runtime cache on reset.

### Files

- `crates/common/src/cache/mod.rs`
- `crates/common/src/cache/tests.rs`
- `crates/model/src/data/mod.rs`
- `crates/model/src/python/data/mod.rs`

### Verification

- `cargo test --locked -p nautilus-common custom_data --lib`: 10 passed.
- `cargo test --locked -p nautilus-model data_type --lib`: 15 passed.
- `make cargo-test-core-local`: 10,838 passed and 14 skipped.
- `make build-debug`: passed.



## Related Issues/PRs

<!-- List any related GitHub issues or PRs (e.g., `Closes #123`, `Related to #456`). -->

## Type of change

<!-- Select all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

<!-- If this is a breaking change, describe the impact and any migration steps required for users or developers. -->

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

<!-- Briefly describe how the changes were tested (e.g., unit tests in `tests/unit/test_file.py`, or *additional* manual testing). -->
