### PR TITLE
Fail fast when infrastructure tests have no Redis or PostgreSQL

### DIFF
--- a/crates/infrastructure/src/redis/msgbus.rs
+++ b/crates/infrastructure/src/redis/msgbus.rs
@@ -1299,10 +1299,14 @@ mod serial_tests {
 
     #[fixture]
     async fn redis_connection() -> ConnectionManager {
-        let config = RedisMessageBusConfig::default();
+        let config = RedisMessageBusConfig {
+            connection_timeout: 1,
+            number_of_retries: 0,
+            ..Default::default()
+        };
         create_redis_connection(MSGBUS_STREAM, &config)
             .await
-            .unwrap()
+            .expect("A running Redis service is required for this test")
     }
 
     #[rstest]

--- a/crates/infrastructure/tests/test_cache_database_postgres.rs
+++ b/crates/infrastructure/tests/test_cache_database_postgres.rs
@@ -28,7 +28,7 @@ mod serial_tests {
     };
     use nautilus_core::{Params, UnixNanos};
     use nautilus_infrastructure::sql::{
-        cache::get_pg_cache_database,
+        cache::{PostgresCacheDatabase, get_pg_cache_database},
         pg::{connect_pg, get_postgres_connect_options, init_postgres},
         queries::DatabaseQueries,
     };
@@ -62,7 +62,7 @@ mod serial_tests {
     use nautilus_serialization::ensure_custom_data_registered;
     use rust_decimal::Decimal;
     use serde::Serialize;
-    use sqlx::AssertSqlSafe;
+    use sqlx::{AssertSqlSafe, PgPool, postgres::PgConnectOptions};
     use ustr::Ustr;
 
     pub(crate) fn assert_entirely_equal<T: Serialize>(a: T, b: T) {
@@ -72,9 +72,33 @@ mod serial_tests {
         assert_eq!(a_serialized, b_serialized);
     }
 
+    async fn get_test_pg_cache_database() -> anyhow::Result<PostgresCacheDatabase> {
+        match tokio::time::timeout(Duration::from_secs(2), get_pg_cache_database()).await {
+            Ok(result) => result.map_err(|e| {
+                anyhow::anyhow!("A running PostgreSQL service is required for this test: {e}")
+            }),
+            Err(e) => Err(anyhow::anyhow!(
+                "A running PostgreSQL service is required for this test: connection timed out: \
+                 {e}"
+            )),
+        }
+    }
+
+    async fn connect_test_pg(options: PgConnectOptions) -> anyhow::Result<PgPool> {
+        match tokio::time::timeout(Duration::from_secs(2), connect_pg(options)).await {
+            Ok(result) => result.map_err(|e| {
+                anyhow::anyhow!("A running PostgreSQL service is required for this test: {e}")
+            }),
+            Err(e) => Err(anyhow::anyhow!(
+                "A running PostgreSQL service is required for this test: connection timed out: \
+                 {e}"
+            )),
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_general_object_adds_to_cache() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let test_id_value = Bytes::from("test_value");
         pg_cache
@@ -109,7 +133,7 @@ mod serial_tests {
     )]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_currency_and_instruments() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         // Define currencies
         let btc = Currency::new("BTC", 8, 0, "BTC", CurrencyType::Crypto);
@@ -323,7 +347,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_truncate() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         // Add items in currency and instrument table
         let instrument = InstrumentAny::CurrencyPair(audusd_sim());
@@ -356,7 +380,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_order_and_load_indexes() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let client_order_id_1 = ClientOrderId::new("O-19700101-000000-001-001-1");
         let client_order_id_2 = ClientOrderId::new("O-19700101-000000-001-001-2");
@@ -444,7 +468,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_index_order_position_round_trip() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let client_order_id = ClientOrderId::new("O-19700101-000000-001-001-1");
         let position_id_1 = PositionId::new("P-19700101-000000-001-001-1");
@@ -491,7 +515,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_and_update_position_round_trip() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         pg_cache
@@ -603,7 +627,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_position_replaces_event_log_for_reused_position_id() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         pg_cache
@@ -707,7 +731,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_load_position_duplicate_fill_returns_error() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         pg_cache
@@ -778,7 +802,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_position_event_without_position_id_returns_error() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         let order = OrderTestBuilder::new(OrderType::Market)
@@ -814,7 +838,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_load_positions_skips_duplicate_fill_position() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         pg_cache
@@ -907,7 +931,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_update_order_for_open_order() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let client_order_id_1 = ClientOrderId::new("O-19700101-000000-001-002-1");
         let instrument = InstrumentAny::CurrencyPair(currency_pair_ethusdt());
@@ -979,7 +1003,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_and_update_account() {
-        let pg_cache = get_pg_cache_database().await.unwrap();
+        let pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let mut account = AccountAny::Cash(CashAccount::new(
             cash_account_state_million_usd("1000000 USD", "0 USD", "1000000 USD"),
@@ -1024,7 +1048,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_update_account_without_existing_event_returns_error() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
         let event = cash_account_state_million_usd("1000000 USD", "100000 USD", "900000 USD");
 
         let result = DatabaseQueries::add_account(&pg_cache.pool, true, event).await;
@@ -1043,7 +1067,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_quote() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         // Add target instrument and currencies
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
@@ -1078,7 +1102,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_trade() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         // Add target instrument and currencies
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
@@ -1113,7 +1137,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_bar() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         // Add target instrument and currencies
         let instrument = InstrumentAny::CurrencyPair(audusd_sim());
@@ -1148,7 +1172,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_signal() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         // Add signal
         let name = Ustr::from("SignalExample");
@@ -1173,7 +1197,7 @@ mod serial_tests {
     async fn test_add_custom_data() {
         ensure_custom_data_registered::<RustTestCustomData>();
 
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let instrument_id = InstrumentId::from("RUST.TEST");
         let metadata = indexmap! {
@@ -1218,7 +1242,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_order_snapshot() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let client_order_id = ClientOrderId::new("O-19700101-000000-001-002-1");
         let instrument = InstrumentAny::CurrencyPair(currency_pair_ethusdt());
@@ -1248,7 +1272,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_order_snapshot_keeps_exact_avg_px_and_slippage() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let client_order_id = ClientOrderId::new("O-19700101-000000-001-002-2");
         let instrument = InstrumentAny::CurrencyPair(currency_pair_ethusdt());
@@ -1300,7 +1324,7 @@ mod serial_tests {
         // database always raises "already exists" on the first statement. The loader must skip it
         // and carry on; it previously mapped that branch to `Err(())` and unwrapped, aborting init.
         let options = get_postgres_connect_options(None, None, None, None, None);
-        let pg = connect_pg(options.clone().into()).await.unwrap();
+        let pg = connect_test_pg(options.clone().into()).await.unwrap();
         let schema_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../../schema/sql").to_string();
 
         let result = init_postgres(&pg, options.database, options.password, Some(schema_dir)).await;
@@ -1315,7 +1339,7 @@ mod serial_tests {
     async fn test_postgres_application_role_owns_schema_objects() {
         let options = get_postgres_connect_options(None, None, None, None, None);
         let expected_owner = options.database.clone();
-        let pg = connect_pg(options.clone().into()).await.unwrap();
+        let pg = connect_test_pg(options.clone().into()).await.unwrap();
         let schema_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../../schema/sql").to_string();
 
         init_postgres(&pg, options.database, options.password, Some(schema_dir))
@@ -1399,7 +1423,7 @@ mod serial_tests {
         const LEGACY_SLIPPAGE: &str = "1.6666666666666667";
 
         let options = get_postgres_connect_options(None, None, None, None, None);
-        let pg = connect_pg(options.into()).await.unwrap();
+        let pg = connect_test_pg(options.into()).await.unwrap();
 
         // The whole exercise runs inside a transaction that is always rolled back: PostgreSQL DDL
         // is transactional, so neither the column downgrade nor the probe row can outlive the
@@ -1456,7 +1480,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_add_position_snapshot() {
-        let mut pg_cache = get_pg_cache_database().await.unwrap();
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 
         let client_order_id = ClientOrderId::new("O-19700101-000000-001-002-1");
         let instrument = InstrumentAny::CurrencyPair(currency_pair_ethusdt());

--- a/crates/infrastructure/tests/test_cache_postgres.rs
+++ b/crates/infrastructure/tests/test_cache_postgres.rs
@@ -28,7 +28,10 @@ mod serial_tests {
 
     use nautilus_common::{cache::database::CacheDatabaseAdapter, testing::wait_until_async};
     use nautilus_core::UUID4;
-    use nautilus_infrastructure::sql::{cache::get_pg_cache_database, queries::DatabaseQueries};
+    use nautilus_infrastructure::sql::{
+        cache::{PostgresCacheDatabase, get_pg_cache_database},
+        queries::DatabaseQueries,
+    };
     use nautilus_model::{
         accounts::AccountAny,
         enums::{CurrencyType, OrderSide, OrderType},
@@ -52,10 +55,22 @@ mod serial_tests {
 
     use crate::get_cache;
 
+    async fn get_test_pg_cache_database() -> anyhow::Result<PostgresCacheDatabase> {
+        match tokio::time::timeout(Duration::from_secs(2), get_pg_cache_database()).await {
+            Ok(result) => result.map_err(|e| {
+                anyhow::anyhow!("A running PostgreSQL service is required for this test: {e}")
+            }),
+            Err(e) => Err(anyhow::anyhow!(
+                "A running PostgreSQL service is required for this test: connection timed out: \
+                 {e}"
+            )),
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_instruments() {
-        let mut database = get_pg_cache_database().await.unwrap();
-        let mut cache = get_cache(Some(Box::new(get_pg_cache_database().await.unwrap())));
+        let mut database = get_test_pg_cache_database().await.unwrap();
+        let mut cache = get_cache(Some(Box::new(get_test_pg_cache_database().await.unwrap())));
 
         let eth = Currency::new("ETH", 2, 0, "ETH", CurrencyType::Crypto);
         let usdt = Currency::new("USDT", 2, 0, "USDT", CurrencyType::Crypto);
@@ -91,8 +106,8 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_orders() {
-        let mut database = get_pg_cache_database().await.unwrap();
-        let mut cache = get_cache(Some(Box::new(get_pg_cache_database().await.unwrap())));
+        let mut database = get_test_pg_cache_database().await.unwrap();
+        let mut cache = get_cache(Some(Box::new(get_test_pg_cache_database().await.unwrap())));
 
         let instrument = currency_pair_ethusdt();
         let market_order = OrderTestBuilder::new(OrderType::Market)
@@ -140,8 +155,8 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_restart_recovery_restores_order_indexes() {
-        let mut database = get_pg_cache_database().await.unwrap();
-        let mut cache = get_cache(Some(Box::new(get_pg_cache_database().await.unwrap())));
+        let mut database = get_test_pg_cache_database().await.unwrap();
+        let mut cache = get_cache(Some(Box::new(get_test_pg_cache_database().await.unwrap())));
 
         let instrument = currency_pair_ethusdt();
         let client_id = ClientId::new("TEST");
@@ -213,8 +228,8 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_restart_recovery_restores_positions() {
-        let mut database = get_pg_cache_database().await.unwrap();
-        let mut cache = get_cache(Some(Box::new(get_pg_cache_database().await.unwrap())));
+        let mut database = get_test_pg_cache_database().await.unwrap();
+        let mut cache = get_cache(Some(Box::new(get_test_pg_cache_database().await.unwrap())));
 
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         database
@@ -299,8 +314,8 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_accounts() {
-        let mut database = get_pg_cache_database().await.unwrap();
-        let mut cache = get_cache(Some(Box::new(get_pg_cache_database().await.unwrap())));
+        let mut database = get_test_pg_cache_database().await.unwrap();
+        let mut cache = get_cache(Some(Box::new(get_test_pg_cache_database().await.unwrap())));
 
         let account = AccountAny::default();
         let last_event = account.last_event().unwrap();
@@ -334,7 +349,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_load_all_and_unsupported_loads_return_results() {
-        let mut database = get_pg_cache_database().await.unwrap();
+        let mut database = get_test_pg_cache_database().await.unwrap();
         database.flush().unwrap();
 
         let loaded = database.load_all().await.unwrap();
@@ -354,7 +369,7 @@ mod serial_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_failed_async_position_load_returns_error() {
-        let mut database = get_pg_cache_database().await.unwrap();
+        let mut database = get_test_pg_cache_database().await.unwrap();
         database.pool.close().await;
 
         let result = database.load_positions().await;
@@ -379,7 +394,7 @@ mod serial_tests {
     #[ignore = "Waiting on PostgreSQL schema completion - needs FK constraints"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_order_cancel_rejected_insert_and_load() {
-        let db = get_pg_cache_database().await.expect("connect db");
+        let db = get_test_pg_cache_database().await.expect("connect db");
         let pool = &db.pool;
 
         let client_id_str = UUID4::new().to_string();
@@ -435,7 +450,7 @@ mod serial_tests {
     #[ignore = "Waiting on PostgreSQL schema completion - needs FK constraints"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_order_modify_rejected_insert_and_load() {
-        let db = get_pg_cache_database().await.expect("connect db");
+        let db = get_test_pg_cache_database().await.expect("connect db");
         let pool = &db.pool;
 
         let client_id_str = UUID4::new().to_string();
@@ -481,7 +496,7 @@ mod serial_tests {
     /// When `buffer_interval` is exposed via config, this test validates the zero-interval path.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_buffer_flushes_immediately() {
-        let mut database = get_pg_cache_database().await.unwrap();
+        let mut database = get_test_pg_cache_database().await.unwrap();
 
         let eth = Currency::new("ETH", 2, 0, "ETH", CurrencyType::Crypto);
         let eth_key = Ustr::from("ETH");
@@ -511,7 +526,7 @@ mod serial_tests {
     /// With `buffer_interval=0` the buffer is typically empty, but this validates the code path.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_buffer_drains_on_close() {
-        let mut database = get_pg_cache_database().await.unwrap();
+        let mut database = get_test_pg_cache_database().await.unwrap();
 
         let usdt = Currency::new("USDT", 2, 0, "USDT", CurrencyType::Crypto);
         let usdt_key = Ustr::from("USDT");
@@ -520,7 +535,7 @@ mod serial_tests {
         database.close().unwrap();
 
         // Reconnect to verify data was persisted
-        let mut database = get_pg_cache_database().await.unwrap();
+        let mut database = get_test_pg_cache_database().await.unwrap();
         let currencies = database.load_currencies().await.unwrap();
 
         assert!(

--- a/crates/infrastructure/tests/test_cache_redis.rs
+++ b/crates/infrastructure/tests/test_cache_redis.rs
@@ -69,6 +69,8 @@ mod serial_tests {
         RedisCacheConfig {
             host: Some("localhost".to_string()),
             port: Some(6379),
+            connection_timeout: 1,
+            number_of_retries: 0,
             ..Default::default()
         }
     }
@@ -92,7 +94,13 @@ mod serial_tests {
 
         let config = CacheConfig::default();
         let database =
-            RedisCacheDatabase::new(trader_id, instance_id, config, redis_cache_config()).await?;
+            RedisCacheDatabase::new(trader_id, instance_id, config, redis_cache_config())
+                .await
+                .map_err(|e| {
+                    std::io::Error::other(format!(
+                        "A running Redis service is required for this test: {e}"
+                    ))
+                })?;
 
         let adapter = RedisCacheDatabaseAdapter { database };
 

--- a/crates/infrastructure/tests/test_redis_queries.rs
+++ b/crates/infrastructure/tests/test_redis_queries.rs
@@ -50,6 +50,8 @@ mod serial_tests {
         RedisCacheConfig {
             host: Some("localhost".to_string()),
             port: Some(6379),
+            connection_timeout: 1,
+            number_of_retries: 0,
             ..Default::default()
         }
     }
@@ -59,7 +61,7 @@ mod serial_tests {
 
         create_redis_connection("test", &config)
             .await
-            .expect("Failed to create Redis connection")
+            .expect("A running Redis service is required for this test")
     }
 
     async fn setup_test_database() -> (RedisCacheDatabase, String) {
@@ -71,7 +73,7 @@ mod serial_tests {
         let mut database =
             RedisCacheDatabase::new(trader_id, instance_id, config, redis_cache_config())
                 .await
-                .expect("Failed to create database");
+                .expect("A running Redis service is required for this test");
 
         // Clean the database at the start
         database.flushdb().await;


### PR DESCRIPTION
The `nautilus-infrastructure` tests that need a live Redis or PostgreSQL server give no indication that they do, and with no server listening they block rather than failing, so a developer running the suite without those services sees an apparent hang.

## Absent services are retried, not reported

87 tests across `crates/infrastructure` require a running service: 11 in the `serial_tests` module of `src/redis/msgbus.rs` and 76 across the four integration binaries under `tests/`. Nothing distinguishes them from ordinary tests - no marker, no feature gate, no probe - and connection refusal reaches a retry loop rather than the test.

The two paths block for different reasons. On the Redis side `create_redis_connection` builds a `redis::aio::ConnectionManagerConfig` carrying the configured retry count and exponential backoff, and a refused connection is a retryable condition for that manager, so an absent server is indistinguishable from a slow one. On the PostgreSQL side `connect_pg` is `PgPool::connect_with`, where SQLx applies a 30 second default pool acquire timeout and retries connection-refused with backoff. Either way the await does not return promptly: a single Redis test measured here was still blocked when killed at 20 seconds, and the full set at that rate is roughly half an hour of wall time before a developer learns anything.

CI never encounters this, because the Linux job provisions healthchecked Redis and PostgreSQL service containers before the suite runs. It is purely a local-developer failure mode, and an expensive one to diagnose from a stalled terminal.

The tests now use test-only connection settings that fail fast: the Redis configurations take zero retries and a one second connection timeout, and the PostgreSQL helpers are wrapped in a two second timeout, each surfacing an explicit message naming the service that is required. Production connection behavior is deliberately untouched - `create_redis_connection`'s manager settings and the SQLx pool defaults are what a real deployment wants, and nothing outside the test paths changes.

## Why not `#[ignore]`

The obvious alternative, marking these with `#[ignore = "requires a running Redis"]`, would silently remove them from CI. `make cargo-test` runs `cargo nextest run --workspace --lib --tests`, and neither it, the workflows, `.config/nextest.toml`, nor the CI scripts pass `--run-ignored`; nextest excludes ignored tests by default. The attribute would therefore trade roughly 85 tests of real coverage for local convenience. Skipping at runtime was rejected for a related reason: a Rust test that returns early records a pass, which manufactures green rather than reporting the truth. Failing quickly with a specific message keeps CI coverage identical and still tells a developer exactly what is missing.

## Testing

No tests are added or removed, and no assertion changes; this alters only how the existing tests obtain their connections. The two `#[ignore]`d tests awaiting PostgreSQL schema work keep their attributes and reason strings.

The differential was measured directly with no services running. `serial_tests::test_scan_keys_empty_database` previously had to be killed at 20 seconds, blocked in a futex wait; it now fails in 0.14 seconds with `A running Redis service is required for this test: Connection refused (os error 111)`. A representative PostgreSQL test fails at its two second boundary with the corresponding message. With both services running, the affected tests execute and pass exactly as before, verified locally against containerised Redis and PostgreSQL.

Because no test gains `#[ignore]`, the set nextest collects is unchanged, so a green CI run on this branch is itself the check that the services-present path is unaffected.
