### PR TITLE
Expose Deribit book summary as requestable custom data

### DIFF
--- a/crates/adapters/deribit/src/data.rs
+++ b/crates/adapters/deribit/src/data.rs
@@ -31,17 +31,17 @@ use nautilus_common::{
     messages::{
         DataEvent, DataResponse,
         data::{
-            BarsResponse, BookResponse, ForwardPricesResponse, InstrumentResponse,
-            InstrumentsResponse, RequestBars, RequestBookSnapshot, RequestForwardPrices,
-            RequestInstrument, RequestInstruments, RequestTrades, SubscribeBars,
-            SubscribeBookDeltas, SubscribeBookDepth10, SubscribeCustomData, SubscribeFundingRates,
-            SubscribeIndexPrices, SubscribeInstrument, SubscribeInstrumentStatus,
-            SubscribeInstruments, SubscribeMarkPrices, SubscribeOptionGreeks, SubscribeQuotes,
-            SubscribeTrades, TradesResponse, UnsubscribeBars, UnsubscribeBookDeltas,
-            UnsubscribeBookDepth10, UnsubscribeCustomData, UnsubscribeFundingRates,
-            UnsubscribeIndexPrices, UnsubscribeInstrument, UnsubscribeInstrumentStatus,
-            UnsubscribeInstruments, UnsubscribeMarkPrices, UnsubscribeOptionGreeks,
-            UnsubscribeQuotes, UnsubscribeTrades,
+            BarsResponse, BookResponse, CustomDataResponse, ForwardPricesResponse,
+            InstrumentResponse, InstrumentsResponse, RequestBars, RequestBookSnapshot,
+            RequestCustomData, RequestForwardPrices, RequestInstrument, RequestInstruments,
+            RequestTrades, SubscribeBars, SubscribeBookDeltas, SubscribeBookDepth10,
+            SubscribeCustomData, SubscribeFundingRates, SubscribeIndexPrices, SubscribeInstrument,
+            SubscribeInstrumentStatus, SubscribeInstruments, SubscribeMarkPrices,
+            SubscribeOptionGreeks, SubscribeQuotes, SubscribeTrades, TradesResponse,
+            UnsubscribeBars, UnsubscribeBookDeltas, UnsubscribeBookDepth10, UnsubscribeCustomData,
+            UnsubscribeFundingRates, UnsubscribeIndexPrices, UnsubscribeInstrument,
+            UnsubscribeInstrumentStatus, UnsubscribeInstruments, UnsubscribeMarkPrices,
+            UnsubscribeOptionGreeks, UnsubscribeQuotes, UnsubscribeTrades,
         },
     },
 };
@@ -51,7 +51,7 @@ use nautilus_core::{
     time::{AtomicTime, get_atomic_clock_realtime},
 };
 use nautilus_model::{
-    data::{Data, ForwardPrice, OrderBookDeltas_API},
+    data::{CustomData, Data, DataType, ForwardPrice, OrderBookDeltas_API},
     enums::BookType,
     identifiers::{ClientId, InstrumentId, Symbol, Venue},
     instruments::{Instrument, InstrumentAny},
@@ -68,7 +68,7 @@ use crate::{
         parse::{bar_spec_to_resolution, parse_instrument_kind_currency},
     },
     config::DeribitDataClientConfig,
-    data_types::register_deribit_custom_data,
+    data_types::{DeribitBookSummary, register_deribit_custom_data},
     http::{
         client::DeribitHttpClient,
         models::{DeribitCurrency, DeribitProductType},
@@ -99,6 +99,8 @@ pub struct DeribitDataClient {
 }
 
 impl DeribitDataClient {
+    const BOOK_SUMMARY_TYPE_NAME: &'static str = "DeribitBookSummary";
+
     /// Creates a new [`DeribitDataClient`] instance.
     ///
     /// # Errors
@@ -384,6 +386,47 @@ impl DeribitDataClient {
             .as_ref()
             .and_then(|params| params.get_bool("subscribe_combo_legs"))
             .unwrap_or(false)
+    }
+
+    fn book_summary_metadata_currency(data_type: &DataType) -> anyhow::Result<String> {
+        data_type
+            .metadata()
+            .and_then(|m| m.get("currency"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_ascii_uppercase)
+            .ok_or_else(|| {
+                anyhow::anyhow!("DeribitBookSummary requests require metadata['currency']")
+            })
+    }
+
+    fn book_summary_metadata_kind(data_type: &DataType) -> Option<String> {
+        data_type
+            .metadata()
+            .and_then(|m| m.get("kind"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_ascii_lowercase)
+    }
+
+    fn book_summary_data_type(currency: &str, kind: Option<&str>) -> DataType {
+        let mut metadata = Params::new();
+        metadata.insert(
+            "currency".to_string(),
+            serde_json::Value::String(currency.to_string()),
+        );
+        let kind = kind.unwrap_or("option");
+        metadata.insert(
+            "kind".to_string(),
+            serde_json::Value::String(kind.to_string()),
+        );
+        DataType::new(
+            Self::BOOK_SUMMARY_TYPE_NAME,
+            Some(metadata),
+            Some(format!("{currency}:{kind}")),
+        )
     }
 
     fn combo_leg_trade_ids(
@@ -1910,6 +1953,96 @@ impl DataClient for DeribitDataClient {
                 }
                 Err(e) => {
                     log::error!("Book snapshot request failed for {instrument_id}: {e:?}");
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    fn request_data(&self, request: RequestCustomData) -> anyhow::Result<()> {
+        if request.data_type.type_name() != Self::BOOK_SUMMARY_TYPE_NAME {
+            log::warn!(
+                "Unsupported custom data request: {}",
+                request.data_type.type_name()
+            );
+            return Ok(());
+        }
+
+        let currency = Self::book_summary_metadata_currency(&request.data_type)?;
+        let kind = Self::book_summary_metadata_kind(&request.data_type);
+        let kind_str = kind.as_deref().unwrap_or("option").to_string();
+        let data_type = Self::book_summary_data_type(&currency, Some(&kind_str));
+        let http_client = self.http_client.clone();
+        let sender = self.data_sender.clone();
+        let request_id = request.request_id;
+        let client_id = request.client_id;
+        let params = request.params;
+        let clock = self.clock;
+        let venue = *DERIBIT_VENUE;
+        let start = request.start;
+        let end = request.end;
+        let start_nanos = datetime_to_unix_nanos(start);
+        let end_nanos = datetime_to_unix_nanos(end);
+
+        get_runtime().spawn(async move {
+            log::debug!(
+                "Requesting Deribit book summaries for currency={currency} kind={kind_str}"
+            );
+
+            match http_client
+                .request_book_summaries_kind(&currency, Some(&kind_str))
+                .await
+            {
+                Ok(summaries) => {
+                    let ts = clock.get_time_ns();
+                    let data: Vec<CustomData> = summaries
+                        .into_iter()
+                        .map(|raw| {
+                            CustomData::new(
+                                Arc::new(DeribitBookSummary::from_raw(raw, ts)),
+                                data_type.clone(),
+                            )
+                        })
+                        .collect();
+
+                    let response = DataResponse::Data(CustomDataResponse::new(
+                        request_id,
+                        client_id,
+                        Some(venue),
+                        data_type,
+                        data,
+                        start_nanos,
+                        end_nanos,
+                        ts,
+                        params,
+                    ));
+
+                    if let Err(e) = sender.send(DataEvent::Response(response)) {
+                        log::error!("Failed to send book summary response: {e}");
+                    }
+                }
+                Err(e) => {
+                    // Empty response keeps request correlation closed for strategy waiters.
+                    log::error!(
+                        "Book summary request failed for currency={currency} kind={kind_str}: {e:?}"
+                    );
+                    let ts = clock.get_time_ns();
+                    let response = DataResponse::Data(CustomDataResponse::new(
+                        request_id,
+                        client_id,
+                        Some(venue),
+                        data_type,
+                        Vec::<CustomData>::new(),
+                        start_nanos,
+                        end_nanos,
+                        ts,
+                        params,
+                    ));
+
+                    if let Err(send_err) = sender.send(DataEvent::Response(response)) {
+                        log::error!("Failed to send empty book summary response: {send_err}");
+                    }
                 }
             }
         });

--- a/crates/adapters/deribit/src/data_types.rs
+++ b/crates/adapters/deribit/src/data_types.rs
@@ -19,7 +19,11 @@
 //! [`CustomData`](nautilus_model::data::CustomData).
 
 use nautilus_core::UnixNanos;
+use nautilus_model::identifiers::{InstrumentId, Symbol};
 use nautilus_persistence_macros::custom_data;
+use rust_decimal::Decimal;
+
+use crate::{common::consts::DERIBIT_VENUE, http::models::DeribitBookSummaryRaw};
 
 /// Deribit volatility index (DVOL) update.
 ///
@@ -43,20 +47,165 @@ pub struct DeribitVolatilityIndex {
     pub ts_init: UnixNanos,
 }
 
+/// Book summary snapshot for one instrument from
+/// `public/get_book_summary_by_currency`.
+///
+/// Numeric venue fields are retained as [`Decimal`] (no `f64` round-trip).
+/// Convert from the wire DTO via [`DeribitBookSummary::from_raw`].
+#[cfg_attr(
+    feature = "arrow",
+    custom_data(pyo3, stub_module = "nautilus_trader.adapters.deribit")
+)]
+#[cfg_attr(
+    not(feature = "arrow"),
+    custom_data(pyo3, no_arrow, stub_module = "nautilus_trader.adapters.deribit")
+)]
+pub struct DeribitBookSummary {
+    /// Nautilus instrument identifier (venue-qualified).
+    pub instrument_id: InstrumentId,
+    /// Venue instrument name (e.g. `"BTC-28MAR25-90000-C"`).
+    pub instrument_name: String,
+    /// Forward/underlying price used for IV calculations.
+    #[custom_data_field(serde)]
+    pub underlying_price: Option<Decimal>,
+    /// Underlying future or index name.
+    #[custom_data_field(serde)]
+    pub underlying_index: Option<String>,
+    /// Mark price.
+    #[custom_data_field(serde)]
+    pub mark_price: Option<Decimal>,
+    /// Mid price.
+    #[custom_data_field(serde)]
+    pub mid_price: Option<Decimal>,
+    /// Best bid price.
+    #[custom_data_field(serde)]
+    pub bid_price: Option<Decimal>,
+    /// Best ask price.
+    #[custom_data_field(serde)]
+    pub ask_price: Option<Decimal>,
+    /// Last traded price.
+    #[custom_data_field(serde)]
+    pub last_price: Option<Decimal>,
+    /// Mark implied volatility.
+    #[custom_data_field(serde)]
+    pub mark_iv: Option<Decimal>,
+    /// Bid implied volatility.
+    #[custom_data_field(serde)]
+    pub bid_iv: Option<Decimal>,
+    /// Ask implied volatility.
+    #[custom_data_field(serde)]
+    pub ask_iv: Option<Decimal>,
+    /// Interest rate used in IV calculations.
+    #[custom_data_field(serde)]
+    pub interest_rate: Option<Decimal>,
+    /// Open interest.
+    #[custom_data_field(serde)]
+    pub open_interest: Option<Decimal>,
+    /// Open interest value when provided.
+    #[custom_data_field(serde)]
+    pub open_interest_value: Option<Decimal>,
+    /// 24h volume.
+    #[custom_data_field(serde)]
+    pub volume: Option<Decimal>,
+    /// 24h volume in USD.
+    #[custom_data_field(serde)]
+    pub volume_usd: Option<Decimal>,
+    /// 24h notional volume.
+    #[custom_data_field(serde)]
+    pub volume_notional: Option<Decimal>,
+    /// 24h volume in BTC when provided.
+    #[custom_data_field(serde)]
+    pub volume_btc: Option<Decimal>,
+    /// 24h high.
+    #[custom_data_field(serde)]
+    pub high: Option<Decimal>,
+    /// 24h low.
+    #[custom_data_field(serde)]
+    pub low: Option<Decimal>,
+    /// 24h price change.
+    #[custom_data_field(serde)]
+    pub price_change: Option<Decimal>,
+    /// Estimated delivery price.
+    #[custom_data_field(serde)]
+    pub estimated_delivery_price: Option<Decimal>,
+    /// Settlement/delivery price when present.
+    #[custom_data_field(serde)]
+    pub delivery_price: Option<Decimal>,
+    /// Base currency.
+    #[custom_data_field(serde)]
+    pub base_currency: Option<String>,
+    /// Quote currency.
+    #[custom_data_field(serde)]
+    pub quote_currency: Option<String>,
+    /// Instrument creation time (milliseconds since UNIX epoch).
+    pub creation_timestamp: i64,
+    /// UNIX timestamp (nanoseconds) when the snapshot was observed.
+    pub ts_event: UnixNanos,
+    /// UNIX timestamp (nanoseconds) when the instance was initialized.
+    pub ts_init: UnixNanos,
+}
+
+impl DeribitBookSummary {
+    /// Builds a domain book summary from a venue wire DTO.
+    #[must_use]
+    pub fn from_raw(raw: DeribitBookSummaryRaw, ts: UnixNanos) -> Self {
+        let instrument_id = InstrumentId::new(Symbol::new(&raw.instrument_name), *DERIBIT_VENUE);
+        Self {
+            instrument_id,
+            instrument_name: raw.instrument_name,
+            underlying_price: raw.underlying_price,
+            underlying_index: raw.underlying_index,
+            mark_price: raw.mark_price,
+            mid_price: raw.mid_price,
+            bid_price: raw.bid_price,
+            ask_price: raw.ask_price,
+            last_price: raw.last_price,
+            mark_iv: raw.mark_iv,
+            bid_iv: raw.bid_iv,
+            ask_iv: raw.ask_iv,
+            interest_rate: raw.interest_rate,
+            open_interest: raw.open_interest,
+            open_interest_value: raw.open_interest_value,
+            volume: raw.volume,
+            volume_usd: raw.volume_usd,
+            volume_notional: raw.volume_notional,
+            volume_btc: raw.volume_btc,
+            high: raw.high,
+            low: raw.low,
+            price_change: raw.price_change,
+            estimated_delivery_price: raw.estimated_delivery_price,
+            delivery_price: raw.delivery_price,
+            base_currency: raw.base_currency,
+            quote_currency: raw.quote_currency,
+            creation_timestamp: raw.creation_timestamp,
+            ts_event: ts,
+            ts_init: ts,
+        }
+    }
+}
+
 /// Registers Deribit custom data types.
 ///
 /// Safe to call multiple times (idempotent via internal `Once` guards).
 pub fn register_deribit_custom_data() {
     #[cfg(feature = "arrow")]
-    nautilus_serialization::ensure_custom_data_registered::<DeribitVolatilityIndex>();
+    {
+        nautilus_serialization::ensure_custom_data_registered::<DeribitVolatilityIndex>();
+        nautilus_serialization::ensure_custom_data_registered::<DeribitBookSummary>();
+    }
 
     #[cfg(not(feature = "arrow"))]
-    let _ = nautilus_model::data::ensure_custom_data_json_registered::<DeribitVolatilityIndex>();
+    {
+        let _ =
+            nautilus_model::data::ensure_custom_data_json_registered::<DeribitVolatilityIndex>();
+        let _ = nautilus_model::data::ensure_custom_data_json_registered::<DeribitBookSummary>();
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use rust_decimal_macros::dec;
 
     use super::*;
 
@@ -64,6 +213,49 @@ mod tests {
     fn test_register_deribit_custom_data_is_idempotent() {
         register_deribit_custom_data();
         register_deribit_custom_data();
+    }
+
+    #[rstest]
+    fn test_book_summary_from_raw_preserves_decimals_and_instrument_id() {
+        let raw = DeribitBookSummaryRaw {
+            instrument_name: "BTC-28MAR25-90000-C".to_string(),
+            underlying_price: Some(dec!(95000.5)),
+            underlying_index: Some("SYN.BTC-28MAR25".to_string()),
+            mark_price: Some(dec!(0.042)),
+            mid_price: None,
+            bid_price: Some(dec!(0.040)),
+            ask_price: Some(dec!(0.042)),
+            last_price: None,
+            mark_iv: Some(dec!(55.2)),
+            bid_iv: None,
+            ask_iv: None,
+            interest_rate: None,
+            open_interest: Some(dec!(123.5)),
+            open_interest_value: None,
+            volume: None,
+            volume_usd: None,
+            volume_notional: None,
+            volume_btc: None,
+            high: None,
+            low: None,
+            price_change: None,
+            estimated_delivery_price: None,
+            delivery_price: None,
+            base_currency: Some("BTC".to_string()),
+            quote_currency: Some("USD".to_string()),
+            creation_timestamp: 1_710_000_000_000,
+        };
+        let ts = UnixNanos::from(42_u64);
+        let summary = DeribitBookSummary::from_raw(raw, ts);
+
+        assert_eq!(
+            summary.instrument_id,
+            InstrumentId::from("BTC-28MAR25-90000-C.DERIBIT")
+        );
+        assert_eq!(summary.mark_iv, Some(dec!(55.2)));
+        assert_eq!(summary.open_interest, Some(dec!(123.5)));
+        assert_eq!(summary.ts_event, ts);
+        assert_eq!(summary.ts_init, ts);
     }
 
     #[cfg(feature = "arrow")]
@@ -83,5 +275,60 @@ mod tests {
         assert_eq!(schema.field(2).data_type(), &DataType::UInt64);
         assert_eq!(schema.field(3).name(), "ts_init");
         assert_eq!(schema.field(3).data_type(), &DataType::UInt64);
+    }
+
+    #[cfg(feature = "arrow")]
+    #[rstest]
+    fn test_book_summary_arrow_roundtrip_preserves_decimals() {
+        use arrow::datatypes::DataType;
+        use nautilus_serialization::arrow::{
+            ArrowSchemaProvider, DecodeDataFromRecordBatch, EncodeToRecordBatch,
+        };
+
+        let original = DeribitBookSummary::from_raw(
+            DeribitBookSummaryRaw {
+                instrument_name: "BTC-28MAR25-90000-C".to_string(),
+                underlying_price: Some(dec!(95000.5)),
+                underlying_index: Some("SYN.BTC-28MAR25".to_string()),
+                mark_price: Some(dec!(0.042)),
+                mid_price: None,
+                bid_price: Some(dec!(0.040)),
+                ask_price: Some(dec!(0.042)),
+                last_price: None,
+                mark_iv: Some(dec!(55.2)),
+                bid_iv: None,
+                ask_iv: None,
+                interest_rate: None,
+                open_interest: Some(dec!(123.5)),
+                open_interest_value: None,
+                volume: None,
+                volume_usd: None,
+                volume_notional: None,
+                volume_btc: None,
+                high: None,
+                low: None,
+                price_change: None,
+                estimated_delivery_price: None,
+                delivery_price: None,
+                base_currency: Some("BTC".to_string()),
+                quote_currency: Some("USD".to_string()),
+                creation_timestamp: 1_710_000_000_000,
+            },
+            UnixNanos::from(1_000_u64),
+        );
+
+        // Built-in #[custom_data_field(serde)] path: Option<Decimal> → Utf8.
+        let schema = DeribitBookSummary::get_schema(None);
+        assert_eq!(
+            schema.field_with_name("mark_iv").unwrap().data_type(),
+            &DataType::Utf8
+        );
+
+        let metadata = original.metadata();
+        let batch =
+            DeribitBookSummary::encode_batch(&metadata, std::slice::from_ref(&original)).unwrap();
+        let decoded = DeribitBookSummary::decode_data_batch(&metadata, batch).unwrap();
+        let decoded = DeribitBookSummary::try_from(decoded.into_iter().next().unwrap()).unwrap();
+        assert_eq!(decoded, original);
     }
 }

--- a/crates/adapters/deribit/src/http/client.rs
+++ b/crates/adapters/deribit/src/http/client.rs
@@ -54,7 +54,7 @@ use ustr::Ustr;
 use super::{
     error::DeribitHttpError,
     models::{
-        DeribitAccountSummariesResponse, DeribitBookSummary, DeribitCombo, DeribitCurrency,
+        DeribitAccountSummariesResponse, DeribitBookSummaryRaw, DeribitCombo, DeribitCurrency,
         DeribitExpirationsResponse, DeribitInstrument, DeribitJsonRpcRequest,
         DeribitJsonRpcResponse, DeribitPosition, DeribitProductType, DeribitTicker,
         DeribitUserTradesResponse,
@@ -848,7 +848,7 @@ impl DeribitRawHttpClient {
     pub async fn get_book_summary_by_currency(
         &self,
         params: GetBookSummaryByCurrencyParams,
-    ) -> Result<DeribitJsonRpcResponse<Vec<DeribitBookSummary>>, DeribitHttpError> {
+    ) -> Result<DeribitJsonRpcResponse<Vec<DeribitBookSummaryRaw>>, DeribitHttpError> {
         self.send_request("public/get_book_summary_by_currency", params, false)
             .await
     }
@@ -1898,10 +1898,10 @@ impl DeribitHttpClient {
             .ok_or_else(|| anyhow::anyhow!("No result in ticker response"))
     }
 
-    /// Requests book summaries for options of a given currency.
+    /// Requests book summaries for a currency via `public/get_book_summary_by_currency`.
     ///
-    /// Returns raw `DeribitBookSummary` items which include `underlying_price`
-    /// (the forward price) for each option instrument.
+    /// Defaults to product kind `option`.
+    /// Entries include mark/IV, bid-ask, volumes, and `underlying_price` (forward) when present.
     ///
     /// # Errors
     ///
@@ -1909,8 +1909,27 @@ impl DeribitHttpClient {
     pub async fn request_book_summaries(
         &self,
         currency: &str,
-    ) -> anyhow::Result<Vec<DeribitBookSummary>> {
-        let params = GetBookSummaryByCurrencyParams::options(currency);
+    ) -> anyhow::Result<Vec<DeribitBookSummaryRaw>> {
+        self.request_book_summaries_kind(currency, Some("option"))
+            .await
+    }
+
+    /// Requests book summaries for a currency with an optional product `kind` filter.
+    ///
+    /// When `kind` is `None`, Deribit returns summaries for all product kinds.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn request_book_summaries_kind(
+        &self,
+        currency: &str,
+        kind: Option<&str>,
+    ) -> anyhow::Result<Vec<DeribitBookSummaryRaw>> {
+        let params = GetBookSummaryByCurrencyParams {
+            currency: currency.to_string(),
+            kind: kind.map(str::to_string),
+        };
         let full_response = self
             .inner
             .get_book_summary_by_currency(params)

--- a/crates/adapters/deribit/src/http/models.rs
+++ b/crates/adapters/deribit/src/http/models.rs
@@ -607,12 +607,12 @@ pub struct DeribitOrderBook {
     pub interest_rate: Option<Decimal>,
 }
 
-/// Book summary data from `/public/get_book_summary_by_currency` endpoint.
+/// Wire DTO for `/public/get_book_summary_by_currency` entries.
 ///
-/// Each entry represents a single instrument's book summary including the
-/// forward/underlying price used for ATM determination.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct DeribitBookSummary {
+/// Pure venue payload (no engine timestamps). Convert to the domain
+/// [`crate::data_types::DeribitBookSummary`] before emitting custom data.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DeribitBookSummaryRaw {
     /// Unique instrument identifier (e.g. "BTC-28MAR25-90000-C")
     pub instrument_name: String,
     /// The forward/underlying price for implied volatility calculations
@@ -624,8 +624,145 @@ pub struct DeribitBookSummary {
     /// Mark price for the instrument
     #[serde(default, deserialize_with = "deserialize_optional_decimal")]
     pub mark_price: Option<Decimal>,
-    /// The time when the instrument was created (milliseconds since UNIX epoch)
+    /// Mid price
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub mid_price: Option<Decimal>,
+    /// Best bid price
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub bid_price: Option<Decimal>,
+    /// Best ask price
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub ask_price: Option<Decimal>,
+    /// Last traded price (`last` on the wire)
+    #[serde(
+        default,
+        rename = "last",
+        deserialize_with = "deserialize_optional_decimal"
+    )]
+    pub last_price: Option<Decimal>,
+    /// Mark implied volatility (options; may be absent on some product kinds)
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub mark_iv: Option<Decimal>,
+    /// Bid implied volatility (options)
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub bid_iv: Option<Decimal>,
+    /// Ask implied volatility (options)
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub ask_iv: Option<Decimal>,
+    /// Interest rate used in IV calculations (options)
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub interest_rate: Option<Decimal>,
+    /// Open interest
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub open_interest: Option<Decimal>,
+    /// Open interest value when provided by the venue
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub open_interest_value: Option<Decimal>,
+    /// 24h volume in contracts / base units
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub volume: Option<Decimal>,
+    /// 24h volume in USD
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub volume_usd: Option<Decimal>,
+    /// 24h notional volume
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub volume_notional: Option<Decimal>,
+    /// 24h volume in BTC (when provided)
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub volume_btc: Option<Decimal>,
+    /// 24h high price
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub high: Option<Decimal>,
+    /// 24h low price
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub low: Option<Decimal>,
+    /// 24h price change (`price_change` on the wire)
+    #[serde(
+        default,
+        rename = "price_change",
+        deserialize_with = "deserialize_optional_decimal"
+    )]
+    pub price_change: Option<Decimal>,
+    /// Estimated delivery price
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub estimated_delivery_price: Option<Decimal>,
+    /// Settlement/delivery price when present
+    #[serde(default, deserialize_with = "deserialize_optional_decimal")]
+    pub delivery_price: Option<Decimal>,
+    /// Base currency
+    #[serde(default)]
+    pub base_currency: Option<String>,
+    /// Quote currency
+    #[serde(default)]
+    pub quote_currency: Option<String>,
+    /// Instrument creation time (milliseconds since UNIX epoch)
+    #[serde(default)]
     pub creation_timestamp: i64,
+}
+
+#[cfg(test)]
+mod book_summary_tests {
+    use rstest::rstest;
+    use rust_decimal_macros::dec;
+
+    use super::*;
+
+    #[rstest]
+    fn test_book_summary_raw_deserializes_full_option_payload() {
+        let json = r#"{
+            "instrument_name": "BTC-28MAR25-90000-C",
+            "underlying_price": 95000.5,
+            "underlying_index": "SYN.BTC-28MAR25",
+            "mark_price": 0.042,
+            "mid_price": 0.041,
+            "bid_price": 0.040,
+            "ask_price": 0.042,
+            "last": 0.0415,
+            "mark_iv": 55.2,
+            "bid_iv": 54.0,
+            "ask_iv": 56.1,
+            "interest_rate": 0.0,
+            "open_interest": 123.5,
+            "volume": 10.0,
+            "volume_usd": 950000.0,
+            "volume_notional": 10.0,
+            "high": 0.05,
+            "low": 0.03,
+            "price_change": 0.01,
+            "estimated_delivery_price": 94900.0,
+            "base_currency": "BTC",
+            "quote_currency": "USD",
+            "creation_timestamp": 1710000000000
+        }"#;
+
+        let summary: DeribitBookSummaryRaw = serde_json::from_str(json).unwrap();
+        assert_eq!(summary.instrument_name, "BTC-28MAR25-90000-C");
+        assert_eq!(summary.underlying_price, Some(dec!(95000.5)));
+        assert_eq!(summary.underlying_index.as_deref(), Some("SYN.BTC-28MAR25"));
+        assert_eq!(summary.mark_price, Some(dec!(0.042)));
+        assert_eq!(summary.last_price, Some(dec!(0.0415)));
+        assert_eq!(summary.mark_iv, Some(dec!(55.2)));
+        assert_eq!(summary.bid_price, Some(dec!(0.040)));
+        assert_eq!(summary.ask_price, Some(dec!(0.042)));
+        assert_eq!(summary.open_interest, Some(dec!(123.5)));
+        assert_eq!(summary.volume_usd, Some(dec!(950000.0)));
+        assert_eq!(summary.price_change, Some(dec!(0.01)));
+        assert_eq!(summary.creation_timestamp, 1_710_000_000_000);
+    }
+
+    #[rstest]
+    fn test_book_summary_raw_deserializes_minimal_payload() {
+        let json = r#"{
+            "instrument_name": "BTC-28MAR25-90000-C",
+            "creation_timestamp": 1710000000000
+        }"#;
+
+        let summary: DeribitBookSummaryRaw = serde_json::from_str(json).unwrap();
+        assert_eq!(summary.instrument_name, "BTC-28MAR25-90000-C");
+        assert!(summary.mark_iv.is_none());
+        assert!(summary.open_interest.is_none());
+        assert_eq!(summary.creation_timestamp, 1_710_000_000_000);
+    }
 }
 
 /// Ticker data from `/public/ticker` endpoint.

--- a/crates/adapters/deribit/src/python/http.rs
+++ b/crates/adapters/deribit/src/python/http.rs
@@ -21,6 +21,7 @@ use jiff::Timestamp;
 use nautilus_core::{
     UnixNanos,
     python::{IntoPyObjectNautilusExt, to_pyruntime_err, to_pyvalue_err},
+    time::get_atomic_clock_realtime,
 };
 use nautilus_model::{
     data::{BarType, forward::ForwardPrice},
@@ -31,6 +32,7 @@ use pyo3::{conversion::IntoPyObjectExt, prelude::*, types::PyList};
 
 use crate::{
     common::{consts::DERIBIT_VENUE, enums::DeribitEnvironment},
+    data_types::DeribitBookSummary,
     http::{
         client::DeribitHttpClient,
         error::DeribitHttpError,
@@ -496,6 +498,54 @@ impl DeribitHttpClient {
                     .map(|report| report.into_py_any(py))
                     .collect();
                 let pylist = PyList::new(py, py_reports?)?.into_any().unbind();
+                Ok(pylist)
+            })
+        })
+    }
+
+    /// Requests book summaries for a currency via `public/get_book_summary_by_currency`.
+    ///
+    /// Defaults to product kind `option`.
+    /// Entries include mark/IV, bid-ask, volumes, and `underlying_price` (forward) when present.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    #[pyo3(name = "request_book_summaries")]
+    #[pyo3(signature = (currency, kind=None))]
+    fn py_request_book_summaries<'py>(
+        &self,
+        py: Python<'py>,
+        currency: String,
+        kind: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let currency = currency.trim().to_ascii_uppercase();
+            if currency.is_empty() {
+                return Err(to_pyvalue_err(
+                    "request_book_summaries requires a non-empty currency",
+                ));
+            }
+            let kind = kind
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map_or_else(|| "option".to_string(), str::to_ascii_lowercase);
+            let summaries = client
+                .request_book_summaries_kind(&currency, Some(kind.as_str()))
+                .await
+                .map_err(to_pyvalue_err)?;
+            // Stamp observed time after the HTTP round-trip completes.
+            let ts = get_atomic_clock_realtime().get_time_ns();
+
+            Python::attach(|py| {
+                let py_items: PyResult<Vec<_>> = summaries
+                    .into_iter()
+                    .map(|raw| Py::new(py, DeribitBookSummary::from_raw(raw, ts)))
+                    .collect();
+                let pylist = PyList::new(py, py_items?)?.into_any().unbind();
                 Ok(pylist)
             })
         })

--- a/crates/adapters/deribit/src/python/mod.rs
+++ b/crates/adapters/deribit/src/python/mod.rs
@@ -36,7 +36,7 @@ use pyo3::prelude::*;
 use crate::{
     common::consts::{DERIBIT, DERIBIT_CLIENT_ID, DERIBIT_VENUE},
     config::{DeribitDataClientConfig, DeribitExecClientConfig},
-    data_types::{DeribitVolatilityIndex, register_deribit_custom_data},
+    data_types::{DeribitBookSummary, DeribitVolatilityIndex, register_deribit_custom_data},
     factories::{DeribitDataClientFactory, DeribitExecutionClientFactory},
 };
 
@@ -109,6 +109,7 @@ pub fn deribit(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::common::enums::DeribitEnvironment>()?;
     m.add_class::<crate::websocket::enums::DeribitUpdateInterval>()?;
     m.add_class::<DeribitVolatilityIndex>()?;
+    m.add_class::<DeribitBookSummary>()?;
     m.add_class::<DeribitDataClientConfig>()?;
     m.add_class::<DeribitExecClientConfig>()?;
     m.add_class::<DeribitDataClientFactory>()?;
@@ -154,6 +155,7 @@ pub fn deribit(_: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     register_deribit_custom_data();
     let _result = ensure_rust_extractor_registered::<DeribitVolatilityIndex>();
+    let _book_summary = ensure_rust_extractor_registered::<DeribitBookSummary>();
 
     Ok(())
 }

--- a/crates/adapters/deribit/test_data/http_get_book_summary_by_currency.json
+++ b/crates/adapters/deribit/test_data/http_get_book_summary_by_currency.json
@@ -1,0 +1,46 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "instrument_name": "BTC-28MAR25-90000-C",
+      "underlying_price": 95000.5,
+      "underlying_index": "SYN.BTC-28MAR25",
+      "mark_price": 0.042,
+      "mid_price": 0.041,
+      "bid_price": 0.040,
+      "ask_price": 0.042,
+      "last": 0.0415,
+      "mark_iv": 55.2,
+      "bid_iv": 54.0,
+      "ask_iv": 56.1,
+      "interest_rate": 0.0,
+      "open_interest": 123.5,
+      "volume": 10.0,
+      "volume_usd": 950000.0,
+      "volume_notional": 10.0,
+      "high": 0.05,
+      "low": 0.03,
+      "price_change": 0.01,
+      "estimated_delivery_price": 94900.0,
+      "base_currency": "BTC",
+      "quote_currency": "USD",
+      "creation_timestamp": 1710000000000
+    },
+    {
+      "instrument_name": "BTC-28MAR25-90000-P",
+      "underlying_price": 95000.5,
+      "underlying_index": "SYN.BTC-28MAR25",
+      "mark_price": 0.038,
+      "bid_price": 0.037,
+      "ask_price": 0.039,
+      "mark_iv": 54.8,
+      "open_interest": 88.0,
+      "volume": 5.0,
+      "base_currency": "BTC",
+      "quote_currency": "USD",
+      "creation_timestamp": 1710000000000
+    }
+  ],
+  "testnet": true
+}

--- a/crates/adapters/deribit/tests/data_client.rs
+++ b/crates/adapters/deribit/tests/data_client.rs
@@ -45,9 +45,10 @@ use nautilus_common::{
     messages::{
         DataEvent, DataResponse,
         data::{
-            InstrumentResponse, RequestInstrument, SubscribeBars, SubscribeBookDeltas,
-            SubscribeBookDepth10, SubscribeFundingRates, SubscribeIndexPrices, SubscribeMarkPrices,
-            SubscribeOptionGreeks, SubscribeQuotes, SubscribeTrades, UnsubscribeTrades,
+            InstrumentResponse, RequestCustomData, RequestInstrument, SubscribeBars,
+            SubscribeBookDeltas, SubscribeBookDepth10, SubscribeFundingRates, SubscribeIndexPrices,
+            SubscribeMarkPrices, SubscribeOptionGreeks, SubscribeQuotes, SubscribeTrades,
+            UnsubscribeTrades,
         },
     },
     testing::wait_until_async,
@@ -57,16 +58,18 @@ use nautilus_deribit::{
     common::{consts::DERIBIT_CLIENT_ID, enums::DeribitEnvironment},
     config::DeribitDataClientConfig,
     data::DeribitDataClient,
+    data_types::DeribitBookSummary,
     http::models::DeribitProductType,
 };
 use nautilus_model::{
-    data::{BarType, Data, TradeTick},
+    data::{BarType, CustomData, Data, DataType, TradeTick},
     enums::BookType,
     identifiers::InstrumentId,
 };
 use nautilus_network::http::HttpClient;
 use nautilus_testkit::events::drain_data_events;
 use rstest::rstest;
+use rust_decimal_macros::dec;
 use serde_json::{Value, json};
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(15);
@@ -197,6 +200,11 @@ async fn handle_jsonrpc_request(
     match method {
         "public/get_instruments" => handle_get_instruments(id, params).await,
         "public/get_combos" => handle_get_combos(id).await,
+        "public/get_book_summary_by_currency" => {
+            let mut data = load_json("http_get_book_summary_by_currency.json");
+            data["id"] = json!(id);
+            Json(data).into_response()
+        }
         "public/get_instrument" => {
             state
                 .get_instrument_request_count
@@ -1667,6 +1675,268 @@ async fn test_data_client_emits_instruments_on_connect() {
     assert!(
         instruments_received.load(Ordering::Relaxed) > 0,
         "Expected to receive instrument events on connect"
+    );
+
+    client.disconnect().await.unwrap();
+}
+
+fn book_summary_data_type(currency: &str, kind: &str) -> DataType {
+    let mut metadata = Params::new();
+    metadata.insert(
+        "currency".to_string(),
+        serde_json::Value::String(currency.to_string()),
+    );
+    metadata.insert(
+        "kind".to_string(),
+        serde_json::Value::String(kind.to_string()),
+    );
+    DataType::new(
+        "DeribitBookSummary",
+        Some(metadata),
+        None, // selector-only; adapter must canonicalize identifier
+    )
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_data_client_request_book_summaries_round_trip() {
+    let (addr, _state) = start_test_server().await.unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+    replace_data_event_sender(tx);
+
+    let config = create_test_config(addr);
+    let mut client = DeribitDataClient::new(*DERIBIT_CLIENT_ID, config).unwrap();
+    client.connect().await.unwrap();
+
+    while rx.try_recv().is_ok() {}
+
+    let request_data_type = book_summary_data_type("btc", "option");
+    assert_eq!(request_data_type.identifier(), None);
+
+    client
+        .request_data(RequestCustomData::new(
+            *DERIBIT_CLIENT_ID,
+            request_data_type.clone(),
+            None,
+            None,
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+        ))
+        .unwrap();
+
+    let response = loop {
+        let event = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
+            .await
+            .expect("timeout waiting for book summary response")
+            .expect("channel closed");
+
+        if let DataEvent::Response(DataResponse::Data(response)) = event {
+            break response;
+        }
+    };
+
+    let items = response
+        .data
+        .as_ref()
+        .downcast_ref::<Vec<CustomData>>()
+        .expect("expected Vec<CustomData> payload");
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(response.data_type.type_name(), "DeribitBookSummary");
+    assert_eq!(
+        response.data_type.identifier(),
+        Some("BTC:option"),
+        "adapter must canonicalize response identity"
+    );
+    assert_eq!(
+        response
+            .data_type
+            .metadata()
+            .and_then(|m| m.get("currency"))
+            .and_then(|v| v.as_str()),
+        Some("BTC"),
+    );
+    assert_eq!(
+        response
+            .data_type
+            .metadata()
+            .and_then(|m| m.get("kind"))
+            .and_then(|v| v.as_str()),
+        Some("option"),
+    );
+
+    for custom in items {
+        assert_eq!(custom.data_type.type_name(), "DeribitBookSummary");
+        assert_eq!(custom.data_type.identifier(), Some("BTC:option"));
+    }
+
+    let first = items[0]
+        .data
+        .as_any()
+        .downcast_ref::<DeribitBookSummary>()
+        .expect("expected DeribitBookSummary");
+    assert_eq!(
+        first.instrument_id,
+        InstrumentId::from("BTC-28MAR25-90000-C.DERIBIT")
+    );
+    assert_eq!(first.instrument_name, "BTC-28MAR25-90000-C");
+    assert_eq!(first.mark_price, Some(dec!(0.042)));
+    assert_eq!(first.mark_iv, Some(dec!(55.2)));
+    assert_eq!(first.bid_price, Some(dec!(0.040)));
+    assert_eq!(first.ask_price, Some(dec!(0.042)));
+    assert_eq!(first.open_interest, Some(dec!(123.5)));
+    assert_eq!(first.last_price, Some(dec!(0.0415)));
+    assert_eq!(first.underlying_price, Some(dec!(95000.5)));
+    assert_ne!(first.ts_event, UnixNanos::default());
+    assert_eq!(first.ts_event, first.ts_init);
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_data_client_request_book_summaries_rejects_missing_currency() {
+    let (addr, _state) = start_test_server().await.unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+    replace_data_event_sender(tx);
+
+    let config = create_test_config(addr);
+    let mut client = DeribitDataClient::new(*DERIBIT_CLIENT_ID, config).unwrap();
+    client.connect().await.unwrap();
+
+    while rx.try_recv().is_ok() {}
+
+    let data_type = DataType::new("DeribitBookSummary", None, None);
+    let result = client.request_data(RequestCustomData::new(
+        *DERIBIT_CLIENT_ID,
+        data_type,
+        None,
+        None,
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+    ));
+    assert!(result.is_err(), "missing currency must reject");
+
+    // No response should be emitted for the rejected request.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), rx.recv())
+            .await
+            .is_err()
+    );
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_data_client_request_book_summaries_defaults_kind_and_uppercases_currency() {
+    let (addr, _state) = start_test_server().await.unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+    replace_data_event_sender(tx);
+
+    let config = create_test_config(addr);
+    let mut client = DeribitDataClient::new(*DERIBIT_CLIENT_ID, config).unwrap();
+    client.connect().await.unwrap();
+
+    while rx.try_recv().is_ok() {}
+
+    // Selector-only: lowercase currency, omit kind, no catalog identifier.
+    let mut metadata = Params::new();
+    metadata.insert(
+        "currency".to_string(),
+        serde_json::Value::String("eth".to_string()),
+    );
+    let request_data_type = DataType::new("DeribitBookSummary", Some(metadata), None);
+
+    client
+        .request_data(RequestCustomData::new(
+            *DERIBIT_CLIENT_ID,
+            request_data_type,
+            None,
+            None,
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+        ))
+        .unwrap();
+
+    let response = loop {
+        let event = tokio::time::timeout(TEST_TIMEOUT, rx.recv())
+            .await
+            .expect("timeout waiting for book summary response")
+            .expect("channel closed");
+
+        if let DataEvent::Response(DataResponse::Data(response)) = event {
+            break response;
+        }
+    };
+
+    assert_eq!(response.data_type.type_name(), "DeribitBookSummary");
+    assert_eq!(response.data_type.identifier(), Some("ETH:option"));
+    assert_eq!(
+        response
+            .data_type
+            .metadata()
+            .and_then(|m| m.get("currency"))
+            .and_then(|v| v.as_str()),
+        Some("ETH"),
+    );
+    assert_eq!(
+        response
+            .data_type
+            .metadata()
+            .and_then(|m| m.get("kind"))
+            .and_then(|v| v.as_str()),
+        Some("option"),
+    );
+
+    let items = response
+        .data
+        .as_ref()
+        .downcast_ref::<Vec<CustomData>>()
+        .expect("expected Vec<CustomData> payload");
+
+    for custom in items {
+        assert_eq!(custom.data_type.identifier(), Some("ETH:option"));
+    }
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_data_client_request_data_ignores_unsupported_custom_type() {
+    let (addr, _state) = start_test_server().await.unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+    replace_data_event_sender(tx);
+
+    let config = create_test_config(addr);
+    let mut client = DeribitDataClient::new(*DERIBIT_CLIENT_ID, config).unwrap();
+    client.connect().await.unwrap();
+
+    while rx.try_recv().is_ok() {}
+
+    let data_type = DataType::new("NotADeribitType", None, None);
+    let result = client.request_data(RequestCustomData::new(
+        *DERIBIT_CLIENT_ID,
+        data_type,
+        None,
+        None,
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+    ));
+    assert!(result.is_ok(), "unsupported type is soft-ignored");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), rx.recv())
+            .await
+            .is_err()
     );
 
     client.disconnect().await.unwrap();

--- a/python/nautilus_trader/adapters/deribit/__init__.py
+++ b/python/nautilus_trader/adapters/deribit/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "DERIBIT",
     "DERIBIT_CLIENT_ID",
     "DERIBIT_VENUE",
+    "DeribitBookSummary",
     "DeribitCurrency",
     "DeribitDataClientConfig",
     "DeribitDataClientFactory",

--- a/python/nautilus_trader/adapters/deribit/__init__.pyi
+++ b/python/nautilus_trader/adapters/deribit/__init__.pyi
@@ -11,6 +11,7 @@ __all__ = [
     "DERIBIT",
     "DERIBIT_CLIENT_ID",
     "DERIBIT_VENUE",
+    "DeribitBookSummary",
     "DeribitCurrency",
     "DeribitDataClientConfig",
     "DeribitDataClientFactory",
@@ -25,6 +26,107 @@ __all__ = [
 DERIBIT: str
 DERIBIT_CLIENT_ID: model.ClientId
 DERIBIT_VENUE: model.Venue
+
+@typing.final
+class DeribitBookSummary:
+    @property
+    def instrument_id(self) -> model.InstrumentId: ...
+    @property
+    def instrument_name(self) -> str: ...
+    @property
+    def underlying_price(self) -> typing.Any: ...
+    @property
+    def underlying_index(self) -> typing.Any: ...
+    @property
+    def mark_price(self) -> typing.Any: ...
+    @property
+    def mid_price(self) -> typing.Any: ...
+    @property
+    def bid_price(self) -> typing.Any: ...
+    @property
+    def ask_price(self) -> typing.Any: ...
+    @property
+    def last_price(self) -> typing.Any: ...
+    @property
+    def mark_iv(self) -> typing.Any: ...
+    @property
+    def bid_iv(self) -> typing.Any: ...
+    @property
+    def ask_iv(self) -> typing.Any: ...
+    @property
+    def interest_rate(self) -> typing.Any: ...
+    @property
+    def open_interest(self) -> typing.Any: ...
+    @property
+    def open_interest_value(self) -> typing.Any: ...
+    @property
+    def volume(self) -> typing.Any: ...
+    @property
+    def volume_usd(self) -> typing.Any: ...
+    @property
+    def volume_notional(self) -> typing.Any: ...
+    @property
+    def volume_btc(self) -> typing.Any: ...
+    @property
+    def high(self) -> typing.Any: ...
+    @property
+    def low(self) -> typing.Any: ...
+    @property
+    def price_change(self) -> typing.Any: ...
+    @property
+    def estimated_delivery_price(self) -> typing.Any: ...
+    @property
+    def delivery_price(self) -> typing.Any: ...
+    @property
+    def base_currency(self) -> typing.Any: ...
+    @property
+    def quote_currency(self) -> typing.Any: ...
+    @property
+    def creation_timestamp(self) -> int: ...
+    @property
+    def ts_event(self) -> int: ...
+    @property
+    def ts_init(self) -> int: ...
+    def __new__(
+        cls,
+        instrument_id: model.InstrumentId,
+        instrument_name: str,
+        underlying_price: typing.Any,
+        underlying_index: typing.Any,
+        mark_price: typing.Any,
+        mid_price: typing.Any,
+        bid_price: typing.Any,
+        ask_price: typing.Any,
+        last_price: typing.Any,
+        mark_iv: typing.Any,
+        bid_iv: typing.Any,
+        ask_iv: typing.Any,
+        interest_rate: typing.Any,
+        open_interest: typing.Any,
+        open_interest_value: typing.Any,
+        volume: typing.Any,
+        volume_usd: typing.Any,
+        volume_notional: typing.Any,
+        volume_btc: typing.Any,
+        high: typing.Any,
+        low: typing.Any,
+        price_change: typing.Any,
+        estimated_delivery_price: typing.Any,
+        delivery_price: typing.Any,
+        base_currency: typing.Any,
+        quote_currency: typing.Any,
+        creation_timestamp: int,
+        ts_event: int,
+        ts_init: int,
+    ) -> DeribitBookSummary: ...
+    def to_json(self) -> str: ...
+    @classmethod
+    def from_json(cls, data: typing.Any) -> typing.Any: ...
+    @classmethod
+    def decode_record_batch_py(
+        cls, metadata: typing.Mapping[str, str], py_batch: typing.Any
+    ) -> typing.Any: ...
+    def encode_record_batch_py(self, items: list) -> typing.Any: ...
 
 @typing.final
 class DeribitDataClientConfig:
@@ -193,6 +295,7 @@ class DeribitHttpClient:
     def request_position_status_reports(
         self, account_id: model.AccountId, instrument_id: model.InstrumentId | None = None
     ) -> typing.Any: ...
+    def request_book_summaries(self, currency: str, kind: str | None = None) -> typing.Any: ...
     def request_forward_prices(
         self, currency: str, instrument_id: model.InstrumentId | None = None
     ) -> typing.Any: ...


### PR DESCRIPTION
## Summary

Expose Deribit's full `public/get_book_summary_by_currency` payload as **requestable custom data**, so strategies can fetch a one-shot option-chain market snapshot (IV / OI / bid-ask / volume / …) without N per-instrument HTTP or WS subscriptions.

Closes #4565

### Why

The adapter already called this endpoint for bulk ATM `request_forward_prices`, but only kept a minimal subset of fields. Everything else was dropped by serde. Strategies could not:

1. Calibrate an IV surface from a single bulk snapshot
2. Filter the chain by OI / volume / bid-ask
3. Avoid N× ticker / order-book requests for bootstrap

### What changes

| Layer | Change |
|-------|--------|
| **Wire** | Rename minimal DTO → `DeribitBookSummaryRaw` with full useful field set (`Decimal` via `deserialize_optional_decimal`) |
| **Domain** | New `#[custom_data]` type `DeribitBookSummary` (`InstrumentId`, `Option<Decimal>` via `#[custom_data_field(serde)]`, `ts_event` / `ts_init`) |
| **DataClient** | Implement `request_data` for `type_name == "DeribitBookSummary"` |
| **HTTP** | `request_book_summaries` / `request_book_summaries_kind`; PyO3 `request_book_summaries(currency, kind=None)` |
| **Python** | Export `DeribitBookSummary` from `nautilus_trader.adapters.deribit` (+ generated `.pyi`) |
| **Unchanged** | `request_forward_prices` still only uses `underlying_price` → `ForwardPrice` (no dual-emit) |

### Design (reviewer guide)

**Request-only custom data**
No fake subscribe path. Streaming updates remain on greeks / ticker channels.

**Selector vs canonical `DataType`** (important for catalog / correlation)

```text
Caller may send:
  DataType("DeribitBookSummary", metadata={currency: "btc"})   # no identifier

Adapter always responds with:
  identifier = "{CURRENCY}:{kind}"   e.g. "BTC:option"
  metadata   = {currency: "BTC", kind: "option"}   # kind defaults to "option"
```

Same canonical `DataType` is applied to the `CustomDataResponse` **and** every `CustomData` item.

**Wire → domain**

```text
HTTP JSON
  → DeribitBookSummaryRaw          (venue only, no engine timestamps)
  → DeribitBookSummary::from_raw   (InstrumentId + ts_event/ts_init)
  → CustomData / PyO3 list
```

**Failure behaviour**

- Missing `metadata['currency']` → `request_data` returns `Err` (no response)
- HTTP failure → empty `CustomDataResponse` (closes correlation for waiters)
- Unknown custom type name → soft ignore (`Ok` + warn), same as Hyperliquid

**PyO3 HTTP helper**

- Normalizes `currency` (upper) / `kind` (lower, default `option`)
- Stamps `ts_event`/`ts_init` from the realtime clock after the HTTP round-trip

### Strategy usage (Python)

```python
from nautilus_trader.adapters.deribit import DERIBIT_CLIENT_ID, DeribitBookSummary
from nautilus_trader.model import DataType

class IvSurfaceStrategy(Strategy):
    def on_start(self) -> None:
        self.request_data(
            DataType(
                "DeribitBookSummary",
                metadata={"currency": "BTC", "kind": "option"},
            ),
            DERIBIT_CLIENT_ID,
        )

    def on_historical_data(self, data) -> None:
        # response payload is list[CustomData]; each .data is DeribitBookSummary
        for item in data:
            summary = item.data  # DeribitBookSummary
            # summary.mark_iv, summary.open_interest, summary.bid_price, ...
```

Direct HTTP (outside the data engine):

```python
summaries = await http_client.request_book_summaries("BTC", kind="option")
# list[DeribitBookSummary]
```

### Files (10)

```text
crates/adapters/deribit/src/http/models.rs      # DeribitBookSummaryRaw + wire tests
crates/adapters/deribit/src/data_types.rs       # domain #[custom_data] + from_raw + arrow test
crates/adapters/deribit/src/http/client.rs      # request_book_summaries[_kind]
crates/adapters/deribit/src/data.rs             # DataClient::request_data
crates/adapters/deribit/src/python/http.rs      # PyO3 request_book_summaries
crates/adapters/deribit/src/python/mod.rs       # class + extractor registration
crates/adapters/deribit/tests/data_client.rs    # request path integration tests
crates/adapters/deribit/test_data/...json       # fixture
python/.../deribit/__init__.py                  # __all__
python/.../deribit/__init__.pyi                 # generated stubs
```

### Testing

Local commands re-run on this head (`a7159b484e`), toolchain pins aligned with CI
(rustc 1.97.1, uv 0.12.0, prek 0.4.11, Node 24):

```bash
cargo test -p nautilus-deribit --features "python,arrow,high-precision" --lib book_summary
# 4 passed (raw deserialize full/minimal, from_raw decimals, arrow round-trip)

cargo test -p nautilus-deribit --features "python,arrow,high-precision" --test data_client book_summaries
# 3 passed (round-trip, defaults kind + uppercases currency, rejects missing currency)

cargo test -p nautilus-deribit --features "python,arrow,high-precision" --test data_client unsupported_custom
# 1 passed (unknown custom type soft-ignore)

make py-stubs && bash scripts/ci/check-generated-drift.bash
# No generated file drift

prek run --files <touched paths>
# pass
```

What these tests pin (would fail without the change):

- Full wire fields deserialize into `DeribitBookSummaryRaw` without dropping IV/OI/bid-ask
- Domain conversion preserves `Decimal` (no `f64` round-trip) and builds `InstrumentId`
- Arrow/custom-data round-trip keeps decimal fields
- `request_data` builds **canonical** response `DataType` (`BTC:option`) even when the caller selector omits identifier / uses lower-case currency
- Missing `currency` is a hard error; unsupported custom type names are soft-ignored

### Out of scope

- LiveNode / TradingNode feather streaming config (not available on pure-PyO3 live runtime yet; see #4273)
- Dual-emitting book summaries into `ForwardPrice`
- Per-instrument subscribe of book summary (request-only by design)

### Review focus

1. Canonical `DataType` construction vs reusing caller selector
2. Decimal path (no `f64` round-trip) via built-in serde helpers
3. Forward-price path still only reads `underlying_price` from `Raw`
4. Empty response on HTTP error vs hard fail (intentional correlation close)