### PR TITLE
Fix reconnect-path liveness and session fencing in network clients

### DIFF
--- a/crates/adapters/lighter/src/websocket/handler.rs
+++ b/crates/adapters/lighter/src/websocket/handler.rs
@@ -1696,10 +1696,15 @@ pub(crate) fn should_retry_lighter_ws_error(error: &LighterWsError) -> bool {
     match error {
         LighterWsError::Network(_) => true,
         // Closed and BrokenPipe are terminal on this client; only Timeout
-        // (wait_for_active) can recover if the connection comes up.
+        // (wait_for_active) can recover if the connection comes up. WriteTimeout
+        // is not retryable: the write was cancelled after it began, so the peer
+        // may already have the message and a retry could duplicate it.
         LighterWsError::Transport(send_error) => match send_error {
             SendError::Timeout => true,
-            SendError::Closed | SendError::ConnectionChanged | SendError::BrokenPipe(_) => false,
+            SendError::Closed
+            | SendError::ConnectionChanged
+            | SendError::BrokenPipe(_)
+            | SendError::WriteTimeout => false,
         },
         LighterWsError::Authentication(_)
         | LighterWsError::Parse(_)
@@ -3130,6 +3135,10 @@ mod tests {
     #[case::client_does_not_retry(LighterWsError::Client("no active WebSocket client".into()), false)]
     #[case::transport_closed_does_not_retry(LighterWsError::Transport(SendError::Closed), false)]
     #[case::transport_timeout_retries(LighterWsError::Transport(SendError::Timeout), true)]
+    #[case::transport_write_timeout_does_not_retry(
+        LighterWsError::Transport(SendError::WriteTimeout),
+        false
+    )]
     #[case::transport_broken_pipe_does_not_retry(
         LighterWsError::Transport(SendError::BrokenPipe(
             "writer closed".into(),
@@ -3144,6 +3153,7 @@ mod tests {
     #[rstest]
     #[case::closed(SendError::Closed)]
     #[case::timeout(SendError::Timeout)]
+    #[case::write_timeout(SendError::WriteTimeout)]
     #[case::broken_pipe(SendError::BrokenPipe("writer dropped".into()))]
     fn send_error_converts_into_transport_variant(#[case] send_error: SendError) {
         let err: LighterWsError = send_error.into();

--- a/crates/network/src/error.rs
+++ b/crates/network/src/error.rs
@@ -28,6 +28,13 @@ pub enum SendError {
     /// Timed out waiting for the client to become active.
     #[error("send failed: timeout waiting for active state")]
     Timeout,
+    /// Timed out while writing to the transport, so delivery is undetermined.
+    ///
+    /// Unlike [`SendError::Timeout`], which reports that a send never started, the write was
+    /// cancelled after it began: the peer may or may not have received the message. Callers must
+    /// not treat this as a plain retry.
+    #[error("send failed: timed out writing to transport, delivery undetermined")]
+    WriteTimeout,
     /// The connection changed before an ownership-bound message reached the writer.
     #[error("send failed: connection changed before write")]
     ConnectionChanged,

--- a/crates/network/src/mode.rs
+++ b/crates/network/src/mode.rs
@@ -15,9 +15,39 @@
 
 //! Connection mode enumeration for socket clients.
 
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU8, Ordering},
+};
 
 use strum::{AsRefStr, Display, EnumString};
+
+/// Irreversible validity token for a single connection's read task.
+#[derive(Clone, Debug)]
+pub(crate) struct ReadSessionFence {
+    valid: Arc<AtomicBool>,
+}
+
+impl ReadSessionFence {
+    /// Creates a valid fence for a newly spawned read task.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            valid: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// Invalidates the associated read session.
+    pub(crate) fn invalidate(&self) {
+        self.valid.store(false, Ordering::SeqCst);
+    }
+
+    /// Returns whether the associated read session is still current.
+    #[must_use]
+    pub(crate) fn is_valid(&self) -> bool {
+        self.valid.load(Ordering::SeqCst)
+    }
+}
 
 /// Connection mode for a socket client.
 ///

--- a/crates/network/src/socket/client.rs
+++ b/crates/network/src/socket/client.rs
@@ -36,7 +36,7 @@ use std::{
     pin::pin,
     sync::{
         Arc,
-        atomic::{AtomicU8, Ordering},
+        atomic::{AtomicBool, AtomicU8, Ordering},
     },
     time::Duration,
 };
@@ -44,7 +44,7 @@ use std::{
 use bytes::Bytes;
 use nautilus_core::CleanDrop;
 use nautilus_cryptography::providers::install_cryptographic_provider;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio_tungstenite::tungstenite::{Error, client::IntoClientRequest, stream::Mode};
 
 use super::{SocketConfig, TcpMessageHandler, TcpReader, TcpWriter, WriterCommand};
@@ -53,7 +53,7 @@ use crate::{
     dst,
     error::{SendError, is_connection_drop_io_error},
     logging::{log_task_aborted, log_task_started, log_task_stopped},
-    mode::ConnectionMode,
+    mode::{ConnectionMode, ReadSessionFence},
     net::TcpStream,
     tls::{Connector, create_tls_config_from_certs_dir, tcp_tls},
 };
@@ -62,9 +62,109 @@ use crate::{
 const CONNECTION_STATE_CHECK_INTERVAL_MS: u64 = 10;
 const GRACEFUL_SHUTDOWN_DELAY_MS: u64 = 100;
 const GRACEFUL_SHUTDOWN_TIMEOUT_SECS: u64 = 5;
+const WRITE_TIMEOUT_SECS: u64 = 5;
 
 // Maximum buffer size for read operations (10 MB)
 const MAX_READ_BUFFER_BYTES: usize = 10 * 1024 * 1024;
+
+pub(crate) struct SocketTerminalFinalizer {
+    connection_mode: Arc<AtomicU8>,
+    post_disconnection: Option<Arc<dyn Fn() + Send + Sync>>,
+    notification_started: AtomicBool,
+    completion: Arc<SocketFinalizationState>,
+}
+
+struct SocketFinalizationState {
+    notification_completed: AtomicBool,
+    completion_notify: tokio::sync::Notify,
+    state_notify: Arc<tokio::sync::Notify>,
+}
+
+struct SocketFinalizationCompletion {
+    state: Arc<SocketFinalizationState>,
+}
+
+impl Drop for SocketFinalizationCompletion {
+    fn drop(&mut self) {
+        self.state
+            .notification_completed
+            .store(true, Ordering::Release);
+        self.state.completion_notify.notify_waiters();
+        self.state.state_notify.notify_waiters();
+    }
+}
+
+impl SocketTerminalFinalizer {
+    pub(crate) fn new(
+        connection_mode: Arc<AtomicU8>,
+        state_notify: Arc<tokio::sync::Notify>,
+        post_disconnection: Option<Arc<dyn Fn() + Send + Sync>>,
+    ) -> Self {
+        Self {
+            connection_mode,
+            post_disconnection,
+            notification_started: AtomicBool::new(false),
+            completion: Arc::new(SocketFinalizationState {
+                notification_completed: AtomicBool::new(false),
+                completion_notify: tokio::sync::Notify::new(),
+                state_notify,
+            }),
+        }
+    }
+
+    pub(crate) fn transition_and_finalize(&self) {
+        self.connection_mode
+            .store(ConnectionMode::Closed.as_u8(), Ordering::SeqCst);
+        self.finalize_closed();
+    }
+
+    fn finalize_closed(&self) {
+        if self
+            .notification_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            if let Some(handler) = self.post_disconnection.clone() {
+                let completion = SocketFinalizationCompletion {
+                    state: Arc::clone(&self.completion),
+                };
+                let job = move || {
+                    let _completion = completion;
+                    handler();
+                    log::debug!("Called `post_disconnection` handler");
+                };
+
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    handle.spawn_blocking(job);
+                } else {
+                    let _ = std::thread::Builder::new() // dst-ok: no runtime context
+                        .name("socket-terminal-finalizer".to_string())
+                        .spawn(job);
+                }
+            } else {
+                drop(SocketFinalizationCompletion {
+                    state: Arc::clone(&self.completion),
+                });
+            }
+        }
+    }
+
+    pub(crate) async fn wait_for_completion(&self) {
+        loop {
+            let mut notified = pin!(self.completion.completion_notify.notified());
+            notified.as_mut().enable();
+
+            if self
+                .completion
+                .notification_completed
+                .load(Ordering::Acquire)
+            {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
 
 /// Creates a `TcpStream` with the server.
 ///
@@ -89,6 +189,7 @@ struct SocketClientInner {
     config: SocketConfig,
     connector: Option<Connector>,
     read_task: Arc<tokio::task::JoinHandle<()>>,
+    read_fence: ReadSessionFence,
     write_task: tokio::task::JoinHandle<()>,
     writer_tx: tokio::sync::mpsc::UnboundedSender<WriterCommand>,
     heartbeat_task: Option<tokio::task::JoinHandle<()>>,
@@ -230,9 +331,11 @@ impl SocketClientInner {
 
         let connection_mode = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
         let state_notify = Arc::new(tokio::sync::Notify::new());
+        let read_fence = ReadSessionFence::new();
 
         let read_task = Arc::new(Self::spawn_read_task(
             connection_mode.clone(),
+            read_fence.clone(),
             reader,
             message_handler.clone(),
             suffix.clone(),
@@ -262,6 +365,7 @@ impl SocketClientInner {
             config,
             connector,
             read_task,
+            read_fence,
             write_task,
             writer_tx,
             heartbeat_task,
@@ -460,6 +564,8 @@ impl SocketClientInner {
             return Ok(());
         }
 
+        self.read_fence.invalidate();
+
         if !self.read_task.is_finished() {
             self.read_task.abort();
             log_task_aborted("read");
@@ -482,8 +588,10 @@ impl SocketClientInner {
         }
 
         // Spawn new read task
+        self.read_fence = ReadSessionFence::new();
         self.read_task = Arc::new(Self::spawn_read_task(
             self.connection_mode.clone(),
+            self.read_fence.clone(),
             reader,
             self.handler.clone(),
             suffix.clone(),
@@ -506,80 +614,133 @@ impl SocketClientInner {
     }
 
     #[must_use]
-    fn spawn_read_task(
+    fn spawn_read_task<R>(
         connection_state: Arc<AtomicU8>,
-        mut reader: TcpReader,
+        read_fence: ReadSessionFence,
+        reader: R,
         handler: Option<TcpMessageHandler>,
         suffix: Vec<u8>,
         idle_timeout_ms: Option<u64>,
-    ) -> tokio::task::JoinHandle<()> {
+    ) -> tokio::task::JoinHandle<()>
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+    {
         log_task_started("read");
 
         // Interval between checking the connection mode
         let check_interval = Duration::from_millis(CONNECTION_STATE_CHECK_INTERVAL_MS);
         let idle_timeout = idle_timeout_ms.map(Duration::from_millis);
 
-        tokio::task::spawn(async move {
-            let mut buf = Vec::new();
-            let mut last_data_time = dst::time::Instant::now();
+        tokio::task::spawn(Self::run_read_loop(
+            connection_state,
+            read_fence,
+            reader,
+            handler,
+            suffix,
+            idle_timeout,
+            check_interval,
+        ))
+    }
 
-            loop {
-                if !ConnectionMode::from_atomic(&connection_state).is_active() {
+    async fn run_read_loop<R>(
+        connection_state: Arc<AtomicU8>,
+        read_fence: ReadSessionFence,
+        mut reader: R,
+        handler: Option<TcpMessageHandler>,
+        suffix: Vec<u8>,
+        idle_timeout: Option<Duration>,
+        check_interval: Duration,
+    ) where
+        R: AsyncRead + Unpin,
+    {
+        let mut buf = Vec::new();
+        let mut last_data_time = dst::time::Instant::now();
+
+        'read: loop {
+            if !ConnectionMode::from_atomic(&connection_state).is_active() || !read_fence.is_valid()
+            {
+                if !buf.is_empty() {
+                    log::debug!(
+                        "Dropping {} buffered bytes after socket session ended",
+                        buf.len()
+                    );
+                    buf.clear();
+                }
+                break;
+            }
+
+            match dst::time::timeout(check_interval, reader.read_buf(&mut buf)).await {
+                // Connection has been terminated or vector buffer is complete
+                Ok(Ok(0)) => {
+                    log::debug!("Connection closed by server");
                     break;
                 }
+                Ok(Err(e)) => {
+                    log::debug!("Connection ended: {e}");
+                    break;
+                }
+                // Received bytes of data
+                Ok(Ok(bytes)) => {
+                    log::trace!("Received <binary> {bytes} bytes");
+                    last_data_time = dst::time::Instant::now();
 
-                match dst::time::timeout(check_interval, reader.read_buf(&mut buf)).await {
-                    // Connection has been terminated or vector buffer is complete
-                    Ok(Ok(0)) => {
-                        log::debug!("Connection closed by server");
+                    if !ConnectionMode::from_atomic(&connection_state).is_active()
+                        || !read_fence.is_valid()
+                    {
+                        log::debug!(
+                            "Dropping {} buffered bytes after socket session ended",
+                            buf.len()
+                        );
+                        buf.clear();
                         break;
                     }
-                    Ok(Err(e)) => {
-                        log::debug!("Connection ended: {e}");
-                        break;
-                    }
-                    // Received bytes of data
-                    Ok(Ok(bytes)) => {
-                        log::trace!("Received <binary> {bytes} bytes");
-                        last_data_time = dst::time::Instant::now();
 
-                        while let Some((i, _)) = &buf
-                            .windows(suffix.len())
-                            .enumerate()
-                            .find(|(_, pair)| pair.eq(&suffix))
-                        {
-                            let mut data: Vec<u8> = buf.drain(0..i + suffix.len()).collect();
-                            data.truncate(data.len() - suffix.len());
+                    while let Some((i, _)) = &buf
+                        .windows(suffix.len())
+                        .enumerate()
+                        .find(|(_, pair)| pair.eq(&suffix))
+                    {
+                        let mut data: Vec<u8> = buf.drain(0..i + suffix.len()).collect();
+                        data.truncate(data.len() - suffix.len());
 
-                            if let Some(ref handler) = handler {
-                                handler(&data);
+                        if let Some(ref handler) = handler {
+                            if !ConnectionMode::from_atomic(&connection_state).is_active()
+                                || !read_fence.is_valid()
+                            {
+                                log::debug!(
+                                    "Dropping {} buffered bytes after socket session ended",
+                                    data.len() + buf.len()
+                                );
+                                buf.clear();
+                                break 'read;
                             }
+                            handler(&data);
                         }
+                    }
 
-                        if buf.len() > MAX_READ_BUFFER_BYTES {
-                            log::error!(
-                                "Read buffer exceeded maximum size ({MAX_READ_BUFFER_BYTES} bytes), closing connection"
+                    if buf.len() > MAX_READ_BUFFER_BYTES {
+                        log::error!(
+                            "Read buffer exceeded maximum size ({MAX_READ_BUFFER_BYTES} bytes), closing connection"
+                        );
+                        break;
+                    }
+                }
+                Err(_) => {
+                    if let Some(timeout) = idle_timeout {
+                        let idle_duration = last_data_time.elapsed();
+                        if idle_duration >= timeout {
+                            log::warn!(
+                                "Read idle timeout: no data received for {:.1}s",
+                                idle_duration.as_secs_f64()
                             );
                             break;
                         }
                     }
-                    Err(_) => {
-                        if let Some(timeout) = idle_timeout {
-                            let idle_duration = last_data_time.elapsed();
-                            if idle_duration >= timeout {
-                                log::warn!(
-                                    "Read idle timeout: no data received for {:.1}s",
-                                    idle_duration.as_secs_f64()
-                                );
-                                break;
-                            }
-                        }
-                    }
                 }
             }
+        }
 
-            log_task_stopped("read");
-        })
+        log_task_stopped("read");
     }
 
     /// Drains buffered messages after reconnection completes.
@@ -591,11 +752,14 @@ impl SocketClientInner {
     ///
     /// Returns `true` if a send error occurred (buffer may still contain unsent messages),
     /// `false` if all messages were sent successfully (buffer is empty).
-    async fn drain_reconnect_buffer(
+    async fn drain_reconnect_buffer<W>(
         buffer: &mut VecDeque<Bytes>,
-        writer: &mut TcpWriter,
+        writer: &mut W,
         suffix: &[u8],
-    ) -> bool {
+    ) -> bool
+    where
+        W: AsyncWrite + Unpin,
+    {
         if buffer.is_empty() {
             return false;
         }
@@ -636,13 +800,16 @@ impl SocketClientInner {
         send_error_occurred
     }
 
-    fn spawn_write_task(
+    fn spawn_write_task<W>(
         connection_state: Arc<AtomicU8>,
         state_notify: Arc<tokio::sync::Notify>,
-        writer: TcpWriter,
-        mut writer_rx: tokio::sync::mpsc::UnboundedReceiver<WriterCommand>,
+        writer: W,
+        mut writer_rx: tokio::sync::mpsc::UnboundedReceiver<WriterCommand<W>>,
         suffix: Vec<u8>,
-    ) -> tokio::task::JoinHandle<()> {
+    ) -> tokio::task::JoinHandle<()>
+    where
+        W: AsyncWrite + Unpin + Send + 'static,
+    {
         log_task_started("write");
 
         // Interval between checking the connection mode
@@ -726,12 +893,30 @@ impl SocketClientInner {
                                 write_buf.extend_from_slice(&msg);
                                 write_buf.extend_from_slice(&suffix);
 
-                                if let Err(e) = active_writer.write_all(&write_buf).await {
-                                    if is_connection_drop_io_error(&e) {
-                                        log::warn!("Failed to send message: {e}");
-                                    } else {
-                                        log::error!("Failed to send message: {e}");
+                                let write_result = dst::time::timeout(
+                                    Duration::from_secs(WRITE_TIMEOUT_SECS),
+                                    active_writer.write_all(&write_buf),
+                                )
+                                .await;
+                                let write_failed = match write_result {
+                                    Ok(Ok(())) => false,
+                                    Ok(Err(e)) => {
+                                        if is_connection_drop_io_error(&e) {
+                                            log::warn!("Failed to send message: {e}");
+                                        } else {
+                                            log::error!("Failed to send message: {e}");
+                                        }
+                                        true
                                     }
+                                    Err(_) => {
+                                        log::warn!(
+                                            "Timed out sending message after {WRITE_TIMEOUT_SECS}s"
+                                        );
+                                        true
+                                    }
+                                };
+
+                                if write_failed {
                                     reconnect_buffer.push_back(msg);
 
                                     // CAS: a disconnect landing mid-write must not be overwritten
@@ -811,6 +996,8 @@ impl Drop for SocketClientInner {
 /// Cleanup on drop: aborts background tasks and clears handlers to break reference cycles.
 impl CleanDrop for SocketClientInner {
     fn clean_drop(&mut self) {
+        self.read_fence.invalidate();
+
         if !self.read_task.is_finished() {
             self.read_task.abort();
             log_task_aborted("read");
@@ -850,6 +1037,7 @@ pub struct SocketClient {
     pub(crate) state_notify: Arc<tokio::sync::Notify>,
     pub(crate) reconnect_timeout: Duration,
     pub writer_tx: tokio::sync::mpsc::UnboundedSender<WriterCommand>,
+    pub(crate) terminal_finalizer: Arc<SocketTerminalFinalizer>,
 }
 
 impl Debug for SocketClient {
@@ -875,13 +1063,18 @@ impl SocketClient {
         let connection_mode = inner.connection_mode.clone();
         let state_notify = inner.state_notify.clone();
         let reconnect_timeout = inner.reconnect_timeout;
+        let terminal_finalizer = Arc::new(SocketTerminalFinalizer::new(
+            connection_mode.clone(),
+            state_notify.clone(),
+            post_disconnection,
+        ));
 
         let controller_task = Self::spawn_controller_task(
             inner,
             connection_mode.clone(),
             state_notify.clone(),
             post_reconnection,
-            post_disconnection,
+            Arc::clone(&terminal_finalizer),
         );
 
         if let Some(handler) = post_connection {
@@ -895,6 +1088,7 @@ impl SocketClient {
             state_notify,
             reconnect_timeout,
             writer_tx,
+            terminal_finalizer,
         })
     }
 
@@ -949,23 +1143,26 @@ impl SocketClient {
     /// Controller task will periodically check the disconnect mode
     /// and shutdown the client if it is not alive.
     pub async fn close(&self) {
+        self.close_with_timeout(Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECS))
+            .await;
+    }
+
+    async fn close_with_timeout(&self, finalization_timeout: Duration) {
         // Preserve a CLOSED terminal state; the controller has already exited
         ConnectionMode::request_disconnect(&self.connection_mode);
         self.state_notify.notify_waiters();
 
-        if dst::time::timeout(Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECS), async {
-            while !self.is_closed() {
-                dst::time::sleep(Duration::from_millis(CONNECTION_STATE_CHECK_INTERVAL_MS)).await;
-            }
-
+        if dst::time::timeout(
+            finalization_timeout,
+            self.terminal_finalizer.wait_for_completion(),
+        )
+        .await
+            == Ok(())
+        {
             if !self.controller_task.is_finished() {
                 self.controller_task.abort();
                 log_task_aborted("controller");
             }
-        })
-        .await
-            == Ok(())
-        {
             log_task_stopped("controller");
         } else {
             log::warn!("Timeout waiting for controller task to finish");
@@ -974,8 +1171,7 @@ impl SocketClient {
                 self.controller_task.abort();
                 log_task_aborted("controller");
             }
-            self.connection_mode
-                .store(ConnectionMode::Closed.as_u8(), Ordering::SeqCst);
+            self.terminal_finalizer.transition_and_finalize();
         }
     }
 
@@ -1062,7 +1258,7 @@ impl SocketClient {
         connection_mode: Arc<AtomicU8>,
         state_notify: Arc<tokio::sync::Notify>,
         post_reconnection: Option<Arc<dyn Fn() + Send + Sync>>,
-        post_disconnection: Option<Arc<dyn Fn() + Send + Sync>>,
+        terminal_finalizer: Arc<SocketTerminalFinalizer>,
     ) -> tokio::task::JoinHandle<()> {
         const CONTROLLER_FALLBACK_INTERVAL_MS: u64 = 100;
 
@@ -1088,6 +1284,7 @@ impl SocketClient {
                         // Delay awaiting graceful shutdown
                         dst::time::sleep(Duration::from_millis(GRACEFUL_SHUTDOWN_DELAY_MS)).await;
 
+                        inner.read_fence.invalidate();
                         if !inner.read_task.is_finished() {
                             inner.read_task.abort();
                             log_task_aborted("read");
@@ -1107,16 +1304,27 @@ impl SocketClient {
                     }
 
                     log::debug!("Closed");
-
-                    if let Some(ref handler) = post_disconnection {
-                        handler();
-                        log::debug!("Called `post_disconnection` handler");
-                    }
+                    terminal_finalizer.transition_and_finalize();
                     break; // Controller finished
                 }
 
                 if mode.is_closed() {
                     log::debug!("Connection closed");
+
+                    inner.read_fence.invalidate();
+                    if !inner.read_task.is_finished() {
+                        inner.read_task.abort();
+                        log_task_aborted("read");
+                    }
+
+                    if let Some(task) = &inner.heartbeat_task
+                        && !task.is_finished()
+                    {
+                        task.abort();
+                        log_task_aborted("heartbeat");
+                    }
+
+                    terminal_finalizer.finalize_closed();
                     break;
                 }
 
@@ -1143,9 +1351,20 @@ impl SocketClient {
                         log::error!(
                             "Max reconnection attempts ({max_attempts}) exceeded, transitioning to CLOSED"
                         );
-                        connection_mode.store(ConnectionMode::Closed.as_u8(), Ordering::SeqCst);
-                        state_notify.notify_waiters();
-                        break;
+
+                        if connection_mode
+                            .compare_exchange(
+                                ConnectionMode::Reconnect.as_u8(),
+                                ConnectionMode::Closed.as_u8(),
+                                Ordering::SeqCst,
+                                Ordering::SeqCst,
+                            )
+                            .is_ok()
+                        {
+                            terminal_finalizer.finalize_closed();
+                            break;
+                        }
+                        continue;
                     }
 
                     inner.reconnect_attempt_count += 1;
@@ -1223,16 +1442,14 @@ impl SocketClient {
                     }
                 }
             }
-            inner
-                .connection_mode
-                .store(ConnectionMode::Closed.as_u8(), Ordering::SeqCst);
+            terminal_finalizer.finalize_closed();
 
             log_task_stopped("controller");
         })
     }
 }
 
-// Abort controller task on drop to clean up background tasks
+// Dropping cancels background work without reporting a terminal lifecycle transition.
 impl Drop for SocketClient {
     fn drop(&mut self) {
         if !self.controller_task.is_finished() {
@@ -1623,16 +1840,804 @@ mod tests {
 #[cfg(not(feature = "turmoil"))]
 #[cfg(not(all(feature = "simulation", madsim)))] // transport-layer I/O not simulated
 mod rust_tests {
+    use std::{
+        pin::Pin,
+        sync::{
+            Arc, Condvar, Mutex as StdMutex,
+            atomic::{AtomicUsize, Ordering as AtomicOrdering},
+        },
+        task::{Context, Poll, Waker},
+    };
+
     use nautilus_common::testing::wait_until_async;
     use rstest::rstest;
     use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
+        io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadBuf},
         net::TcpListener,
-        task,
+        sync::oneshot,
+        task::{self, yield_now},
         time::{Duration, sleep},
     };
 
     use super::*;
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    struct CondvarReleaseGuard {
+        release: Arc<(StdMutex<bool>, Condvar)>,
+    }
+
+    impl CondvarReleaseGuard {
+        fn new(release: Arc<(StdMutex<bool>, Condvar)>) -> Self {
+            Self { release }
+        }
+
+        fn release(&self) {
+            let (lock, condvar) = self.release.as_ref();
+            let mut released = lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *released = true;
+            condvar.notify_all();
+        }
+    }
+
+    impl Drop for CondvarReleaseGuard {
+        fn drop(&mut self) {
+            self.release();
+        }
+    }
+
+    async fn recv_rendezvous<T: Send + 'static>(
+        receiver: std::sync::mpsc::Receiver<T>,
+        name: &'static str,
+    ) -> T {
+        let receive_task = tokio::task::spawn_blocking(move || receiver.recv_timeout(TEST_TIMEOUT));
+
+        match tokio::time::timeout(TEST_TIMEOUT * 2, receive_task).await {
+            Ok(Ok(Ok(value))) => value,
+            Ok(Ok(Err(e))) => {
+                panic!("{name} did not arrive within the test timeout: {e}")
+            }
+            Ok(Err(e)) => panic!("{name} receive task failed: {e}"),
+            Err(e) => panic!("{name} receive task did not finish: {e}"),
+        }
+    }
+
+    async fn await_task_termination(
+        task: tokio::task::JoinHandle<()>,
+        name: &'static str,
+        cancellation_ok: bool,
+    ) {
+        match tokio::time::timeout(TEST_TIMEOUT, task).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) if cancellation_ok && e.is_cancelled() => {}
+            Ok(Err(e)) => panic!("{name} failed: {e}"),
+            Err(e) => panic!("{name} did not terminate within the test timeout: {e}"),
+        }
+    }
+
+    async fn wait_for_finalizer(finalizer: &SocketTerminalFinalizer, name: &'static str) {
+        tokio::time::timeout(TEST_TIMEOUT, finalizer.wait_for_completion())
+            .await
+            .unwrap_or_else(|_| panic!("{name} completion was not published"));
+    }
+
+    struct ScriptedReader {
+        first: Option<Vec<u8>>,
+        remainder: Arc<StdMutex<Option<Vec<u8>>>>,
+        pending_tx: Option<oneshot::Sender<()>>,
+        waker: Arc<StdMutex<Option<Waker>>>,
+    }
+
+    impl AsyncRead for ScriptedReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            if let Some(first) = self.first.take() {
+                buf.put_slice(&first);
+                return Poll::Ready(Ok(()));
+            }
+
+            if let Some(remainder) = self.remainder.lock().unwrap().take() {
+                buf.put_slice(&remainder);
+                return Poll::Ready(Ok(()));
+            }
+
+            if let Some(tx) = self.pending_tx.take() {
+                let _ = tx.send(());
+            }
+            *self.waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    struct BackpressuredWriter {
+        stream: DuplexStream,
+        pending_tx: Option<oneshot::Sender<()>>,
+    }
+
+    impl AsyncWrite for BackpressuredWriter {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let result = Pin::new(&mut self.stream).poll_write(cx, buf);
+            if result.is_pending()
+                && let Some(tx) = self.pending_tx.take()
+            {
+                let _ = tx.send(());
+            }
+            result
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.stream).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.stream).poll_shutdown(cx)
+        }
+    }
+
+    struct RecordingWriter {
+        bytes: Arc<StdMutex<Vec<u8>>>,
+    }
+
+    impl AsyncWrite for RecordingWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            self.bytes.lock().unwrap().extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn test_socket_client(
+        connection_state: Arc<AtomicU8>,
+        state_notify: Arc<tokio::sync::Notify>,
+        terminal_finalizer: Arc<SocketTerminalFinalizer>,
+        controller_task: tokio::task::JoinHandle<()>,
+    ) -> SocketClient {
+        let (writer_tx, _writer_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        SocketClient {
+            controller_task,
+            connection_mode: connection_state,
+            state_notify,
+            reconnect_timeout: Duration::from_secs(1),
+            writer_tx,
+            terminal_finalizer,
+        }
+    }
+
+    fn wait_for_finalizer_sync(finalizer: &SocketTerminalFinalizer) {
+        let deadline = std::time::Instant::now() + TEST_TIMEOUT * 2;
+
+        while !finalizer
+            .completion
+            .notification_completed
+            .load(Ordering::Acquire)
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "terminal callback did not complete"
+            );
+            std::thread::yield_now();
+        }
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_close_finalizes_after_controller_was_aborted() {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_clone = Arc::clone(&callback_count);
+        let terminal_finalizer = Arc::new(SocketTerminalFinalizer::new(
+            Arc::clone(&connection_state),
+            Arc::clone(&state_notify),
+            Some(Arc::new(move || {
+                callback_count_clone.fetch_add(1, AtomicOrdering::SeqCst);
+            })),
+        ));
+
+        let controller_task = tokio::spawn(std::future::pending::<()>());
+        controller_task.abort();
+        let client = test_socket_client(
+            connection_state,
+            state_notify,
+            terminal_finalizer,
+            controller_task,
+        );
+
+        client.close_with_timeout(Duration::from_millis(1)).await;
+        wait_for_finalizer_sync(&client.terminal_finalizer);
+
+        assert!(client.is_closed());
+        assert_eq!(callback_count.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_close_does_not_wait_for_aborted_controller_to_finish() {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let callback_release = Arc::new((StdMutex::new(false), Condvar::new()));
+        let callback_release_guard = CondvarReleaseGuard::new(Arc::clone(&callback_release));
+        let callback_release_clone = Arc::clone(&callback_release);
+        let (callback_entered_tx, callback_entered_rx) = std::sync::mpsc::channel();
+        let terminal_finalizer = Arc::new(SocketTerminalFinalizer::new(
+            Arc::clone(&connection_state),
+            Arc::clone(&state_notify),
+            Some(Arc::new(move || {
+                callback_entered_tx.send(()).unwrap();
+                let (lock, condvar) = callback_release_clone.as_ref();
+                let mut released = lock.lock().unwrap();
+
+                while !*released {
+                    released = condvar.wait(released).unwrap();
+                }
+            })),
+        ));
+        let controller_finalizer = Arc::clone(&terminal_finalizer);
+        let controller_task = tokio::spawn(async move {
+            controller_finalizer.transition_and_finalize();
+        });
+        recv_rendezvous(
+            callback_entered_rx,
+            "controller-claimed terminal callback entry",
+        )
+        .await;
+        let client = test_socket_client(
+            connection_state,
+            state_notify,
+            terminal_finalizer,
+            controller_task,
+        );
+
+        let close_result = tokio::time::timeout(
+            TEST_TIMEOUT,
+            client.close_with_timeout(Duration::from_millis(1)),
+        )
+        .await;
+
+        callback_release_guard.release();
+
+        assert!(
+            close_result.is_ok(),
+            "close should return after aborting a controller blocked in a callback"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_close_dispatches_unclaimed_blocking_callback() {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_clone = Arc::clone(&callback_count);
+        let callback_release = Arc::new((StdMutex::new(false), Condvar::new()));
+        let callback_release_guard = CondvarReleaseGuard::new(Arc::clone(&callback_release));
+        let callback_release_clone = Arc::clone(&callback_release);
+        let (callback_entered_tx, callback_entered_rx) = std::sync::mpsc::channel();
+        let terminal_finalizer = Arc::new(SocketTerminalFinalizer::new(
+            Arc::clone(&connection_state),
+            Arc::clone(&state_notify),
+            Some(Arc::new(move || {
+                callback_count_clone.fetch_add(1, AtomicOrdering::SeqCst);
+                callback_entered_tx.send(()).unwrap();
+                let (lock, condvar) = callback_release_clone.as_ref();
+                let mut released = lock.lock().unwrap();
+
+                while !*released {
+                    released = condvar.wait(released).unwrap();
+                }
+            })),
+        ));
+
+        let controller_task = tokio::spawn(std::future::pending::<()>());
+        let client = Arc::new(test_socket_client(
+            connection_state,
+            state_notify,
+            Arc::clone(&terminal_finalizer),
+            controller_task,
+        ));
+        let close_client = Arc::clone(&client);
+        let (close_finished_tx, close_finished_rx) = std::sync::mpsc::channel();
+
+        let close_task = tokio::spawn(async move {
+            close_client
+                .close_with_timeout(Duration::from_millis(1))
+                .await;
+            let _ = close_finished_tx.send(());
+        });
+
+        recv_rendezvous(callback_entered_rx, "close-claimed terminal callback entry").await;
+        recv_rendezvous(
+            close_finished_rx,
+            "close task completion while terminal callback was blocked",
+        )
+        .await;
+        let completion_while_blocked = terminal_finalizer
+            .completion
+            .notification_completed
+            .load(Ordering::Acquire);
+
+        callback_release_guard.release();
+
+        await_task_termination(close_task, "close task", false).await;
+        wait_for_finalizer(&terminal_finalizer, "close-claimed terminal callback").await;
+
+        assert!(!completion_while_blocked);
+        assert_eq!(callback_count.load(AtomicOrdering::SeqCst), 1);
+
+        tokio::time::timeout(
+            TEST_TIMEOUT,
+            client.close_with_timeout(Duration::from_millis(1)),
+        )
+        .await
+        .expect("second close did not return within the test timeout");
+        terminal_finalizer.transition_and_finalize();
+        assert_eq!(callback_count.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_panicking_terminal_callback_still_completes_notification() {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Closed.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let finalizer = SocketTerminalFinalizer::new(
+            connection_state,
+            state_notify,
+            Some(Arc::new(|| panic!("terminal callback panic"))),
+        );
+
+        finalizer.finalize_closed();
+        wait_for_finalizer_sync(&finalizer);
+        assert!(
+            finalizer
+                .completion
+                .notification_completed
+                .load(Ordering::Acquire)
+        );
+    }
+
+    #[rstest]
+    fn test_concurrent_terminal_finalizers_notify_once() {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Closed.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_clone = Arc::clone(&callback_count);
+        let (callback_entered_tx, callback_entered_rx) = std::sync::mpsc::channel();
+        let (callback_release_tx, callback_release_rx) = std::sync::mpsc::channel();
+        let callback_release_rx = Arc::new(StdMutex::new(callback_release_rx));
+        let callback_release_rx_clone = Arc::clone(&callback_release_rx);
+        let finalizer = Arc::new(SocketTerminalFinalizer::new(
+            connection_state,
+            state_notify,
+            Some(Arc::new(move || {
+                callback_entered_tx.send(()).unwrap();
+                callback_release_rx_clone
+                    .lock()
+                    .unwrap()
+                    .recv_timeout(TEST_TIMEOUT)
+                    .expect("terminal callback release did not arrive within the test timeout");
+                callback_count_clone.fetch_add(1, AtomicOrdering::SeqCst);
+            })),
+        ));
+        let first_finalizer = Arc::clone(&finalizer);
+        let first = std::thread::spawn(move || first_finalizer.finalize_closed());
+        callback_entered_rx
+            .recv_timeout(TEST_TIMEOUT)
+            .expect("terminal callback entry did not arrive within the test timeout");
+        let second_finalizer = Arc::clone(&finalizer);
+        let second = std::thread::spawn(move || second_finalizer.finalize_closed());
+
+        second.join().unwrap();
+        callback_release_tx.send(()).unwrap();
+        first.join().unwrap();
+        wait_for_finalizer_sync(&finalizer);
+
+        assert_eq!(callback_count.load(AtomicOrdering::SeqCst), 1);
+        assert!(
+            finalizer
+                .completion
+                .notification_completed
+                .load(Ordering::Acquire)
+        );
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn test_terminal_finalizer_cas_interleavings_notify_once(#[case] exhaustion_wins: bool) {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Reconnect.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_clone = Arc::clone(&callback_count);
+        let callback_state = Arc::clone(&connection_state);
+        let finalizer = SocketTerminalFinalizer::new(
+            Arc::clone(&connection_state),
+            state_notify,
+            Some(Arc::new(move || {
+                assert_eq!(
+                    ConnectionMode::from_atomic(&callback_state),
+                    ConnectionMode::Closed
+                );
+                callback_count_clone.fetch_add(1, AtomicOrdering::SeqCst);
+            })),
+        );
+
+        if exhaustion_wins {
+            assert!(
+                connection_state
+                    .compare_exchange(
+                        ConnectionMode::Reconnect.as_u8(),
+                        ConnectionMode::Closed.as_u8(),
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_ok()
+            );
+            finalizer.finalize_closed();
+            assert!(!ConnectionMode::request_disconnect(&connection_state));
+        } else {
+            assert!(ConnectionMode::request_disconnect(&connection_state));
+            assert!(
+                connection_state
+                    .compare_exchange(
+                        ConnectionMode::Reconnect.as_u8(),
+                        ConnectionMode::Closed.as_u8(),
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_err()
+            );
+            finalizer.transition_and_finalize();
+        }
+
+        finalizer.transition_and_finalize();
+        wait_for_finalizer_sync(&finalizer);
+        assert_eq!(
+            ConnectionMode::from_atomic(&connection_state),
+            ConnectionMode::Closed
+        );
+        assert_eq!(callback_count.load(AtomicOrdering::SeqCst), 1);
+        assert!(
+            finalizer
+                .completion
+                .notification_completed
+                .load(Ordering::Acquire)
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_reconnect_exhaustion_notifies_disconnection_once() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+
+        let server = task::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let _ = accepted_tx.send(());
+            let _ = release_rx.await;
+            drop(socket);
+            drop(listener);
+        });
+
+        let config = SocketConfig {
+            url: format!("127.0.0.1:{port}"),
+            mode: Mode::Plain,
+            suffix: b"\r\n".to_vec(),
+            message_handler: None,
+            heartbeat: None,
+            reconnect_timeout_ms: Some(100),
+            reconnect_delay_initial_ms: Some(1),
+            reconnect_delay_max_ms: Some(1),
+            reconnect_backoff_factor: Some(1.0),
+            reconnect_jitter_ms: Some(0),
+            connection_max_retries: Some(1),
+            reconnect_max_attempts: Some(1),
+            idle_timeout_ms: None,
+            certs_dir: None,
+        };
+
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_clone = Arc::clone(&callback_count);
+        let (callback_tx, callback_rx) = oneshot::channel();
+        let callback_tx = Arc::new(StdMutex::new(Some(callback_tx)));
+        let post_disconnection = Arc::new(move || {
+            callback_count_clone.fetch_add(1, AtomicOrdering::SeqCst);
+
+            if let Some(tx) = callback_tx.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+        });
+
+        let client = SocketClient::connect(config, None, None, Some(post_disconnection))
+            .await
+            .unwrap();
+        accepted_rx.await.unwrap();
+        release_tx.send(()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), callback_rx)
+            .await
+            .expect("reconnect exhaustion should invoke post_disconnection")
+            .unwrap();
+        assert!(client.is_closed());
+        assert_eq!(callback_count.load(AtomicOrdering::SeqCst), 1);
+
+        client.close().await;
+        assert_eq!(callback_count.load(AtomicOrdering::SeqCst), 1);
+        server.await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_graceful_close_notifies_disconnection_once() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+
+        let server = task::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            let _ = accepted_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        let config = SocketConfig {
+            url: format!("127.0.0.1:{port}"),
+            mode: Mode::Plain,
+            suffix: b"\r\n".to_vec(),
+            message_handler: None,
+            heartbeat: None,
+            reconnect_timeout_ms: None,
+            reconnect_delay_initial_ms: None,
+            reconnect_delay_max_ms: None,
+            reconnect_backoff_factor: None,
+            reconnect_jitter_ms: None,
+            connection_max_retries: None,
+            reconnect_max_attempts: None,
+            idle_timeout_ms: None,
+            certs_dir: None,
+        };
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_clone = Arc::clone(&callback_count);
+        let post_disconnection = Arc::new(move || {
+            callback_count_clone.fetch_add(1, AtomicOrdering::SeqCst);
+        });
+        let client = SocketClient::connect(config, None, None, Some(post_disconnection))
+            .await
+            .unwrap();
+        accepted_rx.await.unwrap();
+
+        client.close().await;
+        client.close().await;
+
+        assert!(client.is_closed());
+        assert_eq!(callback_count.load(AtomicOrdering::SeqCst), 1);
+        server.abort();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_read_loop_drops_remaining_frames_after_session_replaced() {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let read_fence = ReadSessionFence::new();
+        let received = Arc::new(StdMutex::new(Vec::<Vec<u8>>::new()));
+        let received_clone = Arc::clone(&received);
+        let handler_release = Arc::new((StdMutex::new(false), Condvar::new()));
+        let handler_release_guard = CondvarReleaseGuard::new(Arc::clone(&handler_release));
+        let handler_release_clone = Arc::clone(&handler_release);
+        let (handler_entered_tx, handler_entered_rx) = std::sync::mpsc::channel();
+        let handler: TcpMessageHandler = Arc::new(move |data| {
+            received_clone.lock().unwrap().push(data.to_vec());
+            handler_entered_tx.send(()).unwrap();
+            let (lock, condvar) = handler_release_clone.as_ref();
+            let mut released = lock.lock().unwrap();
+
+            while !*released {
+                released = condvar.wait(released).unwrap();
+            }
+        });
+        let reader = ScriptedReader {
+            first: Some(b"first\r\nsecond\r\n".to_vec()),
+            remainder: Arc::new(StdMutex::new(None)),
+            pending_tx: None,
+            waker: Arc::new(StdMutex::new(None)),
+        };
+        let read_task = SocketClientInner::spawn_read_task(
+            Arc::clone(&connection_state),
+            read_fence.clone(),
+            reader,
+            Some(handler),
+            b"\r\n".to_vec(),
+            None,
+        );
+
+        recv_rendezvous(handler_entered_rx, "socket first-handler entry").await;
+        connection_state.store(ConnectionMode::Reconnect.as_u8(), Ordering::SeqCst);
+        read_fence.invalidate();
+        read_task.abort();
+        connection_state.store(ConnectionMode::Active.as_u8(), Ordering::SeqCst);
+
+        handler_release_guard.release();
+        await_task_termination(read_task, "old socket read task", true).await;
+
+        assert_eq!(received.lock().unwrap().as_slice(), &[b"first".to_vec()]);
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_read_loop_drops_partial_old_session_frame() {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let old_read_fence = ReadSessionFence::new();
+        let received = Arc::new(StdMutex::new(Vec::<Vec<u8>>::new()));
+        let received_clone = Arc::clone(&received);
+        let handler: TcpMessageHandler =
+            Arc::new(move |data| received_clone.lock().unwrap().push(data.to_vec()));
+        let (pending_tx, pending_rx) = oneshot::channel();
+        let remainder = Arc::new(StdMutex::new(None));
+        let waker = Arc::new(StdMutex::new(None));
+        let reader = ScriptedReader {
+            first: Some(b"old".to_vec()),
+            remainder: Arc::clone(&remainder),
+            pending_tx: Some(pending_tx),
+            waker: Arc::clone(&waker),
+        };
+
+        let read_task = SocketClientInner::spawn_read_task(
+            Arc::clone(&connection_state),
+            old_read_fence.clone(),
+            reader,
+            Some(handler),
+            b"\r\n".to_vec(),
+            None,
+        );
+
+        pending_rx.await.unwrap();
+        connection_state.store(ConnectionMode::Reconnect.as_u8(), Ordering::SeqCst);
+        old_read_fence.invalidate();
+        connection_state.store(ConnectionMode::Active.as_u8(), Ordering::SeqCst);
+        *remainder.lock().unwrap() = Some(b"\r\nnew\r\n".to_vec());
+        waker.lock().unwrap().take().unwrap().wake();
+        read_task.await.unwrap();
+
+        let fresh_reader = ScriptedReader {
+            first: Some(b"new\r\n".to_vec()),
+            remainder: Arc::new(StdMutex::new(None)),
+            pending_tx: None,
+            waker: Arc::new(StdMutex::new(None)),
+        };
+        let fresh_connection_state = Arc::clone(&connection_state);
+        let fresh_received = Arc::clone(&received);
+        let fresh_handler: TcpMessageHandler = Arc::new(move |data| {
+            fresh_received.lock().unwrap().push(data.to_vec());
+            fresh_connection_state.store(ConnectionMode::Reconnect.as_u8(), Ordering::SeqCst);
+        });
+        SocketClientInner::spawn_read_task(
+            Arc::clone(&connection_state),
+            ReadSessionFence::new(),
+            fresh_reader,
+            Some(fresh_handler),
+            b"\r\n".to_vec(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(received.lock().unwrap().as_slice(), &[b"new".to_vec()]);
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_read_loop_stops_when_first_handler_ends_session() {
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let handler_state = Arc::clone(&connection_state);
+        let received = Arc::new(StdMutex::new(Vec::<Vec<u8>>::new()));
+        let received_clone = Arc::clone(&received);
+        let handler: TcpMessageHandler = Arc::new(move |data| {
+            received_clone.lock().unwrap().push(data.to_vec());
+            handler_state.store(ConnectionMode::Reconnect.as_u8(), Ordering::SeqCst);
+        });
+        let (pending_tx, _pending_rx) = oneshot::channel();
+        let reader = ScriptedReader {
+            first: Some(b"first\r\nsecond\r\n".to_vec()),
+            remainder: Arc::new(StdMutex::new(None)),
+            pending_tx: Some(pending_tx),
+            waker: Arc::new(StdMutex::new(None)),
+        };
+
+        SocketClientInner::spawn_read_task(
+            connection_state,
+            ReadSessionFence::new(),
+            reader,
+            Some(handler),
+            b"\r\n".to_vec(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(received.lock().unwrap().as_slice(), &[b"first".to_vec()]);
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_stalled_socket_write_reconnects_and_replays_complete_message() {
+        type TestWriter = Pin<Box<dyn AsyncWrite + Send>>;
+
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let (stream, _non_reading_peer) = tokio::io::duplex(1);
+        let (pending_tx, pending_rx) = oneshot::channel();
+        let writer: TestWriter = Box::pin(BackpressuredWriter {
+            stream,
+            pending_tx: Some(pending_tx),
+        });
+        let (writer_tx, writer_rx) =
+            tokio::sync::mpsc::unbounded_channel::<WriterCommand<TestWriter>>();
+        let write_task = SocketClientInner::spawn_write_task(
+            Arc::clone(&connection_state),
+            Arc::clone(&state_notify),
+            writer,
+            writer_rx,
+            b"\r\n".to_vec(),
+        );
+
+        writer_tx
+            .send(WriterCommand::Send(Bytes::from_static(b"complete-message")))
+            .unwrap();
+        pending_rx.await.unwrap();
+
+        let recorded = Arc::new(StdMutex::new(Vec::new()));
+        let new_writer: TestWriter = Box::pin(RecordingWriter {
+            bytes: Arc::clone(&recorded),
+        });
+        let (update_tx, update_rx) = oneshot::channel();
+        writer_tx
+            .send(WriterCommand::Update(new_writer, update_tx))
+            .unwrap();
+
+        tokio::time::advance(Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECS)).await;
+        yield_now().await;
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(10), update_rx)
+                .await
+                .expect("writer update should not remain queued behind a stalled write")
+                .unwrap(),
+            "writer should report successful replay"
+        );
+        assert_eq!(
+            ConnectionMode::from_atomic(&connection_state),
+            ConnectionMode::Reconnect
+        );
+        assert_eq!(recorded.lock().unwrap().as_slice(), b"complete-message\r\n");
+
+        connection_state.store(ConnectionMode::Closed.as_u8(), Ordering::SeqCst);
+        state_notify.notify_waiters();
+        drop(writer_tx);
+        write_task.await.unwrap();
+    }
 
     #[rstest]
     #[tokio::test]

--- a/crates/network/src/socket/types.rs
+++ b/crates/network/src/socket/types.rs
@@ -29,9 +29,9 @@ pub type TcpMessageHandler = Arc<dyn Fn(&[u8]) + Send + Sync>;
 
 /// Represents a command for the writer task.
 #[derive(Debug)]
-pub enum WriterCommand {
+pub enum WriterCommand<W = TcpWriter> {
     /// Update the writer reference with a new one after reconnection.
-    Update(TcpWriter, tokio::sync::oneshot::Sender<bool>),
+    Update(W, tokio::sync::oneshot::Sender<bool>),
     /// Send data to the server.
     Send(Bytes),
 }

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -101,10 +101,12 @@ use crate::{
     dst,
     error::{SendError, is_connection_drop_io_error},
     logging::{log_task_aborted, log_task_started, log_task_stopped},
-    mode::ConnectionMode,
+    mode::{ConnectionMode, ReadSessionFence},
     ratelimiter::{RateLimiter, clock::MonotonicClock, quota::Quota},
     transport::{BoxedWsTransport, Message, TransportError, tungstenite::TungsteniteTransport},
 };
+
+const WRITE_TIMEOUT_SECS: u64 = 5;
 
 /// Shared headers used by future automatic WebSocket reconnects.
 ///
@@ -194,6 +196,7 @@ pub struct WebSocketClientInner {
     /// The handler for incoming pings (stored separately from config).
     ping_handler: Option<PingHandler>,
     read_task: Option<tokio::task::JoinHandle<()>>,
+    read_fence: Option<ReadSessionFence>,
     write_task: tokio::task::JoinHandle<()>,
     writer_tx: tokio::sync::mpsc::UnboundedSender<WriterCommand>,
     heartbeat_task: Option<tokio::task::JoinHandle<()>>,
@@ -255,6 +258,7 @@ impl WebSocketClientInner {
 
         // Note: We don't spawn a read task here since the reader is handled externally
         let read_task = None;
+        let read_fence = None;
 
         // Stream mode ignores reconnect settings, use harmless defaults
         let backoff = ExponentialBackoff::new(
@@ -311,6 +315,7 @@ impl WebSocketClientInner {
             reconnect_timeout,
             heartbeat_task,
             read_task,
+            read_fence,
             write_task,
             backoff,
             is_stream_mode: true,
@@ -413,19 +418,22 @@ impl WebSocketClientInner {
         let connection_epoch = Arc::new(AtomicU64::new(0));
         let state_notify = Arc::new(tokio::sync::Notify::new());
 
-        let read_task = if is_stream_mode {
-            None
+        let (read_task, read_fence) = if is_stream_mode {
+            (None, None)
         } else {
-            Some(Self::spawn_message_handler_task(
+            let read_fence = ReadSessionFence::new();
+            let read_task = Self::spawn_message_handler_task(
                 connection_mode.clone(),
                 state_notify.clone(),
+                read_fence.clone(),
                 reader,
                 0,
                 message_handler.as_ref(),
                 epoch_handler.as_ref(),
                 ping_handler.as_ref(),
                 config.idle_timeout_ms,
-            ))
+            );
+            (Some(read_task), Some(read_fence))
         };
 
         let auth_tracker = Arc::new(OnceLock::new());
@@ -462,6 +470,7 @@ impl WebSocketClientInner {
             epoch_handler,
             ping_handler,
             read_task,
+            read_fence,
             write_task,
             writer_tx,
             heartbeat_task,
@@ -1063,6 +1072,10 @@ impl WebSocketClientInner {
             return Ok(());
         }
 
+        if let Some(read_fence) = self.read_fence.take() {
+            read_fence.invalidate();
+        }
+
         if let Some(ref read_task) = self.read_task.take()
             && !read_task.is_finished()
         {
@@ -1086,20 +1099,24 @@ impl WebSocketClientInner {
             return Ok(());
         }
 
-        self.read_task = if self.message_handler.is_some() || self.epoch_handler.is_some() {
-            Some(Self::spawn_message_handler_task(
+        if self.message_handler.is_some() || self.epoch_handler.is_some() {
+            let read_fence = ReadSessionFence::new();
+            self.read_task = Some(Self::spawn_message_handler_task(
                 self.connection_mode.clone(),
                 self.state_notify.clone(),
+                read_fence.clone(),
                 reader,
                 connection_epoch,
                 self.message_handler.as_ref(),
                 self.epoch_handler.as_ref(),
                 self.ping_handler.as_ref(),
                 self.config.idle_timeout_ms,
-            ))
+            ));
+            self.read_fence = Some(read_fence);
         } else {
-            None
-        };
+            self.read_task = None;
+            self.read_fence = None;
+        }
 
         log::debug!("Reconnect succeeded");
         Ok(())
@@ -1126,6 +1143,7 @@ impl WebSocketClientInner {
     fn spawn_message_handler_task(
         connection_state: Arc<AtomicU8>,
         state_notify: Arc<tokio::sync::Notify>,
+        read_fence: ReadSessionFence,
         mut reader: MessageReader,
         connection_epoch: u64,
         message_handler: Option<&MessageHandler>,
@@ -1147,14 +1165,39 @@ impl WebSocketClientInner {
             let mut last_data_time = dst::time::Instant::now();
 
             loop {
-                if !ConnectionMode::from_atomic(&connection_state).is_active() {
+                if !ConnectionMode::from_atomic(&connection_state).is_active()
+                    || !read_fence.is_valid()
+                {
                     break;
                 }
 
-                match dst::time::timeout(check_interval, reader.next()).await {
+                let read_result = dst::time::timeout(check_interval, reader.next()).await;
+
+                if let Ok(Some(Ok(ref message))) = read_result
+                    && (!ConnectionMode::from_atomic(&connection_state).is_active()
+                        || !read_fence.is_valid())
+                {
+                    log::debug!(
+                        "Dropping WebSocket message with {} bytes after session ended",
+                        message.as_bytes().len()
+                    );
+                    break;
+                }
+
+                match read_result {
                     Ok(Some(Ok(Message::Binary(data)))) => {
                         log::trace!("Received message <binary> {} bytes", data.len());
                         last_data_time = dst::time::Instant::now();
+
+                        if !ConnectionMode::from_atomic(&connection_state).is_active()
+                            || !read_fence.is_valid()
+                        {
+                            log::debug!(
+                                "Dropping WebSocket message with {} bytes after session ended",
+                                data.len()
+                            );
+                            break;
+                        }
 
                         if let Some(ref handler) = message_handler {
                             handler(Message::Binary(data.clone()));
@@ -1167,6 +1210,16 @@ impl WebSocketClientInner {
                     Ok(Some(Ok(Message::Text(data)))) => {
                         log::trace!("Received message: {data:?}");
                         last_data_time = dst::time::Instant::now();
+
+                        if !ConnectionMode::from_atomic(&connection_state).is_active()
+                            || !read_fence.is_valid()
+                        {
+                            log::debug!(
+                                "Dropping WebSocket message with {} bytes after session ended",
+                                data.len()
+                            );
+                            break;
+                        }
 
                         if let Some(ref handler) = message_handler {
                             handler(Message::Text(data.clone()));
@@ -1183,6 +1236,15 @@ impl WebSocketClientInner {
                         // Checked here too: a ping flood faster than the check interval starves the timeout branch
 
                         if let Some(ref handler) = ping_handler {
+                            if !ConnectionMode::from_atomic(&connection_state).is_active()
+                                || !read_fence.is_valid()
+                            {
+                                log::debug!(
+                                    "Dropping WebSocket ping with {} bytes after session ended",
+                                    ping_data.len()
+                                );
+                                break;
+                            }
                             handler(ping_data.to_vec());
                         }
 
@@ -1368,11 +1430,21 @@ impl WebSocketClientInner {
                         &auth_tracker,
                     ) {
                         ReconnectBufferAction::Drain => {
-                            let send_error = Self::drain_reconnect_buffer(
-                                &mut reconnect_buffer,
-                                &mut active_writer,
+                            let drain_result = dst::time::timeout(
+                                Duration::from_secs(WRITE_TIMEOUT_SECS),
+                                Self::drain_reconnect_buffer(
+                                    &mut reconnect_buffer,
+                                    &mut active_writer,
+                                ),
                             )
                             .await;
+                            let send_error = drain_result.unwrap_or_else(|_| {
+                                log::warn!(
+                                    "Timed out draining reconnect buffer after {WRITE_TIMEOUT_SECS}s, {} messages remain",
+                                    reconnect_buffer.len()
+                                );
+                                true
+                            });
 
                             // CAS: a disconnect landing mid-drain must not be overwritten
                             if send_error && ConnectionMode::request_reconnect(&connection_state) {
@@ -1452,16 +1524,35 @@ impl WebSocketClientInner {
                                     _ = response_tx.send(Err(SendError::ConnectionChanged));
                                     continue;
                                 }
-                                let result = active_writer.send(message).await;
-                                if let Err(e) = &result {
-                                    if is_connection_drop_transport_error(e) {
-                                        log::warn!("Failed to send message: {e}");
-                                    } else {
-                                        log::error!("Failed to send message: {e}");
+
+                                let send_result = dst::time::timeout(
+                                    Duration::from_secs(WRITE_TIMEOUT_SECS),
+                                    active_writer.send(message),
+                                )
+                                .await;
+
+                                // An ownership-bound message is never replayed, so an expired
+                                // deadline reports failure to the caller instead of buffering
+                                // the message as the ordinary send path does.
+                                let result = match send_result {
+                                    Ok(Ok(())) => Ok(()),
+                                    Ok(Err(e)) => {
+                                        if is_connection_drop_transport_error(&e) {
+                                            log::warn!("Failed to send message: {e}");
+                                        } else {
+                                            log::error!("Failed to send message: {e}");
+                                        }
+
+                                        Err(SendError::BrokenPipe(e.to_string()))
                                     }
-                                }
-                                let result =
-                                    result.map_err(|e| SendError::BrokenPipe(e.to_string()));
+                                    Err(_) => {
+                                        log::warn!(
+                                            "Timed out sending message after {WRITE_TIMEOUT_SECS}s"
+                                        );
+
+                                        Err(SendError::WriteTimeout)
+                                    }
+                                };
                                 let send_failed = result.is_err();
                                 _ = response_tx.send(result);
 
@@ -1477,12 +1568,30 @@ impl WebSocketClientInner {
                                 }
                             }
                             WriterCommand::Send(msg) => {
-                                if let Err(e) = active_writer.send(msg.clone()).await {
-                                    if is_connection_drop_transport_error(&e) {
-                                        log::warn!("Failed to send message: {e}");
-                                    } else {
-                                        log::error!("Failed to send message: {e}");
+                                let send_result = dst::time::timeout(
+                                    Duration::from_secs(WRITE_TIMEOUT_SECS),
+                                    active_writer.send(msg.clone()),
+                                )
+                                .await;
+                                let send_failed = match send_result {
+                                    Ok(Ok(())) => false,
+                                    Ok(Err(e)) => {
+                                        if is_connection_drop_transport_error(&e) {
+                                            log::warn!("Failed to send message: {e}");
+                                        } else {
+                                            log::error!("Failed to send message: {e}");
+                                        }
+                                        true
                                     }
+                                    Err(_) => {
+                                        log::warn!(
+                                            "Timed out sending message after {WRITE_TIMEOUT_SECS}s"
+                                        );
+                                        true
+                                    }
+                                };
+
+                                if send_failed {
                                     reconnect_buffer.push_back(msg);
 
                                     // CAS: a disconnect landing mid-send must not be overwritten
@@ -1586,6 +1695,10 @@ impl Drop for WebSocketClientInner {
 /// Cleanup on drop: aborts background tasks and clears handlers to break reference cycles.
 impl CleanDrop for WebSocketClientInner {
     fn clean_drop(&mut self) {
+        if let Some(read_fence) = self.read_fence.take() {
+            read_fence.invalidate();
+        }
+
         if let Some(ref read_task) = self.read_task.take()
             && !read_task.is_finished()
         {
@@ -2193,9 +2306,12 @@ impl WebSocketClient {
     ///
     /// Returns:
     /// - [`SendError::Closed`] if the client closes.
-    /// - [`SendError::Timeout`] if the active wait times out.
+    /// - [`SendError::Timeout`] if the active wait times out before the write starts.
     /// - [`SendError::ConnectionChanged`] if the expected connection no longer owns the writer.
     /// - [`SendError::BrokenPipe`] if the command or transport write fails.
+    /// - [`SendError::WriteTimeout`] if the write starts but does not complete within the write
+    ///   deadline. Delivery is undetermined in that case: the message is not replayed, and it
+    ///   must not be resent blindly.
     pub async fn send_text_on_connection(
         &self,
         data: String,
@@ -2305,6 +2421,10 @@ impl WebSocketClient {
                     if dst::time::timeout(timeout, async {
                         // Delay awaiting graceful shutdown
                         dst::time::sleep(Duration::from_millis(GRACEFUL_SHUTDOWN_DELAY_MS)).await;
+
+                        if let Some(read_fence) = inner.read_fence.take() {
+                            read_fence.invalidate();
+                        }
 
                         if let Some(task) = &inner.read_task
                             && !task.is_finished()
@@ -2905,9 +3025,13 @@ mod tests {
 #[cfg(not(feature = "turmoil"))]
 #[cfg(not(all(feature = "simulation", madsim)))] // transport-layer I/O not simulated
 mod rust_tests {
-    use std::sync::{
-        Arc, OnceLock,
-        atomic::{AtomicBool, AtomicU8, Ordering},
+    use std::{
+        pin::Pin,
+        sync::{
+            Arc, Condvar, Mutex as StdMutex, OnceLock,
+            atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
+        },
+        task::{Context, Poll},
     };
 
     use futures_util::{SinkExt, StreamExt};
@@ -2934,6 +3058,58 @@ mod rust_tests {
 
     use super::*;
     use crate::websocket::types::channel_message_handler;
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    struct CondvarReleaseGuard<'a> {
+        release: &'a (StdMutex<bool>, Condvar),
+    }
+
+    impl<'a> CondvarReleaseGuard<'a> {
+        fn new(release: &'a (StdMutex<bool>, Condvar)) -> Self {
+            Self { release }
+        }
+
+        fn release(&self) {
+            let (lock, condvar) = self.release;
+            let mut released = lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *released = true;
+            condvar.notify_all();
+        }
+    }
+
+    impl Drop for CondvarReleaseGuard<'_> {
+        fn drop(&mut self) {
+            self.release();
+        }
+    }
+
+    async fn recv_rendezvous<T: Send + 'static>(
+        receiver: std::sync::mpsc::Receiver<T>,
+        name: &'static str,
+    ) -> T {
+        let receive_task = tokio::task::spawn_blocking(move || receiver.recv_timeout(TEST_TIMEOUT));
+
+        match tokio::time::timeout(TEST_TIMEOUT * 2, receive_task).await {
+            Ok(Ok(Ok(value))) => value,
+            Ok(Ok(Err(e))) => {
+                panic!("{name} did not arrive within the test timeout: {e}")
+            }
+            Ok(Err(e)) => panic!("{name} receive task failed: {e}"),
+            Err(e) => panic!("{name} receive task did not finish: {e}"),
+        }
+    }
+
+    async fn await_task_termination(task: tokio::task::JoinHandle<()>, name: &'static str) {
+        match tokio::time::timeout(TEST_TIMEOUT, task).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) if e.is_cancelled() => {}
+            Ok(Err(e)) => panic!("{name} failed: {e}"),
+            Err(e) => panic!("{name} did not terminate within the test timeout: {e}"),
+        }
+    }
 
     struct RecordingServer {
         task: JoinHandle<()>,
@@ -4507,6 +4683,7 @@ mod rust_tests {
     #[derive(Default)]
     struct BlockingFailState {
         send_entered: AtomicBool,
+        send_entered_notify: tokio::sync::Notify,
         fail: AtomicBool,
         waker: std::sync::Mutex<Option<std::task::Waker>>,
     }
@@ -4560,6 +4737,7 @@ mod rust_tests {
             // cannot slip between the check and the registration
             *self.state.waker.lock().unwrap() = Some(cx.waker().clone());
             self.state.send_entered.store(true, Ordering::SeqCst);
+            self.state.send_entered_notify.notify_one();
 
             if self.state.fail.load(Ordering::SeqCst) {
                 std::task::Poll::Ready(Err(TransportError::ConnectionReset))
@@ -4574,6 +4752,434 @@ mod rust_tests {
         ) -> std::task::Poll<Result<(), Self::Error>> {
             std::task::Poll::Ready(Ok(()))
         }
+    }
+
+    struct BlockingMessageState {
+        polled_tx: StdMutex<Option<std::sync::mpsc::Sender<()>>>,
+        release: (StdMutex<bool>, std::sync::Condvar),
+        message: StdMutex<Option<Message>>,
+    }
+
+    struct BlockingMessageTransport {
+        state: Arc<BlockingMessageState>,
+    }
+
+    impl futures_util::Stream for BlockingMessageTransport {
+        type Item = Result<Message, TransportError>;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if let Some(polled_tx) = self.state.polled_tx.lock().unwrap().take() {
+                polled_tx.send(()).unwrap();
+            }
+            let (lock, condvar) = &self.state.release;
+            let mut released = lock.lock().unwrap();
+
+            while !*released {
+                released = condvar.wait(released).unwrap();
+            }
+
+            Poll::Ready(self.state.message.lock().unwrap().take().map(Ok))
+        }
+    }
+
+    impl futures_util::Sink<Message> for BlockingMessageTransport {
+        type Error = TransportError;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    struct RecordingState {
+        messages: Arc<StdMutex<Vec<Message>>>,
+        recorded_notify: tokio::sync::Notify,
+    }
+
+    struct RecordingTransport {
+        state: Arc<RecordingState>,
+    }
+
+    impl futures_util::Stream for RecordingTransport {
+        type Item = Result<Message, TransportError>;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Pending
+        }
+    }
+
+    impl futures_util::Sink<Message> for RecordingTransport {
+        type Error = TransportError;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            self.state.messages.lock().unwrap().push(item);
+            self.state.recorded_notify.notify_one();
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[rstest]
+    #[case(Message::text("stale"))]
+    #[case(Message::Binary(vec![1, 2, 3].into()))]
+    #[case(Message::Ping(vec![1, 2, 3].into()))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_message_handler_drops_old_session_message(#[case] message: Message) {
+        let (polled_tx, polled_rx) = std::sync::mpsc::channel();
+        let state = Arc::new(BlockingMessageState {
+            polled_tx: StdMutex::new(Some(polled_tx)),
+            release: (StdMutex::new(false), Condvar::new()),
+            message: StdMutex::new(Some(message)),
+        });
+        let release_guard = CondvarReleaseGuard::new(&state.release);
+        let transport: BoxedWsTransport = Box::pin(BlockingMessageTransport {
+            state: Arc::clone(&state),
+        });
+        let (_writer, reader) = transport.split();
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let read_fence = ReadSessionFence::new();
+        let message_count = Arc::new(AtomicUsize::new(0));
+        let ping_count = Arc::new(AtomicUsize::new(0));
+        let message_count_clone = Arc::clone(&message_count);
+        let ping_count_clone = Arc::clone(&ping_count);
+        let message_handler: MessageHandler =
+            Arc::new(move |_| _ = message_count_clone.fetch_add(1, Ordering::SeqCst));
+        let ping_handler: PingHandler =
+            Arc::new(move |_| _ = ping_count_clone.fetch_add(1, Ordering::SeqCst));
+
+        let read_task = WebSocketClientInner::spawn_message_handler_task(
+            Arc::clone(&connection_state),
+            state_notify,
+            read_fence.clone(),
+            reader,
+            0,
+            Some(&message_handler),
+            None,
+            Some(&ping_handler),
+            None,
+        );
+
+        recv_rendezvous(polled_rx, "WebSocket reader poll entry").await;
+        connection_state.store(ConnectionMode::Reconnect.as_u8(), Ordering::SeqCst);
+        read_fence.invalidate();
+        read_task.abort();
+        connection_state.store(ConnectionMode::Active.as_u8(), Ordering::SeqCst);
+        release_guard.release();
+        await_task_termination(read_task, "old WebSocket read task").await;
+
+        assert_eq!(message_count.load(Ordering::SeqCst), 0);
+        assert_eq!(ping_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_stalled_websocket_send_reconnects_and_replays() {
+        let state = Arc::new(BlockingFailState::default());
+        let transport: BoxedWsTransport = Box::pin(BlockingFailTransport {
+            state: Arc::clone(&state),
+        });
+        let (writer, _reader) = transport.split();
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let auth_tracker = Arc::new(OnceLock::new());
+        let reconnect_buffer_waits_for_auth = Arc::new(AtomicBool::new(false));
+        let (writer_tx, writer_rx) = tokio::sync::mpsc::unbounded_channel();
+        let write_task = WebSocketClientInner::spawn_write_task(
+            Arc::clone(&connection_state),
+            Arc::clone(&state_notify),
+            writer,
+            writer_rx,
+            Arc::new(AtomicU64::new(0)),
+            Arc::clone(&auth_tracker),
+            reconnect_buffer_waits_for_auth,
+        );
+
+        writer_tx
+            .send(WriterCommand::Send(Message::text("complete-message")))
+            .unwrap();
+        state.send_entered_notify.notified().await;
+
+        let recorded = Arc::new(StdMutex::new(Vec::new()));
+        let recording_state = Arc::new(RecordingState {
+            messages: Arc::clone(&recorded),
+            recorded_notify: tokio::sync::Notify::new(),
+        });
+        let transport: BoxedWsTransport = Box::pin(RecordingTransport {
+            state: Arc::clone(&recording_state),
+        });
+        let (new_writer, _reader) = transport.split();
+        let (update_tx, update_rx) = tokio::sync::oneshot::channel();
+        writer_tx
+            .send(WriterCommand::Update(new_writer, update_tx))
+            .unwrap();
+
+        tokio::time::advance(Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECS)).await;
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), update_rx)
+                .await
+                .expect("writer update should not remain queued behind a stalled send")
+                .unwrap(),
+            1,
+            "the replacement sink should install as connection epoch 1"
+        );
+        assert_eq!(
+            ConnectionMode::from_atomic(&connection_state),
+            ConnectionMode::Reconnect
+        );
+
+        connection_state.store(ConnectionMode::Active.as_u8(), Ordering::SeqCst);
+        state_notify.notify_waiters();
+        tokio::time::advance(Duration::from_millis(CONNECTION_STATE_CHECK_INTERVAL_MS)).await;
+        recording_state.recorded_notify.notified().await;
+        assert_eq!(
+            recorded.lock().unwrap().as_slice(),
+            &[Message::text("complete-message")]
+        );
+
+        connection_state.store(ConnectionMode::Closed.as_u8(), Ordering::SeqCst);
+        state_notify.notify_waiters();
+        drop(writer_tx);
+        write_task.await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_stalled_ownership_bound_send_times_out_without_replay() {
+        let state = Arc::new(BlockingFailState::default());
+        let transport: BoxedWsTransport = Box::pin(BlockingFailTransport {
+            state: Arc::clone(&state),
+        });
+        let (writer, _reader) = transport.split();
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Active.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let auth_tracker = Arc::new(OnceLock::new());
+        let reconnect_buffer_waits_for_auth = Arc::new(AtomicBool::new(false));
+        let (writer_tx, writer_rx) = tokio::sync::mpsc::unbounded_channel();
+        let write_task = WebSocketClientInner::spawn_write_task(
+            Arc::clone(&connection_state),
+            Arc::clone(&state_notify),
+            writer,
+            writer_rx,
+            Arc::new(AtomicU64::new(0)),
+            Arc::clone(&auth_tracker),
+            reconnect_buffer_waits_for_auth,
+        );
+
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        writer_tx
+            .send(WriterCommand::SendOnConnection {
+                message: Message::text("ownership-bound"),
+                connection_epoch: 0,
+                response_tx,
+            })
+            .unwrap();
+        state.send_entered_notify.notified().await;
+
+        tokio::time::advance(Duration::from_secs(WRITE_TIMEOUT_SECS)).await;
+        let outcome = tokio::time::timeout(Duration::from_secs(1), response_rx)
+            .await
+            .expect("a stalled ownership-bound send must not wedge the writer task")
+            .unwrap();
+        assert!(
+            matches!(outcome, Err(SendError::WriteTimeout)),
+            "expected the write deadline to be reported, was {outcome:?}"
+        );
+        assert_eq!(
+            ConnectionMode::from_atomic(&connection_state),
+            ConnectionMode::Reconnect
+        );
+
+        // The timed-out message is ownership-bound, so unlike an ordinary send it must
+        // NOT be buffered for replay onto the replacement sink.
+        let recorded = Arc::new(StdMutex::new(Vec::new()));
+        let recording_state = Arc::new(RecordingState {
+            messages: Arc::clone(&recorded),
+            recorded_notify: tokio::sync::Notify::new(),
+        });
+        let transport: BoxedWsTransport = Box::pin(RecordingTransport {
+            state: Arc::clone(&recording_state),
+        });
+        let (new_writer, _reader) = transport.split();
+        let (update_tx, update_rx) = tokio::sync::oneshot::channel();
+        writer_tx
+            .send(WriterCommand::Update(new_writer, update_tx))
+            .unwrap();
+
+        tokio::time::advance(Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECS)).await;
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), update_rx)
+                .await
+                .expect("writer update should not remain queued behind a stalled send")
+                .unwrap(),
+            1
+        );
+
+        connection_state.store(ConnectionMode::Active.as_u8(), Ordering::SeqCst);
+        state_notify.notify_waiters();
+        tokio::time::advance(Duration::from_millis(CONNECTION_STATE_CHECK_INTERVAL_MS)).await;
+
+        // Barrier: two sentinels bound to the NEW epoch, the second sent only after the first
+        // is acknowledged. The writer can accept the first from a `recv()` that was already
+        // pending when the mode flipped, so only the second is necessarily processed after the
+        // intervening loop-top drain - which is where a mistakenly buffered message would be
+        // replayed. One sentinel alone would leave the ordering to chance.
+        for name in ["sentinel-1", "sentinel-2"] {
+            let (sentinel_tx, sentinel_rx) = tokio::sync::oneshot::channel();
+            writer_tx
+                .send(WriterCommand::SendOnConnection {
+                    message: Message::text(name),
+                    connection_epoch: 1,
+                    response_tx: sentinel_tx,
+                })
+                .unwrap();
+            recording_state.recorded_notify.notified().await;
+            sentinel_rx
+                .await
+                .unwrap()
+                .expect("the sentinel should send on the replacement connection");
+        }
+
+        assert_eq!(
+            recorded.lock().unwrap().as_slice(),
+            &[Message::text("sentinel-1"), Message::text("sentinel-2")],
+            "an ownership-bound message must never be replayed after its deadline expires"
+        );
+
+        connection_state.store(ConnectionMode::Closed.as_u8(), Ordering::SeqCst);
+        state_notify.notify_waiters();
+        drop(writer_tx);
+        write_task.await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_stalled_websocket_replay_reconnects_and_retries_buffer() {
+        let initial_messages = Arc::new(StdMutex::new(Vec::new()));
+        let initial_recording_state = Arc::new(RecordingState {
+            messages: initial_messages,
+            recorded_notify: tokio::sync::Notify::new(),
+        });
+        let transport: BoxedWsTransport = Box::pin(RecordingTransport {
+            state: initial_recording_state,
+        });
+        let (writer, _reader) = transport.split();
+        let connection_state = Arc::new(AtomicU8::new(ConnectionMode::Reconnect.as_u8()));
+        let state_notify = Arc::new(tokio::sync::Notify::new());
+        let auth_tracker = Arc::new(OnceLock::new());
+        let reconnect_buffer_waits_for_auth = Arc::new(AtomicBool::new(false));
+        let (writer_tx, writer_rx) = tokio::sync::mpsc::unbounded_channel();
+        let write_task = WebSocketClientInner::spawn_write_task(
+            Arc::clone(&connection_state),
+            Arc::clone(&state_notify),
+            writer,
+            writer_rx,
+            Arc::new(AtomicU64::new(0)),
+            Arc::clone(&auth_tracker),
+            reconnect_buffer_waits_for_auth,
+        );
+
+        writer_tx
+            .send(WriterCommand::Send(Message::text("buffered-message")))
+            .unwrap();
+
+        let blocking_state = Arc::new(BlockingFailState::default());
+        let transport: BoxedWsTransport = Box::pin(BlockingFailTransport {
+            state: Arc::clone(&blocking_state),
+        });
+        let (blocking_writer, _reader) = transport.split();
+        let (blocking_tx, blocking_rx) = tokio::sync::oneshot::channel();
+        writer_tx
+            .send(WriterCommand::Update(blocking_writer, blocking_tx))
+            .unwrap();
+        assert_eq!(blocking_rx.await.unwrap(), 1);
+
+        connection_state.store(ConnectionMode::Active.as_u8(), Ordering::SeqCst);
+        state_notify.notify_waiters();
+        tokio::time::advance(Duration::from_millis(CONNECTION_STATE_CHECK_INTERVAL_MS)).await;
+        blocking_state.send_entered_notify.notified().await;
+
+        let recorded = Arc::new(StdMutex::new(Vec::new()));
+        let recording_state = Arc::new(RecordingState {
+            messages: Arc::clone(&recorded),
+            recorded_notify: tokio::sync::Notify::new(),
+        });
+        let transport: BoxedWsTransport = Box::pin(RecordingTransport {
+            state: Arc::clone(&recording_state),
+        });
+        let (new_writer, _reader) = transport.split();
+        let (update_tx, update_rx) = tokio::sync::oneshot::channel();
+        writer_tx
+            .send(WriterCommand::Update(new_writer, update_tx))
+            .unwrap();
+
+        tokio::time::advance(Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECS)).await;
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), update_rx)
+                .await
+                .expect("writer update should not remain queued behind stalled replay")
+                .unwrap(),
+            2,
+            "the second replacement sink should install as connection epoch 2"
+        );
+        assert_eq!(
+            ConnectionMode::from_atomic(&connection_state),
+            ConnectionMode::Reconnect
+        );
+
+        connection_state.store(ConnectionMode::Active.as_u8(), Ordering::SeqCst);
+        state_notify.notify_waiters();
+        tokio::time::advance(Duration::from_millis(CONNECTION_STATE_CHECK_INTERVAL_MS)).await;
+        recording_state.recorded_notify.notified().await;
+        assert_eq!(
+            recorded.lock().unwrap().as_slice(),
+            &[Message::text("buffered-message")]
+        );
+
+        connection_state.store(ConnectionMode::Closed.as_u8(), Ordering::SeqCst);
+        state_notify.notify_waiters();
+        drop(writer_tx);
+        write_task.await.unwrap();
     }
 
     #[rstest]


### PR DESCRIPTION
Three defects on the reconnect path in `crates/network`, one of which can wedge a client permanently.

## A stalled write can wedge reconnect indefinitely

The socket writer task writes with `active_writer.write_all(&write_buf).await` and no deadline. If the peer accepts the connection and then stops reading, the socket buffer fills and that await never returns, so the writer never loops back to `writer_rx.recv()`. The reconnect path queues `WriterCommand::Update` on that same channel and then waits on a oneshot for the drain confirmation, so it waits for a reply the wedged writer cannot send. Reconnect stalls forever, and because the controller is inside `inner.reconnect()`, the attempt counter never advances either, so `reconnect_max_attempts` cannot terminate it. The websocket client has the same shape in two places: an unbounded active `send`, and an unbounded reconnect-buffer drain (the socket client already bounds its drain).

The fix bounds the writes with a new internal `WRITE_TIMEOUT_SECS` deadline - not the configurable dial timeout - and treats a timeout exactly as the existing I/O-error path does: requeue the whole logical message, CAS `Active -> Reconnect`, and abandon the old writer. The controller's confirmation awaits are deliberately left untimed. Cancelling them would risk orphaning an already-swapped writer, which is why the reconnect timeout covers dialing only; with the writes bounded there is no longer unbounded I/O ahead of those awaits.

Cancellation does not roll back bytes, so a stalled write may leave a prefix in the kernel send buffer. Closing the old socket makes that prefix end at EOF rather than allowing a replay to be appended behind it, and the complete message is replayed on the new connection - the same at-least-once property the existing failed-send requeue already had.

## `post_disconnection` never fired when reconnects were exhausted

The owner's `post_disconnection` handler was invoked only from the controller's disconnect branch. On reconnect exhaustion the controller stored `Closed` and exited silently, so the one case an owner most needs to observe - the client giving up permanently - was the one case it was never told about. `close()` was also silent, while `disconnect()` notified.

The fix introduces a terminal finalizer holding the callback behind an atomic once-guard, reached from every controller exit and from `close()`. The handler runs after the `Closed` transition, so it observes the true terminal state, and before `notify_waiters`, so a woken waiter cannot outrun it. Exhaustion transitions with `compare_exchange(Reconnect, Closed)` and yields to a concurrent disconnect rather than overwriting it. `close()` waits for finalization rather than for `is_closed()`, and on timeout forces finalization through the same guard instead of waiting on an abort that cooperative cancellation may never deliver. A panicking callback still publishes completion, so a panic cannot strand later callers. Dropping the client aborts the controller without notifying, which is deliberate: a drop is not a connection lifecycle event.

## One stale frame could be dispatched after the session ended

Both read loops checked the connection mode before awaiting a read and dispatched whatever arrived without re-checking, so a frame that arrived while the mode moved to `Reconnect` was delivered from the abandoned session. In the socket client a single read can also contain several delimited frames, and a handler can itself end the session, so one check is not enough.

The fix re-checks after the read returns and again immediately before each handler call, and on either observation discards the entire task-local buffer - new bytes, undispatched frames, and any partial frame accumulated by earlier reads. Carrying a partial frame across would splice an old fragment onto bytes from a new connection and manufacture a frame that neither session sent. The websocket loop checks before both the message and ping handlers. Each drop logs its byte or message count at debug: this is an expected reconnect race rather than an error, but silent discards would make future investigation opaque.

## Deliberately not in this PR

The fourth member of this class is the zero-backoff reconnect storm: both controllers reset the backoff *and* the attempt count on handshake success, so an accept-then-close server is retried forever and `reconnect_max_attempts` never trips. Fixing it needs a decision about when a connection counts as proven stable, which is a contract question rather than a mechanical change, so it is left alone here.

The Python `close()` path also still stores `Closed` directly rather than going through the finalizer, so `post_disconnection` does not fire when that path times out and forces closure. The fix is a few lines, but it edits `crates/network/src/python/socket.rs`, which is part of the v2 python-generation surface. The change is body-only - no signature, attribute or docstring changes, so nothing the stub generator reads - but I could not verify that locally, so I have kept it out rather than guess. I'd rather you deal with the python side of things.

## Testing

Fourteen tests in `crates/network`. Liveness: a scripted `AsyncWrite` that accepts a prefix, signals backpressure and then stays pending, driven under `#[tokio::test(start_paused = true)]`, asserting reconnect is requested, the complete message is retained, the queued `Update` is consumed and the message is replayed through a recording writer; `tokio::io::duplex(1)` models "accepted, then stopped reading" deterministically, since kernel buffer sizes are platform-dependent. Equivalents cover the websocket active send and the websocket replay drain. Notification: exhaustion and graceful close each assert exactly one callback, with further tests for concurrent finalizers, both CAS interleavings, a controller aborted before finalization, and a panicking callback. Fencing: scripted readers deliver a partial frame that completes only after the mode flips, plus a two-frames-in-one-read case where the first handler ends the session, and a websocket case asserting neither the message nor the ping handler runs.

Ordering comes from channels, `Notify` signals and virtual time; no test uses a sleep as an ordering primitive, and the one real-time timeout is a deadlock watchdog. Each defect was verified by mutation rather than only against the unfixed baseline: removing a write bound fails the corresponding liveness test with "writer update should not remain queued behind a stalled write"; removing the notification calls fails the exhaustion test on the callback assertion; removing the fences fails both stale-frame tests. Note the guards are intentionally redundant - the controller epilogue also finalizes on exit, and the two socket fences cover different windows - so falsifying a defect requires removing all of its guards, which is how these were checked.
