### PR TITLE
Compute FX session boundaries with calendar-day arithmetic

### DIFF
--- a/crates/trading/src/sessions.rs
+++ b/crates/trading/src/sessions.rs
@@ -24,7 +24,7 @@
 //! - London Session    0800-1600 (Europe / London)
 //! - New York Session  0800-1700 (America / New York)
 
-use chrono::{DateTime, Datelike, Duration, NaiveTime, TimeZone, Timelike, Utc};
+use chrono::{DateTime, Datelike, Days, NaiveTime, TimeZone, Utc, Weekday};
 use chrono_tz::{America::New_York, Asia::Tokyo, Australia::Sydney, Europe::London, Tz};
 use strum::{Display, EnumIter, EnumString, FromRepr};
 
@@ -93,120 +93,92 @@ pub fn fx_local_from_utc(session: ForexSession, time_now: DateTime<Utc>) -> Date
     session.timezone().from_utc_datetime(&time_now.naive_utc())
 }
 
+fn fx_next_boundary(local_now: DateTime<Tz>, session_time: NaiveTime) -> DateTime<Utc> {
+    let timezone = local_now.timezone();
+    let mut date = local_now.date_naive();
+
+    if local_now.time() > session_time {
+        date = date
+            .checked_add_days(Days::new(1))
+            .expect("FX session date must be representable");
+    }
+
+    let weekend_days = match date.weekday() {
+        Weekday::Sat => 2,
+        Weekday::Sun => 1,
+        _ => 0,
+    };
+    date = date
+        .checked_add_days(Days::new(weekend_days))
+        .expect("FX session date must be representable");
+
+    timezone
+        .from_local_datetime(&date.and_time(session_time))
+        .single()
+        .expect("FX session boundary must be a unique local time")
+        .with_timezone(&Utc)
+}
+
+fn fx_prev_boundary(local_now: DateTime<Tz>, session_time: NaiveTime) -> DateTime<Utc> {
+    let timezone = local_now.timezone();
+    let mut date = local_now.date_naive();
+
+    if local_now.time() < session_time {
+        date = date
+            .checked_sub_days(Days::new(1))
+            .expect("FX session date must be representable");
+    }
+
+    let weekend_days = match date.weekday() {
+        Weekday::Sat => 1,
+        Weekday::Sun => 2,
+        _ => 0,
+    };
+    date = date
+        .checked_sub_days(Days::new(weekend_days))
+        .expect("FX session date must be representable");
+
+    timezone
+        .from_local_datetime(&date.and_time(session_time))
+        .single()
+        .expect("FX session boundary must be a unique local time")
+        .with_timezone(&Utc)
+}
+
 /// Returns the next session start time in UTC.
 #[must_use]
 pub fn fx_next_start(session: ForexSession, time_now: DateTime<Utc>) -> DateTime<Utc> {
-    let timezone = session.timezone();
     let local_now = fx_local_from_utc(session, time_now);
     let (start_time, _) = session.session_times();
 
-    let mut next_start = timezone
-        .with_ymd_and_hms(
-            local_now.year(),
-            local_now.month(),
-            local_now.day(),
-            start_time.hour(),
-            start_time.minute(),
-            0,
-        )
-        .unwrap();
-
-    if local_now > next_start {
-        next_start += Duration::days(1);
-    }
-
-    if next_start.weekday().number_from_monday() > 5 {
-        next_start += Duration::days(8 - i64::from(next_start.weekday().number_from_monday()));
-    }
-
-    next_start.with_timezone(&Utc)
+    fx_next_boundary(local_now, start_time)
 }
 
 /// Returns the previous session start time in UTC.
 #[must_use]
 pub fn fx_prev_start(session: ForexSession, time_now: DateTime<Utc>) -> DateTime<Utc> {
-    let timezone = session.timezone();
     let local_now = fx_local_from_utc(session, time_now);
     let (start_time, _) = session.session_times();
 
-    let mut prev_start = timezone
-        .with_ymd_and_hms(
-            local_now.year(),
-            local_now.month(),
-            local_now.day(),
-            start_time.hour(),
-            start_time.minute(),
-            0,
-        )
-        .unwrap();
-
-    if local_now < prev_start {
-        prev_start -= Duration::days(1);
-    }
-
-    if prev_start.weekday().number_from_monday() > 5 {
-        prev_start -= Duration::days(i64::from(prev_start.weekday().number_from_monday()) - 5);
-    }
-
-    prev_start.with_timezone(&Utc)
+    fx_prev_boundary(local_now, start_time)
 }
 
 /// Returns the next session end time in UTC.
 #[must_use]
 pub fn fx_next_end(session: ForexSession, time_now: DateTime<Utc>) -> DateTime<Utc> {
-    let timezone = session.timezone();
     let local_now = fx_local_from_utc(session, time_now);
     let (_, end_time) = session.session_times();
 
-    let mut next_end = timezone
-        .with_ymd_and_hms(
-            local_now.year(),
-            local_now.month(),
-            local_now.day(),
-            end_time.hour(),
-            end_time.minute(),
-            0,
-        )
-        .unwrap();
-
-    if local_now > next_end {
-        next_end += Duration::days(1);
-    }
-
-    if next_end.weekday().number_from_monday() > 5 {
-        next_end += Duration::days(8 - i64::from(next_end.weekday().number_from_monday()));
-    }
-
-    next_end.with_timezone(&Utc)
+    fx_next_boundary(local_now, end_time)
 }
 
 /// Returns the previous session end time in UTC.
 #[must_use]
 pub fn fx_prev_end(session: ForexSession, time_now: DateTime<Utc>) -> DateTime<Utc> {
-    let timezone = session.timezone();
     let local_now = fx_local_from_utc(session, time_now);
     let (_, end_time) = session.session_times();
 
-    let mut prev_end = timezone
-        .with_ymd_and_hms(
-            local_now.year(),
-            local_now.month(),
-            local_now.day(),
-            end_time.hour(),
-            end_time.minute(),
-            0,
-        )
-        .unwrap();
-
-    if local_now < prev_end {
-        prev_end -= Duration::days(1);
-    }
-
-    if prev_end.weekday().number_from_monday() > 5 {
-        prev_end -= Duration::days(i64::from(prev_end.weekday().number_from_monday()) - 5);
-    }
-
-    prev_end.with_timezone(&Utc)
+    fx_prev_boundary(local_now, end_time)
 }
 
 #[cfg(test)]
@@ -214,6 +186,19 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    fn local_datetime(
+        session: ForexSession,
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+    ) -> DateTime<Tz> {
+        session
+            .timezone()
+            .with_ymd_and_hms(year, month, day, hour, 0, 0)
+            .unwrap()
+    }
 
     #[rstest]
     #[case(ForexSession::Sydney, "1970-01-01T10:00:00+10:00")]
@@ -268,6 +253,126 @@ mod tests {
         let unix_epoch = Utc.timestamp_opt(0, 0).unwrap();
         let result = fx_prev_end(session, unix_epoch);
         assert_eq!(result.to_rfc3339(), expected);
+    }
+
+    #[rstest]
+    #[case(ForexSession::Sydney, (2024, 4, 5), (2024, 4, 8), 7)]
+    #[case(ForexSession::Sydney, (2024, 10, 4), (2024, 10, 7), 7)]
+    #[case(ForexSession::London, (2024, 3, 29), (2024, 4, 1), 8)]
+    #[case(ForexSession::London, (2024, 10, 25), (2024, 10, 28), 8)]
+    #[case(ForexSession::NewYork, (2024, 3, 8), (2024, 3, 11), 8)]
+    #[case(ForexSession::NewYork, (2024, 11, 1), (2024, 11, 4), 8)]
+    // Saturday input: advances to Sunday, then takes the Sunday weekend arm.
+    #[case(ForexSession::London, (2024, 3, 30), (2024, 4, 1), 8)]
+    fn test_fx_next_start_across_dst_weekend(
+        #[case] session: ForexSession,
+        #[case] input_date: (i32, u32, u32),
+        #[case] expected_date: (i32, u32, u32),
+        #[case] expected_hour: u32,
+    ) {
+        let (input_year, input_month, input_day) = input_date;
+        let (expected_year, expected_month, expected_day) = expected_date;
+        let time_now =
+            local_datetime(session, input_year, input_month, input_day, 18).with_timezone(&Utc);
+        let expected = local_datetime(
+            session,
+            expected_year,
+            expected_month,
+            expected_day,
+            expected_hour,
+        )
+        .with_timezone(&Utc);
+
+        assert_eq!(fx_next_start(session, time_now), expected);
+    }
+
+    #[rstest]
+    #[case(ForexSession::Sydney, (2024, 4, 8), (2024, 4, 5), 7)]
+    #[case(ForexSession::Sydney, (2024, 10, 7), (2024, 10, 4), 7)]
+    #[case(ForexSession::London, (2024, 4, 1), (2024, 3, 29), 8)]
+    #[case(ForexSession::London, (2024, 10, 28), (2024, 10, 25), 8)]
+    #[case(ForexSession::NewYork, (2024, 3, 11), (2024, 3, 8), 8)]
+    #[case(ForexSession::NewYork, (2024, 11, 4), (2024, 11, 1), 8)]
+    // Sunday input: retreats to Saturday, then takes the Saturday weekend arm.
+    #[case(ForexSession::London, (2024, 3, 31), (2024, 3, 29), 8)]
+    fn test_fx_prev_start_across_dst_weekend(
+        #[case] session: ForexSession,
+        #[case] input_date: (i32, u32, u32),
+        #[case] expected_date: (i32, u32, u32),
+        #[case] expected_hour: u32,
+    ) {
+        let (input_year, input_month, input_day) = input_date;
+        let (expected_year, expected_month, expected_day) = expected_date;
+        let time_now =
+            local_datetime(session, input_year, input_month, input_day, 6).with_timezone(&Utc);
+        let expected = local_datetime(
+            session,
+            expected_year,
+            expected_month,
+            expected_day,
+            expected_hour,
+        )
+        .with_timezone(&Utc);
+
+        assert_eq!(fx_prev_start(session, time_now), expected);
+    }
+
+    #[rstest]
+    #[case(ForexSession::Sydney, (2024, 4, 5), (2024, 4, 8), 16)]
+    #[case(ForexSession::Sydney, (2024, 10, 4), (2024, 10, 7), 16)]
+    #[case(ForexSession::London, (2024, 3, 29), (2024, 4, 1), 16)]
+    #[case(ForexSession::London, (2024, 10, 25), (2024, 10, 28), 16)]
+    #[case(ForexSession::NewYork, (2024, 3, 8), (2024, 3, 11), 17)]
+    #[case(ForexSession::NewYork, (2024, 11, 1), (2024, 11, 4), 17)]
+    fn test_fx_next_end_across_dst_weekend(
+        #[case] session: ForexSession,
+        #[case] input_date: (i32, u32, u32),
+        #[case] expected_date: (i32, u32, u32),
+        #[case] expected_hour: u32,
+    ) {
+        let (input_year, input_month, input_day) = input_date;
+        let (expected_year, expected_month, expected_day) = expected_date;
+        let time_now =
+            local_datetime(session, input_year, input_month, input_day, 18).with_timezone(&Utc);
+        let expected = local_datetime(
+            session,
+            expected_year,
+            expected_month,
+            expected_day,
+            expected_hour,
+        )
+        .with_timezone(&Utc);
+
+        assert_eq!(fx_next_end(session, time_now), expected);
+    }
+
+    #[rstest]
+    #[case(ForexSession::Sydney, (2024, 4, 8), (2024, 4, 5), 16)]
+    #[case(ForexSession::Sydney, (2024, 10, 7), (2024, 10, 4), 16)]
+    #[case(ForexSession::London, (2024, 4, 1), (2024, 3, 29), 16)]
+    #[case(ForexSession::London, (2024, 10, 28), (2024, 10, 25), 16)]
+    #[case(ForexSession::NewYork, (2024, 3, 11), (2024, 3, 8), 17)]
+    #[case(ForexSession::NewYork, (2024, 11, 4), (2024, 11, 1), 17)]
+    fn test_fx_prev_end_across_dst_weekend(
+        #[case] session: ForexSession,
+        #[case] input_date: (i32, u32, u32),
+        #[case] expected_date: (i32, u32, u32),
+        #[case] expected_hour: u32,
+    ) {
+        let (input_year, input_month, input_day) = input_date;
+        let (expected_year, expected_month, expected_day) = expected_date;
+        let time_now =
+            local_datetime(session, input_year, input_month, input_day, 6).with_timezone(&Utc);
+        let expected = local_datetime(
+            session,
+            expected_year,
+            expected_month,
+            expected_day,
+            expected_hour,
+        )
+        .with_timezone(&Utc);
+
+        assert_eq!(fx_prev_end(session, time_now), expected);
     }
 
     #[rstest]


### PR DESCRIPTION
FX session boundaries in `crates/trading/src/sessions.rs` are stepped with `chrono::Duration`, which measures absolute time rather than calendar days, so any boundary whose computation spans a daylight-saving transition lands an hour away from its configured local wall clock.

## Session boundaries stepped in absolute time

`fx_next_start`, `fx_prev_start`, `fx_next_end` and `fx_prev_end` each built a zone-aware anchor for the session time on the current local date with `Tz::with_ymd_and_hms`, advanced or retreated it by `Duration::days(1)`, and then applied the Monday-to-Friday weekend skip with a second `Duration::days` step. `Duration::days(1)` is 86,400 absolute seconds, not one calendar day, so a step that spans a UTC offset transition shifts the local wall-clock time by the offset delta. Every zone here transitions on a Sunday by rule, which is precisely the day the Friday-to-Monday skip crosses, so the drift is reachable from an ordinary Friday or Monday query rather than only from a timestamp inside the transition weekend.

Concretely, `fx_next_start(ForexSession::London, ..)` for Friday 2024-03-29 18:00 GMT returned Monday 2024-04-01 09:00 BST instead of 08:00: the first step lands on Saturday 08:00 GMT, the weekend skip adds a further 48 absolute hours, and BST began at 01:00 UTC on the Sunday in between. In the other direction `fx_prev_start` for Monday 2024-04-01 06:00 BST returned Friday 07:00 GMT instead of 08:00. The end functions drift identically. Only the wall-clock hour is affected, not the selected weekday: a one-hour drift cannot cross local midnight for boundaries that sit between 07:00 and 18:00 local.

The four functions now delegate to two private helpers that perform all arithmetic on the local `NaiveDate` - one calendar-day step, then the weekend rule applied to that date - and resolve the final business date and session time in the session timezone exactly once. No offset-bearing intermediate value reaches the weekend rule, and a Sunday boundary that is about to be skipped is never resolved. The `LocalResult` contract is unchanged: the previous code panicked through `LocalResult::unwrap()` for a nonexistent or ambiguous local time, and `.single().expect(..)` preserves that behavior exactly, differing only in the panic message.

The tz-unaware daily bar origin reported in #4398 is a separate instance of this class in `TimeBarAggregator` and is not addressed here.

## Testing

Four parameterized tests - `test_fx_next_start_across_dst_weekend`, `test_fx_prev_start_across_dst_weekend`, `test_fx_next_end_across_dst_weekend` and `test_fx_prev_end_across_dst_weekend` - cover six real transition weekends: Sydney 2024-04-05 to 04-08 and 2024-10-04 to 10-07, London 2024-03-29 to 04-01 and 2024-10-25 to 10-28, New York 2024-03-08 to 03-11 and 2024-11-01 to 11-04. Each case builds both the input and the expected value as a known local zoned datetime and asserts a single exact UTC equality, which pins the date, the wall-clock time and the offset in one assertion rather than only the instant.

Two further cases cover the weekend arms the Friday and Monday fixtures never reach: a Saturday input that advances to Sunday before the weekend rule runs, and a Sunday input that retreats to Saturday. Neither arm was exercised by any test before this change, so a transposition between them would have passed the whole suite.

All 26 cases were verified to fail against the previous implementation, each by exactly 3,600 seconds. The tests are deterministic and free of wall-clock dependence: every input is a fixed historical date, with no sleeps and no reads of the current time. The existing epoch-based and 2020-dated cases are unchanged and continue to pass, including the Tokyo cases, whose zone observes no daylight saving and therefore acts as a control.
