### PR TITLE
Allow custom data injection into PyO3 backtests

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -397,14 +397,15 @@ impl BacktestEngine {
         Ok(())
     }
 
-    /// Adds market data to the engine for replay during the backtest run.
+    /// Adds data to the engine for replay during the backtest run.
     ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - `data` is empty.
-    /// - `validate` is `true` and the instrument for the first element has not been
-    ///   added to the cache via [`add_instrument`](Self::add_instrument).
+    /// - `validate` is `true`, the first element is built-in market data (excluding
+    ///   custom and DeFi data), and its instrument has not been added to the cache via
+    ///   [`add_instrument`](Self::add_instrument).
     /// - `validate` is `true` and the first element is a [`Data::Bar`] whose
     ///   `aggregation_source` is not [`AggregationSource::External`].
     pub fn add_data(
@@ -435,7 +436,7 @@ impl BacktestEngine {
             #[cfg(not(feature = "defi"))]
             let first_is_defi = false;
 
-            if !first_is_defi {
+            if !first_is_defi && !matches!(first, Data::Custom(_)) {
                 let first_instrument_id = first.instrument_id();
                 anyhow::ensure!(
                     self.kernel
@@ -471,11 +472,17 @@ impl BacktestEngine {
         }
 
         for item in &to_add {
+            let ts = item.ts_init();
+            batch_min_ts = Some(batch_min_ts.map_or(ts, |cur| cur.min(ts)));
+            batch_max_ts = Some(batch_max_ts.map_or(ts, |cur| cur.max(ts)));
+
             #[cfg(feature = "defi")]
             if matches!(item, Data::Defi(_)) {
-                let ts = item.ts_init();
-                batch_min_ts = Some(batch_min_ts.map_or(ts, |cur| cur.min(ts)));
-                batch_max_ts = Some(batch_max_ts.map_or(ts, |cur| cur.max(ts)));
+                continue;
+            }
+
+            if matches!(item, Data::Custom(_)) {
+                // Custom data routes by DataType and is independent of market venue bookkeeping.
                 continue;
             }
 
@@ -487,10 +494,6 @@ impl BacktestEngine {
             }
 
             self.add_market_data_client_if_not_exists(instr_id.venue);
-
-            let ts = item.ts_init();
-            batch_min_ts = Some(batch_min_ts.map_or(ts, |cur| cur.min(ts)));
-            batch_max_ts = Some(batch_max_ts.map_or(ts, |cur| cur.max(ts)));
         }
 
         if let Some(ts) = batch_min_ts

--- a/crates/backtest/src/python/engine.rs
+++ b/crates/backtest/src/python/engine.rs
@@ -40,9 +40,9 @@ use nautilus_model::defi::DefiData;
 use nautilus_model::{
     accounts::margin_model::{LeveragedMarginModel, MarginModelAny, StandardMarginModel},
     data::{
-        Bar, Data, FundingRateUpdate, IndexPriceUpdate, InstrumentClose, InstrumentStatus,
-        MarkPriceUpdate, OptionGreeks, OrderBookDelta, OrderBookDeltas, OrderBookDeltas_API,
-        OrderBookDepth10, QuoteTick, TradeTick,
+        Bar, CustomData, Data, FundingRateUpdate, IndexPriceUpdate, InstrumentClose,
+        InstrumentStatus, MarkPriceUpdate, OptionGreeks, OrderBookDelta, OrderBookDeltas,
+        OrderBookDeltas_API, OrderBookDepth10, QuoteTick, TradeTick,
     },
     enums::{AccountType, BookType, OmsType, OtoTriggerMode},
     identifiers::{
@@ -1787,6 +1787,10 @@ fn pyobject_to_data(_py: Python, obj: &Bound<'_, PyAny>) -> PyResult<Data> {
         return Ok(Data::InstrumentClose(close));
     }
 
+    if let Ok(custom) = obj.extract::<CustomData>() {
+        return Ok(Data::Custom(custom));
+    }
+
     #[cfg(feature = "defi")]
     if let Ok(defi) = obj.extract::<DefiData>() {
         return Ok(Data::Defi(Box::new(defi)));
@@ -1841,6 +1845,7 @@ fn pyobject_to_data(_py: Python, obj: &Bound<'_, PyAny>) -> PyResult<Data> {
 mod model_tests {
     use nautilus_execution::python::{fee::PyFeeModel, fill::PyFillModel};
     use nautilus_model::{
+        data::{Data, stubs::stub_custom_data},
         enums::{AccountType, BookType, OmsType, OtoTriggerMode},
         identifiers::Venue,
         types::{Currency, Money},
@@ -1853,6 +1858,23 @@ mod model_tests {
     use rstest::rstest;
 
     use crate::{config::BacktestEngineConfig, engine::BacktestEngine};
+
+    #[rstest]
+    fn test_pyobject_to_data_accepts_custom_data() {
+        Python::initialize();
+
+        Python::attach(|py| {
+            let custom = stub_custom_data(2, 42, None, None);
+            let obj = custom.into_py_any(py).unwrap();
+            let converted = super::pyobject_to_data(py, obj.bind(py)).unwrap();
+
+            let Data::Custom(converted) = converted else {
+                panic!("Expected Data::Custom");
+            };
+            assert_eq!(converted.data_type.type_name(), "StubCustomData");
+            assert_eq!(converted.data.ts_init().as_u64(), 2);
+        });
+    }
 
     #[rstest]
     fn test_add_venue_accepts_python_defined_fee_and_fill_models() {

--- a/crates/backtest/tests/backtest_engine.rs
+++ b/crates/backtest/tests/backtest_engine.rs
@@ -14,8 +14,9 @@
 // -------------------------------------------------------------------------------------------------
 
 use std::{
-    cell::Cell,
+    cell::{Cell, RefCell},
     fmt::Debug,
+    rc::Rc,
     sync::atomic::{AtomicU32, Ordering},
 };
 
@@ -43,8 +44,9 @@ use nautilus_indicators::{
 use nautilus_model::{
     accounts::{Account, AccountAny},
     data::{
-        Bar, BarSpecification, BarType, BookOrder, Data, FundingRateUpdate, InstrumentClose,
-        MarkPriceUpdate, OrderBookDelta, QuoteTick, TradeTick,
+        Bar, BarSpecification, BarType, BookOrder, CustomData, Data, DataType, FundingRateUpdate,
+        InstrumentClose, MarkPriceUpdate, OrderBookDelta, QuoteTick, TradeTick,
+        stubs::{StubCustomData, stub_custom_data},
     },
     enums::{
         AccountType, AggregationSource, AggressorSide, AssetClass, BarAggregation, BookAction,
@@ -156,6 +158,51 @@ impl Debug for EmptyActor {
 }
 
 impl DataActor for EmptyActor {}
+
+struct CustomDataRecorder {
+    core: DataActorCore,
+    data_type: DataType,
+    received: Rc<RefCell<Vec<i64>>>,
+}
+
+impl CustomDataRecorder {
+    fn new(data_type: DataType, received: Rc<RefCell<Vec<i64>>>) -> Self {
+        let config = DataActorConfig {
+            actor_id: Some(ActorId::from("CUSTOM-DATA-RECORDER")),
+            ..Default::default()
+        };
+        Self {
+            core: DataActorCore::new(config),
+            data_type,
+            received,
+        }
+    }
+}
+
+nautilus_actor!(CustomDataRecorder);
+
+impl Debug for CustomDataRecorder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(stringify!(CustomDataRecorder)).finish()
+    }
+}
+
+impl DataActor for CustomDataRecorder {
+    fn on_start(&mut self) -> anyhow::Result<()> {
+        self.subscribe_data(self.data_type.clone(), None, None);
+        Ok(())
+    }
+
+    fn on_data(&mut self, data: &CustomData) -> anyhow::Result<()> {
+        let payload = data
+            .data
+            .as_any()
+            .downcast_ref::<StubCustomData>()
+            .ok_or_else(|| anyhow::anyhow!("Expected StubCustomData"))?;
+        self.received.borrow_mut().push(payload.value);
+        Ok(())
+    }
+}
 
 struct EmptyExecAlgorithm {
     core: ExecutionAlgorithmCore,
@@ -964,6 +1011,82 @@ fn create_engine() -> BacktestEngine {
         .unwrap();
     engine.add_venue(venue_config).unwrap();
     engine
+}
+
+#[rstest]
+fn test_add_custom_data_bypasses_market_setup_and_replays_in_order(
+    crypto_perpetual_ethusdt: CryptoPerpetual,
+) {
+    let config = BacktestEngineConfig {
+        bypass_logging: true,
+        run_analysis: false,
+        ..Default::default()
+    };
+    let mut engine = BacktestEngine::new(config).unwrap();
+    let first = stub_custom_data(2, 2, None, None);
+    let second = stub_custom_data(1, 1, None, None);
+    let unscoped_data_type = first.data_type.clone();
+    // DataType identifiers scope catalog paths, not messaging topics.
+    let instrument_id = crypto_perpetual_ethusdt.id();
+    let third = stub_custom_data(4, 4, None, Some(instrument_id.to_string()));
+    let fourth = stub_custom_data(3, 3, None, Some(instrument_id.to_string()));
+    let received = Rc::new(RefCell::new(Vec::new()));
+
+    engine
+        .add_actor(CustomDataRecorder::new(
+            unscoped_data_type,
+            Rc::clone(&received),
+        ))
+        .unwrap();
+    engine
+        .add_data(
+            vec![Data::Custom(first), Data::Custom(second)],
+            None,
+            true,
+            true,
+        )
+        .unwrap();
+    engine
+        .add_data(
+            vec![Data::Custom(third), Data::Custom(fourth)],
+            None,
+            true,
+            true,
+        )
+        .unwrap();
+
+    assert!(
+        engine
+            .kernel()
+            .data_engine
+            .borrow()
+            .registered_clients()
+            .is_empty()
+    );
+
+    let venue_config = SimulatedVenueConfig::builder()
+        .venue(Venue::from("BINANCE"))
+        .oms_type(OmsType::Netting)
+        .account_type(AccountType::Margin)
+        .book_type(BookType::L2_MBP)
+        .starting_balances(vec![Money::from("1_000_000 USDT")])
+        .build()
+        .unwrap();
+    engine.add_venue(venue_config).unwrap();
+    engine
+        .add_instrument(&InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt))
+        .unwrap();
+
+    let data_count_before_run = engine.kernel().data_engine.borrow().data_count();
+    engine.run(None, None, None, false).unwrap();
+
+    assert_eq!(*received.borrow(), vec![1, 2, 3, 4]);
+    assert_eq!(engine.get_result().iterations, 4);
+    assert_eq!(
+        engine.kernel().data_engine.borrow().data_count(),
+        data_count_before_run + 4
+    );
+    engine.dispose();
 }
 
 fn create_eur_base_margin_engine() -> BacktestEngine {

--- a/python/tests/unit/backtest/test_backtest_engine_custom_data.py
+++ b/python/tests/unit/backtest/test_backtest_engine_custom_data.py
@@ -1,0 +1,89 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.backtest import BacktestEngine
+from nautilus_trader.backtest import BacktestEngineConfig
+from nautilus_trader.model import CustomData
+from nautilus_trader.model import DataType
+from nautilus_trader.model import InstrumentId
+from nautilus_trader.model import StrategyId
+from nautilus_trader.model import register_custom_data_class
+from nautilus_trader.persistence import ParquetDataCatalog
+from nautilus_trader.persistence import RustTestCustomData
+from nautilus_trader.trading import Strategy
+from nautilus_trader.trading import StrategyConfig
+
+
+class _CustomDataStrategy(Strategy):
+    def on_start(self) -> None:
+        self.subscribe_data(self.data_type)
+
+    def on_data(self, data: CustomData) -> None:
+        self.received.append(data)
+
+
+def test_catalog_custom_data_reaches_backtest_strategy(tmp_path) -> None:
+    register_custom_data_class(RustTestCustomData)
+    catalog_path = tmp_path / "catalog"
+    catalog_path.mkdir()
+    catalog = ParquetDataCatalog(str(catalog_path))
+    instrument_id = InstrumentId.from_str("CUSTOM.TEST")
+    data_type = DataType("RustTestCustomData", identifier=str(instrument_id))
+    custom_data = [
+        CustomData(
+            data_type,
+            RustTestCustomData(instrument_id, 1.25, True, 1, 1),
+        ),
+        CustomData(
+            data_type,
+            RustTestCustomData(instrument_id, 2.5, False, 2, 2),
+        ),
+    ]
+    catalog.write_custom_data(custom_data)
+    loaded = catalog.query_custom_data(
+        "RustTestCustomData",
+        identifiers=[str(instrument_id)],
+    )
+    assert len(loaded) == 2
+
+    strategy = _CustomDataStrategy(
+        StrategyConfig(
+            strategy_id=StrategyId("CUSTOM-DATA-STRATEGY"),
+            log_events=False,
+            log_commands=False,
+        ),
+    )
+    strategy.data_type = data_type
+    strategy.received = []
+    engine = BacktestEngine(
+        BacktestEngineConfig(
+            bypass_logging=True,
+            run_analysis=False,
+        ),
+    )
+    engine.add_strategy(strategy)
+
+    try:
+        engine.add_data(list(reversed(loaded)), validate=True, sort=True)
+        engine.run()
+        result = engine.get_result()
+
+        assert result.iterations == 2
+        assert engine.backtest_start == 1
+        assert engine.backtest_end == 2
+        assert [item.data.value for item in strategy.received] == [1.25, 2.5]
+        assert [item.ts_init for item in strategy.received] == [1, 2]
+    finally:
+        engine.dispose()


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and followed the established practices
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

PyO3 `BacktestEngine.add_data` currently rejects the existing `CustomData` wrapper even though catalog persistence and runtime routing already support `Data::Custom`. This change adds the missing conversion and treats custom input as non-market data during instrument validation and client/bookkeeping setup while retaining sorting, replay, and backtest time bounds; an end-to-end regression verifies catalog data reaches `Strategy.on_data`.

## Related issues/PRs

- Related to #3542
- No issue was filed for this focused v2 follow-up.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A. The public Python signature is unchanged; the accepted input set is expanded to include the existing PyO3 `CustomData` type.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs-v2` and committed the generated output

No documentation files or public stubs changed. Stub generation reported no generated doc-comment updates.

## Testing

**Ensure new or changed logic is covered by tests.** Check at least one:

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Validated with:

- `make format`
- `make pre-commit`
- Rust regression tests for PyO3 conversion, custom-data replay, validation, client bookkeeping, ordering, and built-in unknown-instrument behavior
- `cd python && .venv/bin/pytest -q tests/unit/backtest/test_backtest_engine_custom_data.py`
- `cd python && .venv/bin/ruff check tests/unit/backtest/test_backtest_engine_custom_data.py`
- `git diff --check`

The standard v2 build target reached stub generation but the macOS linker emitted `__eh_frame section too large`, which the project promotes to an error through `warnings = "deny"`. Re-running the same `maturin develop` build with process-local `CARGO_BUILD_WARNINGS=allow` completed successfully, after which the catalog-to-strategy Python regression passed.