### PR TITLE
Convert serialization decode against the model's resolved raw types

### DIFF
--- a/crates/serialization/src/capnp/conversions.rs
+++ b/crates/serialization/src/capnp/conversions.rs
@@ -46,7 +46,10 @@ use nautilus_model::{
         AccountId, ActorId, ClientId, ClientOrderId, ComponentId, ExecAlgorithmId, InstrumentId,
         OrderListId, PositionId, StrategyId, Symbol, TradeId, TraderId, Venue, VenueOrderId,
     },
-    types::{AccountBalance, Currency, MarginBalance, Money, Price, Quantity},
+    types::{
+        AccountBalance, Currency, MarginBalance, Money, Price, Quantity, money::MoneyRaw,
+        price::PriceRaw, quantity::QuantityRaw,
+    },
 };
 use rust_decimal::Decimal;
 use ustr::Ustr;
@@ -54,8 +57,9 @@ use uuid::Uuid;
 
 use super::{FromCapnp, ToCapnp};
 use crate::{
-    base_capnp, enums_capnp, identifiers_capnp, market_capnp, order_capnp, position_capnp,
-    types_capnp,
+    base_capnp, enums_capnp, identifiers_capnp, market_capnp,
+    numeric::{raw_to_wire, wire_to_raw},
+    order_capnp, position_capnp, types_capnp,
 };
 
 trait CapnpWriteExt<'a, T>
@@ -442,9 +446,8 @@ impl<'a> FromCapnp<'a> for InstrumentId {
 impl<'a> ToCapnp<'a> for Price {
     type Builder = types_capnp::price::Builder<'a>;
 
-    #[expect(clippy::useless_conversion)] // Needed for non-high-precision builds
     fn to_capnp(&self, mut builder: Self::Builder) {
-        let raw_i128: i128 = self.raw.into();
+        let raw_i128: i128 = raw_to_wire(self.raw);
         let lo = raw_i128 as u64;
         let hi = (raw_i128 >> 64) as u64;
 
@@ -470,25 +473,19 @@ impl<'a> FromCapnp<'a> for Price {
         // to all upper bits when widened to i128, preserving two's complement.
         let raw_i128 = ((hi as i64 as i128) << 64) | (lo as i128);
 
-        #[cfg(not(feature = "high-precision"))]
-        let raw = i64::try_from(raw_i128).map_err(|_| -> Box<dyn Error> {
+        let raw: PriceRaw = wire_to_raw(raw_i128).ok_or_else(|| -> Box<dyn Error> {
             "Price value overflows i64 in standard precision mode".into()
         })?;
 
-        #[cfg(feature = "high-precision")]
-        let raw = raw_i128;
-
-        #[expect(clippy::useless_conversion)] // Needed for non-high-precision builds
-        Ok(Self::from_raw(raw.into(), precision))
+        Ok(Self::from_raw(raw, precision))
     }
 }
 
 impl<'a> ToCapnp<'a> for Quantity {
     type Builder = types_capnp::quantity::Builder<'a>;
 
-    #[expect(clippy::useless_conversion)] // Needed for non-high-precision builds
     fn to_capnp(&self, mut builder: Self::Builder) {
-        let raw_u128: u128 = self.raw.into();
+        let raw_u128: u128 = raw_to_wire(self.raw);
         let lo = raw_u128 as u64;
         let hi = (raw_u128 >> 64) as u64;
 
@@ -512,16 +509,11 @@ impl<'a> FromCapnp<'a> for Quantity {
         // Reconstruct u128 from two u64 halves (unsigned, no sign extension needed)
         let raw_u128 = ((hi as u128) << 64) | (lo as u128);
 
-        #[cfg(not(feature = "high-precision"))]
-        let raw = u64::try_from(raw_u128).map_err(|_| -> Box<dyn Error> {
+        let raw: QuantityRaw = wire_to_raw(raw_u128).ok_or_else(|| -> Box<dyn Error> {
             "Quantity value overflows u64 in standard precision mode".into()
         })?;
 
-        #[cfg(feature = "high-precision")]
-        let raw = raw_u128;
-
-        #[expect(clippy::useless_conversion)] // Needed for non-high-precision builds
-        Ok(Self::from_raw(raw.into(), precision))
+        Ok(Self::from_raw(raw, precision))
     }
 }
 
@@ -1216,11 +1208,10 @@ impl<'a> FromCapnp<'a> for Currency {
 impl<'a> ToCapnp<'a> for Money {
     type Builder = types_capnp::money::Builder<'a>;
 
-    #[expect(clippy::useless_conversion)] // Needed for non-high-precision builds
     fn to_capnp(&self, mut builder: Self::Builder) {
         let mut raw_builder = builder.reborrow().init_raw();
 
-        let raw_i128: i128 = self.raw.into();
+        let raw_i128: i128 = raw_to_wire(self.raw);
         raw_builder.set_lo(raw_i128 as u64);
         raw_builder.set_hi((raw_i128 >> 64) as u64);
 
@@ -1243,18 +1234,11 @@ impl<'a> FromCapnp<'a> for Money {
         let currency_reader = reader.get_currency()?;
         let currency = Currency::from_capnp(currency_reader)?;
 
-        #[cfg(not(feature = "high-precision"))]
-        {
-            let raw = i64::try_from(raw_i128).map_err(|_| -> Box<dyn Error> {
-                "Money value overflows i64 in standard precision mode".into()
-            })?;
-            Ok(Self::from_raw(raw.into(), currency))
-        }
+        let raw: MoneyRaw = wire_to_raw(raw_i128).ok_or_else(|| -> Box<dyn Error> {
+            "Money value overflows i64 in standard precision mode".into()
+        })?;
 
-        #[cfg(feature = "high-precision")]
-        {
-            Ok(Self::from_raw(raw_i128, currency))
-        }
+        Ok(Self::from_raw(raw, currency))
     }
 }
 

--- a/crates/serialization/src/lib.rs
+++ b/crates/serialization/src/lib.rs
@@ -108,6 +108,9 @@ pub mod capnp;
 #[cfg(feature = "sbe")]
 pub mod sbe;
 
+#[cfg(any(feature = "capnp", feature = "sbe"))]
+mod numeric;
+
 #[cfg(feature = "capnp")]
 macro_rules! include_capnp_module {
     ($name:ident, $path:expr) => {

--- a/crates/serialization/src/numeric.rs
+++ b/crates/serialization/src/numeric.rs
@@ -1,0 +1,40 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Numeric conversions between wire integers and model raw types.
+//!
+//! These generic boundaries follow the model's resolved raw aliases independently of this
+//! crate's `high-precision` forwarding feature. Keeping them generic is deliberate: the target
+//! width comes from `PriceRaw`, `QuantityRaw` and `MoneyRaw`, so codec code never needs to
+//! inspect a precision feature of its own to decide how wide a value may be. Inlining these
+//! conversions back into the codecs would reintroduce that coupling.
+
+/// Converts a wire integer into the resolved model raw type, returning `None` on overflow.
+#[inline]
+pub(crate) fn wire_to_raw<R, W>(wire: W) -> Option<R>
+where
+    R: TryFrom<W>,
+{
+    R::try_from(wire).ok()
+}
+
+/// Converts a model raw integer into its lossless wire representation.
+#[inline]
+pub(crate) fn raw_to_wire<W, R>(raw: R) -> W
+where
+    W: From<R>,
+{
+    W::from(raw)
+}

--- a/crates/serialization/src/sbe/market/common.rs
+++ b/crates/serialization/src/sbe/market/common.rs
@@ -31,6 +31,7 @@ use super::{
     super::{MAX_GROUP_SIZE, SbeCursor, SbeDecodeError, SbeEncodeError, SbeWriter},
     MARKET_SCHEMA_ID, MARKET_SCHEMA_VERSION,
 };
+use crate::numeric::{raw_to_wire, wire_to_raw};
 
 pub(super) const PRICE_BLOCK_LENGTH: u16 = 17;
 pub(super) const QUANTITY_BLOCK_LENGTH: u16 = 17;
@@ -116,13 +117,9 @@ pub(super) fn validate_header(
 
 #[inline]
 pub(super) fn encode_price(writer: &mut SbeWriter<'_>, price: &Price) {
-    #[allow(
-        clippy::useless_conversion,
-        reason = "from is a no-op when PriceRaw is i128 (high-precision), and widens when i64"
-    )]
-    let raw = i128::from(price.raw);
+    let raw_i128: i128 = raw_to_wire(price.raw);
 
-    writer.write_i128_le(raw);
+    writer.write_i128_le(raw_i128);
     writer.write_u8(price.precision);
 }
 
@@ -132,25 +129,17 @@ pub(super) fn decode_price(cursor: &mut SbeCursor<'_>) -> Result<Price, SbeDecod
     let precision = cursor.read_u8()?;
     validate_precision("Price.precision", precision)?;
 
-    #[cfg(not(feature = "high-precision"))]
-    let raw = i64::try_from(raw_i128)
-        .map_err(|_| SbeDecodeError::NumericOverflow { type_name: "Price" })?;
+    let raw: PriceRaw =
+        wire_to_raw(raw_i128).ok_or(SbeDecodeError::NumericOverflow { type_name: "Price" })?;
 
-    #[cfg(feature = "high-precision")]
-    let raw = raw_i128;
-
-    Ok(Price::from_raw(raw as PriceRaw, precision))
+    Ok(Price::from_raw(raw, precision))
 }
 
 #[inline]
 pub(super) fn encode_quantity(writer: &mut SbeWriter<'_>, quantity: &Quantity) {
-    #[allow(
-        clippy::useless_conversion,
-        reason = "from is a no-op when QuantityRaw is u128 (high-precision), and widens when u64"
-    )]
-    let raw = u128::from(quantity.raw);
+    let raw_u128: u128 = raw_to_wire(quantity.raw);
 
-    writer.write_u128_le(raw);
+    writer.write_u128_le(raw_u128);
     writer.write_u8(quantity.precision);
 }
 
@@ -160,15 +149,11 @@ pub(super) fn decode_quantity(cursor: &mut SbeCursor<'_>) -> Result<Quantity, Sb
     let precision = cursor.read_u8()?;
     validate_precision("Quantity.precision", precision)?;
 
-    #[cfg(not(feature = "high-precision"))]
-    let raw = u64::try_from(raw_u128).map_err(|_| SbeDecodeError::NumericOverflow {
+    let raw: QuantityRaw = wire_to_raw(raw_u128).ok_or(SbeDecodeError::NumericOverflow {
         type_name: "Quantity",
     })?;
 
-    #[cfg(feature = "high-precision")]
-    let raw = raw_u128;
-
-    Ok(Quantity::from_raw(raw as QuantityRaw, precision))
+    Ok(Quantity::from_raw(raw, precision))
 }
 
 #[inline]

--- a/crates/serialization/tests/test_market_data_capnp.rs
+++ b/crates/serialization/tests/test_market_data_capnp.rs
@@ -36,9 +36,16 @@ use nautilus_model::{
         MarketStatusAction, OrderSide, PriceType,
     },
     identifiers::{InstrumentId, TradeId},
-    types::{Price, Quantity},
+    types::{Currency, Money, Price, Quantity},
 };
-use nautilus_serialization::capnp::{FromCapnp, ToCapnp, market_capnp};
+use nautilus_serialization::capnp::{
+    FromCapnp, ToCapnp,
+    conversions::{
+        deserialize_money, deserialize_price, deserialize_quantity, serialize_money,
+        serialize_price, serialize_quantity,
+    },
+    market_capnp,
+};
 use rstest::rstest;
 use rust_decimal_macros::dec;
 use ustr::Ustr;
@@ -77,6 +84,24 @@ fn test_quote_tick_roundtrip() {
     assert_eq!(quote.ask_size, decoded.ask_size);
     assert_eq!(quote.ts_event, decoded.ts_event);
     assert_eq!(quote.ts_init, decoded.ts_init);
+}
+
+#[rstest]
+fn test_capnp_resolved_raw_width_roundtrip() {
+    // Values chosen so their fixed-point raw crosses 64 bits only when the model resolves to
+    // high precision, which is what makes this decode against the resolved alias rather than
+    // this crate's own feature.
+    let price = Price::from("50000.00");
+    let quantity = Quantity::from("20000.00");
+    let money = Money::new(20_000.0, Currency::USD());
+
+    let price_bytes = serialize_price(&price).unwrap();
+    let quantity_bytes = serialize_quantity(&quantity).unwrap();
+    let money_bytes = serialize_money(&money).unwrap();
+
+    assert_eq!(deserialize_price(&price_bytes).unwrap(), price);
+    assert_eq!(deserialize_quantity(&quantity_bytes).unwrap(), quantity);
+    assert_eq!(deserialize_money(&money_bytes).unwrap(), money);
 }
 
 #[rstest]

--- a/crates/serialization/tests/test_market_data_sbe.rs
+++ b/crates/serialization/tests/test_market_data_sbe.rs
@@ -110,6 +110,23 @@ fn test_book_order_roundtrip() {
 }
 
 #[rstest]
+fn test_sbe_resolved_raw_width_roundtrip() {
+    // Price and Quantity raws exceed 64 bits only under high precision, so this pins decode to
+    // the model's resolved alias rather than this crate's own feature.
+    let value = BookOrder::new(
+        OrderSide::Buy,
+        Price::from("50000.00"),
+        Quantity::from("20000.00"),
+        123_456,
+    );
+
+    let bytes = value.to_sbe().unwrap();
+    let decoded = BookOrder::from_sbe(&bytes).unwrap();
+
+    assert_book_order_fields(&value, &decoded);
+}
+
+#[rstest]
 fn test_order_book_delta_roundtrip() {
     let value = stub_delta();
 


### PR DESCRIPTION
A follow-up to #4550 implementing the root fix you asked for on that thread.

## Decode narrowing keyed on the serializer's own feature

`nautilus-model` resolves `PriceRaw`, `QuantityRaw` and `MoneyRaw` to 128-bit or 64-bit integers from its `high-precision` feature. The five `nautilus-serialization` decode sites - `decode_price` and `decode_quantity` in `sbe/market/common.rs`, and `Price`/`Quantity`/`Money` `from_capnp` in `capnp/conversions.rs` - instead branch on `nautilus-serialization`'s own `high-precision`, which only forwards to the model. The two are not the same predicate: a build can activate `nautilus-model/high-precision` without `nautilus-serialization/high-precision`, and then decode compiles its `#[cfg(not(feature = "high-precision"))]` path against 128-bit aliases. Any raw beyond the 64-bit range fails with `SbeDecodeError::NumericOverflow` or the capnp overflow string, even though `Price::from_raw` would accept it. Encode is unaffected: all five encoders widen to a fixed 128-bit wire representation with no feature branch.

`nautilus-common` is a concrete in-tree route - its `capnp` and `sbe` features activate `dep:nautilus-serialization` independently, while the `nautilus-serialization?/high-precision` forward hangs off `nautilus-common/high-precision`, so `nautilus-common/capnp` plus a direct `nautilus-model/high-precision` reproduces the desync. `nautilus-common/defi` is another, since model `defi` implies model high precision. Any external crate can do the same.

The fix adds one crate-private `numeric.rs` with `wire_to_raw` and `raw_to_wire`, generic over the resolved raw type, and routes all ten codec sites through it. Decode now converts into `PriceRaw`/`QuantityRaw`/`MoneyRaw` directly, so it tracks the model's actual width and `nautilus-serialization/high-precision` becomes a convenience alias rather than a correctness input. Error variants and message strings are unchanged.

## Feature-conditional lint attributes left only one configuration buildable

The same asymmetry had a second consequence. Five `#[expect(clippy::useless_conversion)]` attributes on the encoders are fulfilled only when the resolved raw is 128-bit, and two on the capnp decoders only when it is 64-bit. An unfulfilled `#[expect]` is itself an error under `-D warnings`, so each width errored on the attributes belonging to the other. Nothing in CI observes this: `make clippy` runs `--all-features`, which always resolves high precision, and `make check-features` is `cargo hack --each-feature`, which is `cargo check` and never evaluates `clippy::` expectations. Separately, `Money::from_capnp`'s standard-precision branch did `from_raw(raw.into())` with `raw` already `i64` - a real `useless_conversion`, not an expectation artifact.

Because clippy checks a generic body before monomorphization, an identity conversion is invisible through the helpers' type parameter, so no suppression is needed in any width. All seven attributes are deleted and none added.

## Testing

`cargo clippy -p nautilus-serialization --all-targets -- -D warnings` and `cargo test -p nautilus-serialization`, across the three width configurations:

| features | before | after |
|---|---|---|
| `capnp,sbe` | 6 clippy errors: 5 unfulfilled expectations, 1 `useless_conversion` | clean, tests pass |
| `capnp,sbe,high-precision` | clean, tests pass | clean, tests pass |
| `capnp,sbe,nautilus-model/high-precision` | 2 clippy errors; clippy aborts before any test runs | clean, tests pass |

`test_capnp_resolved_raw_width_roundtrip` round-trips `Price`, `Quantity` and `Money` through the crate's `serialize_*`/`deserialize_*` helpers; `test_sbe_resolved_raw_width_roundtrip` round-trips a `BookOrder` carrying the same price and quantity. Both use ordinary economic values whose fixed-point raw crosses 64 bits only when the model resolves to high precision - `Price::from("50000.00")`, `Quantity::from("20000.00")`, `Money::new(20_000.0, Currency::USD())` - so they carry no `cfg` and no width-dependent assertions; the dependency graph supplies the differential.

Both tests were verified to FAIL against the unfixed decode in the third configuration, and each decode site was then reverted individually to confirm the assertions bite separately rather than all tripping on the first one: reverting only capnp `Money` fails at the money assertion with `"Money value overflows i64 in standard precision mode"`, only capnp `Quantity` fails at the quantity assertion with its own message, and only SBE `decode_quantity` fails inside `from_sbe` with `NumericOverflow { type_name: "Quantity" }`. The existing direct Money capnp test used raw `100_000_000`, which fits both widths and so could not catch this.

## Guarding against a recurrence

As you noted, a compile-only feature sweep cannot catch this class, and no Rust test can select the dependency graph it is compiled in - so the committed tests and the third invocation above are jointly the regression. What the change enforces structurally is that codec code no longer inspects its own precision feature: after this there is no `cfg(feature = "high-precision")` left in the SBE or capnp paths, so the desync cannot reappear by omission. If you want a mechanical guard, a `.pre-commit-hooks` check forbidding that `cfg` under `crates/serialization/src/{sbe,capnp}` would do it.
