### PR TITLE
Clean all index entries when purging an order

### DIFF
--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -3243,29 +3243,26 @@ impl Cache {
                 }
             }
 
-            if let Some(instrument_orders) =
-                self.index.instrument_orders.get_mut(&details.instrument_id)
-            {
-                instrument_orders.remove(&client_order_id);
-            }
+            // As with the strategy buckets below, an absent bucket is left absent: recreating
+            // it would suppress the `index.instrument_positions` integrity check.
+            // As with the strategy buckets below, an absent bucket is left absent: recreating
+            // it would suppress the `index.instrument_positions` integrity check.
+            let instrument_orders_became_empty = self
+                .index
+                .instrument_orders
+                .get_mut(&details.instrument_id)
+                .is_some_and(|instrument_orders| {
+                    instrument_orders.remove(&client_order_id);
+                    instrument_orders.is_empty()
+                });
 
             let has_instrument_positions = self
                 .index
                 .instrument_positions
                 .get(&details.instrument_id)
                 .is_some_and(|positions| !positions.is_empty());
-            let has_instrument_orders = self
-                .index
-                .instrument_orders
-                .get(&details.instrument_id)
-                .is_some_and(|orders| !orders.is_empty());
 
-            if has_instrument_positions {
-                self.index
-                    .instrument_orders
-                    .entry(details.instrument_id)
-                    .or_default();
-            } else if !has_instrument_orders {
+            if instrument_orders_became_empty && !has_instrument_positions {
                 self.index.instrument_orders.remove(&details.instrument_id);
             }
 
@@ -3377,24 +3374,27 @@ impl Cache {
         }
 
         for strategy_id in strategy_ids {
-            if let Some(strategy_orders) = self.index.strategy_orders.get_mut(&strategy_id) {
-                strategy_orders.remove(&client_order_id);
-            }
-
-            let has_orders = self
+            // An absent reverse bucket is not an empty one: it means the index is already
+            // inconsistent, possibly while another cached order still uses this strategy.
+            // Retiring the registry entry here would both drop a live strategy from
+            // `strategy_ids` and stop `check_integrity` reporting the missing bucket, so the
+            // absent case is left exactly as found.
+            let strategy_orders_became_empty = self
                 .index
                 .strategy_orders
-                .get(&strategy_id)
-                .is_some_and(|strategy_orders| !strategy_orders.is_empty());
+                .get_mut(&strategy_id)
+                .is_some_and(|strategy_orders| {
+                    strategy_orders.remove(&client_order_id);
+                    strategy_orders.is_empty()
+                });
+
             let has_positions = self
                 .index
                 .strategy_positions
                 .get(&strategy_id)
                 .is_some_and(|strategy_positions| !strategy_positions.is_empty());
 
-            if has_positions {
-                self.index.strategy_orders.entry(strategy_id).or_default();
-            } else if !has_orders {
+            if strategy_orders_became_empty && !has_positions {
                 self.index.strategy_orders.remove(&strategy_id);
                 self.index.strategies.remove(&strategy_id);
             }

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -3184,82 +3184,108 @@ impl Cache {
     ///
     /// For safety, an order is prevented from being purged if it's open.
     pub fn purge_order(&mut self, client_order_id: ClientOrderId) {
-        // Check if order exists and is safe to purge before removing
-        let order_cell = self.orders.get(&client_order_id).cloned();
+        struct OrderDetails {
+            is_open: bool,
+            instrument_id: InstrumentId,
+            strategy_id: StrategyId,
+            account_id: Option<AccountId>,
+            exec_algorithm_id: Option<ExecAlgorithmId>,
+            exec_spawn_id: Option<ClientOrderId>,
+            position_id: Option<PositionId>,
+            venue_order_id: Option<VenueOrderId>,
+            venue_order_ids: Vec<VenueOrderId>,
+        }
 
-        // Prevent purging open orders
-        if let Some(ref order_cell) = order_cell
-            && order_cell.borrow().is_open()
+        let order_cell = self.orders.get(&client_order_id).cloned();
+        let order_details = order_cell.as_ref().map(|cell| {
+            let order = cell.borrow();
+            OrderDetails {
+                is_open: order.is_open(),
+                instrument_id: order.instrument_id(),
+                strategy_id: order.strategy_id(),
+                account_id: order.account_id(),
+                exec_algorithm_id: order.exec_algorithm_id(),
+                exec_spawn_id: order.exec_spawn_id(),
+                position_id: order.position_id(),
+                venue_order_id: order.venue_order_id(),
+                venue_order_ids: order.venue_order_ids().into_iter().copied().collect(),
+            }
+        });
+
+        if order_details
+            .as_ref()
+            .is_some_and(|details| details.is_open)
         {
             log::warn!("Order {client_order_id} found open when purging, skipping purge");
             return;
         }
 
-        // If order exists in cache, remove it and clean up order-specific indices
-        if let Some(ref order_cell) = order_cell {
-            let order = order_cell.borrow();
-            // Safe to purge
+        if order_details.is_some() {
             self.orders.remove(&client_order_id);
+        } else {
+            log::warn!("Order {client_order_id} not found when purging");
+        }
 
-            // Remove order from venue index
+        let indexed_position_id = self.index.order_position.remove(&client_order_id);
+        let indexed_strategy_id = self.index.order_strategy.remove(&client_order_id);
+        self.index.order_client.remove(&client_order_id);
+        let indexed_venue_order_id = self.index.client_order_ids.remove(&client_order_id);
+
+        if let Some(details) = &order_details {
             if let Some(venue_orders) = self
                 .index
                 .venue_orders
-                .get_mut(&order.instrument_id().venue)
+                .get_mut(&details.instrument_id.venue)
             {
                 venue_orders.remove(&client_order_id);
                 if venue_orders.is_empty() {
-                    self.index.venue_orders.remove(&order.instrument_id().venue);
+                    self.index.venue_orders.remove(&details.instrument_id.venue);
                 }
             }
 
-            // Remove venue order ID index if exists
-            if let Some(venue_order_id) = order.venue_order_id() {
-                self.index.venue_order_ids.remove(&venue_order_id);
-            }
-
-            // Remove from instrument orders index
             if let Some(instrument_orders) =
-                self.index.instrument_orders.get_mut(&order.instrument_id())
+                self.index.instrument_orders.get_mut(&details.instrument_id)
             {
                 instrument_orders.remove(&client_order_id);
-                if instrument_orders.is_empty() {
-                    self.index.instrument_orders.remove(&order.instrument_id());
-                }
             }
 
-            // Remove from position orders index if associated with a position
-            if let Some(position_id) = order.position_id()
-                && let Some(position_orders) = self.index.position_orders.get_mut(&position_id)
-            {
-                position_orders.remove(&client_order_id);
-                if position_orders.is_empty() {
-                    self.index.position_orders.remove(&position_id);
-                }
+            let has_instrument_positions = self
+                .index
+                .instrument_positions
+                .get(&details.instrument_id)
+                .is_some_and(|positions| !positions.is_empty());
+            let has_instrument_orders = self
+                .index
+                .instrument_orders
+                .get(&details.instrument_id)
+                .is_some_and(|orders| !orders.is_empty());
+
+            if has_instrument_positions {
+                self.index
+                    .instrument_orders
+                    .entry(details.instrument_id)
+                    .or_default();
+            } else if !has_instrument_orders {
+                self.index.instrument_orders.remove(&details.instrument_id);
             }
 
-            // Remove from exec algorithm orders index if it has an exec algorithm
-            if let Some(exec_algorithm_id) = order.exec_algorithm_id()
-                && let Some(exec_algorithm_orders) =
-                    self.index.exec_algorithm_orders.get_mut(&exec_algorithm_id)
-            {
-                exec_algorithm_orders.remove(&client_order_id);
-                if exec_algorithm_orders.is_empty() {
+            if let Some(exec_algorithm_id) = details.exec_algorithm_id {
+                let became_empty = self
+                    .index
+                    .exec_algorithm_orders
+                    .get_mut(&exec_algorithm_id)
+                    .is_some_and(|orders| {
+                        orders.remove(&client_order_id);
+                        orders.is_empty()
+                    });
+
+                if became_empty {
                     self.index.exec_algorithm_orders.remove(&exec_algorithm_id);
+                    self.index.exec_algorithms.remove(&exec_algorithm_id);
                 }
             }
 
-            // Clean up strategy orders reverse index
-            if let Some(strategy_orders) = self.index.strategy_orders.get_mut(&order.strategy_id())
-            {
-                strategy_orders.remove(&client_order_id);
-                if strategy_orders.is_empty() {
-                    self.index.strategy_orders.remove(&order.strategy_id());
-                }
-            }
-
-            // Clean up account orders index
-            if let Some(account_id) = order.account_id()
+            if let Some(account_id) = details.account_id
                 && let Some(account_orders) = self.index.account_orders.get_mut(&account_id)
             {
                 account_orders.remove(&client_order_id);
@@ -3268,8 +3294,7 @@ impl Cache {
                 }
             }
 
-            // Clean up exec spawn reverse index (if this order is a spawned child)
-            if let Some(exec_spawn_id) = order.exec_spawn_id()
+            if let Some(exec_spawn_id) = details.exec_spawn_id
                 && let Some(spawn_orders) = self.index.exec_spawn_orders.get_mut(&exec_spawn_id)
             {
                 spawn_orders.remove(&client_order_id);
@@ -3277,29 +3302,122 @@ impl Cache {
                     self.index.exec_spawn_orders.remove(&exec_spawn_id);
                 }
             }
-
-            log::info!("Purged order {client_order_id}");
-        } else {
-            log::warn!("Order {client_order_id} not found when purging");
         }
 
-        // Always clean up order indices (even if order was not in cache)
-        self.index.order_position.remove(&client_order_id);
-        let strategy_id = self.index.order_strategy.remove(&client_order_id);
-        self.index.order_client.remove(&client_order_id);
-        self.index.client_order_ids.remove(&client_order_id);
+        let mut position_ids = AHashSet::new();
+        if let Some(position_id) = indexed_position_id {
+            position_ids.insert(position_id);
+        }
 
-        // Clean up reverse index when order not in cache (using forward index)
-        if let Some(strategy_id) = strategy_id
-            && let Some(strategy_orders) = self.index.strategy_orders.get_mut(&strategy_id)
+        if let Some(position_id) = order_details
+            .as_ref()
+            .and_then(|details| details.position_id)
         {
-            strategy_orders.remove(&client_order_id);
-            if strategy_orders.is_empty() {
-                self.index.strategy_orders.remove(&strategy_id);
+            position_ids.insert(position_id);
+        }
+
+        let mut strategy_ids = AHashSet::new();
+        if let Some(strategy_id) = indexed_strategy_id {
+            strategy_ids.insert(strategy_id);
+        }
+
+        if let Some(details) = &order_details {
+            strategy_ids.insert(details.strategy_id);
+        }
+
+        for position_id in position_ids {
+            if self.positions.contains_key(&position_id) {
+                if let Some(position_orders) = self.index.position_orders.get_mut(&position_id) {
+                    position_orders.remove(&client_order_id);
+                }
+                continue;
+            }
+
+            let has_other_orders =
+                if let Some(position_orders) = self.index.position_orders.get_mut(&position_id) {
+                    position_orders.remove(&client_order_id);
+                    !position_orders.is_empty()
+                } else {
+                    self.index
+                        .order_position
+                        .values()
+                        .any(|candidate| *candidate == position_id)
+                };
+
+            if has_other_orders {
+                continue;
+            }
+
+            self.index.position_orders.remove(&position_id);
+            if let Some(strategy_id) = self.index.position_strategy.remove(&position_id) {
+                strategy_ids.insert(strategy_id);
+                if let Some(strategy_positions) =
+                    self.index.strategy_positions.get_mut(&strategy_id)
+                {
+                    strategy_positions.remove(&position_id);
+                    if strategy_positions.is_empty() {
+                        self.index.strategy_positions.remove(&strategy_id);
+                    }
+                }
+            }
+
+            if let Some(details) = &order_details
+                && let Some(venue_positions) = self
+                    .index
+                    .venue_positions
+                    .get_mut(&details.instrument_id.venue)
+            {
+                venue_positions.remove(&position_id);
+                if venue_positions.is_empty() {
+                    self.index
+                        .venue_positions
+                        .remove(&details.instrument_id.venue);
+                }
             }
         }
 
-        // Remove spawn parent entry if this order was a spawn root
+        for strategy_id in strategy_ids {
+            if let Some(strategy_orders) = self.index.strategy_orders.get_mut(&strategy_id) {
+                strategy_orders.remove(&client_order_id);
+            }
+
+            let has_orders = self
+                .index
+                .strategy_orders
+                .get(&strategy_id)
+                .is_some_and(|strategy_orders| !strategy_orders.is_empty());
+            let has_positions = self
+                .index
+                .strategy_positions
+                .get(&strategy_id)
+                .is_some_and(|strategy_positions| !strategy_positions.is_empty());
+
+            if has_positions {
+                self.index.strategy_orders.entry(strategy_id).or_default();
+            } else if !has_orders {
+                self.index.strategy_orders.remove(&strategy_id);
+                self.index.strategies.remove(&strategy_id);
+            }
+        }
+
+        let mut venue_order_ids = AHashSet::new();
+        if let Some(venue_order_id) = indexed_venue_order_id {
+            venue_order_ids.insert(venue_order_id);
+        }
+
+        if let Some(details) = &order_details {
+            venue_order_ids.extend(details.venue_order_ids.iter().copied());
+            if let Some(venue_order_id) = details.venue_order_id {
+                venue_order_ids.insert(venue_order_id);
+            }
+        }
+
+        for venue_order_id in venue_order_ids {
+            if self.index.venue_order_ids.get(&venue_order_id) == Some(&client_order_id) {
+                self.index.venue_order_ids.remove(&venue_order_id);
+            }
+        }
+
         self.index.exec_spawn_orders.remove(&client_order_id);
 
         self.index.orders.remove(&client_order_id);
@@ -3309,6 +3427,10 @@ impl Cache {
         self.index.orders_emulated.remove(&client_order_id);
         self.index.orders_inflight.remove(&client_order_id);
         self.index.orders_pending_cancel.remove(&client_order_id);
+
+        if order_details.is_some() {
+            log::info!("Purged order {client_order_id}");
+        }
     }
 
     /// Purges the position with the `position_id` from the cache (if found).
@@ -3344,22 +3466,49 @@ impl Cache {
             }
 
             // Remove from instrument positions index
-            if let Some(instrument_positions) =
-                self.index.instrument_positions.get_mut(&pos.instrument_id)
-            {
-                instrument_positions.remove(&position_id);
-                if instrument_positions.is_empty() {
-                    self.index.instrument_positions.remove(&pos.instrument_id);
+            let instrument_positions_became_empty = self
+                .index
+                .instrument_positions
+                .get_mut(&pos.instrument_id)
+                .is_some_and(|positions| {
+                    positions.remove(&position_id);
+                    positions.is_empty()
+                });
+
+            if instrument_positions_became_empty {
+                self.index.instrument_positions.remove(&pos.instrument_id);
+                let instrument_orders_empty = self
+                    .index
+                    .instrument_orders
+                    .get(&pos.instrument_id)
+                    .is_some_and(|orders| orders.is_empty());
+
+                if instrument_orders_empty {
+                    self.index.instrument_orders.remove(&pos.instrument_id);
                 }
             }
 
             // Remove from strategy positions index
-            if let Some(strategy_positions) =
-                self.index.strategy_positions.get_mut(&pos.strategy_id)
-            {
-                strategy_positions.remove(&position_id);
-                if strategy_positions.is_empty() {
-                    self.index.strategy_positions.remove(&pos.strategy_id);
+            let strategy_positions_became_empty = self
+                .index
+                .strategy_positions
+                .get_mut(&pos.strategy_id)
+                .is_some_and(|positions| {
+                    positions.remove(&position_id);
+                    positions.is_empty()
+                });
+
+            if strategy_positions_became_empty {
+                self.index.strategy_positions.remove(&pos.strategy_id);
+                let strategy_orders_empty = self
+                    .index
+                    .strategy_orders
+                    .get(&pos.strategy_id)
+                    .is_some_and(|orders| orders.is_empty());
+
+                if strategy_orders_empty {
+                    self.index.strategy_orders.remove(&pos.strategy_id);
+                    self.index.strategies.remove(&pos.strategy_id);
                 }
             }
 

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -3823,6 +3823,551 @@ fn test_purge_order() {
 }
 
 #[rstest]
+fn test_purge_order_cleans_command_position_link() {
+    let mut cache = Cache::default();
+    let position_id = PositionId::new("P-COMMAND");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    assert!(order.position_id().is_none());
+    cache
+        .add_order(order, Some(position_id), None, false)
+        .unwrap();
+
+    cache.purge_order(client_order_id);
+
+    assert!(cache.orders_for_position(&position_id).is_empty());
+}
+
+#[rstest]
+fn test_purge_order_removes_historical_venue_order_ids() {
+    let mut cache = Cache::default();
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+    let account_id = AccountId::new("SIM-001");
+    let original_venue_order_id = VenueOrderId::new("V-ORIGINAL");
+    let updated_venue_order_id = VenueOrderId::new("V-UPDATED");
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00000"))
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+    let submitted = TestOrderEventStubs::submitted(&order, account_id);
+    update_order_with_event(&mut cache, &mut order, submitted);
+    let accepted = TestOrderEventStubs::accepted(&order, account_id, original_venue_order_id);
+    update_order_with_event(&mut cache, &mut order, accepted);
+    let updated = build_order_updated(
+        order.trader_id(),
+        order.strategy_id(),
+        order.instrument_id(),
+        client_order_id,
+        order.quantity(),
+        Some(updated_venue_order_id),
+        Some(account_id),
+        order.price(),
+        None,
+        None,
+    );
+    update_order_with_event(&mut cache, &mut order, OrderEventAny::Updated(updated));
+    let canceled = build_order_canceled(
+        order.trader_id(),
+        order.strategy_id(),
+        order.instrument_id(),
+        client_order_id,
+        Some(updated_venue_order_id),
+        Some(account_id),
+    );
+    update_order_with_event(&mut cache, &mut order, OrderEventAny::Canceled(canceled));
+
+    cache.purge_order(client_order_id);
+
+    assert!(cache.client_order_id(&original_venue_order_id).is_none());
+    assert!(cache.client_order_id(&updated_venue_order_id).is_none());
+    assert!(cache.check_integrity());
+}
+
+#[rstest]
+fn test_purge_order_preserves_rebound_historical_venue_order_id() {
+    let mut cache = Cache::default();
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+    let account_id = AccountId::new("SIM-001");
+    let historical_venue_order_id = VenueOrderId::new("V-HISTORICAL");
+    let current_venue_order_id = VenueOrderId::new("V-CURRENT");
+    let mut former_owner = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00000"))
+        .quantity(Quantity::from(100_000))
+        .build();
+    let former_owner_id = former_owner.client_order_id();
+    cache
+        .add_order(former_owner.clone(), None, None, false)
+        .unwrap();
+    let submitted = TestOrderEventStubs::submitted(&former_owner, account_id);
+    update_order_with_event(&mut cache, &mut former_owner, submitted);
+    let accepted =
+        TestOrderEventStubs::accepted(&former_owner, account_id, historical_venue_order_id);
+    update_order_with_event(&mut cache, &mut former_owner, accepted);
+    let updated = build_order_updated(
+        former_owner.trader_id(),
+        former_owner.strategy_id(),
+        former_owner.instrument_id(),
+        former_owner_id,
+        former_owner.quantity(),
+        Some(current_venue_order_id),
+        Some(account_id),
+        former_owner.price(),
+        None,
+        None,
+    );
+    update_order_with_event(
+        &mut cache,
+        &mut former_owner,
+        OrderEventAny::Updated(updated),
+    );
+    let canceled = build_order_canceled(
+        former_owner.trader_id(),
+        former_owner.strategy_id(),
+        former_owner.instrument_id(),
+        former_owner_id,
+        Some(current_venue_order_id),
+        Some(account_id),
+    );
+    update_order_with_event(
+        &mut cache,
+        &mut former_owner,
+        OrderEventAny::Canceled(canceled),
+    );
+
+    let rebound_owner = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new("O-REBOUND"))
+        .build();
+    let rebound_owner_id = rebound_owner.client_order_id();
+    cache.add_order(rebound_owner, None, None, false).unwrap();
+    cache
+        .index
+        .venue_order_ids
+        .insert(historical_venue_order_id, rebound_owner_id);
+    cache
+        .index
+        .client_order_ids
+        .insert(rebound_owner_id, historical_venue_order_id);
+
+    cache.purge_order(former_owner_id);
+
+    assert_eq!(
+        cache.client_order_id(&historical_venue_order_id),
+        Some(&rebound_owner_id)
+    );
+}
+
+#[rstest]
+fn test_purge_order_cleans_last_speculative_position_metadata() {
+    let mut cache = Cache::default();
+    let position_id = PositionId::new("P-SPECULATIVE");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    let strategy_id = order.strategy_id();
+    let venue = order.instrument_id().venue;
+    cache
+        .add_order(order, Some(position_id), None, false)
+        .unwrap();
+
+    cache.purge_order(client_order_id);
+
+    assert!(!cache.index.position_orders.contains_key(&position_id));
+    assert!(!cache.index.position_strategy.contains_key(&position_id));
+    assert!(
+        !cache
+            .index
+            .strategy_positions
+            .get(&strategy_id)
+            .is_some_and(|positions| positions.contains(&position_id))
+    );
+    assert!(
+        !cache
+            .index
+            .venue_positions
+            .get(&venue)
+            .is_some_and(|positions| positions.contains(&position_id))
+    );
+}
+
+#[rstest]
+fn test_purge_order_keeps_empty_bucket_for_real_position() {
+    let mut cache = Cache::default();
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+    let position_id = PositionId::new("P-REAL");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    let strategy_id = order.strategy_id();
+    cache
+        .add_order(order.clone(), Some(position_id), None, false)
+        .unwrap();
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(TradeId::new("T-REAL")),
+        Some(position_id),
+        Some(Price::from("1.00001")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let position = Position::new(&instrument, filled.into());
+    cache.add_position(&position, OmsType::Netting).unwrap();
+
+    cache.purge_order(client_order_id);
+
+    assert!(
+        cache
+            .index
+            .position_orders
+            .get(&position_id)
+            .is_some_and(|orders| orders.is_empty())
+    );
+    assert_eq!(
+        cache.index.position_strategy.get(&position_id),
+        Some(&strategy_id)
+    );
+    assert!(
+        cache
+            .index
+            .strategy_orders
+            .get(&strategy_id)
+            .is_some_and(|orders| orders.is_empty())
+    );
+    assert!(cache.check_integrity());
+}
+
+#[rstest]
+fn test_purge_position_retires_empty_order_companion_buckets() {
+    let mut cache = Cache::default();
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+    let instrument_id = instrument.id();
+    let position_id = PositionId::new("P-COMPANION-BUCKETS");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_id)
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    let strategy_id = order.strategy_id();
+    cache
+        .add_order(order.clone(), Some(position_id), None, false)
+        .unwrap();
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(TradeId::new("T-COMPANION-OPEN")),
+        Some(position_id),
+        Some(Price::from("1.00001")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let mut position = Position::new(&instrument, filled.into());
+    cache.add_position(&position, OmsType::Netting).unwrap();
+
+    let closing_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_id)
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new("O-COMPANION-CLOSE"))
+        .build();
+    let closing_fill = TestOrderEventStubs::filled(
+        &closing_order,
+        &instrument,
+        Some(TradeId::new("T-COMPANION-CLOSE")),
+        Some(position_id),
+        Some(Price::from("1.00010")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    position.apply(&closing_fill.into());
+    cache.update_position(&position).unwrap();
+    assert!(position.is_closed());
+
+    cache.purge_order(client_order_id);
+    assert!(
+        cache
+            .index
+            .instrument_orders
+            .get(&instrument_id)
+            .is_some_and(|orders| orders.is_empty())
+    );
+    assert!(
+        cache
+            .index
+            .strategy_orders
+            .get(&strategy_id)
+            .is_some_and(|orders| orders.is_empty())
+    );
+
+    cache.purge_position(position_id);
+
+    assert!(!cache.index.instrument_orders.contains_key(&instrument_id));
+    assert!(!cache.index.strategy_orders.contains_key(&strategy_id));
+    assert!(!cache.index.strategies.contains(&strategy_id));
+}
+
+#[rstest]
+fn test_purge_order_cleans_object_position_id_without_forward_entry() {
+    let mut cache = Cache::default();
+    let position_id = PositionId::new("P-OBJECT-ONLY");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    cache
+        .add_order(order, Some(position_id), None, false)
+        .unwrap();
+    cache
+        .order_mut(&client_order_id)
+        .unwrap()
+        .set_position_id(Some(position_id));
+    cache.index.order_position.remove(&client_order_id);
+
+    cache.purge_order(client_order_id);
+
+    assert!(!cache.index.position_orders.contains_key(&position_id));
+    assert!(!cache.index.position_strategy.contains_key(&position_id));
+}
+
+#[rstest]
+fn test_purge_order_cleans_current_object_venue_id_without_other_sources() {
+    let mut cache = Cache::default();
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+    let account_id = AccountId::new("SIM-001");
+    let venue_order_id = VenueOrderId::new("V-OBJECT-ONLY");
+    let mut order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+    let submitted = TestOrderEventStubs::submitted(&order, account_id);
+    update_order_with_event(&mut cache, &mut order, submitted);
+    let filled = build_order_filled(
+        order.trader_id(),
+        order.strategy_id(),
+        order.instrument_id(),
+        client_order_id,
+        venue_order_id,
+        account_id,
+        TradeId::new("T-OBJECT-ONLY"),
+        order.order_side(),
+        order.order_type(),
+        order.quantity(),
+        Price::from("1.00001"),
+        instrument.quote_currency(),
+        LiquiditySide::Maker,
+        None,
+        None,
+    );
+    update_order_with_event(&mut cache, &mut order, OrderEventAny::Filled(filled));
+    assert!(order.venue_order_ids().is_empty());
+    cache.index.client_order_ids.remove(&client_order_id);
+
+    cache.purge_order(client_order_id);
+
+    assert!(cache.client_order_id(&venue_order_id).is_none());
+}
+
+#[rstest]
+fn test_purge_order_cleans_index_only_forward_venue_id() {
+    let mut cache = Cache::default();
+    let venue_order_id = VenueOrderId::new("V-INDEX-ONLY");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    assert!(order.venue_order_id().is_none());
+    cache.add_order(order, None, None, false).unwrap();
+    cache
+        .index
+        .client_order_ids
+        .insert(client_order_id, venue_order_id);
+    cache
+        .index
+        .venue_order_ids
+        .insert(venue_order_id, client_order_id);
+
+    cache.purge_order(client_order_id);
+
+    assert!(cache.client_order_id(&venue_order_id).is_none());
+}
+
+#[rstest]
+fn test_purge_order_does_not_manufacture_missing_real_position_bucket() {
+    let mut cache = Cache::default();
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+    let position_id = PositionId::new("P-REAL-MISSING-BUCKET");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    cache
+        .add_order(order.clone(), Some(position_id), None, false)
+        .unwrap();
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(TradeId::new("T-REAL-MISSING-BUCKET")),
+        Some(position_id),
+        Some(Price::from("1.00001")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let position = Position::new(&instrument, filled.into());
+    cache.add_position(&position, OmsType::Netting).unwrap();
+    cache.index.position_orders.remove(&position_id);
+
+    cache.purge_order(client_order_id);
+
+    assert!(!cache.index.position_orders.contains_key(&position_id));
+}
+
+#[rstest]
+fn test_purge_order_preserves_speculative_metadata_when_reverse_bucket_is_missing() {
+    let mut cache = Cache::default();
+    let position_id = PositionId::new("P-SPECULATIVE-SHARED");
+    let first_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new("O-SPECULATIVE-FIRST"))
+        .build();
+    let second_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new("O-SPECULATIVE-SECOND"))
+        .build();
+    let first_order_id = first_order.client_order_id();
+    let second_order_id = second_order.client_order_id();
+    let strategy_id = first_order.strategy_id();
+    let venue = first_order.instrument_id().venue;
+    cache
+        .add_order(first_order, Some(position_id), None, false)
+        .unwrap();
+    cache
+        .add_order(second_order, Some(position_id), None, false)
+        .unwrap();
+    cache.index.position_orders.remove(&position_id);
+
+    cache.purge_order(first_order_id);
+
+    assert_eq!(
+        cache.index.order_position.get(&second_order_id),
+        Some(&position_id)
+    );
+    assert_eq!(
+        cache.index.position_strategy.get(&position_id),
+        Some(&strategy_id)
+    );
+    assert!(
+        cache
+            .index
+            .strategy_positions
+            .get(&strategy_id)
+            .is_some_and(|positions| positions.contains(&position_id))
+    );
+    assert!(
+        cache
+            .index
+            .venue_positions
+            .get(&venue)
+            .is_some_and(|positions| positions.contains(&position_id))
+    );
+}
+
+#[rstest]
+fn test_purge_order_preserves_exec_algorithm_when_reverse_bucket_is_missing() {
+    let mut cache = Cache::default();
+    let exec_algorithm_id = ExecAlgorithmId::new("TWAP");
+    let first_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new("O-EXEC-FIRST"))
+        .exec_algorithm_id(exec_algorithm_id)
+        .build();
+    let second_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new("O-EXEC-SECOND"))
+        .exec_algorithm_id(exec_algorithm_id)
+        .build();
+    let first_order_id = first_order.client_order_id();
+    let second_order_id = second_order.client_order_id();
+    cache.add_order(first_order, None, None, false).unwrap();
+    cache.add_order(second_order, None, None, false).unwrap();
+    cache.index.exec_algorithm_orders.remove(&exec_algorithm_id);
+
+    cache.purge_order(first_order_id);
+
+    assert!(cache.order_exists(&second_order_id));
+    assert!(cache.index.exec_algorithms.contains(&exec_algorithm_id));
+}
+
+#[rstest]
+fn test_purge_order_retires_last_strategy_and_exec_algorithm() {
+    let mut cache = Cache::default();
+    let strategy_id = StrategyId::new("S-PURGE");
+    let exec_algorithm_id = ExecAlgorithmId::new("TWAP");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .strategy_id(strategy_id)
+        .exec_algorithm_id(exec_algorithm_id)
+        .build();
+    let client_order_id = order.client_order_id();
+    cache.add_order(order, None, None, false).unwrap();
+
+    cache.purge_order(client_order_id);
+
+    assert!(!cache.index.strategies.contains(&strategy_id));
+    assert!(!cache.index.exec_algorithms.contains(&exec_algorithm_id));
+    assert!(cache.check_integrity());
+}
+
+#[rstest]
 fn test_purge_open_order_skips_purge() {
     // Test that attempting to purge an open order is prevented by the guard
     let mut cache = Cache::default();

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -5091,6 +5091,107 @@ fn test_purge_order_cleans_up_strategy_orders_index() {
 }
 
 #[rstest]
+fn test_purge_order_preserves_absent_strategy_orders_bucket() {
+    let mut cache = Cache::default();
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim());
+    let strategy_id = StrategyId::new("S-SHARED");
+
+    let order1 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .strategy_id(strategy_id)
+        .client_order_id(ClientOrderId::new("O-SHARED-1"))
+        .build();
+    let order2 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .strategy_id(strategy_id)
+        .client_order_id(ClientOrderId::new("O-SHARED-2"))
+        .build();
+
+    let client_order_id_1 = order1.client_order_id();
+
+    cache.add_order(order1, None, None, false).unwrap();
+    cache.add_order(order2, None, None, false).unwrap();
+
+    // The inconsistent state `check_integrity` exists to report: the reverse bucket is
+    // missing while two cached orders still use the strategy.
+    cache.index.strategy_orders.remove(&strategy_id);
+
+    cache.purge_order(client_order_id_1);
+
+    assert!(
+        cache.index.strategies.contains(&strategy_id),
+        "strategy still used by a cached order must not be retired"
+    );
+    assert!(
+        !cache.index.strategy_orders.contains_key(&strategy_id),
+        "an absent reverse bucket must be left absent, not fabricated"
+    );
+    assert!(
+        !cache.check_integrity(),
+        "the missing reverse bucket must remain reportable"
+    );
+}
+
+#[rstest]
+fn test_purge_order_preserves_absent_instrument_orders_bucket() {
+    let mut cache = Cache::default();
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+    let instrument_id = instrument.id();
+    let position_id = PositionId::new("P-ABSENT-INSTRUMENT-BUCKET");
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_id)
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    cache
+        .add_order(order.clone(), Some(position_id), None, false)
+        .unwrap();
+
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(TradeId::new("T-ABSENT-INSTRUMENT-BUCKET")),
+        Some(position_id),
+        Some(Price::from("1.00001")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let position = Position::new(&instrument, filled.into());
+    cache.add_position(&position, OmsType::Netting).unwrap();
+
+    // The inconsistent state `check_integrity` exists to report: the instrument keeps an
+    // open position while its orders bucket has gone missing.
+    cache.index.instrument_orders.remove(&instrument_id);
+
+    cache.purge_order(client_order_id);
+
+    assert!(
+        !cache.index.instrument_orders.contains_key(&instrument_id),
+        "an absent instrument bucket must be left absent, not fabricated"
+    );
+    assert!(
+        cache
+            .index
+            .instrument_positions
+            .contains_key(&instrument_id),
+        "the live position must still be indexed"
+    );
+    assert!(
+        !cache.check_integrity(),
+        "the missing instrument bucket must remain reportable"
+    );
+}
+
+#[rstest]
 fn test_purge_order_cleans_up_exec_spawn_orders_index() {
     // Regression test for exec_spawn_orders index cleanup bug
     // Verifies that after purging a spawned child order, it is removed from the parent's set


### PR DESCRIPTION
`Cache::purge_order` leaves several index entries behind, one of which makes a later query panic outright, and the cleanup it does perform cannot see state the order object never learned.

## A purged order can remain in `position_orders`, and `orders_for_position` then panics

`add_position_id` writes both the forward `index.order_position` and the reverse `index.position_orders` from a *supplied* position ID - the path taken when a position ID arrives on a command, including `add_order(.., Some(position_id), ..)` and the matching engine's OTO handling. An order's own `position_id` field, by contrast, is assigned only when a fill applies. So a fill-less order with a command-supplied position ID is present in both indexes while `order.position_id()` is `None`.

`purge_order` cleaned the reverse index only under `if let Some(position_id) = order.position_id()`, and discarded the value returned by `index.order_position.remove(..)` - the one piece of state that identified the entry. The stale `ClientOrderId` then reaches `get_orders_for_position` -> `get_orders_for_ids`, which does `.unwrap_or_else(|| panic!("Order {client_order_id} not found"))`. Any `orders_for_position` call for that position panics.

The fix cleans the union of both sources - the order object's position ID and the value returned from the forward index - rather than choosing one as authoritative, since neither covers the other's case.

## Historical venue order IDs survive the purge

An order accumulates a history of venue order IDs across cancel/replace, kept in `venue_order_ids` and exposed by `Order::venue_order_ids()`. `purge_order` removed only the current one, so every earlier ID stayed in `index.venue_order_ids` pointing at an order that no longer exists. `check_integrity` iterates that map and reports a failure when the client order is absent, and the map grows without bound across a long session of replaces.

The fix collects the history, the current ID and the value returned from the forward `client_order_ids` map - the current ID must be included separately because a fill assigns `venue_order_id` without appending to the history - and removes each entry only if the reverse map still names the purged order as its owner. An unconditional removal would be unsafe: a collision can already have rebound a historical ID to another live order, and deleting that mapping would turn an index leak into index corruption. A cancel/replace chain is not a cross-order transfer in this model, so a different owner always means a collision rather than a legitimate handover.

## Speculative position metadata and empty registries

`add_position_id` also seeds `position_strategy`, `strategy_positions` and `venue_positions`, so a fill-less order could leave an entire position family behind after its last association was purged. `check_integrity` rejects stale `position_strategy` and `strategy_positions` entries, and a position query can panic when a reverse bucket names a missing position. These are now retired when no cached `Position` exists for the ID and no other order references it - determined from the reverse bucket, or by consulting the remaining forward mappings when that bucket is itself absent.

The `strategies` and `exec_algorithms` registries were never retired at all, which violates the invariant that every registry entry has a corresponding orders bucket. They are now retired when their last order goes, and an absent bucket is deliberately distinguished from an empty one throughout: an absent bucket is left alone so a pre-existing defect stays visible to `check_integrity` rather than being silently papered over.

Where a real position or another position for the same instrument still exists, the companion `position_orders`, `strategy_orders` and `instrument_orders` buckets are preserved but emptied, because `check_integrity` requires those keys to exist. `purge_position` now completes that lifecycle, retiring a companion bucket when its last position disappears and the bucket is present and empty.

## Deliberately deferred to a follow-up

Two related defects in the same area are not in this PR, because both hinge on a trade-off worth your call rather than mine.

`add_venue_order_id` validates only the client-to-venue direction. It rejects a different venue ID for the same order, but never checks whether the incoming venue order ID is already owned by a different client order before rebinding `index.venue_order_ids`, so a second claim silently steals the mapping and venue-ID lookups then resolve to the wrong order. Rejecting the claim is the obvious fix, but it converts today's silent misrouting into a fail-fast error: `IdsGenerator::get_venue_order_id` propagates the result and its production callers `unwrap`, so a duplicate generated ID would abort a backtest rather than quietly misroute. Silent wrong-order routing seems clearly worse to me, but that is a behavioural change I would rather raise than bundle.

`Cache::refresh_order` compounds it by skipping `add_venue_order_id` whenever the reverse key merely exists, without checking who owns it, so cross-owner collisions are never reported through that path. It only becomes meaningful once the validation above exists, so the two travel together.

One test in this PR seeds a rebound venue-ID mapping directly through the index maps rather than through `add_venue_order_id`, specifically so it keeps passing once that validation lands.

## Testing

Eleven tests in `crates/common/src/cache/tests.rs` cover: the command-supplied position link, historical venue IDs, a rebound historical ID surviving the purge of its former owner, speculative position metadata cleanup, an empty bucket preserved for a real position with `check_integrity` asserted, registry retirement for the last strategy and exec-algorithm order, the `purge_order` -> `purge_position` companion-bucket sequence asserted directly on the index maps, and one test per union source in isolation - the object's position ID with the forward entry absent, the current venue ID present in neither history nor forward map, and an index-only forward venue ID with no object venue ID.

Verified against mutants rather than only against the unfixed baseline: replacing the ownership predicate with an unconditional removal fails exactly the rebound test; dropping the forward half of the position union fails three tests, and the command-position case fails with the real panic rather than a soft assertion; and the companion-bucket test fails without the `purge_position` change.
