### PR TITLE
Fix reverse exchange-rate spread side and make route selection deterministic

### DIFF
--- a/crates/common/src/python/xrate.rs
+++ b/crates/common/src/python/xrate.rs
@@ -31,10 +31,11 @@ use crate::xrate::get_exchange_rate;
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - `price_type` is equal to `Last` or `Mark` (cannot calculate from quotes).
+/// For conversions between distinct currencies (an identical `from_currency` and `to_currency`
+/// returns a rate of one without inspecting the quotes), returns an error if:
 /// - `quotes_bid` or `quotes_ask` is empty.
 /// - `quotes_bid` and `quotes_ask` lengths are not equal.
+/// - `price_type` is equal to `Last` or `Mark` (cannot calculate from quotes).
 /// - The bid or ask side of a pair is missing.
 #[pyfunction]
 #[pyo3_stub_gen::derive::gen_stub_pyfunction(module = "nautilus_trader.common")]

--- a/crates/common/src/xrate.rs
+++ b/crates/common/src/xrate.rs
@@ -22,6 +22,18 @@ use nautilus_model::enums::PriceType;
 use rust_decimal::Decimal;
 use ustr::Ustr;
 
+fn directional_rates(bid: Decimal, ask: Decimal, price_type: PriceType) -> (Decimal, Decimal) {
+    match price_type {
+        PriceType::Bid => (bid, Decimal::ONE / ask),
+        PriceType::Ask => (ask, Decimal::ONE / bid),
+        PriceType::Mid => {
+            let mid = (bid + ask) / Decimal::TWO;
+            (mid, Decimal::ONE / mid)
+        }
+        _ => unreachable!("Price type was validated before graph construction"),
+    }
+}
+
 /// Calculates the exchange rate between two currencies using provided bid and ask quotes.
 ///
 /// This function builds a graph of direct conversion rates from the quotes and uses a DFS to
@@ -31,17 +43,18 @@ use ustr::Ustr;
 ///
 /// # Errors
 ///
-/// Returns an error if:
-/// - `price_type` is equal to `Last` or `Mark` (cannot calculate from quotes).
+/// For conversions between distinct currencies (an identical `from_currency` and `to_currency`
+/// returns a rate of one without inspecting the quotes), returns an error if:
 /// - `quotes_bid` or `quotes_ask` is empty.
 /// - `quotes_bid` and `quotes_ask` lengths are not equal.
+/// - `price_type` is equal to `Last` or `Mark` (cannot calculate from quotes).
 /// - The bid or ask side of a pair is missing.
 pub fn get_exchange_rate(
     from_currency: Ustr,
     to_currency: Ustr,
     price_type: PriceType,
     quotes_bid: AHashMap<Ustr, Decimal>,
-    quotes_ask: AHashMap<Ustr, Decimal>,
+    mut quotes_ask: AHashMap<Ustr, Decimal>,
 ) -> anyhow::Result<Option<Decimal>> {
     if from_currency == to_currency {
         // When the source and target currencies are identical,
@@ -57,46 +70,44 @@ pub fn get_exchange_rate(
         anyhow::bail!("Quote maps must have equal lengths");
     }
 
-    // Build effective quotes based on the requested price type
-    let effective_quotes: AHashMap<Ustr, Decimal> = match price_type {
-        PriceType::Bid => quotes_bid,
-        PriceType::Ask => quotes_ask,
-        PriceType::Mid => {
-            let mut mid_quotes = AHashMap::new();
-
-            for (pair, bid) in &quotes_bid {
-                let ask = quotes_ask
-                    .get(pair)
-                    .ok_or_else(|| anyhow::anyhow!("Missing ask quote for pair {pair}"))?;
-                mid_quotes.insert(*pair, (bid + ask) / Decimal::TWO);
-            }
-            mid_quotes
-        }
-        _ => anyhow::bail!("Invalid `price_type`, was '{price_type}'"),
-    };
+    // Validated here, in the same position as the price-type match this replaced, so the
+    // identical-currency shortcut and the quote-map errors keep their original precedence.
+    if !matches!(price_type, PriceType::Bid | PriceType::Ask | PriceType::Mid) {
+        anyhow::bail!("Invalid `price_type`, was '{price_type}'");
+    }
 
     // Construct a graph: each currency maps to its neighbors and corresponding conversion rate
     let mut graph: AHashMap<Ustr, Vec<(Ustr, Decimal)>> = AHashMap::new();
-    for (pair, rate) in effective_quotes {
+
+    for (pair, bid) in quotes_bid {
+        let ask = quotes_ask
+            .remove(&pair)
+            .ok_or_else(|| anyhow::anyhow!("Missing ask quote for pair {pair}"))?;
         let parts: Vec<&str> = pair.split('/').collect();
+
         if parts.len() != 2 {
             log::warn!("Skipping invalid pair string: {pair}");
             continue;
         }
 
-        if rate <= Decimal::ZERO {
-            // A non-positive quote would divide by zero on the inverse edge
-            log::warn!("Skipping non-positive rate for pair {pair}");
+        if bid <= Decimal::ZERO || ask <= Decimal::ZERO {
+            // Both sides are required to build valid forward and reverse edges.
+            log::warn!("Skipping pair with non-positive bid or ask rate: {pair}");
             continue;
         }
+
         let base = Ustr::from(parts[0]);
         let quote = Ustr::from(parts[1]);
+        let (forward_rate, reverse_rate) = directional_rates(bid, ask, price_type);
 
-        graph.entry(base).or_default().push((quote, rate));
-        graph
-            .entry(quote)
-            .or_default()
-            .push((base, Decimal::ONE / rate));
+        graph.entry(base).or_default().push((quote, forward_rate));
+        graph.entry(quote).or_default().push((base, reverse_rate));
+    }
+
+    // Descending total order makes the smallest distinct neighbor the first branch popped from
+    // the LIFO stack. The rate only breaks ties between parallel edges.
+    for neighbors in graph.values_mut() {
+        neighbors.sort_unstable_by(|left, right| right.cmp(left));
     }
 
     // DFS: search for a conversion path from `from_currency` to `to_currency`
@@ -124,7 +135,7 @@ pub fn get_exchange_rate(
 
 #[cfg(test)]
 mod tests {
-    use ahash::AHashMap;
+    use ahash::{AHashMap, RandomState};
     use rstest::rstest;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
@@ -241,6 +252,69 @@ mod tests {
         }
     }
 
+    #[rstest(
+        price_type,
+        expected,
+        case(PriceType::Bid, Decimal::ONE / dec!(1.1002)),
+        case(PriceType::Ask, Decimal::ONE / dec!(1.1000)),
+        case(PriceType::Mid, Decimal::ONE / dec!(1.1001))
+    )]
+    fn test_inverse_pair_uses_opposite_spread_side(price_type: PriceType, expected: Decimal) {
+        let (quotes_bid, quotes_ask) = setup_test_quotes();
+
+        let rate = get_exchange_rate(
+            Ustr::from("USD"),
+            Ustr::from("EUR"),
+            price_type,
+            quotes_bid,
+            quotes_ask,
+        )
+        .unwrap();
+
+        assert_eq!(rate, Some(expected));
+    }
+
+    #[rstest]
+    fn test_indirect_route_is_deterministic_across_hash_seeds() {
+        let pairs = [
+            ("AAA/BBB", dec!(2)),
+            ("BBB/DDD", dec!(3)),
+            ("AAA/CCC", dec!(5)),
+            ("CCC/DDD", dec!(7)),
+        ];
+        let seeds = [(0, 0, 0, 0), (1, 2, 3, 4), (5, 6, 7, 8), (10, 20, 30, 40)];
+        let mut iteration_orders = Vec::new();
+
+        let rates = seeds.map(|(k0, k1, k2, k3)| {
+            let random_state = RandomState::with_seeds(k0, k1, k2, k3);
+            let mut quotes_bid = AHashMap::with_hasher(random_state.clone());
+            let mut quotes_ask = AHashMap::with_hasher(random_state);
+
+            for (pair, rate) in pairs {
+                quotes_bid.insert(Ustr::from(pair), rate);
+                quotes_ask.insert(Ustr::from(pair), rate);
+            }
+            iteration_orders.push(quotes_bid.keys().copied().collect::<Vec<_>>());
+
+            get_exchange_rate(
+                Ustr::from("AAA"),
+                Ustr::from("DDD"),
+                PriceType::Bid,
+                quotes_bid,
+                quotes_ask,
+            )
+            .unwrap()
+        });
+
+        assert!(
+            iteration_orders
+                .windows(2)
+                .any(|orders| orders[0] != orders[1]),
+            "Explicit hash seeds must produce different raw iteration orders",
+        );
+        assert_eq!(rates, [Some(dec!(6)); 4]);
+    }
+
     #[rstest]
     fn test_cross_pair_through_usd() {
         let (quotes_bid, quotes_ask) = setup_test_quotes();
@@ -271,6 +345,34 @@ mod tests {
             Ustr::from("EUR"),
             Ustr::from("USD"),
             PriceType::Mid,
+            quotes_bid,
+            quotes_ask,
+        );
+
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[rstest(
+        bid,
+        ask,
+        price_type,
+        case(dec!(1.1), Decimal::ZERO, PriceType::Bid),
+        case(Decimal::ZERO, dec!(1.1), PriceType::Ask)
+    )]
+    fn test_non_positive_opposite_side_is_skipped(
+        bid: Decimal,
+        ask: Decimal,
+        price_type: PriceType,
+    ) {
+        let mut quotes_bid = AHashMap::new();
+        let mut quotes_ask = AHashMap::new();
+        quotes_bid.insert(Ustr::from("EUR/USD"), bid);
+        quotes_ask.insert(Ustr::from("EUR/USD"), ask);
+
+        let result = get_exchange_rate(
+            Ustr::from("EUR"),
+            Ustr::from("USD"),
+            price_type,
             quotes_bid,
             quotes_ask,
         );
@@ -334,6 +436,24 @@ mod tests {
     }
 
     #[rstest]
+    fn test_equal_length_quotes_with_different_keys() {
+        let mut quotes_bid = AHashMap::new();
+        let mut quotes_ask = AHashMap::new();
+        quotes_bid.insert(Ustr::from("EUR/USD"), dec!(1.1000));
+        quotes_ask.insert(Ustr::from("GBP/USD"), dec!(1.3002));
+
+        let result = get_exchange_rate(
+            Ustr::from("EUR"),
+            Ustr::from("USD"),
+            PriceType::Bid,
+            quotes_bid,
+            quotes_ask,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[rstest]
     fn test_invalid_price_type() {
         let (quotes_bid, quotes_ask) = setup_test_quotes();
         // Using an invalid price type variant (assume PriceType::Last is unsupported)
@@ -345,6 +465,57 @@ mod tests {
             quotes_ask,
         );
         assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn test_same_currency_shortcut_precedes_all_validation() {
+        // The identical-currency shortcut runs before any quote or price-type validation, so an
+        // unsupported price type and empty quote maps still yield a rate of one.
+        let result = get_exchange_rate(
+            Ustr::from("USD"),
+            Ustr::from("USD"),
+            PriceType::Last,
+            AHashMap::new(),
+            AHashMap::new(),
+        );
+
+        assert_eq!(result.unwrap(), Some(Decimal::ONE));
+    }
+
+    #[rstest]
+    fn test_quote_map_errors_precede_invalid_price_type() {
+        // Empty maps are reported before an unsupported price type for distinct currencies.
+        let empty = get_exchange_rate(
+            Ustr::from("EUR"),
+            Ustr::from("USD"),
+            PriceType::Last,
+            AHashMap::new(),
+            AHashMap::new(),
+        );
+
+        assert_eq!(
+            empty.unwrap_err().to_string(),
+            "Quote maps must not be empty"
+        );
+
+        let mut quotes_bid = AHashMap::new();
+        let mut quotes_ask = AHashMap::new();
+        quotes_bid.insert(Ustr::from("EUR/USD"), dec!(1.1000));
+        quotes_bid.insert(Ustr::from("GBP/USD"), dec!(1.3000));
+        quotes_ask.insert(Ustr::from("EUR/USD"), dec!(1.1002));
+
+        let unequal = get_exchange_rate(
+            Ustr::from("EUR"),
+            Ustr::from("USD"),
+            PriceType::Last,
+            quotes_bid,
+            quotes_ask,
+        );
+
+        assert_eq!(
+            unequal.unwrap_err().to_string(),
+            "Quote maps must have equal lengths"
+        );
     }
 
     #[rstest]
@@ -366,9 +537,9 @@ mod tests {
         )
         .unwrap();
 
-        // Edge order is non-deterministic, so allow a small tolerance around the mid rate
+        // The total adjacency ordering encounters the higher parallel rate first.
         let expected = dec!(1.1001);
-        assert!((rate.unwrap() - expected).abs() < dec!(0.0001));
+        assert_eq!(rate, Some(expected));
     }
 
     #[rstest]

--- a/tests/unit_tests/accounting/test_calculators.py
+++ b/tests/unit_tests/accounting/test_calculators.py
@@ -106,8 +106,8 @@ class TestExchangeRateCalculator:
 
     def test_get_rate_for_inverse1(self):
         # Arrange
-        bid_rates = {"BTC/USD": 10501.5}
-        ask_rates = {"BTC/USD": 10500.0}
+        bid_rates = {"BTC/USD": 10500.0}
+        ask_rates = {"BTC/USD": 10501.5}
 
         # Act
         result = nautilus_pyo3.get_exchange_rate(
@@ -136,7 +136,7 @@ class TestExchangeRateCalculator:
         )
 
         # Assert
-        assert result == pytest.approx(Decimal("0.009082652134423252"), abs=Decimal("1e-9"))
+        assert result == pytest.approx(Decimal("0.009080177971488241"), abs=Decimal("1e-9"))
 
     def test_calculate_exchange_rate_by_inference(self):
         # Arrange
@@ -167,7 +167,7 @@ class TestExchangeRateCalculator:
         )
 
         # Assert
-        assert result1 == pytest.approx(Decimal("0.011353315168029066"), abs=Decimal("1e-9"))
+        assert result1 == pytest.approx(Decimal("0.011348803863877317"), abs=Decimal("1e-9"))
         assert result2 == pytest.approx(Decimal("88.115013"), abs=Decimal("1e-9"))
 
     def test_calculate_exchange_rate_for_mid_price_type(self):


### PR DESCRIPTION
`get_exchange_rate` in `crates/common/src/xrate.rs` is the only exchange-rate implementation in the codebase - reached from `Cache::get_xrate` for portfolio valuation and PnL, and from the Cython cache through the pyo3 binding - and it has two defects in how it builds its conversion graph.

## Reverse edges invert the requested side instead of the opposite side

The function collapsed `quotes_bid` and `quotes_ask` into a single `effective_quotes` map according to `price_type`, then built the graph from that one map, adding `BASE -> QUOTE` at rate `r` and `QUOTE -> BASE` at `1/r`. Since `r` is the already-selected side, a `Bid` request produced a reverse edge of `1/bid`. That is the wrong side of the spread: selling QUOTE to acquire BASE crosses the original ask, so the reverse bid is `1/ask`, and symmetrically the reverse ask is `1/bid`. The collapse had already discarded the other side by the time the reverse edge was built, so the error was structural rather than arithmetic. A reverse-bid rate came out too high, flattering any position valued through an inverted pair, and the error compounds once per inverted leg on a multi-hop route.

The fix pairs each bid with its ask by key before constructing the graph and derives both directional rates per pair: `Bid -> (bid, 1/ask)`, `Ask -> (ask, 1/bid)`, `Mid -> (mid, 1/mid)`. `Mid` is deliberately unchanged: the inverse of the midpoint preserves reciprocity, `mid(A/B) * mid(B/A) = 1`, which the arithmetic midpoint of the inverted market does not. The public signature is unchanged, so `Cache::get_xrate` and the pyo3 wrapper are untouched.

## Route selection depends on hash iteration order

The graph was populated by iterating an `AHashMap`, whose order varies per process, and the DFS marks a node visited when pushing it. When several indirect routes exist, whichever route the arbitrary adjacency order happened to reach first won, so two runs over identical quotes could return rates differing by the compounded spread of a different path. A direct one-hop edge could not lose - it is pushed with the direct rate and returns it when popped - so the nondeterminism was confined to the choice among indirect routes.

The fix sorts every adjacency list by `(neighbor, rate)` before the search, which removes all map-iteration influence while leaving the DFS itself unchanged. The ordering is total rather than by neighbor alone because parallel edges - a caller supplying both `EUR/USD` and `USD/EUR` - would otherwise retain their randomized relative order. Among parallel edges to the same neighbour the higher rate wins the visited claim; that is a mechanical tie-break, not a best-route policy, since the rate never affects ordering between distinct neighbours. Callers whose ordering happened to select a different indirect route may see a changed rate, which is unavoidable when removing nondeterminism; the function does not promise a shorter or better route, only a consistent one.

## Missing and non-positive quote sides

Pairing by key also makes the documented "missing side" error real for `Bid` and `Ask`, which previously never consulted the other map at all - only `Mid` did. The `quotes_bid.len() != quotes_ask.len()` check proves equal counts, not equal key sets; equal counts plus a successful lookup for every bid key now does prove it. The positivity guard also only examined the selected side, so a zero or negative value on the unused side could still become a denominator; both sides are now validated before either is inverted.

## Testing

`test_inverse_pair_uses_opposite_spread_side` covers all three price types against `1/ask`, `1/bid` and `1/mid`. `test_indirect_route_is_deterministic_across_hash_seeds` builds the same logical quote table under four explicit `ahash::RandomState::with_seeds` states, asserts the raw iteration orders actually differ, and requires all four to return the one canonically ordered route - a loop over a cloned map would prove nothing about hash order. `test_non_positive_opposite_side_is_skipped` and `test_equal_length_quotes_with_different_keys` cover the validation changes, and `test_cycle_handling` now asserts an exact canonical rate where it previously tolerated a range because the edge order was nondeterministic.

Both defects were verified to FAIL against the unfixed code, separately: restoring the same-side inversion fails only the `Bid` and `Ask` cases while `Mid` continues to pass, and removing the adjacency sort fails only the determinism test, on its rate assertion rather than its iteration-order assertion. Two further tests, `test_same_currency_shortcut_precedes_all_validation` and `test_quote_map_errors_precede_invalid_price_type`, pin the validation order so the identical-currency shortcut keeps returning a rate of one before any quote or price-type inspection.

No existing Rust expectation changed: every prior test in the file used `Mid`, or `Bid`/`Ask` on a direct edge only, which is how the reverse-side error survived. Three Python expectations in `tests/unit_tests/accounting/test_calculators.py` did encode it and are updated - `test_get_rate_for_inverse2` and `result1` of `test_calculate_exchange_rate_by_inference` to their recomputed values, and `test_get_rate_for_inverse1`'s fixture, which quoted `BTC/USD` with a bid above its ask, is corrected to a valid spread; its expected value is unchanged but now follows from `1/ask`. The forward-`Ask` and `Mid` expectations are untouched.
