### PR TITLE
Fix Polymarket reconciliation report completeness

### DIFF
--- a/crates/adapters/polymarket/src/execution/parse.rs
+++ b/crates/adapters/polymarket/src/execution/parse.rs
@@ -125,9 +125,113 @@ pub fn parse_order_status_report(
     size_precision: u8,
     ts_init: UnixNanos,
 ) -> OrderStatusReport {
-    let venue_order_id = VenueOrderId::from(order.id.as_str());
-    let order_side = OrderSide::from(order.side);
-    let time_in_force = TimeInForce::from(order.order_type);
+    let quantity = Quantity::from_decimal_dp(order.original_size, size_precision)
+        .unwrap_or_else(|_| Quantity::zero(size_precision));
+    let raw_filled_qty = Quantity::from_decimal_dp(order.size_matched, size_precision)
+        .unwrap_or_else(|_| Quantity::zero(size_precision));
+    let price = Price::from_decimal_dp(order.price, price_precision)
+        .unwrap_or_else(|_| Price::zero(price_precision));
+    let ts_accepted = UnixNanos::from(order.created_at * NANOSECONDS_IN_SECOND);
+    let expire_time = order
+        .expiration
+        .as_deref()
+        .and_then(parse_expiration_nanos)
+        .map(UnixNanos::from);
+
+    build_order_status_report(
+        order,
+        instrument_id,
+        account_id,
+        client_order_id,
+        quantity,
+        raw_filled_qty,
+        price,
+        ts_accepted,
+        ts_init,
+        expire_time,
+    )
+}
+
+/// Strictly parses a venue open order for authoritative reconciliation.
+pub(crate) fn try_parse_order_status_report(
+    order: &PolymarketOpenOrder,
+    instrument_id: InstrumentId,
+    account_id: AccountId,
+    client_order_id: Option<ClientOrderId>,
+    price_precision: u8,
+    size_precision: u8,
+    ts_init: UnixNanos,
+) -> anyhow::Result<OrderStatusReport> {
+    let quantity = Quantity::from_decimal_dp(order.original_size, size_precision).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot represent venue open order {} quantity {}: {e}",
+            order.id,
+            order.original_size
+        )
+    })?;
+    let raw_filled_qty =
+        Quantity::from_decimal_dp(order.size_matched, size_precision).map_err(|e| {
+            anyhow::anyhow!(
+                "cannot represent venue open order {} filled quantity {}: {e}",
+                order.id,
+                order.size_matched
+            )
+        })?;
+    let price = Price::from_decimal_dp(order.price, price_precision).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot represent venue open order {} price {}: {e}",
+            order.id,
+            order.price
+        )
+    })?;
+    let ts_accepted = UnixNanos::from(
+        order
+            .created_at
+            .checked_mul(NANOSECONDS_IN_SECOND)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "venue open order {} created_at {} overflows nanoseconds",
+                    order.id,
+                    order.created_at
+                )
+            })?,
+    );
+    let expire_time = order
+        .expiration
+        .as_deref()
+        .map(try_parse_expiration_nanos)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("venue open order {} has invalid expiration: {e}", order.id))?
+        .flatten()
+        .map(UnixNanos::from);
+
+    Ok(build_order_status_report(
+        order,
+        instrument_id,
+        account_id,
+        client_order_id,
+        quantity,
+        raw_filled_qty,
+        price,
+        ts_accepted,
+        ts_init,
+        expire_time,
+    ))
+}
+
+#[expect(clippy::too_many_arguments)]
+fn build_order_status_report(
+    order: &PolymarketOpenOrder,
+    instrument_id: InstrumentId,
+    account_id: AccountId,
+    client_order_id: Option<ClientOrderId>,
+    quantity: Quantity,
+    raw_filled_qty: Quantity,
+    price: Price,
+    ts_accepted: UnixNanos,
+    ts_init: UnixNanos,
+    expire_time: Option<UnixNanos>,
+) -> OrderStatusReport {
     let order_status = if order.status == PolymarketOrderStatus::Matched
         && order.order_type == PolymarketOrderType::FAK
         && order.size_matched < order.original_size
@@ -136,37 +240,25 @@ pub fn parse_order_status_report(
     } else {
         OrderStatus::from(order.status)
     };
-    let quantity = Quantity::from_decimal_dp(order.original_size, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
-    let raw_filled_qty = Quantity::from_decimal_dp(order.size_matched, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
     let filled_qty = snap_filled_qty_to_quantity(quantity, raw_filled_qty, order_status);
-    let price = Price::from_decimal_dp(order.price, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
-
-    let ts_accepted = UnixNanos::from(order.created_at * NANOSECONDS_IN_SECOND);
-
     let mut report = OrderStatusReport::new(
         account_id,
         instrument_id,
         client_order_id,
-        venue_order_id,
-        order_side,
+        VenueOrderId::from(order.id.as_str()),
+        OrderSide::from(order.side),
         OrderType::Limit,
-        time_in_force,
+        TimeInForce::from(order.order_type),
         order_status,
         quantity,
         filled_qty,
         ts_accepted,
-        ts_accepted, // ts_last
+        ts_accepted,
         ts_init,
-        None, // report_id
+        None,
     );
     report.price = Some(price);
-    // CLOB V2 emits `expiration` as Unix seconds; "0" means no expiration.
-    if let Some(nanos) = order.expiration.as_deref().and_then(parse_expiration_nanos) {
-        report.expire_time = Some(UnixNanos::from(nanos));
-    }
+    report.expire_time = expire_time;
     report
 }
 
@@ -175,11 +267,19 @@ pub fn parse_order_status_report(
 /// overflow `u64` when scaled to nanoseconds (e.g. accidentally-passed
 /// millisecond timestamps that exceed Unix-seconds bounds).
 fn parse_expiration_nanos(value: &str) -> Option<u64> {
-    let secs: u64 = value.parse().ok()?;
+    try_parse_expiration_nanos(value).ok().flatten()
+}
+
+fn try_parse_expiration_nanos(value: &str) -> anyhow::Result<Option<u64>> {
+    let secs: u64 = value
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid expiration {value}: {e}"))?;
     if secs == 0 {
-        return None;
+        return Ok(None);
     }
     secs.checked_mul(NANOSECONDS_IN_SECOND)
+        .map(Some)
+        .ok_or_else(|| anyhow::anyhow!("expiration {value} overflows nanoseconds"))
 }
 
 /// Parses a [`PolymarketTradeReport`] into a [`FillReport`].
@@ -199,27 +299,111 @@ pub fn parse_fill_report(
     taker_fee_rate: Decimal,
     ts_init: UnixNanos,
 ) -> FillReport {
-    let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
-    let trade_id = TradeId::from(trade.id.as_str());
-    let order_side = OrderSide::from(trade.side);
     let last_qty = Quantity::from_decimal_dp(trade.size, size_precision)
         .unwrap_or_else(|_| Quantity::zero(size_precision));
     let last_px = Price::from_decimal_dp(trade.price, price_precision)
         .unwrap_or_else(|_| Price::zero(price_precision));
     let liquidity_side = parse_liquidity_side(trade.trader_side);
-
     let commission_value =
         compute_commission(taker_fee_rate, trade.size, trade.price, liquidity_side);
     let commission = Money::new(commission_value, currency);
-
     let ts_event = parse_timestamp(&trade.match_time).unwrap_or(ts_init);
 
+    build_fill_report(
+        trade,
+        instrument_id,
+        account_id,
+        client_order_id,
+        last_qty,
+        last_px,
+        commission,
+        liquidity_side,
+        ts_event,
+        ts_init,
+    )
+}
+
+/// Strictly parses a confirmed taker fill for authoritative reconciliation.
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn try_parse_fill_report(
+    trade: &PolymarketTradeReport,
+    instrument_id: InstrumentId,
+    account_id: AccountId,
+    client_order_id: Option<ClientOrderId>,
+    price_precision: u8,
+    size_precision: u8,
+    currency: Currency,
+    taker_fee_rate: Decimal,
+    ts_init: UnixNanos,
+) -> anyhow::Result<FillReport> {
+    let last_qty = Quantity::from_decimal_dp(trade.size, size_precision).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot represent confirmed taker fill {} quantity {}: {e}",
+            trade.id,
+            trade.size
+        )
+    })?;
+    let last_px = Price::from_decimal_dp(trade.price, price_precision).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot represent confirmed taker fill {} price {}: {e}",
+            trade.id,
+            trade.price
+        )
+    })?;
+    let liquidity_side = parse_liquidity_side(trade.trader_side);
+    let commission = try_compute_commission(
+        taker_fee_rate,
+        trade.size,
+        trade.price,
+        liquidity_side,
+        currency,
+    )
+    .map_err(|e| {
+        anyhow::anyhow!(
+            "cannot represent confirmed taker fill {} commission: {e}",
+            trade.id
+        )
+    })?;
+    let ts_event = try_parse_timestamp(&trade.match_time).map_err(|e| {
+        anyhow::anyhow!(
+            "confirmed taker fill {} has invalid match_time: {e}",
+            trade.id
+        )
+    })?;
+
+    Ok(build_fill_report(
+        trade,
+        instrument_id,
+        account_id,
+        client_order_id,
+        last_qty,
+        last_px,
+        commission,
+        liquidity_side,
+        ts_event,
+        ts_init,
+    ))
+}
+
+#[expect(clippy::too_many_arguments)]
+fn build_fill_report(
+    trade: &PolymarketTradeReport,
+    instrument_id: InstrumentId,
+    account_id: AccountId,
+    client_order_id: Option<ClientOrderId>,
+    last_qty: Quantity,
+    last_px: Price,
+    commission: Money,
+    liquidity_side: LiquiditySide,
+    ts_event: UnixNanos,
+    ts_init: UnixNanos,
+) -> FillReport {
     FillReport {
         account_id,
         instrument_id,
-        venue_order_id,
-        trade_id,
-        order_side,
+        venue_order_id: VenueOrderId::from(trade.taker_order_id.as_str()),
+        trade_id: TradeId::from(trade.id.as_str()),
+        order_side: OrderSide::from(trade.side),
         last_qty,
         last_px,
         commission,
@@ -254,14 +438,6 @@ pub fn build_maker_fill_report(
     ts_event: UnixNanos,
     ts_init: UnixNanos,
 ) -> FillReport {
-    let venue_order_id = VenueOrderId::from(mo.order_id.as_str());
-    let fill_trade_id = make_composite_trade_id(trade_id, &mo.order_id);
-    let order_side = determine_order_side(
-        trader_side,
-        trade_side,
-        taker_asset_id,
-        mo.asset_id.as_str(),
-    );
     let last_qty = Quantity::from_decimal_dp(mo.matched_amount, size_precision)
         .unwrap_or_else(|_| Quantity::zero(size_precision));
     let last_px = Price::from_decimal_dp(mo.price, price_precision)
@@ -271,15 +447,112 @@ pub fn build_maker_fill_report(
     let commission_value =
         compute_commission(Decimal::ZERO, mo.matched_amount, mo.price, liquidity_side);
 
+    build_maker_report(
+        mo,
+        trade_id,
+        trader_side,
+        trade_side,
+        taker_asset_id,
+        account_id,
+        instrument_id,
+        last_qty,
+        last_px,
+        Money::new(commission_value, currency),
+        liquidity_side,
+        ts_event,
+        ts_init,
+    )
+}
+
+/// Strictly builds a confirmed maker fill for authoritative reconciliation.
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn try_build_maker_fill_report(
+    mo: &PolymarketMakerOrder,
+    trade_id: &str,
+    trader_side: PolymarketLiquiditySide,
+    trade_side: PolymarketOrderSide,
+    taker_asset_id: &str,
+    account_id: AccountId,
+    instrument_id: InstrumentId,
+    price_precision: u8,
+    size_precision: u8,
+    currency: Currency,
+    liquidity_side: LiquiditySide,
+    ts_event: UnixNanos,
+    ts_init: UnixNanos,
+) -> anyhow::Result<FillReport> {
+    let last_qty = Quantity::from_decimal_dp(mo.matched_amount, size_precision).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot represent confirmed maker fill {} quantity {}: {e}",
+            trade_id,
+            mo.matched_amount
+        )
+    })?;
+    let last_px = Price::from_decimal_dp(mo.price, price_precision).map_err(|e| {
+        anyhow::anyhow!(
+            "cannot represent confirmed maker fill {} price {}: {e}",
+            trade_id,
+            mo.price
+        )
+    })?;
+    let commission = try_compute_commission(
+        Decimal::ZERO,
+        mo.matched_amount,
+        mo.price,
+        liquidity_side,
+        currency,
+    )
+    .map_err(|e| {
+        anyhow::anyhow!("cannot represent confirmed maker fill {trade_id} commission: {e}")
+    })?;
+
+    Ok(build_maker_report(
+        mo,
+        trade_id,
+        trader_side,
+        trade_side,
+        taker_asset_id,
+        account_id,
+        instrument_id,
+        last_qty,
+        last_px,
+        commission,
+        liquidity_side,
+        ts_event,
+        ts_init,
+    ))
+}
+
+#[expect(clippy::too_many_arguments)]
+fn build_maker_report(
+    mo: &PolymarketMakerOrder,
+    trade_id: &str,
+    trader_side: PolymarketLiquiditySide,
+    trade_side: PolymarketOrderSide,
+    taker_asset_id: &str,
+    account_id: AccountId,
+    instrument_id: InstrumentId,
+    last_qty: Quantity,
+    last_px: Price,
+    commission: Money,
+    liquidity_side: LiquiditySide,
+    ts_event: UnixNanos,
+    ts_init: UnixNanos,
+) -> FillReport {
     FillReport {
         account_id,
         instrument_id,
-        venue_order_id,
-        trade_id: fill_trade_id,
-        order_side,
+        venue_order_id: VenueOrderId::from(mo.order_id.as_str()),
+        trade_id: make_composite_trade_id(trade_id, &mo.order_id),
+        order_side: determine_order_side(
+            trader_side,
+            trade_side,
+            taker_asset_id,
+            mo.asset_id.as_str(),
+        ),
         last_qty,
         last_px,
-        commission: Money::new(commission_value, currency),
+        commission,
         liquidity_side,
         avg_px: None,
         report_id: UUID4::new(),
@@ -412,25 +685,68 @@ pub fn compute_commission(
     rounded.to_string().parse().unwrap_or(0.0)
 }
 
-/// Sums `last_qty` across fills as a decimal.
-pub(crate) fn sum_filled_quantity(fills: &[FillReport]) -> Decimal {
-    fills.iter().map(|f| f.last_qty.as_decimal()).sum()
+fn try_compute_commission(
+    fee_rate: Decimal,
+    size: Decimal,
+    price: Decimal,
+    liquidity_side: LiquiditySide,
+    currency: Currency,
+) -> anyhow::Result<Money> {
+    if liquidity_side != LiquiditySide::Taker || fee_rate.is_zero() {
+        return Ok(Money::zero(currency));
+    }
+
+    let complement = Decimal::ONE
+        .checked_sub(price)
+        .ok_or_else(|| anyhow::anyhow!("price complement overflow"))?;
+    let commission = size
+        .checked_mul(fee_rate)
+        .and_then(|value| value.checked_mul(price))
+        .and_then(|value| value.checked_mul(complement))
+        .ok_or_else(|| anyhow::anyhow!("commission arithmetic overflow"))?
+        .round_dp(5);
+    Money::from_decimal(commission, currency).map_err(Into::into)
 }
 
-/// Quantity-weighted average price across fills, or `None` when total filled
-/// is zero (avoids divide-by-zero on empty/all-zero fill lists).
-pub(crate) fn weighted_average_price(
+/// Strictly sums fill quantities for authoritative reconciliation.
+pub(crate) fn try_sum_filled_quantity(fills: &[FillReport]) -> anyhow::Result<Decimal> {
+    fills.iter().try_fold(Decimal::ZERO, |total, fill| {
+        total
+            .checked_add(fill.last_qty.as_decimal())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "confirmed fill quantity overflow for venue order {}",
+                    fill.venue_order_id
+                )
+            })
+    })
+}
+
+/// Strictly computes a quantity-weighted average for authoritative reconciliation.
+pub(crate) fn try_weighted_average_price(
     fills: &[FillReport],
     total_filled: Decimal,
-) -> Option<Decimal> {
+) -> anyhow::Result<Option<Decimal>> {
     if total_filled.is_zero() {
-        return None;
+        return Ok(None);
     }
-    let weighted: Decimal = fills
-        .iter()
-        .map(|f| f.last_qty.as_decimal() * f.last_px.as_decimal())
-        .sum();
-    Some(weighted / total_filled)
+
+    let weighted = fills.iter().try_fold(Decimal::ZERO, |total, fill| {
+        fill.last_qty
+            .as_decimal()
+            .checked_mul(fill.last_px.as_decimal())
+            .and_then(|notional| total.checked_add(notional))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "confirmed fill notional overflow for venue order {}",
+                    fill.venue_order_id
+                )
+            })
+    })?;
+    weighted
+        .checked_div(total_filled)
+        .map(Some)
+        .ok_or_else(|| anyhow::anyhow!("confirmed fill average-price division failed"))
 }
 
 /// At terminal `Filled` status, snap `filled_qty` to `quantity` when the
@@ -569,15 +885,29 @@ pub fn calculate_market_price(
 /// Accepts millisecond integers ("1703875200000"), second integers ("1703875200"),
 /// and RFC3339 strings ("2024-01-01T00:00:00Z").
 pub fn parse_timestamp(ts_str: &str) -> Option<UnixNanos> {
+    try_parse_timestamp(ts_str).ok()
+}
+
+pub(crate) fn try_parse_timestamp(ts_str: &str) -> anyhow::Result<UnixNanos> {
     if let Ok(n) = ts_str.parse::<u64>() {
-        return if n > 1_000_000_000_000 {
-            Some(UnixNanos::from(n * NANOSECONDS_IN_MILLISECOND))
+        let multiplier = if n > 1_000_000_000_000 {
+            NANOSECONDS_IN_MILLISECOND
         } else {
-            Some(UnixNanos::from(n * NANOSECONDS_IN_SECOND))
+            NANOSECONDS_IN_SECOND
         };
+        return n
+            .checked_mul(multiplier)
+            .map(UnixNanos::from)
+            .ok_or_else(|| anyhow::anyhow!("timestamp {ts_str} overflows nanoseconds"));
     }
-    let dt = chrono::DateTime::parse_from_rfc3339(ts_str).ok()?;
-    Some(UnixNanos::from(dt.timestamp_nanos_opt()? as u64))
+    let dt = chrono::DateTime::parse_from_rfc3339(ts_str)
+        .map_err(|e| anyhow::anyhow!("invalid timestamp {ts_str}: {e}"))?;
+    let nanos = dt
+        .timestamp_nanos_opt()
+        .ok_or_else(|| anyhow::anyhow!("timestamp {ts_str} is outside nanosecond range"))?;
+    let nanos = u64::try_from(nanos)
+        .map_err(|_| anyhow::anyhow!("timestamp {ts_str} is before Unix epoch"))?;
+    Ok(UnixNanos::from(nanos))
 }
 
 #[cfg(test)]
@@ -665,7 +995,7 @@ mod tests {
 
     #[rstest]
     fn test_sum_filled_quantity_empty() {
-        assert_eq!(sum_filled_quantity(&[]), Decimal::ZERO);
+        assert_eq!(try_sum_filled_quantity(&[]).unwrap(), Decimal::ZERO);
     }
 
     #[rstest]
@@ -675,27 +1005,37 @@ mod tests {
             make_test_fill(1.0, 0.60),
             make_test_fill(3.0, 0.55),
         ];
-        assert_eq!(sum_filled_quantity(&fills), dec!(6.5));
+        assert_eq!(try_sum_filled_quantity(&fills).unwrap(), dec!(6.5));
     }
 
     #[rstest]
     fn test_weighted_average_price_zero_total_returns_none() {
-        assert!(weighted_average_price(&[], Decimal::ZERO).is_none());
+        assert!(
+            try_weighted_average_price(&[], Decimal::ZERO)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[rstest]
     fn test_weighted_average_price_single_fill() {
         let fills = vec![make_test_fill(10.0, 0.5)];
-        let total = sum_filled_quantity(&fills);
-        assert_eq!(weighted_average_price(&fills, total), Some(dec!(0.5)));
+        let total = try_sum_filled_quantity(&fills).unwrap();
+        assert_eq!(
+            try_weighted_average_price(&fills, total).unwrap(),
+            Some(dec!(0.5))
+        );
     }
 
     #[rstest]
     fn test_weighted_average_price_weighted_by_quantity() {
         // 2 @ 0.40 + 8 @ 0.60 -> (0.8 + 4.8) / 10 = 0.56
         let fills = vec![make_test_fill(2.0, 0.40), make_test_fill(8.0, 0.60)];
-        let total = sum_filled_quantity(&fills);
-        assert_eq!(weighted_average_price(&fills, total), Some(dec!(0.56)));
+        let total = try_sum_filled_quantity(&fills).unwrap();
+        assert_eq!(
+            try_weighted_average_price(&fills, total).unwrap(),
+            Some(dec!(0.56))
+        );
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/execution/reconciliation.rs
+++ b/crates/adapters/polymarket/src/execution/reconciliation.rs
@@ -15,7 +15,7 @@
 
 //! Reconciliation report generation for the Polymarket execution client.
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use anyhow::Context;
 use nautilus_core::{UnixNanos, collections::AtomicMap, time::AtomicTime};
 use nautilus_model::{
@@ -31,13 +31,13 @@ use ustr::Ustr;
 use super::{
     order_fill_tracker::OrderFillTrackerMap,
     parse::{
-        build_maker_fill_report, instrument_taker_fee, parse_fill_report,
-        parse_order_status_report, parse_timestamp,
+        instrument_taker_fee, try_build_maker_fill_report, try_parse_fill_report,
+        try_parse_order_status_report, try_parse_timestamp,
     },
 };
 use crate::{
     common::{
-        consts::{DUST_POSITION_THRESHOLD, DUST_SNAP_THRESHOLD_DEC, USDC_DECIMALS},
+        consts::{DUST_POSITION_THRESHOLD, DUST_SNAP_THRESHOLD_DEC},
         enums::{PolymarketLiquiditySide, PolymarketTradeStatus},
     },
     http::{
@@ -57,17 +57,69 @@ pub(crate) struct FillContext<'a> {
     pub clock: &'static AtomicTime,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) enum FillReconciliationScope {
+    All,
+    Instrument(InstrumentId),
+    VenueOrder(VenueOrderId),
+    Order {
+        instrument_id: InstrumentId,
+        venue_order_id: VenueOrderId,
+    },
+    Orders {
+        instrument_id: Option<InstrumentId>,
+        venue_order_ids: AHashSet<VenueOrderId>,
+    },
+}
+
+pub(crate) fn resolve_requested_instrument(
+    instruments: &AtomicMap<Ustr, InstrumentAny>,
+    instrument_id: InstrumentId,
+) -> anyhow::Result<(Ustr, InstrumentAny)> {
+    instruments
+        .load()
+        .iter()
+        .find(|(_, instrument)| instrument.id() == instrument_id)
+        .map(|(token_id, instrument)| (*token_id, instrument.clone()))
+        .with_context(|| {
+            format!(
+                "Polymarket reconciliation cannot resolve requested NT instrument {instrument_id}"
+            )
+        })
+}
+
 /// Converts trade reports into fill reports: single implementation of maker/taker
 /// parsing used by both `generate_fill_reports()` and `generate_mass_status()`.
 pub(crate) fn build_fill_reports_from_trades(
     trades: &[PolymarketTradeReport],
     ctx: &FillContext<'_>,
     instruments: &AtomicMap<Ustr, InstrumentAny>,
-    instrument_filter: Option<InstrumentId>,
+    scope: &FillReconciliationScope,
     ts_init: UnixNanos,
-) -> (Vec<FillReport>, usize) {
+) -> anyhow::Result<Vec<FillReport>> {
     let mut reports = Vec::new();
-    let mut filtered = 0usize;
+    let instrument_filter = match scope {
+        FillReconciliationScope::All | FillReconciliationScope::VenueOrder(_) => None,
+        FillReconciliationScope::Instrument(instrument_id)
+        | FillReconciliationScope::Order { instrument_id, .. } => Some(*instrument_id),
+        FillReconciliationScope::Orders { instrument_id, .. } => *instrument_id,
+    };
+    let filter_token = instrument_filter
+        .map(|instrument_id| resolve_requested_instrument(instruments, instrument_id))
+        .transpose()?
+        .map(|(token_id, _)| token_id);
+    let target_order_ids = match scope {
+        FillReconciliationScope::All | FillReconciliationScope::Instrument(_) => None,
+        FillReconciliationScope::VenueOrder(venue_order_id) => {
+            Some(AHashSet::from_iter([*venue_order_id]))
+        }
+        FillReconciliationScope::Order { venue_order_id, .. } => {
+            Some(AHashSet::from_iter([*venue_order_id]))
+        }
+        FillReconciliationScope::Orders {
+            venue_order_ids, ..
+        } => Some(venue_order_ids.clone()),
+    };
 
     for trade in trades {
         if trade.status != PolymarketTradeStatus::Confirmed {
@@ -81,25 +133,47 @@ pub(crate) fn build_fill_reports_from_trades(
                 if mo.maker_address != ctx.user_address && mo.owner != ctx.api_key {
                     continue;
                 }
+                let venue_order_id = VenueOrderId::from(mo.order_id.as_str());
+
+                if target_order_ids
+                    .as_ref()
+                    .is_some_and(|target_ids| !target_ids.contains(&venue_order_id))
+                {
+                    continue;
+                }
+
+                if filter_token.is_some_and(|token_id| mo.asset_id != token_id) {
+                    if target_order_ids.is_some() {
+                        anyhow::bail!(
+                            "Polymarket reconciliation target maker fill {} asset {} \
+                             does not match requested NT instrument",
+                            trade.id,
+                            mo.asset_id
+                        );
+                    }
+                    continue;
+                }
                 let token_id = Ustr::from(mo.asset_id.as_str());
                 let instrument = instruments.get_cloned(&token_id);
                 let (instrument_id, price_prec, size_prec) = match instrument {
                     Some(i) => (i.id(), i.price_precision(), i.size_precision()),
                     None => {
-                        filtered += 1;
-                        continue;
+                        anyhow::bail!(
+                            "Polymarket reconciliation cannot map confirmed maker fill {} \
+                             asset {} to an NT instrument",
+                            trade.id,
+                            mo.asset_id
+                        );
                     }
                 };
 
-                if let Some(filter_id) = instrument_filter
-                    && instrument_id != filter_id
-                {
-                    continue;
-                }
-
-                let ts_event =
-                    parse_timestamp(&trade.match_time).unwrap_or(ctx.clock.get_time_ns());
-                let report = build_maker_fill_report(
+                let ts_event = try_parse_timestamp(&trade.match_time).map_err(|e| {
+                    anyhow::anyhow!(
+                        "confirmed maker fill {} has invalid match_time: {e}",
+                        trade.id
+                    )
+                })?;
+                let report = try_build_maker_fill_report(
                     mo,
                     &trade.id,
                     trade.trader_side,
@@ -113,10 +187,30 @@ pub(crate) fn build_fill_reports_from_trades(
                     LiquiditySide::Maker,
                     ts_event,
                     ts_init,
-                );
+                )?;
                 reports.push(report);
             }
         } else {
+            let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+
+            if target_order_ids
+                .as_ref()
+                .is_some_and(|target_ids| !target_ids.contains(&venue_order_id))
+            {
+                continue;
+            }
+
+            if filter_token.is_some_and(|token_id| trade.asset_id != token_id) {
+                if target_order_ids.is_some() {
+                    anyhow::bail!(
+                        "Polymarket reconciliation target taker fill {} asset {} \
+                         does not match requested NT instrument",
+                        trade.id,
+                        trade.asset_id
+                    );
+                }
+                continue;
+            }
             let token_id = Ustr::from(trade.asset_id.as_str());
             let instrument = instruments.get_cloned(&token_id);
             let (instrument_id, price_prec, size_prec, taker_fee_rate) = match instrument {
@@ -127,18 +221,16 @@ pub(crate) fn build_fill_reports_from_trades(
                     instrument_taker_fee(&i),
                 ),
                 None => {
-                    filtered += 1;
-                    continue;
+                    anyhow::bail!(
+                        "Polymarket reconciliation cannot map confirmed taker fill {} \
+                         asset {} to an NT instrument",
+                        trade.id,
+                        trade.asset_id
+                    );
                 }
             };
 
-            if let Some(filter_id) = instrument_filter
-                && instrument_id != filter_id
-            {
-                continue;
-            }
-
-            let report = parse_fill_report(
+            let report = try_parse_fill_report(
                 trade,
                 instrument_id,
                 ctx.account_id,
@@ -148,12 +240,12 @@ pub(crate) fn build_fill_reports_from_trades(
                 ctx.pusd,
                 taker_fee_rate,
                 ts_init,
-            );
+            )?;
             reports.push(report);
         }
     }
 
-    (reports, filtered)
+    Ok(reports)
 }
 
 /// Converts open orders into order status reports.
@@ -163,28 +255,31 @@ pub(crate) fn build_order_reports_from_orders(
     account_id: AccountId,
     instrument_filter: Option<InstrumentId>,
     ts_init: UnixNanos,
-) -> (Vec<OrderStatusReport>, usize) {
+) -> anyhow::Result<Vec<OrderStatusReport>> {
     let mut reports = Vec::new();
-    let mut filtered = 0usize;
+    let filter_token = instrument_filter
+        .map(|instrument_id| resolve_requested_instrument(instruments, instrument_id))
+        .transpose()?
+        .map(|(token_id, _)| token_id);
 
     for order in orders {
+        if filter_token.is_some_and(|token_id| order.asset_id != token_id) {
+            continue;
+        }
         let token_id = Ustr::from(order.asset_id.as_str());
         let instrument = instruments.get_cloned(&token_id);
         let (instrument_id, price_prec, size_prec) = match instrument {
             Some(i) => (i.id(), i.price_precision(), i.size_precision()),
             None => {
-                filtered += 1;
-                continue;
+                anyhow::bail!(
+                    "Polymarket reconciliation cannot map venue open order asset {} \
+                     to an NT instrument",
+                    order.asset_id
+                );
             }
         };
 
-        if let Some(filter_id) = instrument_filter
-            && instrument_id != filter_id
-        {
-            continue;
-        }
-
-        let report = parse_order_status_report(
+        let report = try_parse_order_status_report(
             order,
             instrument_id,
             account_id,
@@ -192,11 +287,11 @@ pub(crate) fn build_order_reports_from_orders(
             price_prec,
             size_prec,
             ts_init,
-        );
+        )?;
         reports.push(report);
     }
 
-    (reports, filtered)
+    Ok(reports)
 }
 
 /// Applies venue_order_id and time-range filters to fill reports.
@@ -223,50 +318,87 @@ pub(crate) fn apply_fill_filters(
 /// Builds position status reports from Data API positions, filtering dust.
 pub(crate) fn build_position_reports(
     positions: &[DataApiPosition],
+    instruments: &AtomicMap<Ustr, InstrumentAny>,
     account_id: AccountId,
+    instrument_filter: Option<InstrumentId>,
     ts: UnixNanos,
-) -> Vec<PositionStatusReport> {
-    positions
-        .iter()
-        .filter(|p| {
-            if p.size > Decimal::ZERO && p.size < DUST_POSITION_THRESHOLD {
-                log::debug!(
-                    "Filtering dust position: {}-{}, size={}",
-                    p.condition_id,
-                    p.asset,
-                    p.size
-                );
-            }
-            p.size >= DUST_POSITION_THRESHOLD
-        })
-        .filter_map(|p| {
-            let instrument_id =
-                InstrumentId::from(format!("{}-{}.POLYMARKET", p.condition_id, p.asset).as_str());
-            let quantity = match Quantity::from_decimal_dp(p.size, USDC_DECIMALS as u8) {
-                Ok(quantity) => quantity,
-                Err(e) => {
-                    log::warn!(
-                        "Skipping invalid Data API position {}-{} size {}: {e}",
-                        p.condition_id,
-                        p.asset,
-                        p.size,
-                    );
-                    return None;
-                }
-            };
-            Some(PositionStatusReport::new(
-                account_id,
-                instrument_id,
-                PositionSideSpecified::Long,
-                quantity,
-                ts,
-                ts,
-                None,
-                None,
-                p.avg_price,
-            ))
-        })
-        .collect()
+) -> anyhow::Result<Vec<PositionStatusReport>> {
+    let mut reports = Vec::new();
+    let filter_token = instrument_filter
+        .map(|instrument_id| resolve_requested_instrument(instruments, instrument_id))
+        .transpose()?
+        .map(|(token_id, _)| token_id);
+
+    for position in positions {
+        if filter_token.is_some_and(|token_id| position.asset != token_id.as_str()) {
+            continue;
+        }
+
+        if position.size.is_sign_negative() {
+            anyhow::bail!(
+                "Polymarket reconciliation received negative Data API position \
+                 {}-{} size {}",
+                position.condition_id,
+                position.asset,
+                position.size
+            );
+        }
+
+        if position.size > Decimal::ZERO && position.size < DUST_POSITION_THRESHOLD {
+            log::debug!(
+                "Filtering dust position: {}-{}, size={}",
+                position.condition_id,
+                position.asset,
+                position.size
+            );
+        }
+
+        if position.size < DUST_POSITION_THRESHOLD {
+            continue;
+        }
+
+        let instrument = instruments
+            .get_cloned(&Ustr::from(position.asset.as_str()))
+            .with_context(|| {
+                format!(
+                    "Polymarket reconciliation cannot map Data API position \
+                     {}-{} to an NT instrument",
+                    position.condition_id, position.asset
+                )
+            })?;
+        let quantity = position_quantity(
+            position.size,
+            instrument.size_precision(),
+            position.condition_id.as_str(),
+            position.asset.as_str(),
+        )?;
+        reports.push(PositionStatusReport::new(
+            account_id,
+            instrument.id(),
+            PositionSideSpecified::Long,
+            quantity,
+            ts,
+            ts,
+            None,
+            None,
+            position.avg_price,
+        ));
+    }
+    Ok(reports)
+}
+
+fn position_quantity(
+    size: Decimal,
+    precision: u8,
+    condition_id: &str,
+    asset: &str,
+) -> anyhow::Result<Quantity> {
+    Quantity::from_decimal_dp(size, precision).with_context(|| {
+        format!(
+            "Polymarket reconciliation cannot represent Data API position \
+             {condition_id}-{asset} size {size}"
+        )
+    })
 }
 
 /// Full reconciliation mass status generation.
@@ -289,8 +421,8 @@ pub(crate) async fn generate_mass_status(
         .await
         .context("failed to fetch orders for mass status")?;
 
-    let (mut order_reports, orders_filtered) =
-        build_order_reports_from_orders(&orders, instruments, ctx.account_id, None, ts_init);
+    let mut order_reports =
+        build_order_reports_from_orders(&orders, instruments, ctx.account_id, None, ts_init)?;
 
     // Fetch and parse fill reports
     let trades = http_client
@@ -298,8 +430,13 @@ pub(crate) async fn generate_mass_status(
         .await
         .context("failed to fetch trades for mass status")?;
 
-    let (mut fill_reports, fills_filtered) =
-        build_fill_reports_from_trades(&trades, ctx, instruments, None, ts_init);
+    let mut fill_reports = build_fill_reports_from_trades(
+        &trades,
+        ctx,
+        instruments,
+        &FillReconciliationScope::All,
+        ts_init,
+    )?;
 
     // Snap dust drift on REST fills the same way the WS path does.
     // Commission stays as venue-reported.
@@ -311,12 +448,17 @@ pub(crate) async fn generate_mass_status(
         .await
         .context("failed to fetch positions for mass status")?;
 
-    let position_reports = build_position_reports(&positions, ctx.account_id, ts_init);
+    let position_reports =
+        build_position_reports(&positions, instruments, ctx.account_id, None, ts_init)?;
 
     // Apply lookback filter
     if let Some(mins) = lookback_mins {
         let now_ns = ctx.clock.get_time_ns();
-        let cutoff_ns = now_ns.as_u64().saturating_sub(mins * 60 * 1_000_000_000);
+        let lookback_ns = mins
+            .checked_mul(60)
+            .and_then(|seconds| seconds.checked_mul(1_000_000_000))
+            .with_context(|| format!("Polymarket reconciliation lookback {mins}min overflows"))?;
+        let cutoff_ns = now_ns.as_u64().saturating_sub(lookback_ns);
         let cutoff = UnixNanos::from(cutoff_ns);
 
         let orders_before = order_reports.len();
@@ -339,16 +481,14 @@ pub(crate) async fn generate_mass_status(
         );
     } else {
         log::debug!(
-            "Generated mass status: {} orders ({} filtered), {} fills ({} filtered), {} positions",
+            "Generated mass status: {} orders, {} fills, {} positions",
             order_reports.len(),
-            orders_filtered,
             fill_reports.len(),
-            fills_filtered,
             position_reports.len(),
         );
     }
 
-    cap_order_reports_to_confirmed_fills(&mut order_reports, &fill_reports);
+    cap_order_reports_to_confirmed_fills(&mut order_reports, &fill_reports)?;
 
     let mut mass_status = ExecutionMassStatus::new(client_id, ctx.account_id, venue, ts_init, None);
 
@@ -362,28 +502,39 @@ pub(crate) async fn generate_mass_status(
 fn cap_order_reports_to_confirmed_fills(
     order_reports: &mut [OrderStatusReport],
     fill_reports: &[FillReport],
-) {
-    let confirmed_by_order = confirmed_filled_quantities(fill_reports);
+) -> anyhow::Result<()> {
+    let confirmed_by_order = confirmed_filled_quantities(fill_reports)?;
 
     for report in order_reports {
         let local_filled = Quantity::zero(report.quantity.precision);
-        cap_order_report_filled_qty(
+        try_cap_order_report_filled_qty(
             report,
             local_filled,
             confirmed_by_order.get(&report.venue_order_id).copied(),
-        );
+        )?;
     }
+    Ok(())
 }
 
 pub(crate) fn confirmed_filled_quantities(
     fill_reports: &[FillReport],
-) -> AHashMap<VenueOrderId, Decimal> {
+) -> anyhow::Result<AHashMap<VenueOrderId, Decimal>> {
     let mut confirmed_by_order = AHashMap::new();
     for fill in fill_reports {
-        *confirmed_by_order.entry(fill.venue_order_id).or_default() += fill.last_qty.as_decimal();
+        let total = confirmed_by_order
+            .entry(fill.venue_order_id)
+            .or_insert(Decimal::ZERO);
+        *total = total
+            .checked_add(fill.last_qty.as_decimal())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "confirmed fill quantity overflow for venue order {}",
+                    fill.venue_order_id
+                )
+            })?;
     }
 
-    confirmed_by_order
+    Ok(confirmed_by_order)
 }
 
 pub(crate) fn cap_order_report_filled_qty(
@@ -394,6 +545,34 @@ pub(crate) fn cap_order_report_filled_qty(
     let confirmed_filled = confirmed_filled
         .and_then(|qty| Quantity::from_decimal_dp(qty, report.quantity.precision).ok())
         .unwrap_or_else(|| Quantity::zero(report.quantity.precision));
+    cap_order_report_with_quantities(report, local_filled, confirmed_filled);
+}
+
+pub(crate) fn try_cap_order_report_filled_qty(
+    report: &mut OrderStatusReport,
+    local_filled: Quantity,
+    confirmed_filled: Option<Decimal>,
+) -> anyhow::Result<()> {
+    let confirmed_filled = confirmed_filled
+        .map(|qty| {
+            Quantity::from_decimal_dp(qty, report.quantity.precision).map_err(|e| {
+                anyhow::anyhow!(
+                    "cannot represent confirmed fill quantity for venue order {}: {e}",
+                    report.venue_order_id
+                )
+            })
+        })
+        .transpose()?
+        .unwrap_or_else(|| Quantity::zero(report.quantity.precision));
+    cap_order_report_with_quantities(report, local_filled, confirmed_filled);
+    Ok(())
+}
+
+fn cap_order_report_with_quantities(
+    report: &mut OrderStatusReport,
+    local_filled: Quantity,
+    confirmed_filled: Quantity,
+) {
     let capped = report.filled_qty.min(local_filled.max(confirmed_filled));
     report.filled_qty = capped;
     normalize_terminal_order_report_quantity(report);
@@ -424,11 +603,334 @@ mod tests {
     use nautilus_model::{
         enums::{LiquiditySide, OrderSide, OrderStatus, OrderType, TimeInForce},
         identifiers::TradeId,
+        instruments::{Instrument, InstrumentAny, stubs::binary_option},
         types::{Money, Price},
     };
     use rstest::rstest;
 
     use super::*;
+
+    fn mapped_instrument() -> (AtomicMap<Ustr, InstrumentAny>, InstrumentAny) {
+        let instrument = InstrumentAny::BinaryOption(binary_option());
+        let instruments = AtomicMap::new();
+        instruments.insert(
+            Ustr::from(instrument.raw_symbol().as_str()),
+            instrument.clone(),
+        );
+        (instruments, instrument)
+    }
+
+    fn open_order_for(instrument: &InstrumentAny) -> PolymarketOpenOrder {
+        let content = std::fs::read_to_string("test_data/http_open_order.json")
+            .expect("open-order fixture should load");
+        let mut order: PolymarketOpenOrder =
+            serde_json::from_str(&content).expect("open-order fixture should decode");
+        order.asset_id = Ustr::from(instrument.raw_symbol().as_str());
+        order
+    }
+
+    fn confirmed_trade_for(instrument: &InstrumentAny) -> PolymarketTradeReport {
+        let content = std::fs::read_to_string("test_data/http_trade_report.json")
+            .expect("trade fixture should load");
+        let mut trade: PolymarketTradeReport =
+            serde_json::from_str(&content).expect("trade fixture should decode");
+        trade.status = PolymarketTradeStatus::Confirmed;
+        trade.asset_id = Ustr::from(instrument.raw_symbol().as_str());
+        for maker_order in &mut trade.maker_orders {
+            maker_order.asset_id = Ustr::from(instrument.raw_symbol().as_str());
+        }
+        trade
+    }
+
+    fn fill_context() -> FillContext<'static> {
+        FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        }
+    }
+
+    #[rstest]
+    fn rejects_unmapped_open_order() {
+        let content = std::fs::read_to_string("test_data/http_open_order.json")
+            .expect("open-order fixture should load");
+        let order: PolymarketOpenOrder =
+            serde_json::from_str(&content).expect("open-order fixture should decode");
+        let instruments = AtomicMap::new();
+
+        let error = build_order_reports_from_orders(
+            &[order],
+            &instruments,
+            AccountId::from("POLYMARKET-001"),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("an unmapped venue open order must fail reconciliation");
+
+        assert!(error.to_string().contains("venue open order asset"));
+    }
+
+    #[rstest]
+    fn rejects_unmapped_confirmed_fill() {
+        let content = std::fs::read_to_string("test_data/http_trade_report.json")
+            .expect("trade fixture should load");
+        let mut trade: PolymarketTradeReport =
+            serde_json::from_str(&content).expect("trade fixture should decode");
+        trade.status = PolymarketTradeStatus::Confirmed;
+        let instruments = AtomicMap::new();
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let error = build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            &FillReconciliationScope::All,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("an unmapped confirmed fill must fail reconciliation");
+
+        assert!(error.to_string().contains("confirmed taker fill"));
+    }
+
+    #[rstest]
+    #[case::quantity(|order: &mut PolymarketOpenOrder| order.original_size = Decimal::MAX)]
+    #[case::filled(|order: &mut PolymarketOpenOrder| order.size_matched = Decimal::MAX)]
+    #[case::price(|order: &mut PolymarketOpenOrder| order.price = Decimal::MAX)]
+    fn rejects_unrepresentable_open_order_numeric(#[case] mutate: fn(&mut PolymarketOpenOrder)) {
+        let (instruments, instrument) = mapped_instrument();
+        let mut order = open_order_for(&instrument);
+        mutate(&mut order);
+
+        let error = build_order_reports_from_orders(
+            &[order],
+            &instruments,
+            AccountId::from("POLYMARKET-001"),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("unrepresentable open-order numerics must fail reconciliation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot represent venue open order")
+        );
+    }
+
+    #[rstest]
+    fn rejects_overflowed_open_order_timestamp() {
+        let (instruments, instrument) = mapped_instrument();
+        let mut order = open_order_for(&instrument);
+        order.created_at = u64::MAX;
+
+        let error = build_order_reports_from_orders(
+            &[order],
+            &instruments,
+            AccountId::from("POLYMARKET-001"),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("overflowed open-order timestamps must fail reconciliation");
+
+        assert!(error.to_string().contains("created_at"));
+    }
+
+    #[rstest]
+    fn rejects_malformed_open_order_expiration() {
+        let (instruments, instrument) = mapped_instrument();
+        let mut order = open_order_for(&instrument);
+        order.expiration = Some("not-a-timestamp".to_string());
+
+        let error = build_order_reports_from_orders(
+            &[order],
+            &instruments,
+            AccountId::from("POLYMARKET-001"),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("malformed open-order expiration must fail reconciliation");
+
+        assert!(error.to_string().contains("expiration"));
+    }
+
+    #[rstest]
+    #[case::quantity(|trade: &mut PolymarketTradeReport| trade.size = Decimal::MAX)]
+    #[case::price(|trade: &mut PolymarketTradeReport| trade.price = Decimal::MAX)]
+    fn rejects_unrepresentable_confirmed_taker_fill_numeric(
+        #[case] mutate: fn(&mut PolymarketTradeReport),
+    ) {
+        let (instruments, instrument) = mapped_instrument();
+        let mut trade = confirmed_trade_for(&instrument);
+        mutate(&mut trade);
+
+        let error = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            &FillReconciliationScope::All,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("unrepresentable confirmed-fill numerics must fail reconciliation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot represent confirmed taker fill")
+        );
+    }
+
+    #[rstest]
+    fn rejects_unrepresentable_confirmed_maker_fill_numeric() {
+        let (instruments, instrument) = mapped_instrument();
+        let mut trade = confirmed_trade_for(&instrument);
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        trade.maker_orders[0].matched_amount = Decimal::MAX;
+
+        let error = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            &FillReconciliationScope::All,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("unrepresentable maker-fill numerics must fail reconciliation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot represent confirmed maker fill")
+        );
+    }
+
+    #[rstest]
+    #[case::malformed("not-a-timestamp")]
+    #[case::overflow("18446744073709551615")]
+    fn rejects_invalid_confirmed_fill_timestamp(#[case] match_time: &str) {
+        let (instruments, instrument) = mapped_instrument();
+        let mut trade = confirmed_trade_for(&instrument);
+        trade.match_time = match_time.to_string();
+
+        let error = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            &FillReconciliationScope::All,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("invalid confirmed-fill timestamps must fail reconciliation");
+
+        assert!(error.to_string().contains("match_time"));
+    }
+
+    #[rstest]
+    fn scoped_order_reconciliation_ignores_unrelated_unmapped_order() {
+        let (instruments, instrument) = mapped_instrument();
+        let mapped = open_order_for(&instrument);
+        let mut unrelated = mapped.clone();
+        unrelated.asset_id = Ustr::from("UNRELATED-UNMAPPED-TOKEN");
+
+        let reports = build_order_reports_from_orders(
+            &[unrelated, mapped],
+            &instruments,
+            AccountId::from("POLYMARKET-001"),
+            Some(instrument.id()),
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect("scoped reconciliation must ignore unrelated venue orders");
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].instrument_id, instrument.id());
+    }
+
+    #[rstest]
+    fn scoped_fill_reconciliation_ignores_unrelated_unmapped_fill() {
+        let (instruments, instrument) = mapped_instrument();
+        let mapped = confirmed_trade_for(&instrument);
+        let mut unrelated = mapped.clone();
+        unrelated.asset_id = Ustr::from("UNRELATED-UNMAPPED-TOKEN");
+
+        let reports = build_fill_reports_from_trades(
+            &[unrelated, mapped],
+            &fill_context(),
+            &instruments,
+            &FillReconciliationScope::Instrument(instrument.id()),
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect("scoped reconciliation must ignore unrelated venue fills");
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].instrument_id, instrument.id());
+    }
+
+    #[rstest]
+    fn rejects_negative_current_position_before_dust_filtering() {
+        let position = DataApiPosition {
+            asset: "token-1".to_string(),
+            condition_id: "condition-1".to_string(),
+            size: Decimal::NEGATIVE_ONE,
+            avg_price: None,
+        };
+
+        let error = build_position_reports(
+            &[position],
+            &AtomicMap::new(),
+            AccountId::from("POLYMARKET-001"),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("negative current positions must fail reconciliation");
+
+        assert!(error.to_string().contains("negative Data API position"));
+    }
+
+    #[rstest]
+    fn scoped_position_reconciliation_ignores_unrelated_invalid_position() {
+        let (instruments, instrument) = mapped_instrument();
+        let unrelated = DataApiPosition {
+            asset: "UNRELATED-UNMAPPED-TOKEN".to_string(),
+            condition_id: "condition-unrelated".to_string(),
+            size: Decimal::NEGATIVE_ONE,
+            avg_price: None,
+        };
+        let mapped = DataApiPosition {
+            asset: instrument.raw_symbol().to_string(),
+            condition_id: "condition-mapped".to_string(),
+            size: Decimal::ONE,
+            avg_price: None,
+        };
+
+        let reports = build_position_reports(
+            &[unrelated, mapped],
+            &instruments,
+            AccountId::from("POLYMARKET-001"),
+            Some(instrument.id()),
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect("scoped reconciliation must ignore unrelated positions");
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].instrument_id, instrument.id());
+    }
+
+    #[rstest]
+    fn rejects_unrepresentable_current_position() {
+        let error = position_quantity(Decimal::MAX, 6, "condition-1", "token-1")
+            .expect_err("an unrepresentable current position must fail reconciliation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot represent Data API position")
+        );
+    }
 
     #[rstest]
     fn caps_order_report_to_confirmed_companion_fills() {
@@ -468,7 +970,7 @@ mod tests {
             None,
         )];
 
-        cap_order_reports_to_confirmed_fills(&mut reports, &fills);
+        cap_order_reports_to_confirmed_fills(&mut reports, &fills).unwrap();
 
         assert_eq!(reports[0].filled_qty, Quantity::from("4.0000"));
     }
@@ -516,7 +1018,7 @@ mod tests {
             None,
         )];
 
-        cap_order_reports_to_confirmed_fills(&mut reports, &fills);
+        cap_order_reports_to_confirmed_fills(&mut reports, &fills).unwrap();
 
         assert_eq!(reports[0].quantity, Quantity::from(expected_quantity));
         assert_eq!(reports[0].filled_qty, Quantity::from(confirmed));

--- a/crates/adapters/polymarket/src/execution/reconciliation.rs
+++ b/crates/adapters/polymarket/src/execution/reconciliation.rs
@@ -129,10 +129,9 @@ pub(crate) fn build_fill_reports_from_trades(
         let is_maker = trade.trader_side == PolymarketLiquiditySide::Maker;
 
         if is_maker {
+            let mut relevant_maker_order_seen = matches!(scope, FillReconciliationScope::All);
+            let mut owned_maker_order_seen = false;
             for mo in &trade.maker_orders {
-                if mo.maker_address != ctx.user_address && mo.owner != ctx.api_key {
-                    continue;
-                }
                 let venue_order_id = VenueOrderId::from(mo.order_id.as_str());
 
                 if target_order_ids
@@ -140,6 +139,9 @@ pub(crate) fn build_fill_reports_from_trades(
                     .is_some_and(|target_ids| !target_ids.contains(&venue_order_id))
                 {
                     continue;
+                }
+                if target_order_ids.is_some() {
+                    relevant_maker_order_seen = true;
                 }
 
                 if filter_token.is_some_and(|token_id| mo.asset_id != token_id) {
@@ -153,6 +155,13 @@ pub(crate) fn build_fill_reports_from_trades(
                     }
                     continue;
                 }
+                if filter_token.is_some() {
+                    relevant_maker_order_seen = true;
+                }
+                if mo.maker_address != ctx.user_address && mo.owner != ctx.api_key {
+                    continue;
+                }
+                owned_maker_order_seen = true;
                 let token_id = Ustr::from(mo.asset_id.as_str());
                 let instrument = instruments.get_cloned(&token_id);
                 let (instrument_id, price_prec, size_prec) = match instrument {
@@ -189,6 +198,12 @@ pub(crate) fn build_fill_reports_from_trades(
                     ts_init,
                 )?;
                 reports.push(report);
+            }
+            if relevant_maker_order_seen && !owned_maker_order_seen {
+                anyhow::bail!(
+                    "Polymarket reconciliation confirmed maker trade {} has no owned maker order",
+                    trade.id
+                );
             }
         } else {
             let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
@@ -808,6 +823,73 @@ mod tests {
                 .to_string()
                 .contains("cannot represent confirmed maker fill")
         );
+    }
+
+    #[rstest]
+    fn rejects_confirmed_maker_fill_without_owned_maker_order() {
+        let (instruments, instrument) = mapped_instrument();
+        let mut trade = confirmed_trade_for(&instrument);
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        for maker_order in &mut trade.maker_orders {
+            maker_order.maker_address = "0x-unrelated-maker".to_string();
+            maker_order.owner = "unrelated-owner".to_string();
+        }
+
+        let error = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            &FillReconciliationScope::All,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("a confirmed maker trade must contain an owned maker order");
+
+        assert!(error.to_string().contains("no owned maker order"));
+    }
+
+    #[rstest]
+    fn targeted_maker_fill_rejects_target_order_ownership_mismatch() {
+        let (instruments, instrument) = mapped_instrument();
+        let mut trade = confirmed_trade_for(&instrument);
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let target_order_id = VenueOrderId::from(trade.maker_orders[0].order_id.as_str());
+        for maker_order in &mut trade.maker_orders {
+            maker_order.maker_address = "0x-unrelated-maker".to_string();
+            maker_order.owner = "unrelated-owner".to_string();
+        }
+
+        let error = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            &FillReconciliationScope::VenueOrder(target_order_id),
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("a targeted maker order with mismatched ownership must fail");
+
+        assert!(error.to_string().contains("no owned maker order"));
+    }
+
+    #[rstest]
+    fn targeted_maker_fill_ignores_unrelated_trade_without_owned_order() {
+        let (instruments, instrument) = mapped_instrument();
+        let mut trade = confirmed_trade_for(&instrument);
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        for maker_order in &mut trade.maker_orders {
+            maker_order.maker_address = "0x-unrelated-maker".to_string();
+            maker_order.owner = "unrelated-owner".to_string();
+        }
+
+        let reports = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            &FillReconciliationScope::VenueOrder(VenueOrderId::from("unrelated-target")),
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect("a targeted query must ignore a trade that does not contain its order");
+
+        assert!(reports.is_empty());
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/execution/reports.rs
+++ b/crates/adapters/polymarket/src/execution/reports.rs
@@ -34,13 +34,14 @@ use ustr::Ustr;
 use super::{
     PolymarketExecutionClient,
     parse::{
-        parse_balance_allowance, parse_order_status_report, sum_filled_quantity,
-        weighted_average_price,
+        parse_balance_allowance, try_parse_order_status_report, try_sum_filled_quantity,
+        try_weighted_average_price,
     },
     reconciliation::{
-        FillContext, apply_fill_filters, build_fill_reports_from_trades, build_position_reports,
-        cap_order_report_filled_qty, confirmed_filled_quantities,
-        normalize_terminal_order_report_quantity,
+        FillContext, FillReconciliationScope, apply_fill_filters, build_fill_reports_from_trades,
+        build_position_reports, confirmed_filled_quantities,
+        normalize_terminal_order_report_quantity, resolve_requested_instrument,
+        try_cap_order_report_filled_qty,
     },
 };
 use crate::{
@@ -94,6 +95,18 @@ impl PolymarketExecutionClient {
         let cached_price = cached.as_ref().and_then(Order::price);
         let cached_side = cached.as_ref().map(Order::order_side);
 
+        let mut order_fills = build_fill_reports_from_trades(
+            &trades,
+            &ctx,
+            &self.shared_token_instruments,
+            &FillReconciliationScope::Order {
+                instrument_id,
+                venue_order_id,
+            },
+            ts_init,
+        )?;
+        self.fill_tracker.snap_fill_reports(&mut order_fills);
+
         let has_pending_trade = trades.iter().any(|trade| {
             trade.status.is_pending_settlement()
                 && (trade.taker_order_id == venue_order_id.as_str()
@@ -139,16 +152,6 @@ impl PolymarketExecutionClient {
             return Ok(Some(report));
         }
 
-        let (mut order_fills, _) = build_fill_reports_from_trades(
-            &trades,
-            &ctx,
-            &self.shared_token_instruments,
-            Some(instrument_id),
-            ts_init,
-        );
-        order_fills.retain(|f| f.venue_order_id == venue_order_id);
-        self.fill_tracker.snap_fill_reports(&mut order_fills);
-
         if order_fills.is_empty() {
             let Some(cached) = cached.as_ref() else {
                 log::debug!(
@@ -187,10 +190,14 @@ impl PolymarketExecutionClient {
             return Ok(None);
         };
 
-        let total_filled_dec = sum_filled_quantity(&order_fills);
-        let avg_px = weighted_average_price(&order_fills, total_filled_dec);
-        let raw_filled_qty = Quantity::from_decimal_dp(total_filled_dec, size_prec)
-            .unwrap_or_else(|_| Quantity::zero(size_prec));
+        let total_filled_dec = try_sum_filled_quantity(&order_fills)?;
+        let avg_px = try_weighted_average_price(&order_fills, total_filled_dec)?;
+        let raw_filled_qty =
+            Quantity::from_decimal_dp(total_filled_dec, size_prec).map_err(|e| {
+                anyhow::anyhow!(
+                    "cannot represent confirmed fills for venue order {venue_order_id}: {e}"
+                )
+            })?;
         let order_side = cached_side.unwrap_or(order_fills[0].order_side);
         let ts_event = order_fills
             .iter()
@@ -260,11 +267,15 @@ impl PolymarketExecutionClient {
         let client_order_id = cmd.client_order_id;
         let account_id = self.core.account_id;
         let cache = self.core.cache();
-
-        let (price_prec, size_prec) = match cache.instrument(&instrument_id) {
-            Some(i) => (i.price_precision(), i.size_precision()),
-            None => (4, 6),
-        };
+        let (expected_token, instrument) =
+            match resolve_requested_instrument(&self.shared_token_instruments, instrument_id) {
+                Ok(resolved) => resolved,
+                Err(e) => {
+                    log::warn!("Failed to query order {venue_order_id}: {e}");
+                    return;
+                }
+            };
+        let (price_prec, size_prec) = (instrument.price_precision(), instrument.size_precision());
 
         let http_client = self.http_client.clone();
         let fill_tracker = self.fill_tracker.clone();
@@ -284,7 +295,16 @@ impl PolymarketExecutionClient {
         self.spawn_task("query_order", async move {
             match http_client.get_order_optional(&venue_order_id).await {
                 Ok(Some(order)) => {
-                    let mut report = parse_order_status_report(
+                    if order.asset_id != expected_token {
+                        anyhow::bail!(
+                            "Polymarket order {} asset {} does not match requested instrument {} token {}",
+                            order.id,
+                            order.asset_id,
+                            instrument_id,
+                            expected_token
+                        );
+                    }
+                    let mut report = try_parse_order_status_report(
                         &order,
                         instrument_id,
                         account_id,
@@ -292,7 +312,7 @@ impl PolymarketExecutionClient {
                         price_prec,
                         size_prec,
                         clock.get_time_ns(),
-                    );
+                    )?;
                     let venue_order_id = VenueOrderId::from(venue_order_id.as_str());
                     let tracked_filled = fill_tracker
                         .get_cumulative_filled(&venue_order_id)
@@ -307,34 +327,25 @@ impl PolymarketExecutionClient {
                             clock,
                         };
 
-                        match fetch_confirmed_fill_reports(
+                        let fills = fetch_confirmed_fill_reports(
                             &http_client,
                             &ctx,
                             &token_instruments,
                             GetTradesParams::default(),
-                            Some(instrument_id),
+                            FillReconciliationScope::Order {
+                                instrument_id,
+                                venue_order_id,
+                            },
                             clock.get_time_ns(),
                         )
-                        .await
-                        {
-                            Ok(fills) => confirmed_filled_quantities(&fills)
-                                .get(&venue_order_id)
-                                .copied(),
-                            Err(e) => {
-                                log::warn!(
-                                    "Failed to fetch confirmed fills for order {venue_order_id}: {e}"
-                                );
-                                None
-                            }
-                        }
+                        .await?;
+                        confirmed_filled_quantities(&fills)?
+                            .get(&venue_order_id)
+                            .copied()
                     } else {
                         None
                     };
-                    cap_order_report_filled_qty(
-                        &mut report,
-                        local_filled,
-                        confirmed_filled,
-                    );
+                    try_cap_order_report_filled_qty(&mut report, local_filled, confirmed_filled)?;
                     emitter.send_order_status_report(report);
                 }
                 Ok(None) => {
@@ -374,14 +385,21 @@ impl PolymarketExecutionClient {
             .await
             .context("failed to fetch order")?;
 
-        let instrument = self.core.cache().instrument(&instrument_id).cloned();
-        let (price_prec, size_prec) = match &instrument {
-            Some(i) => (i.price_precision(), i.size_precision()),
-            None => (4, 6),
-        };
+        let (expected_token, instrument) =
+            resolve_requested_instrument(&self.shared_token_instruments, instrument_id)?;
+        let (price_prec, size_prec) = (instrument.price_precision(), instrument.size_precision());
 
         if let Some(order) = order {
-            let mut report = parse_order_status_report(
+            if order.asset_id != expected_token {
+                anyhow::bail!(
+                    "Polymarket order {} asset {} does not match requested instrument {} token {}",
+                    order.id,
+                    order.asset_id,
+                    instrument_id,
+                    expected_token
+                );
+            }
+            let mut report = try_parse_order_status_report(
                 &order,
                 instrument_id,
                 self.core.account_id,
@@ -389,7 +407,7 @@ impl PolymarketExecutionClient {
                 price_prec,
                 size_prec,
                 self.clock.get_time_ns(),
-            );
+            )?;
             let cached_filled = cmd
                 .client_order_id
                 .and_then(|id| self.core.cache().order(&id).map(|order| order.filled_qty()))
@@ -406,30 +424,25 @@ impl PolymarketExecutionClient {
                 .unwrap_or_else(|| Quantity::zero(size_prec));
             let local_filled = cached_filled.max(tracked_filled);
             let confirmed_filled = if report.filled_qty > local_filled {
-                match fetch_confirmed_fill_reports(
+                let fills = fetch_confirmed_fill_reports(
                     &self.http_client,
                     &self.fill_context(),
                     &self.shared_token_instruments,
                     GetTradesParams::default(),
-                    Some(instrument_id),
+                    FillReconciliationScope::Order {
+                        instrument_id,
+                        venue_order_id,
+                    },
                     self.clock.get_time_ns(),
                 )
-                .await
-                {
-                    Ok(fills) => confirmed_filled_quantities(&fills)
-                        .get(&venue_order_id)
-                        .copied(),
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to fetch confirmed fills for order {venue_order_id}: {e}"
-                        );
-                        None
-                    }
-                }
+                .await?;
+                confirmed_filled_quantities(&fills)?
+                    .get(&venue_order_id)
+                    .copied()
             } else {
                 None
             };
-            cap_order_report_filled_qty(&mut report, local_filled, confirmed_filled);
+            try_cap_order_report_filled_qty(&mut report, local_filled, confirmed_filled)?;
             return Ok(Some(report));
         }
 
@@ -453,13 +466,13 @@ impl PolymarketExecutionClient {
             .await
             .context("failed to fetch orders")?;
 
-        let (mut reports, _) = super::reconciliation::build_order_reports_from_orders(
+        let mut reports = super::reconciliation::build_order_reports_from_orders(
             &orders,
             &self.shared_token_instruments,
             self.core.account_id,
             cmd.instrument_id,
             self.clock.get_time_ns(),
-        );
+        )?;
 
         let needs_confirmed_fills = reports.iter().any(|report| {
             let cached_filled = report
@@ -469,22 +482,19 @@ impl PolymarketExecutionClient {
             report.filled_qty > cached_filled
         });
         let confirmed_fills = if needs_confirmed_fills {
-            match fetch_confirmed_fill_reports(
+            let fills = fetch_confirmed_fill_reports(
                 &self.http_client,
                 &self.fill_context(),
                 &self.shared_token_instruments,
                 GetTradesParams::default(),
-                cmd.instrument_id,
+                FillReconciliationScope::Orders {
+                    instrument_id: cmd.instrument_id,
+                    venue_order_ids: reports.iter().map(|report| report.venue_order_id).collect(),
+                },
                 self.clock.get_time_ns(),
             )
-            .await
-            {
-                Ok(fills) => confirmed_filled_quantities(&fills),
-                Err(e) => {
-                    log::warn!("Failed to fetch confirmed fills for open-order check: {e}");
-                    Default::default()
-                }
-            }
+            .await?;
+            confirmed_filled_quantities(&fills)?
         } else {
             Default::default()
         };
@@ -504,11 +514,11 @@ impl PolymarketExecutionClient {
                 .fill_tracker
                 .get_cumulative_filled(&report.venue_order_id)
                 .unwrap_or_else(|| Quantity::zero(report.quantity.precision));
-            cap_order_report_filled_qty(
+            try_cap_order_report_filled_qty(
                 report,
                 cached_filled.max(tracked_filled),
                 confirmed_fills.get(&report.venue_order_id).copied(),
-            );
+            )?;
         }
 
         let reports = if cmd.open_only {
@@ -528,20 +538,40 @@ impl PolymarketExecutionClient {
         &self,
         cmd: GenerateFillReports,
     ) -> anyhow::Result<Vec<FillReport>> {
+        let mut params = GetTradesParams::default();
+
+        if let Some(instrument_id) = cmd.instrument_id {
+            let (token_id, _) =
+                resolve_requested_instrument(&self.shared_token_instruments, instrument_id)?;
+            params.asset_id = Some(token_id.to_string());
+        }
+        params.after = cmd
+            .start
+            .map(|timestamp| timestamp.as_u64() / 1_000_000_000);
+        params.before = cmd.end.map(|timestamp| timestamp.as_u64() / 1_000_000_000);
         let trades = self
             .http_client
-            .get_trades(GetTradesParams::default())
+            .get_trades(params)
             .await
             .context("failed to fetch trades")?;
 
         let ctx = self.fill_context();
-        let (mut reports, _) = build_fill_reports_from_trades(
+        let scope = match (cmd.instrument_id, cmd.venue_order_id) {
+            (Some(instrument_id), Some(venue_order_id)) => FillReconciliationScope::Order {
+                instrument_id,
+                venue_order_id,
+            },
+            (Some(instrument_id), None) => FillReconciliationScope::Instrument(instrument_id),
+            (None, Some(venue_order_id)) => FillReconciliationScope::VenueOrder(venue_order_id),
+            (None, None) => FillReconciliationScope::All,
+        };
+        let mut reports = build_fill_reports_from_trades(
             &trades,
             &ctx,
             &self.shared_token_instruments,
-            cmd.instrument_id,
+            &scope,
             self.clock.get_time_ns(),
-        );
+        )?;
 
         self.fill_tracker.snap_fill_reports(&mut reports);
 
@@ -563,11 +593,13 @@ impl PolymarketExecutionClient {
             .context("failed to fetch positions from Data API")?;
 
         let ts_now = self.clock.get_time_ns();
-        let mut reports = build_position_reports(&positions, self.core.account_id, ts_now);
-
-        if let Some(ref filter_id) = cmd.instrument_id {
-            reports.retain(|r| &r.instrument_id == filter_id);
-        }
+        let reports = build_position_reports(
+            &positions,
+            &self.shared_token_instruments,
+            self.core.account_id,
+            cmd.instrument_id,
+            ts_now,
+        )?;
 
         log::debug!("Generated {} position status reports", reports.len());
         Ok(reports)
@@ -614,16 +646,14 @@ async fn fetch_confirmed_fill_reports(
     ctx: &FillContext<'_>,
     token_instruments: &AtomicMap<Ustr, InstrumentAny>,
     params: GetTradesParams,
-    instrument_id: Option<InstrumentId>,
+    scope: FillReconciliationScope,
     ts_init: UnixNanos,
 ) -> anyhow::Result<Vec<FillReport>> {
     let trades = http_client
         .get_trades(params)
         .await
         .context("failed to fetch confirmed trades")?;
-    let (reports, _) =
-        build_fill_reports_from_trades(&trades, ctx, token_instruments, instrument_id, ts_init);
-    Ok(reports)
+    build_fill_reports_from_trades(&trades, ctx, token_instruments, &scope, ts_init)
 }
 
 pub(crate) fn get_pusd_currency() -> Currency {

--- a/crates/adapters/polymarket/src/execution/responses.rs
+++ b/crates/adapters/polymarket/src/execution/responses.rs
@@ -1069,13 +1069,14 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, _) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let reports = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
-            None,
+            &crate::execution::reconciliation::FillReconciliationScope::All,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("non-confirmed trades should be ignored without reconciliation failure");
 
         assert!(reports.is_empty());
     }

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -424,12 +424,16 @@ fn parse_trade_ticks(
 
 #[cfg(test)]
 mod tests {
+    use nautilus_core::collections::AtomicMap;
     use nautilus_model::{
-        enums::AggressorSide,
-        identifiers::{AccountId, InstrumentId},
+        enums::{AggressorSide, AssetClass},
+        identifiers::{AccountId, InstrumentId, Symbol},
+        instruments::{BinaryOption, InstrumentAny},
+        types::{Currency, Price, Quantity},
     };
     use rstest::rstest;
     use rust_decimal_macros::dec;
+    use ustr::Ustr;
 
     use super::*;
     use crate::{
@@ -442,6 +446,49 @@ mod tests {
         let path = "test_data/data_api_positions_response.json";
         let content = std::fs::read_to_string(path).expect("Failed to read test data");
         serde_json::from_str(&content).expect("Failed to parse test data")
+    }
+
+    fn position_instruments(positions: &[DataApiPosition]) -> AtomicMap<Ustr, InstrumentAny> {
+        let instruments = AtomicMap::new();
+
+        for position in positions {
+            let instrument_id = InstrumentId::from(
+                format!("{}-{}.POLYMARKET", position.condition_id, position.asset).as_str(),
+            );
+            let instrument = BinaryOption::new(
+                instrument_id,
+                Symbol::from(position.asset.as_str()),
+                AssetClass::Alternative,
+                Currency::pUSD(),
+                nautilus_core::UnixNanos::default(),
+                nautilus_core::UnixNanos::from(u64::MAX),
+                4,
+                USDC_DECIMALS as u8,
+                Price::from("0.0001"),
+                Quantity::from("0.000001"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                nautilus_core::UnixNanos::default(),
+                nautilus_core::UnixNanos::default(),
+            );
+            instruments.insert(
+                Ustr::from(position.asset.as_str()),
+                InstrumentAny::BinaryOption(instrument),
+            );
+        }
+        instruments
     }
 
     fn load_trades() -> Vec<DataApiTrade> {
@@ -468,8 +515,10 @@ mod tests {
         let positions = load_positions();
         let account_id = AccountId::from("POLYMARKET-001");
         let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
+        let instruments = position_instruments(&positions);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let reports = build_position_reports(&positions, &instruments, account_id, None, ts_now)
+            .expect("valid position reports");
 
         // 4 positions: 150.5, 0.0, 42.0, 0.005 (dust)
         // Only 150.5 and 42.0 pass the DUST_POSITION_THRESHOLD (0.01)
@@ -483,8 +532,10 @@ mod tests {
         let positions = load_positions();
         let account_id = AccountId::from("POLYMARKET-001");
         let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
+        let instruments = position_instruments(&positions);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let reports = build_position_reports(&positions, &instruments, account_id, None, ts_now)
+            .expect("valid position reports");
 
         assert_eq!(reports.len(), 2);
         assert_eq!(reports[0].avg_px_open, Some(dec!(0.55)));
@@ -496,8 +547,10 @@ mod tests {
         let positions = load_positions();
         let account_id = AccountId::from("POLYMARKET-001");
         let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
+        let instruments = position_instruments(&positions);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let reports = build_position_reports(&positions, &instruments, account_id, None, ts_now)
+            .expect("valid position reports");
 
         assert_eq!(reports.len(), 2);
         assert_eq!(reports[0].quantity.precision, USDC_DECIMALS as u8);
@@ -514,8 +567,10 @@ mod tests {
         }];
         let account_id = AccountId::from("POLYMARKET-001");
         let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
+        let instruments = position_instruments(&positions);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let reports = build_position_reports(&positions, &instruments, account_id, None, ts_now)
+            .expect("valid position reports");
 
         assert_eq!(reports.len(), 1);
         assert_eq!(reports[0].avg_px_open, None);

--- a/crates/adapters/polymarket/tests/exec_client.rs
+++ b/crates/adapters/polymarket/tests/exec_client.rs
@@ -93,6 +93,8 @@ use serde_json::{Value, json};
 const TEST_PRIVATE_KEY: &str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
 const TEST_SIGNER_ADDRESS: &str = "0x1be31a94361a391bbafb2a4ccd704f57dc04d4bb";
 const TEST_API_SECRET_B64: &str = "dGVzdF9zZWNyZXRfa2V5XzMyYnl0ZXNfcGFkMTIzNDU=";
+const TEST_TOKEN_ID: &str =
+    "71321045679252212594626385532706912750332728571942532289631379312455583992563";
 const DEFAULT_ACCEPTED_ORDER_ID: &str =
     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
 const CANCEL_ALREADY_DONE_ORDER_ID: &str =
@@ -197,6 +199,7 @@ struct TestServerState {
     book_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     single_order_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     trades_response_override: Arc<tokio::sync::Mutex<Option<Value>>>,
+    positions_response_override: Arc<tokio::sync::Mutex<Option<Value>>>,
 }
 
 impl Default for TestServerState {
@@ -241,6 +244,7 @@ impl Default for TestServerState {
             orders_response_override: Arc::new(tokio::sync::Mutex::new(None)),
             single_order_response: Arc::new(tokio::sync::Mutex::new(None)),
             trades_response_override: Arc::new(tokio::sync::Mutex::new(None)),
+            positions_response_override: Arc::new(tokio::sync::Mutex::new(None)),
             book_response: Arc::new(tokio::sync::Mutex::new(Some(json!({
                 "bids": [
                     {"price": "0.48", "size": "100.00"},
@@ -682,8 +686,14 @@ async fn handle_health() -> impl IntoResponse {
     StatusCode::OK
 }
 
-async fn handle_get_positions() -> impl IntoResponse {
-    Json(serde_json::json!([]))
+async fn handle_get_positions(State(state): State<TestServerState>) -> impl IntoResponse {
+    let positions = state
+        .positions_response_override
+        .lock()
+        .await
+        .clone()
+        .unwrap_or_else(|| json!([]));
+    Json(positions)
 }
 
 fn create_test_router(state: TestServerState) -> Router {
@@ -1123,7 +1133,7 @@ async fn test_exec_client_get_account_after_cache_add() {
 
 #[rstest]
 #[tokio::test]
-async fn test_generate_order_status_reports_empty_without_instruments() {
+async fn test_generate_order_status_reports_fails_without_instruments() {
     let state = TestServerState::default();
     let addr = start_mock_server(state).await;
     let (client, _rx, _cache) = create_test_execution_client(addr);
@@ -1141,10 +1151,17 @@ async fn test_generate_order_status_reports_empty_without_instruments() {
         causation_id: None,
     };
 
-    let reports = client.generate_order_status_reports(&cmd).await.unwrap();
+    let error = client
+        .generate_order_status_reports(&cmd)
+        .await
+        .unwrap_err();
 
-    // Without loaded instruments, orders cannot be resolved to instrument IDs
-    assert!(reports.is_empty());
+    assert!(
+        error
+            .to_string()
+            .contains("cannot map venue open order asset"),
+        "{error}"
+    );
 }
 
 #[rstest]
@@ -1212,7 +1229,52 @@ async fn test_generate_order_status_reports_recovers_confirmed_rest_fill() {
 
 #[rstest]
 #[tokio::test]
-async fn test_generate_fill_reports_empty_without_instruments() {
+async fn test_generate_order_status_reports_fails_on_unmapped_confirmed_fill() {
+    let venue_order_id_str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+    let state = TestServerState::default();
+    let mut order = load_json("http_open_orders_page.json")["data"][0].clone();
+    order["id"] = Value::String(venue_order_id_str.to_string());
+    order["status"] = Value::String("MATCHED".to_string());
+    order["original_size"] = Value::String("10.0000".to_string());
+    order["size_matched"] = Value::String("10.0000".to_string());
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [order],
+        "next_cursor": "LTE=",
+    }));
+    let mut trades = recovery_trades_response(venue_order_id_str, "10.0000", "0.5000");
+    trades["data"][0]["asset_id"] = Value::String("UNMAPPED-TOKEN".to_string());
+    *state.trades_response_override.lock().await = Some(trades);
+    let addr = start_mock_server(state.clone()).await;
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
+
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    let cmd = GenerateOrderStatusReports {
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        open_only: false,
+        instrument_id: Some(instrument_id),
+        start: None,
+        end: None,
+        params: None,
+        log_receipt_level: LogLevel::Info,
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    let error = client
+        .generate_order_status_reports(&cmd)
+        .await
+        .expect_err("an unmapped confirmed fill must fail order reconciliation");
+
+    assert!(error.to_string().contains("target taker fill"), "{error}");
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_fill_reports_fails_without_instruments() {
     let state = TestServerState::default();
     let addr = start_mock_server(state).await;
     let (client, _rx, _cache) = create_test_execution_client(addr);
@@ -1230,9 +1292,14 @@ async fn test_generate_fill_reports_empty_without_instruments() {
         causation_id: None,
     };
 
-    let reports = client.generate_fill_reports(cmd).await.unwrap();
+    let error = client.generate_fill_reports(cmd).await.unwrap_err();
 
-    assert!(reports.is_empty());
+    assert!(
+        error
+            .to_string()
+            .contains("cannot map confirmed taker fill"),
+        "{error}"
+    );
 }
 
 #[rstest]
@@ -1258,6 +1325,77 @@ async fn test_generate_position_status_reports_always_empty() {
 
     // Polymarket has no position endpoint
     assert!(reports.is_empty());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_position_status_reports_fails_on_unmapped_current_position() {
+    let state = TestServerState::default();
+    *state.positions_response_override.lock().await = Some(json!([{
+        "asset": "UNMAPPED-TOKEN",
+        "conditionId": "0xcondition",
+        "size": 10,
+        "avgPrice": 0.5,
+    }]));
+    let addr = start_mock_server(state).await;
+    let (client, _rx, _cache) = create_test_execution_client(addr);
+    let cmd = GeneratePositionStatusReports {
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        instrument_id: None,
+        start: None,
+        end: None,
+        params: None,
+        log_receipt_level: LogLevel::Info,
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    let error = client
+        .generate_position_status_reports(&cmd)
+        .await
+        .expect_err("an unmapped current position must fail reconciliation");
+
+    assert!(
+        error.to_string().contains("cannot map Data API position"),
+        "{error}"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_mass_status_fails_on_unmapped_current_position() {
+    let state = TestServerState::default();
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [],
+        "next_cursor": "LTE=",
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [],
+        "next_cursor": "LTE=",
+    }));
+    *state.positions_response_override.lock().await = Some(json!([{
+        "asset": "UNMAPPED-TOKEN",
+        "conditionId": "0xcondition",
+        "size": 10,
+        "avgPrice": 0.5,
+    }]));
+    let addr = start_mock_server(state).await;
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+
+    let error = client
+        .generate_mass_status(None)
+        .await
+        .expect_err("mass reconciliation must fail on an unmapped current position");
+
+    assert!(
+        error.to_string().contains("cannot map Data API position"),
+        "{error}"
+    );
 }
 
 #[rstest]
@@ -1311,9 +1449,12 @@ async fn test_generate_order_status_report_single_requires_instrument_id() {
 async fn test_generate_order_status_report_single_returns_report() {
     let state = TestServerState::default();
     let addr = start_mock_server(state).await;
-    let (client, _rx, _cache) = create_test_execution_client(addr);
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
 
     let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
     let cmd = GenerateOrderStatusReport {
         command_id: UUID4::new(),
         ts_init: UnixNanos::default(),
@@ -1334,6 +1475,42 @@ async fn test_generate_order_status_report_single_returns_report() {
     assert_eq!(report.order_type, OrderType::Limit,);
     assert_eq!(report.filled_qty, Quantity::zero(4));
     assert!(report.price.is_some());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_order_status_report_rejects_asset_mismatch() {
+    let state = TestServerState::default();
+    let mut order = load_json("http_open_order.json");
+    order["asset_id"] = Value::String("UNMAPPED-TOKEN".to_string());
+    *state.single_order_response.lock().await = Some(order);
+    let addr = start_mock_server(state).await;
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    let cmd = GenerateOrderStatusReport {
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        instrument_id: Some(instrument_id),
+        client_order_id: None,
+        venue_order_id: Some(VenueOrderId::from("0x123")),
+        params: None,
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    let error = client
+        .generate_order_status_report(&cmd)
+        .await
+        .expect_err("a venue order for another asset must not be relabeled");
+
+    assert!(
+        error
+            .to_string()
+            .contains("does not match requested instrument")
+    );
 }
 
 #[rstest]
@@ -1388,6 +1565,63 @@ async fn test_generate_order_status_report_defers_while_trade_is_unconfirmed() {
 
     assert_eq!(report.order_status, OrderStatus::Accepted);
     assert_eq!(report.filled_qty, Quantity::zero(4));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_pending_trade_does_not_hide_invalid_confirmed_fill() {
+    let venue_order_id_str = DEFAULT_ACCEPTED_ORDER_ID;
+    let state = TestServerState::default();
+    *state.single_order_response.lock().await = Some(Value::Null);
+    let mut pending =
+        recovery_trades_response(venue_order_id_str, "1.0000", "0.5000")["data"][0].clone();
+    pending["status"] = Value::String("MINED".to_string());
+    let mut invalid_confirmed =
+        recovery_trades_response(venue_order_id_str, "1.0000", "0.5000")["data"][0].clone();
+    invalid_confirmed["id"] = Value::String("invalid-confirmed".to_string());
+    invalid_confirmed["asset_id"] = Value::String("UNMAPPED-TOKEN".to_string());
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [pending, invalid_confirmed],
+        "next_cursor": "LTE=",
+    }));
+    let addr = start_mock_server(state).await;
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    let client_order_id = ClientOrderId::from("O-PENDING-WITH-INVALID-CONFIRMED");
+    let mut order = make_limit_order(
+        client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        false,
+        false,
+        false,
+        TimeInForce::Gtc,
+    );
+    cache
+        .borrow_mut()
+        .add_order(order.clone(), None, None, false)
+        .unwrap();
+    submit_and_accept_order(&cache, &mut order, venue_order_id_str);
+    let cmd = GenerateOrderStatusReport {
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        instrument_id: Some(instrument_id),
+        client_order_id: Some(client_order_id),
+        venue_order_id: Some(VenueOrderId::from(venue_order_id_str)),
+        params: None,
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    let error = client
+        .generate_order_status_report(&cmd)
+        .await
+        .expect_err("a pending fill must not bypass confirmed-fill validation");
+
+    assert!(error.to_string().contains("target taker fill"));
 }
 
 #[rstest]
@@ -1448,6 +1682,46 @@ async fn test_generate_active_order_report_recovers_confirmed_rest_fill() {
 
     assert_eq!(report.order_status, OrderStatus::Filled);
     assert_eq!(report.filled_qty, Quantity::from("10.0000"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_active_order_report_fails_on_unmapped_confirmed_fill() {
+    let venue_order_id_str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+    let state = TestServerState::default();
+    let mut order = load_json("http_open_order.json");
+    order["id"] = Value::String(venue_order_id_str.to_string());
+    order["status"] = Value::String("MATCHED".to_string());
+    order["original_size"] = Value::String("10.0000".to_string());
+    order["size_matched"] = Value::String("10.0000".to_string());
+    *state.single_order_response.lock().await = Some(order);
+    let mut trades = recovery_trades_response(venue_order_id_str, "10.0000", "0.5000");
+    trades["data"][0]["asset_id"] = Value::String("UNMAPPED-TOKEN".to_string());
+    *state.trades_response_override.lock().await = Some(trades);
+    let addr = start_mock_server(state).await;
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
+
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    let cmd = GenerateOrderStatusReport {
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        instrument_id: Some(instrument_id),
+        client_order_id: None,
+        venue_order_id: Some(VenueOrderId::from(venue_order_id_str)),
+        params: None,
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    let error = client
+        .generate_order_status_report(&cmd)
+        .await
+        .expect_err("an unmapped confirmed fill must fail order reconciliation");
+
+    assert!(error.to_string().contains("target taker fill"), "{error}");
 }
 
 #[rstest]
@@ -2652,7 +2926,7 @@ async fn test_fok_deferred_check_emits_terminal_event(
         "price": "0.5100",
         "side": "BUY",
         "size_matched": "0.0000",
-        "asset_id": "TEST-TOKEN",
+        "asset_id": TEST_TOKEN_ID,
         "expiration": null,
         "order_type": "FOK",
         "created_at": 1_703_875_200_000_i64
@@ -2727,7 +3001,7 @@ async fn test_fok_deferred_check_filled_emits_report_for_reconciliation() {
         "price": "0.5100",
         "side": "BUY",
         "size_matched": "10.0000",
-        "asset_id": "TEST-TOKEN",
+        "asset_id": TEST_TOKEN_ID,
         "expiration": null,
         "order_type": "FOK",
         "created_at": 1_703_875_200_000_i64
@@ -2983,7 +3257,7 @@ fn add_instrument_to_cache_with_precisions(
     price_precision: u8,
     size_precision: u8,
 ) {
-    let symbol = "71321045679252212594626385532706912750332728571942532289631379312455583992563";
+    let symbol = TEST_TOKEN_ID;
     let size_increment = if size_precision == 0 {
         Quantity::from("1")
     } else {
@@ -6201,6 +6475,8 @@ async fn test_query_order_does_not_block_within_runtime() {
 
     let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
     add_instrument_to_cache(&cache, instrument_id);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
 
     let cmd = QueryOrder::new(
         TraderId::from("TESTER-001"),
@@ -6230,10 +6506,11 @@ async fn test_query_order_does_not_block_within_runtime() {
 #[rstest]
 #[tokio::test]
 async fn test_query_order_excludes_unconfirmed_matched_quantity() {
+    let venue_order_id_str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
     let state = TestServerState::default();
     *state.single_order_response.lock().await = Some(json!({
         "associate_trades": ["pending-trade"],
-        "id": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12",
+        "id": venue_order_id_str,
         "status": "MATCHED",
         "market": "0xtest",
         "original_size": "10.0000",
@@ -6243,26 +6520,29 @@ async fn test_query_order_excludes_unconfirmed_matched_quantity() {
         "price": "0.5100",
         "side": "BUY",
         "size_matched": "10.0000",
-        "asset_id": "TEST-TOKEN",
+        "asset_id": TEST_TOKEN_ID,
         "expiration": null,
         "order_type": "GTC",
         "created_at": 1_703_875_200_i64
     }));
+    let mut trades = recovery_trades_response(venue_order_id_str, "10.0000", "0.5000");
+    trades["data"][0]["status"] = Value::String("MINED".to_string());
+    *state.trades_response_override.lock().await = Some(trades);
     let addr = start_mock_server(state).await;
     let (mut client, mut rx, cache) = create_test_execution_client(addr);
     client.start().unwrap();
 
     let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
     add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
     let cmd = QueryOrder::new(
         TraderId::from("TESTER-001"),
         Some(*POLYMARKET_CLIENT_ID),
         StrategyId::from("S-001"),
         instrument_id,
         ClientOrderId::from("O-QUERY-PENDING"),
-        Some(VenueOrderId::from(
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12",
-        )),
+        Some(VenueOrderId::from(venue_order_id_str)),
         UUID4::new(),
         UnixNanos::default(),
         None,
@@ -6283,6 +6563,71 @@ async fn test_query_order_excludes_unconfirmed_matched_quantity() {
         }
         other => panic!("Expected Order report, was {other:?}"),
     }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_emits_no_partial_report_for_unmapped_confirmed_fill() {
+    let venue_order_id_str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+    let state = TestServerState::default();
+    *state.single_order_response.lock().await = Some(json!({
+        "associate_trades": ["confirmed-trade"],
+        "id": venue_order_id_str,
+        "status": "MATCHED",
+        "market": "0xtest",
+        "original_size": "10.0000",
+        "outcome": "Yes",
+        "maker_address": "0xtest",
+        "owner": "test-owner",
+        "price": "0.5100",
+        "side": "BUY",
+        "size_matched": "10.0000",
+        "asset_id": TEST_TOKEN_ID,
+        "expiration": null,
+        "order_type": "GTC",
+        "created_at": 1_703_875_200_i64
+    }));
+    let mut trades = recovery_trades_response(venue_order_id_str, "10.0000", "0.5000");
+    trades["data"][0]["asset_id"] = Value::String("UNMAPPED-TOKEN".to_string());
+    *state.trades_response_override.lock().await = Some(trades);
+    let addr = start_mock_server(state.clone()).await;
+    let (mut client, mut rx, cache) = create_test_execution_client(addr);
+    client.start().unwrap();
+
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    let cmd = QueryOrder::new(
+        TraderId::from("TESTER-001"),
+        Some(*POLYMARKET_CLIENT_ID),
+        StrategyId::from("S-001"),
+        instrument_id,
+        ClientOrderId::from("O-QUERY-UNMAPPED-FILL"),
+        Some(VenueOrderId::from(venue_order_id_str)),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.query_order(cmd).unwrap();
+
+    let observed_state = state.clone();
+    wait_until_async(
+        || {
+            let observed_state = observed_state.clone();
+            async move { observed_state.last_path.lock().await.as_str() == "/data/trades" }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), rx.recv())
+            .await
+            .is_err(),
+        "query_order must not emit a partial report after reconciliation loses a confirmed fill"
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

- reject Polymarket reconciliation snapshots that contain unmapped or unrepresentable orders, confirmed fills, or positions
- preserve complete order/fill/position report relationships across pagination and terminal-order reconstruction
- keep the change entirely inside the Polymarket adapter

## Why

The adapter could silently omit venue state it could not map into NautilusTrader. During startup reconciliation, that made an incomplete venue snapshot indistinguishable from a complete one and could let the live node start from incomplete execution state.

The corrected adapter returns an error instead. NautilusTrader's existing startup reconciliation path propagates that error and aborts startup.

This is the adapter-only portion split from #4557 following maintainer feedback. It does not add an execution-engine mode, public reconciliation-capability API, or live-node policy.

## Validation

- `make pre-commit`
- `cargo nextest run -p nautilus-polymarket --no-fail-fast` — 1,150 passed, 0 skipped
