### PR TITLE
Run Rust doctests before nextest

### DIFF
--- a/.github/workflows/build-v2.yml
+++ b/.github/workflows/build-v2.yml
@@ -198,6 +198,12 @@ jobs:
         if: needs.plan.outputs.run-rust-tests == 'true'
         uses: ./.github/actions/common-test-data
 
+      # Doctests run before nextest so their transient linker artifacts are
+      # released before the full test-binary set accumulates on disk.
+      - name: Run Rust doctests
+        if: needs.plan.outputs.run-rust-tests == 'true'
+        run: make cargo-test-doc HYPERSYNC=true
+
       - name: Run Rust tests (core)
         if: needs.plan.outputs.run-rust-tests == 'true'
         run: make cargo-test-core-selected HYPERSYNC=true NEXTEST_PROFILE=ci
@@ -205,12 +211,6 @@ jobs:
       - name: Run Rust tests (adapters)
         if: needs.plan.outputs.run-rust-tests == 'true'
         run: make cargo-test-adapters HYPERSYNC=true NEXTEST_PROFILE=ci
-
-      # Doctests run here rather than in their own job so they reuse the
-      # artifacts the nextest steps just built. `cargo nextest` cannot run them.
-      - name: Run Rust doctests
-        if: needs.plan.outputs.run-rust-tests == 'true'
-        run: make cargo-test-doc HYPERSYNC=true
 
       - name: Clean Rust test artifacts
         if: needs.plan.outputs.run-rust-tests == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,6 +311,12 @@ jobs:
             echo "::warning::Only ${avail_gb}G free, the Rust build may run out of space, re-run if it fails."
           fi
 
+      # Doctests run before nextest so their transient linker artifacts are
+      # released before the full test-binary set accumulates on disk.
+      - name: Run Rust doctests
+        if: needs.plan.outputs.run-rust-tests == 'true'
+        run: make cargo-test-doc EXTRA_FEATURES="capnp,hypersync"
+
       - name: Run Rust tests (core)
         if: needs.plan.outputs.run-rust-tests == 'true'
         run: make cargo-test-core-selected EXTRA_FEATURES="capnp,hypersync" NEXTEST_PROFILE=ci
@@ -318,12 +324,6 @@ jobs:
       - name: Run Rust tests (adapters)
         if: needs.plan.outputs.run-rust-tests == 'true'
         run: make cargo-test-adapters EXTRA_FEATURES="capnp,hypersync" NEXTEST_PROFILE=ci
-
-      # Doctests run here rather than in their own job so they reuse the
-      # artifacts the nextest steps just built. `cargo nextest` cannot run them.
-      - name: Run Rust doctests
-        if: needs.plan.outputs.run-rust-tests == 'true'
-        run: make cargo-test-doc EXTRA_FEATURES="capnp,hypersync"
 
       - name: Clean Rust test artifacts
         if: needs.plan.outputs.run-rust-tests == 'true'


### PR DESCRIPTION
## Summary

- run Rust doctests before the core and adapter nextest suites in both Linux x86 workflows
- keep the existing workspace, feature, profile, and cleanup commands unchanged

## Root cause

The new doctest gate ran after the full nextest build had accumulated the complete test-binary set. On unrelated pull requests, `nautilus-persistence` doctest linking then exhausted the 146 GB GitHub runner filesystem, causing `lld` to terminate with `SIGBUS` followed by `No space left on device` errors in `/tmp`.

Running doctests first releases their transient rustdoc/linker files before nextest adds the full test-binary set. This preserves the gate and avoids a retry, suppression, reduced feature set, or separate compatibility path.

## Verification

- `make pre-commit`
- `git diff --check`

