### PR TITLE
Assign backtest matching engine raw IDs from a monotonic counter

### DIFF
--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -136,6 +136,7 @@ pub struct SimulatedExchange {
     latency_model: Option<Box<dyn LatencyModel>>,
     instruments: AHashMap<InstrumentId, InstrumentAny>,
     matching_engines: IndexMap<InstrumentId, OrderMatchingEngine>,
+    last_raw_id: u32,
     settlement_prices: AHashMap<InstrumentId, Price>,
     pending_funding_rates: AHashMap<InstrumentId, FundingRateUpdate>,
     funding_settled_through: AHashMap<InstrumentId, UnixNanos>,
@@ -221,6 +222,7 @@ impl SimulatedExchange {
             latency_model: config.latency_model,
             instruments: AHashMap::new(),
             matching_engines: IndexMap::new(),
+            last_raw_id: 0,
             settlement_prices: config.settlement_prices,
             pending_funding_rates: AHashMap::new(),
             funding_settled_through: AHashMap::new(),
@@ -365,7 +367,9 @@ impl SimulatedExchange {
     ///
     /// # Errors
     ///
-    /// Returns an error if the exchange account type is `Cash` and the instrument is a `CryptoPerpetual` or `CryptoFuture`.
+    /// Returns an error if:
+    /// - The exchange account type is `Cash` and the instrument is a `CryptoPerpetual` or `CryptoFuture`.
+    /// - The matching engine raw ID is exhausted.
     ///
     /// # Panics
     ///
@@ -386,8 +390,6 @@ impl SimulatedExchange {
         {
             anyhow::bail!("Cash account cannot trade futures or perpetuals")
         }
-
-        self.instruments.insert(instrument.id(), instrument.clone());
 
         let price_protection = if self.price_protection_points == 0 {
             None
@@ -412,10 +414,13 @@ impl SimulatedExchange {
             .maybe_price_protection_points(price_protection)
             .build();
         let instrument_id = instrument.id();
-        let raw_id = u32::try_from(self.instruments.len())
-            .map_err(|e| anyhow::anyhow!("number of instruments exceeds u32::MAX: {e}"))?;
+        let raw_id = self
+            .last_raw_id
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("matching engine raw ID exhausted at u32::MAX"))?;
+        self.last_raw_id = raw_id;
         let matching_engine = OrderMatchingEngine::new(
-            instrument,
+            instrument.clone(),
             raw_id,
             self.fill_model.clone(),
             self.fee_model.clone(),
@@ -426,6 +431,7 @@ impl SimulatedExchange {
             Rc::clone(&self.cache),
             matching_engine_config,
         );
+        self.instruments.insert(instrument_id, instrument);
         self.matching_engines.insert(instrument_id, matching_engine);
 
         log::info!("Added instrument {instrument_id} and created matching engine");
@@ -1772,6 +1778,7 @@ mod tests {
     use nautilus_model::{
         enums::{AccountType, BookType},
         identifiers::{ClientOrderId, StrategyId, TraderId},
+        instruments::{CurrencyPair, InstrumentAny, stubs::audusd_sim},
         stubs::TestDefault,
     };
     use rstest::rstest;
@@ -1868,5 +1875,18 @@ mod tests {
 
         assert!(!exchange.has_pending_commands(UnixNanos::from(u64::MAX)));
         assert_eq!(exchange.max_inflight_command_ts(), None);
+    }
+
+    #[rstest]
+    fn test_add_instrument_raw_id_overflow_does_not_mutate_maps(audusd_sim: CurrencyPair) {
+        let mut exchange = setup_exchange(Dispatch::Immediate);
+        exchange.last_raw_id = u32::MAX;
+
+        let result = exchange.add_instrument(InstrumentAny::CurrencyPair(audusd_sim));
+
+        assert!(result.is_err());
+        assert!(exchange.instruments.is_empty());
+        assert!(exchange.matching_engines.is_empty());
+        assert_eq!(exchange.last_raw_id, u32::MAX);
     }
 }

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -80,11 +80,21 @@ fn get_exchange(
     book_type: BookType,
     cache: Option<Rc<RefCell<Cache>>>,
 ) -> Rc<RefCell<SimulatedExchange>> {
+    get_exchange_with_oms(venue, OmsType::Netting, account_type, book_type, cache)
+}
+
+fn get_exchange_with_oms(
+    venue: Venue,
+    oms_type: OmsType,
+    account_type: AccountType,
+    book_type: BookType,
+    cache: Option<Rc<RefCell<Cache>>>,
+) -> Rc<RefCell<SimulatedExchange>> {
     let cache = cache.unwrap_or(Rc::new(RefCell::new(Cache::default())));
     let clock = Rc::new(RefCell::new(TestClock::new()));
     let config = SimulatedVenueConfig::builder()
         .venue(venue)
-        .oms_type(OmsType::Netting)
+        .oms_type(oms_type)
         .account_type(account_type)
         .book_type(book_type)
         .starting_balances(vec![Money::new(1000.0, Currency::USD())])
@@ -207,6 +217,145 @@ fn test_matching_engine_iteration_order_is_stable_across_rebuilds(
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);
     }
+}
+
+#[rstest]
+fn test_append_only_matching_engine_raw_ids_start_at_one_and_increment(
+    crypto_perpetual_ethusdt: CryptoPerpetual,
+) {
+    let first_instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt.clone());
+    let mut second = crypto_perpetual_ethusdt;
+    second.id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    second.raw_symbol = Symbol::from("BTCUSDT");
+    second.base_currency = Currency::from("BTC");
+    let second_instrument = InstrumentAny::CryptoPerpetual(second);
+    let exchange = get_exchange(
+        Venue::new("BINANCE"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        None,
+    );
+
+    exchange
+        .borrow_mut()
+        .add_instrument(first_instrument.clone())
+        .unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(second_instrument.clone())
+        .unwrap();
+
+    let exchange = exchange.borrow();
+    assert_eq!(
+        exchange
+            .get_matching_engine(&first_instrument.id())
+            .unwrap()
+            .raw_id,
+        1
+    );
+    assert_eq!(
+        exchange
+            .get_matching_engine(&second_instrument.id())
+            .unwrap()
+            .raw_id,
+        2
+    );
+}
+
+#[rstest]
+fn test_readded_instrument_does_not_collide_generated_fill_ids(
+    crypto_perpetual_ethusdt: CryptoPerpetual,
+) {
+    let saving_handler = register_order_event_saving_handler();
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let exchange = get_exchange_with_oms(
+        Venue::new("BINANCE"),
+        OmsType::Hedging,
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    let first_instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt.clone());
+    let mut second = crypto_perpetual_ethusdt;
+    second.id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    second.raw_symbol = Symbol::from("BTCUSDT");
+    second.base_currency = Currency::from("BTC");
+    let second_instrument = InstrumentAny::CryptoPerpetual(second);
+
+    exchange
+        .borrow_mut()
+        .add_instrument(first_instrument.clone())
+        .unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(second_instrument.clone())
+        .unwrap();
+
+    let fill_timestamp = UnixNanos::from(2);
+    exchange.borrow_mut().process_quote_tick(&QuoteTick::new(
+        first_instrument.id(),
+        Price::from("1000.00"),
+        Price::from("1001.00"),
+        Quantity::from("10.000"),
+        Quantity::from("10.000"),
+        UnixNanos::from(1),
+        UnixNanos::from(1),
+    ));
+    let pre_readd_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(first_instrument.id())
+        .client_order_id(ClientOrderId::from("O-READD-PRE"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("1.000"))
+        .price(Price::from("1001.00"))
+        .build();
+    submit_matching_option_limit(&exchange, &cache, &pre_readd_order, fill_timestamp);
+
+    exchange
+        .borrow_mut()
+        .add_instrument(first_instrument.clone())
+        .unwrap();
+
+    for instrument in [&first_instrument, &second_instrument] {
+        exchange.borrow_mut().process_quote_tick(&QuoteTick::new(
+            instrument.id(),
+            Price::from("1000.00"),
+            Price::from("1001.00"),
+            Quantity::from("10.000"),
+            Quantity::from("10.000"),
+            UnixNanos::from(1),
+            UnixNanos::from(1),
+        ));
+    }
+
+    let first_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(first_instrument.id())
+        .client_order_id(ClientOrderId::from("O-READD-FIRST"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("1.000"))
+        .price(Price::from("1001.00"))
+        .build();
+    let second_order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(second_instrument.id())
+        .client_order_id(ClientOrderId::from("O-READD-SECOND"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("1.000"))
+        .price(Price::from("1001.00"))
+        .build();
+
+    submit_matching_option_limit(&exchange, &cache, &first_order, fill_timestamp);
+    submit_matching_option_limit(&exchange, &cache, &second_order, fill_timestamp);
+
+    let messages = saving_handler.get_messages();
+    let pre_readd_fill = matching_option_fill(&messages, pre_readd_order.client_order_id());
+    let first_fill = matching_option_fill(&messages, first_order.client_order_id());
+    let second_fill = matching_option_fill(&messages, second_order.client_order_id());
+    assert_eq!(pre_readd_fill.ts_event, first_fill.ts_event);
+    assert_ne!(pre_readd_fill.venue_order_id, first_fill.venue_order_id);
+    assert_ne!(pre_readd_fill.trade_id, first_fill.trade_id);
+    assert_eq!(first_fill.ts_event, second_fill.ts_event);
+    assert_ne!(first_fill.venue_order_id, second_fill.venue_order_id);
+    assert_ne!(first_fill.position_id, second_fill.position_id);
+    assert_ne!(first_fill.trade_id, second_fill.trade_id);
 }
 
 #[rstest]


### PR DESCRIPTION
Re-registering an instrument on a simulated venue currently hands the replacement matching engine a `raw_id` that another live engine already holds.

## Instrument re-registration mints a colliding matching-engine `raw_id`

`SimulatedExchange::add_instrument` in `crates/backtest/src/exchange.rs` inserts into `self.instruments` and only then derives `let raw_id = u32::try_from(self.instruments.len())`. Because the insert precedes the length read, the value is the count of distinct instruments registered so far, which is not monotonic across a re-registration: adding A yields 1, adding B yields 2, and re-adding A replaces the map entry without changing the length, so A's replacement engine is constructed with 2 - the ID B is already using.

`raw_id` is an identity discriminator rather than a label. `IdsGenerator` in `crates/execution/src/matching_engine/ids_generator.rs` formats venue order IDs as `{venue}-{raw_id}-{order_count}` and position IDs as `{venue}-{raw_id}-{position_count}`, and feeds `raw_id` into `fnv1a_trade_id_hash`. Two live matching engines on one venue sharing a `raw_id` therefore mint colliding venue order IDs and, under a hedging OMS, colliding position IDs; trade IDs collide when both engines fill at the same timestamp with the same fill ordinal. Venue order and position IDs are unaffected when `use_random_ids` is enabled, but the trade-ID hash is always deterministic.

Re-registration cannot simply be rejected: it is supported and covered by `test_instrument_update_cancels_previous_expiry_timer`, which calls `add_instrument` twice for one ID with a changed expiration, and `BacktestEngine::add_instrument` reads the previous expiration specifically to reschedule that timer.

The fix allocates from a lifetime-monotonic `last_raw_id` counter on the exchange, incremented for every matching engine constructed, including a replacement. Reproducing the current values on the ordinary append-only path matters, since `raw_id` appears verbatim in generated ID strings: the counter starts at zero and allocates with `checked_add(1)`, so first-registered instruments still receive 1, 2, 3 and no existing backtest's IDs shift. Only the re-registration case differs, where the replacement now receives a fresh number instead of a live one. Reusing the retired engine's `raw_id` would not be sufficient - the replacement engine starts its order and position sequences at zero, so it would regenerate IDs the retired engine had already emitted.

The allocation also moves ahead of the instrument insert, so the exhaustion error at `u32::MAX` now leaves both `instruments` and `matching_engines` unmodified. Previously the instrument was inserted before the checked conversion, and a failure left the map mutated with no corresponding matching engine.

## The same defect exists in the Cython engine

`nautilus_trader/backtest/engine.pyx` performs the same `self.instruments[instrument.id] = instrument` followed by `raw_id=len(self.instruments)` in its own `add_instrument`, so both engines are wrong in the same way and this is not a Rust-side parity gap. This change is Rust-only; I have not touched the Cython path.

## Whether re-registration should preserve matching state

Separate from the collision, re-registration silently discards the previous matching engine along with its resting orders, book state and ID sequences. `OrderMatchingEngine::update_instrument` already exists and is built for exactly this - it updates the definition, resets only precision-dependent state, and drops incompatible orders while preserving the engine - and the Cython engine keeps `update_instrument` as a separate method reached from the instrument-data path. Routing an existing instrument ID through it would change whether resting orders survive a re-registration, whether book state is retained when precision is unchanged, and whether ID sequences continue, so it is a behavioural decision rather than a correctness one and is left out of this change. Happy to follow up with it, or with documentation of the destructive behaviour as intended, whichever you prefer.

## Testing

`test_readded_instrument_does_not_collide_generated_fill_ids` pins the observable consequence rather than the counter value. It registers A and B, fills A once, re-adds A, then fills the replacement A and B at one shared timestamp, and asserts that all three fills carry distinct venue order IDs and trade IDs and that the two live engines produce distinct position IDs under a hedging OMS. The pre-replacement fill is what distinguishes a monotonic counter from a reused retired ID. Both assertions were verified to FAIL against the corresponding unfixed implementations: restoring the insert-before-length derivation fails on the A-versus-B venue order ID, and modelling a reused retired `raw_id` fails on the pre-versus-post-replacement venue order ID.

`test_append_only_matching_engine_raw_ids_start_at_one_and_increment` pins that ordinary registration still yields 1 and 2, so a future change to the allocator cannot silently renumber existing backtests. `test_add_instrument_raw_id_overflow_does_not_mutate_maps` drives the counter to `u32::MAX` and asserts the registration is rejected with both maps and the counter unchanged.

All three tests are deterministic and use no wall-clock waits.
