### PR TITLE
Preserve stop-market protection price on updates that omit it

### DIFF
--- a/crates/model/src/orders/stop_market.rs
+++ b/crates/model/src/orders/stop_market.rs
@@ -494,7 +494,9 @@ impl Order for StopMarketOrder {
             self.trigger_price = trigger_price;
         }
 
-        self.protection_price = event.protection_price;
+        if let Some(protection_price) = event.protection_price {
+            self.protection_price = Some(protection_price);
+        }
         self.quantity = event.quantity;
         self.leaves_qty = self.quantity.saturating_sub(self.filled_qty);
     }
@@ -870,6 +872,62 @@ mod tests {
 
         // Verify updates were applied correctly
         assert_eq!(accepted_order.price(), Some(calculated_protection_price));
+        assert!(accepted_order.has_price());
+    }
+
+    #[rstest]
+    fn test_stop_market_order_update_preserves_protection_price_when_omitted() {
+        let order = OrderTestBuilder::new(OrderType::StopMarket)
+            .instrument_id(InstrumentId::from("BTC-USDT.BINANCE"))
+            .quantity(Quantity::from(10))
+            .trigger_price(Price::new(100.0, 2))
+            .build();
+        let mut accepted_order = TestOrderStubs::make_accepted_order(&order);
+        let protection_price = Price::new(95.0, 2);
+
+        let set_protection_event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            quantity: accepted_order.quantity(),
+            protection_price: Some(protection_price),
+            ..Default::default()
+        };
+        accepted_order
+            .apply(OrderEventAny::Updated(set_protection_event))
+            .unwrap();
+
+        let updated_quantity = Quantity::from(5);
+        let updated_trigger_price = Price::new(105.0, 2);
+        let omitted_protection_event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            quantity: updated_quantity,
+            trigger_price: Some(updated_trigger_price),
+            protection_price: None,
+            ..Default::default()
+        };
+        accepted_order
+            .apply(OrderEventAny::Updated(omitted_protection_event))
+            .unwrap();
+
+        assert_eq!(accepted_order.quantity(), updated_quantity);
+        assert_eq!(accepted_order.trigger_price(), Some(updated_trigger_price));
+        assert_eq!(accepted_order.price(), Some(protection_price));
+        assert!(accepted_order.has_price());
+
+        let updated_protection_price = Price::new(90.0, 2);
+        let overwrite_protection_event = OrderUpdated {
+            client_order_id: accepted_order.client_order_id(),
+            strategy_id: accepted_order.strategy_id(),
+            quantity: accepted_order.quantity(),
+            protection_price: Some(updated_protection_price),
+            ..Default::default()
+        };
+        accepted_order
+            .apply(OrderEventAny::Updated(overwrite_protection_event))
+            .unwrap();
+
+        assert_eq!(accepted_order.price(), Some(updated_protection_price));
         assert!(accepted_order.has_price());
     }
 }


### PR DESCRIPTION
The second half of the #4530 split, following #4549.

## `StopMarketOrder::update` clears `protection_price` on every update that omits it

`StopMarketOrder::update` in `crates/model/src/orders/stop_market.rs` assigns `self.protection_price = event.protection_price` unconditionally, so an `OrderUpdated` that carries no protection price - the ordinary shape of a quantity or trigger-price modify - overwrites a stored value with `None`. `MarketOrder::update` gates the same field on `Some` (`crates/model/src/orders/market.rs:434`), and `StopMarketOrder::update` itself gates `trigger_price` two lines above the defect, so the unconditional assignment is the odd one out. `OrderUpdated` is a patch rather than a full-state snapshot throughout the codebase: every other optional price and trigger field in every Rust order updater is gated, the Cython updaters gate theirs, and the matching engine deliberately passes `None` for prices on quantity-only updates. There is also no way to express "clear this field" as distinct from "field omitted" without an `Option<Option<Price>>` or an update mask.

The asymmetry is a leftover. `ff1be34471` (#3065) introduced `protection_price` on both order types with the unconditional assignment in both `update()` bodies, alongside a submission-time producer, `OrderMatchingEngine::update_protection_price`, which emitted an `OrderUpdated` carrying `Some`. `fa3733861e` moved protection to a fill-time calculation and deleted that producer. `3dfb7e0858` then gated the field in `MarketOrder::update` while resequencing `apply()` in both files; the stop-market assignment was not given the same treatment. This change applies the same gate there.

Because the producer is gone, no in-tree path currently emits `Some(protection_price)`: every `generate_order_updated` call in the matching engine, the order emulator, reconciliation, the backtest exchange, and each venue adapter passes `None`, and the Cython `OrderUpdated` has no such parameter. The defect is therefore dormant for a run driven only by current in-tree producers, and reachable through replay of event streams recorded before `fa3733861e`, the pyo3 `OrderUpdated` constructor, serde or Cap'n Proto reconstruction, external adapters, and any future producer.

The stored field is not the fill-protection input, so nothing about fill safety changes either way: `fill_market_order` computes its boundary locally from `price_protection_points` and the current bid/ask, and `protection_price_calculate` reads only the order's type and side. What the field does feed is `Order::price()` and `Order::has_price()` for stop-market orders. `AccountManager` prefers `order.price()` over `order.trigger_price()` when computing locked balance and initial margin (`crates/portfolio/src/manager.rs`), so clearing it silently moves a stop-market order's margin basis to the trigger price; `should_handle_own_book_order` and `Cache::update_own_order_book` return early once `has_price()` is false, leaving an already-added entry stale and skipping its delete on close; and `OrderStatusReport::is_order_updated` gates its price comparison on `has_price()`.

## Testing

`test_stop_market_order_update_preserves_protection_price_when_omitted` establishes a protection price through one `OrderUpdated`, applies a second carrying `protection_price: None` together with a different quantity and trigger price, and asserts that the quantity and trigger changes landed while `price()` and `has_price()` still report the original protection price. The changed quantity and trigger are what make the assertion non-vacuous: a rejected event would fail at `unwrap()` and a no-op would fail those two assertions, so the preservation assertion can only pass by exercising the gate. A third update carrying `Some` then pins that an explicit value still overwrites. The preservation assertions were verified to FAIL against the unfixed assignment, and only that test fails - the existing `test_stop_market_order_protection_price_update` continues to pass, keeping standalone coverage of the set path.
