### PR TITLE
Consume response handlers after data response dispatch

### DIFF
--- a/crates/common/src/msgbus/api.rs
+++ b/crates/common/src/msgbus/api.rs
@@ -1371,7 +1371,7 @@ pub fn send_response(correlation_id: &UUID4, message: &DataResponse) {
     let handler = {
         let bus = get_message_bus();
         let mut bus = bus.borrow_mut();
-        let handler = bus.get_response_handler(correlation_id).cloned();
+        let handler = bus.take_response_handler(correlation_id);
         bus.increment_res_count();
         handler
     };
@@ -1620,16 +1620,18 @@ mod tests {
     use nautilus_model::{data::OptionGreekValues, enums::GreeksConvention};
     use nautilus_model::{
         data::{
-            Bar, FundingRateUpdate, IndexPriceUpdate, MarkPriceUpdate, OptionGreeks,
-            OrderBookDelta, OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick,
+            Bar, BarType, DataType, FundingRateUpdate, IndexPriceUpdate, MarkPriceUpdate,
+            OptionGreeks, OrderBookDelta, OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick,
             stubs::{stub_custom_data, stub_deltas, stub_depth10},
         },
-        enums::{AccountType, OrderSide, PositionSide},
+        enums::{AccountType, BookType, OrderSide, PositionSide},
         events::{OrderEventAny, PositionEvent, PositionOpened, order::spec::OrderDeniedSpec},
         identifiers::{
             AccountId, ClientId, ClientOrderId, InstrumentId, PositionId, StrategyId, TraderId,
+            Venue,
         },
         instruments::{InstrumentAny, stubs::audusd_sim},
+        orderbook::OrderBook,
         types::{Currency, Price, Quantity},
     };
     #[cfg(feature = "sbe")]
@@ -1644,8 +1646,10 @@ mod tests {
         enums::SerializationEncoding,
         messages::{
             data::{
-                DataCommand, DataResponse, QuotesResponse, RequestCommand, RequestQuotes,
-                SubscribeCommand, SubscribeQuotes,
+                BarsResponse, BookDeltasResponse, BookDepthResponse, BookResponse,
+                CustomDataResponse, DataCommand, DataResponse, ForwardPricesResponse,
+                FundingRatesResponse, InstrumentResponse, InstrumentsResponse, QuotesResponse,
+                RequestCommand, RequestQuotes, SubscribeCommand, SubscribeQuotes, TradesResponse,
             },
             execution::{CancelAllOrders, TradingCommand},
         },
@@ -1728,6 +1732,45 @@ mod tests {
     fn reset_message_bus() {
         get_message_bus().borrow_mut().dispose();
         set_message_bus(Rc::new(RefCell::new(MessageBus::default())));
+    }
+
+    fn assert_response_handler_is_consumed<T>(response: &DataResponse)
+    where
+        T: 'static,
+    {
+        reset_message_bus();
+
+        let correlation_id = *response.correlation_id();
+        let response_kind = response.kind();
+        let calls = Rc::new(Cell::new(0));
+        let handler_calls = calls.clone();
+        register_response_handler(
+            &correlation_id,
+            ShareableMessageHandler::from_typed(move |_response: &T| {
+                handler_calls.set(handler_calls.get() + 1);
+            }),
+        );
+
+        send_response(&correlation_id, response);
+        send_response(&correlation_id, response);
+
+        assert_eq!(
+            calls.get(),
+            1,
+            "{response_kind} response handler must only run once",
+        );
+        assert!(
+            get_message_bus()
+                .borrow()
+                .get_response_handler(&correlation_id)
+                .is_none(),
+            "{response_kind} response handler must be removed after dispatch",
+        );
+        assert_eq!(
+            get_message_bus().borrow().res_count(),
+            2,
+            "{response_kind} duplicate responses must still increment the response count",
+        );
     }
 
     #[rstest]
@@ -3267,6 +3310,223 @@ mod tests {
     }
 
     #[rstest]
+    fn test_send_response_consumes_handler_for_all_variants() {
+        let client_id = ClientId::new("SIM");
+        let instrument = audusd_sim();
+        let instrument_id = instrument.id;
+        let venue = Venue::new("SIM");
+        let bar_type = BarType::from("AUD/USD.SIM-1-MINUTE-LAST-EXTERNAL");
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<CustomDataResponse>(&DataResponse::Data(
+            CustomDataResponse::new(
+                correlation_id,
+                client_id,
+                Some(venue),
+                DataType::new("TestData", None, None),
+                Vec::<u8>::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<InstrumentResponse>(&DataResponse::Instrument(
+            Box::new(InstrumentResponse::new(
+                correlation_id,
+                client_id,
+                instrument_id,
+                InstrumentAny::CurrencyPair(instrument),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            )),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<InstrumentsResponse>(&DataResponse::Instruments(
+            InstrumentsResponse::new(
+                correlation_id,
+                client_id,
+                venue,
+                Vec::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<BookResponse>(&DataResponse::Book(
+            BookResponse::new(
+                correlation_id,
+                client_id,
+                instrument_id,
+                OrderBook::new(instrument_id, BookType::L2_MBP),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<BookDeltasResponse>(&DataResponse::BookDeltas(
+            BookDeltasResponse::new(
+                correlation_id,
+                client_id,
+                instrument_id,
+                Vec::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<BookDepthResponse>(&DataResponse::BookDepth(
+            BookDepthResponse::new(
+                correlation_id,
+                client_id,
+                instrument_id,
+                Vec::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<QuotesResponse>(&DataResponse::Quotes(
+            QuotesResponse::new(
+                correlation_id,
+                client_id,
+                instrument_id,
+                Vec::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<TradesResponse>(&DataResponse::Trades(
+            TradesResponse::new(
+                correlation_id,
+                client_id,
+                instrument_id,
+                Vec::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<FundingRatesResponse>(&DataResponse::FundingRates(
+            FundingRatesResponse::new(
+                correlation_id,
+                client_id,
+                instrument_id,
+                Vec::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<ForwardPricesResponse>(&DataResponse::ForwardPrices(
+            ForwardPricesResponse::new(
+                correlation_id,
+                client_id,
+                venue,
+                Vec::new(),
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+
+        let correlation_id = UUID4::new();
+        assert_response_handler_is_consumed::<BarsResponse>(&DataResponse::Bars(
+            BarsResponse::new(
+                correlation_id,
+                client_id,
+                bar_type,
+                Vec::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ),
+        ));
+    }
+
+    #[rstest]
+    fn test_send_response_allows_reentrant_same_correlation_registration() {
+        reset_message_bus();
+
+        let correlation_id = UUID4::new();
+        let first_calls = Rc::new(Cell::new(0));
+        let second_calls = Rc::new(Cell::new(0));
+        let first_handler_calls = first_calls.clone();
+        let second_handler_calls = second_calls.clone();
+        register_response_handler(
+            &correlation_id,
+            ShareableMessageHandler::from_typed(move |_response: &QuotesResponse| {
+                first_handler_calls.set(first_handler_calls.get() + 1);
+                let second_handler_calls = second_handler_calls.clone();
+                register_response_handler(
+                    &correlation_id,
+                    ShareableMessageHandler::from_typed(move |_response: &QuotesResponse| {
+                        second_handler_calls.set(second_handler_calls.get() + 1);
+                    }),
+                );
+            }),
+        );
+
+        let response = DataResponse::Quotes(QuotesResponse::new(
+            correlation_id,
+            ClientId::new("SIM"),
+            InstrumentId::from("TEST.VENUE"),
+            Vec::new(),
+            None,
+            None,
+            UnixNanos::default(),
+            None,
+        ));
+
+        send_response(&correlation_id, &response);
+        assert_eq!(first_calls.get(), 1);
+        assert_eq!(second_calls.get(), 0);
+        assert!(
+            get_message_bus()
+                .borrow()
+                .get_response_handler(&correlation_id)
+                .is_some(),
+        );
+
+        send_response(&correlation_id, &response);
+        assert_eq!(first_calls.get(), 1);
+        assert_eq!(second_calls.get(), 1);
+        assert!(
+            get_message_bus()
+                .borrow()
+                .get_response_handler(&correlation_id)
+                .is_none(),
+        );
+    }
+
+    #[rstest]
     fn test_send_execution_report_allows_reentrant_topic_access() {
         use nautilus_model::{
             identifiers::{AccountId, ClientId, Venue},
@@ -3710,17 +3970,20 @@ mod tests {
 
     #[rstest]
     fn set_bus_tap_then_send_response_invokes_tap() {
-        let _msgbus = get_message_bus();
+        reset_message_bus();
+        clear_bus_tap();
+        let msgbus = get_message_bus();
+        let initial_response_count = msgbus.borrow().res_count();
         let tap = Rc::new(RecordingTap::default());
         set_bus_tap(tap.clone());
 
         let correlation_id = UUID4::new();
-        let handler_called = Rc::new(RefCell::new(false));
-        let handler_called_clone = handler_called.clone();
+        let handler_calls = Rc::new(Cell::new(0));
+        let handler_calls_clone = handler_calls.clone();
         register_response_handler(
             &correlation_id,
             ShareableMessageHandler::from_typed(move |_resp: &QuotesResponse| {
-                *handler_called_clone.borrow_mut() = true;
+                handler_calls_clone.set(handler_calls_clone.get() + 1);
             }),
         );
 
@@ -3735,11 +3998,22 @@ mod tests {
             params: None,
         });
         send_response(&correlation_id, &response);
+        send_response(&correlation_id, &response);
 
         clear_bus_tap();
 
-        assert!(*handler_called.borrow());
-        assert_eq!(tap.response_correlation_ids(), vec![correlation_id]);
+        assert_eq!(handler_calls.get(), 1);
+        assert_eq!(
+            tap.response_correlation_ids(),
+            vec![correlation_id, correlation_id],
+        );
+        assert_eq!(msgbus.borrow().res_count(), initial_response_count + 2);
+        assert!(
+            msgbus
+                .borrow()
+                .get_response_handler(&correlation_id)
+                .is_none(),
+        );
     }
 
     #[rstest]

--- a/crates/common/src/msgbus/core.rs
+++ b/crates/common/src/msgbus/core.rs
@@ -720,6 +720,14 @@ impl MessageBus {
         self.correlation_index.get(correlation_id)
     }
 
+    /// Removes and returns the handler for the `correlation_id`.
+    pub(crate) fn take_response_handler(
+        &mut self,
+        correlation_id: &UUID4,
+    ) -> Option<ShareableMessageHandler> {
+        self.correlation_index.remove(correlation_id)
+    }
+
     /// Finds the subscriptions with pattern matching the `topic`.
     pub(crate) fn find_topic_matches(&self, topic: MStr<Topic>) -> Vec<Subscription> {
         self.subscriptions
@@ -1010,6 +1018,23 @@ mod tests {
 
         let handler = msgbus_ref.get_response_handler(&request_id).unwrap();
         assert_eq!(handler.id(), handler.id());
+    }
+
+    #[rstest]
+    fn test_take_response_handler_removes_registration_and_allows_reregistration() {
+        let mut msgbus = MessageBus::default();
+        let request_id = UUID4::new();
+        let handler = get_stub_shareable_handler(None);
+        let handler_id = handler.id();
+        msgbus
+            .register_response_handler(&request_id, handler)
+            .unwrap();
+
+        let taken = msgbus.take_response_handler(&request_id).unwrap();
+
+        assert_eq!(taken.id(), handler_id);
+        assert!(msgbus.get_response_handler(&request_id).is_none());
+        assert!(msgbus.register_response_handler(&request_id, taken).is_ok());
     }
 
     #[rstest]

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -17464,7 +17464,6 @@ fn test_request_join_two_phase_emits_parent_response(
     stub_msgbus: Rc<RefCell<MessageBus>>,
     client_id: ClientId,
 ) {
-    let _ = stub_msgbus;
     let instrument_id = audusd_sim.id;
     let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
     let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
@@ -17543,6 +17542,49 @@ fn test_request_join_two_phase_emits_parent_response(
         .copied()
         .expect("joined quote data must reach the cache");
     assert_eq!(cached.ts_init, UnixNanos::from(2_000));
+
+    for request_id in [leg_a, leg_b, join_id] {
+        assert!(
+            stub_msgbus
+                .borrow()
+                .get_response_handler(&request_id)
+                .is_none(),
+            "completed join response handler must be removed for {request_id}",
+        );
+    }
+
+    data_engine.response(leg_quotes_response(
+        leg_a,
+        instrument_id,
+        client_id,
+        vec![pipeline_quote(instrument_id, 3_000)],
+        None,
+        None,
+    ));
+    data_engine.response(leg_quotes_response(
+        leg_b,
+        instrument_id,
+        client_id,
+        vec![pipeline_quote(instrument_id, 4_000)],
+        None,
+        None,
+    ));
+    data_engine.response(leg_quotes_response(
+        join_id,
+        instrument_id,
+        client_id,
+        vec![pipeline_quote(instrument_id, 5_000)],
+        None,
+        None,
+    ));
+
+    assert_eq!(
+        parent_saver.get_messages().len(),
+        1,
+        "late leg and parent responses must not complete the join again",
+    );
+    assert_eq!(leg_a_saver.get_messages().len(), 1);
+    assert_eq!(leg_b_saver.get_messages().len(), 1);
 }
 
 #[rstest]
@@ -17950,7 +17992,6 @@ fn test_reset_clears_pipeline_and_join_state(
     stub_msgbus: Rc<RefCell<MessageBus>>,
     client_id: ClientId,
 ) {
-    let _ = stub_msgbus;
     let instrument_id = audusd_sim.id;
     let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
     let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
@@ -17979,11 +18020,24 @@ fn test_reset_clears_pipeline_and_join_state(
     let (parent_handler, parent_saver) =
         get_any_saving_handler::<QuotesResponse>(Some(Ustr::from("reset-parent")));
     msgbus::register_response_handler(&join_id, parent_handler);
+    let (leg_b_handler, leg_b_saver) =
+        get_any_saving_handler::<QuotesResponse>(Some(Ustr::from("reset-leg-b")));
+    msgbus::register_response_handler(&leg_b, leg_b_handler);
 
     data_engine.reset();
 
     assert_eq!(data_engine.request_pipeline_count(), 0);
     assert_eq!(data_engine.pending_join_request_count(), 0);
+
+    for request_id in [leg_b, join_id] {
+        assert!(
+            stub_msgbus
+                .borrow()
+                .get_response_handler(&request_id)
+                .is_some(),
+            "data engine reset must not clear message bus response handlers for {request_id}",
+        );
+    }
 
     data_engine.response(leg_quotes_response(
         leg_a,
@@ -18002,9 +18056,37 @@ fn test_reset_clears_pipeline_and_join_state(
         None,
     ));
 
+    assert_eq!(leg_b_saver.get_messages().len(), 1);
+    assert_eq!(leg_b_saver.get_messages()[0].correlation_id, leg_b);
+    assert!(
+        stub_msgbus.borrow().get_response_handler(&leg_b).is_none(),
+        "the first late leg response must consume its handler",
+    );
+
+    data_engine.response(leg_quotes_response(
+        leg_b,
+        instrument_id,
+        client_id,
+        vec![pipeline_quote(instrument_id, 3_000)],
+        None,
+        None,
+    ));
+
+    assert_eq!(
+        leg_b_saver.get_messages().len(),
+        1,
+        "a duplicate late leg response must not invoke the handler again",
+    );
     assert!(
         parent_saver.get_messages().is_empty(),
         "reset must clear pipeline state so no rebuilt parent fires",
+    );
+    assert!(
+        stub_msgbus
+            .borrow()
+            .get_response_handler(&join_id)
+            .is_some(),
+        "reset must not clear unrelated message bus response handlers",
     );
 }
 
@@ -18277,7 +18359,6 @@ fn test_request_join_single_leg_fires_immediately(
     stub_msgbus: Rc<RefCell<MessageBus>>,
     client_id: ClientId,
 ) {
-    let _ = stub_msgbus;
     let instrument_id = audusd_sim.id;
     let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
     let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
@@ -18332,6 +18413,16 @@ fn test_request_join_single_leg_fires_immediately(
 
     assert_eq!(data_engine.request_pipeline_count(), 0);
     assert_eq!(data_engine.pending_join_request_count(), 0);
+
+    for request_id in [leg, join_id] {
+        assert!(
+            stub_msgbus
+                .borrow()
+                .get_response_handler(&request_id)
+                .is_none(),
+            "completed single-leg join handler must be removed for {request_id}",
+        );
+    }
 }
 
 #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and followed the established practices
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`send_response` currently clones correlation handlers and leaves them registered after a completed data response, so duplicate or late responses can invoke callbacks again and completed handlers accumulate without bound. This change atomically takes the handler before dispatch while preserving bus taps and response-count semantics, with coverage for every typed historical response plus join and reset behavior.

## Related issues/PRs

- Related to #3038
- Related to #3310
- No issue was filed for this focused v2 follow-up.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A. The public API is unchanged; correlation handlers now follow the request/response completion lifecycle and are consumed on the first response.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs-v2` and committed the generated output

No documentation files or Python stubs changed.

## Testing

**Ensure new or changed logic is covered by tests.** Check at least one:

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Validated with:

- `make format`
- `cargo test -p nautilus-common response_handler`
- `cargo test -p nautilus-common send_response`
- `cargo test -p nautilus-data --test engine` (256 tests)
- Targeted `cargo clippy` runs for `nautilus-common` and `nautilus-data`
- `SKIP=uv-lock make pre-commit`
- `git diff --check`

The response tests cover all 11 `DataResponse` variants, duplicate delivery, bus taps and response counts, same-ID re-registration, join leg and parent completion, single- and multi-request joins, and late responses after reset. The `uv-lock` hook was excluded because it rewrites pre-existing root `bitarray` exclusion metadata on current `develop`; that unrelated generated change is not part of this PR.