### PR TITLE
Restore execution algorithm subscriptions from cached orders

### DIFF
--- a/crates/system/src/trader.rs
+++ b/crates/system/src/trader.rs
@@ -48,6 +48,7 @@ use nautilus_model::{
     identifiers::{
         ActorId, ComponentId, ExecAlgorithmId, StrategyId, TraderId, normalize_order_id_tag,
     },
+    orders::Order,
 };
 use nautilus_portfolio::portfolio::Portfolio;
 use nautilus_trading::{
@@ -78,6 +79,8 @@ use crate::{
 pub(crate) enum StrategyCommand {
     ExitMarket,
 }
+
+type ExecAlgorithmSubscriptionFn = Box<dyn FnMut() -> anyhow::Result<()>>;
 
 /// Central orchestrator for managing trading components.
 ///
@@ -119,6 +122,10 @@ pub struct Trader {
     strategy_handler_ids: AHashMap<StrategyId, (Ustr, Ustr)>,
     /// Registered exec algorithm IDs (algorithms stored in global registry).
     exec_algorithm_ids: Vec<ExecAlgorithmId>,
+    /// Restores strategy event subscriptions for concrete execution algorithms.
+    exec_algorithm_restore_fns: AHashMap<ExecAlgorithmId, ExecAlgorithmSubscriptionFn>,
+    /// Removes strategy event subscriptions for concrete execution algorithms.
+    exec_algorithm_cleanup_fns: AHashMap<ExecAlgorithmId, ExecAlgorithmSubscriptionFn>,
     /// Component clocks for individual components.
     clocks: IndexMap<ComponentId, Rc<RefCell<dyn Clock>>>,
     /// Timestamp when the trader was created.
@@ -162,6 +169,8 @@ impl Trader {
             strategy_stop_fns: AHashMap::new(),
             strategy_handler_ids: AHashMap::new(),
             exec_algorithm_ids: Vec::new(),
+            exec_algorithm_restore_fns: AHashMap::new(),
+            exec_algorithm_cleanup_fns: AHashMap::new(),
             clocks: IndexMap::new(),
             ts_created,
             ts_started: None,
@@ -966,6 +975,44 @@ impl Trader {
         // Register the {id}.execute endpoint so the order manager can
         // route TradingCommands to this algorithm via msgbus::send_any
         let actor_id = Ustr::from(exec_algorithm_id.inner().as_str());
+        let restore_actor_id = actor_id;
+        let restore_fn: ExecAlgorithmSubscriptionFn = Box::new(move || {
+            let Some(mut algo) = try_get_actor_unchecked::<T>(&restore_actor_id) else {
+                anyhow::bail!(
+                    "Execution algorithm {restore_actor_id} not found while restoring subscriptions"
+                );
+            };
+
+            let mut strategy_ids = {
+                let cache = algo.exec_algorithm_core_mut().cache_ref();
+                cache
+                    .orders_for_exec_algorithm(&exec_algorithm_id, None, None, None, None, None)
+                    .into_iter()
+                    .filter(|order| {
+                        !order.is_closed() && order.exec_algorithm_id() == Some(exec_algorithm_id)
+                    })
+                    .map(|order| order.strategy_id())
+                    .collect::<Vec<_>>()
+            };
+            strategy_ids.sort_unstable();
+            strategy_ids.dedup();
+
+            for strategy_id in strategy_ids {
+                algo.subscribe_to_strategy_events(strategy_id);
+            }
+
+            Ok(())
+        });
+        let cleanup_actor_id = actor_id;
+        let cleanup_fn: ExecAlgorithmSubscriptionFn = Box::new(move || {
+            let Some(mut algo) = try_get_actor_unchecked::<T>(&cleanup_actor_id) else {
+                anyhow::bail!(
+                    "Execution algorithm {cleanup_actor_id} not found while cleaning subscriptions"
+                );
+            };
+            algo.unsubscribe_all_strategy_events();
+            Ok(())
+        });
         let endpoint: Ustr = format!("{exec_algorithm_id}.execute").into();
         let handler = ShareableMessageHandler::from_typed(move |command: &TradingCommand| {
             if let Some(mut algo) = try_get_actor_unchecked::<T>(&actor_id) {
@@ -979,6 +1026,10 @@ impl Trader {
         msgbus::register_any(endpoint.into(), handler);
 
         self.exec_algorithm_ids.push(exec_algorithm_id);
+        self.exec_algorithm_restore_fns
+            .insert(exec_algorithm_id, restore_fn);
+        self.exec_algorithm_cleanup_fns
+            .insert(exec_algorithm_id, cleanup_fn);
 
         log::info!(
             "Registered execution algorithm {exec_algorithm_id} with trader {}",
@@ -1046,9 +1097,21 @@ impl Trader {
             Self::start_component_if_not_running(strategy_id.inner())?;
         }
 
+        let mut restored_exec_algorithm_ids = Vec::new();
+
         for exec_algorithm_id in exec_algorithm_ids {
             log::debug!("Starting execution algorithm {exec_algorithm_id}");
-            Self::start_component_if_not_running(exec_algorithm_id.inner())?;
+            match self.start_exec_algorithm_if_not_running(exec_algorithm_id) {
+                Ok(true) => restored_exec_algorithm_ids.push(exec_algorithm_id),
+                Ok(false) => {}
+                Err(start_err) => {
+                    return Err(self.exec_algorithm_start_error_with_rollback(
+                        exec_algorithm_id,
+                        &restored_exec_algorithm_ids,
+                        start_err,
+                    ));
+                }
+            }
         }
 
         Ok(())
@@ -1083,9 +1146,53 @@ impl Trader {
             Self::start_component_if_not_running(strategy_id.inner())?;
         }
 
+        let mut restored_exec_algorithm_ids = Vec::new();
+
         for exec_algorithm_id in exec_algorithm_ids {
             log::debug!("Starting execution algorithm {exec_algorithm_id}");
-            Self::start_component_if_not_running(exec_algorithm_id.inner())?;
+            let component_state = match component_state(&exec_algorithm_id.inner()) {
+                Ok(state) => state,
+                Err(start_err) => {
+                    let e = trader
+                        .borrow_mut()
+                        .exec_algorithm_start_error_with_rollback(
+                            exec_algorithm_id,
+                            &restored_exec_algorithm_ids,
+                            start_err,
+                        );
+                    return Err(e);
+                }
+            };
+
+            if component_state == ComponentState::Running {
+                continue;
+            }
+
+            if let Err(start_err) = trader
+                .borrow_mut()
+                .restore_exec_algorithm_subscriptions(exec_algorithm_id)
+            {
+                let e = trader
+                    .borrow_mut()
+                    .exec_algorithm_start_error_with_rollback(
+                        exec_algorithm_id,
+                        &restored_exec_algorithm_ids,
+                        start_err,
+                    );
+                return Err(e);
+            }
+            restored_exec_algorithm_ids.push(exec_algorithm_id);
+
+            if let Err(start_err) = start_component(&exec_algorithm_id.inner()) {
+                let e = trader
+                    .borrow_mut()
+                    .exec_algorithm_start_error_with_rollback(
+                        exec_algorithm_id,
+                        &restored_exec_algorithm_ids,
+                        start_err,
+                    );
+                return Err(e);
+            }
         }
 
         let mut trader_ref = trader.borrow_mut();
@@ -1102,6 +1209,82 @@ impl Trader {
         }
 
         start_component(&component_id)
+    }
+
+    fn start_exec_algorithm_if_not_running(
+        &mut self,
+        exec_algorithm_id: ExecAlgorithmId,
+    ) -> anyhow::Result<bool> {
+        if component_state(&exec_algorithm_id.inner())? == ComponentState::Running {
+            return Ok(false);
+        }
+
+        self.restore_exec_algorithm_subscriptions(exec_algorithm_id)?;
+        if let Err(start_err) = start_component(&exec_algorithm_id.inner()) {
+            return match self.cleanup_exec_algorithm_subscriptions(exec_algorithm_id) {
+                Ok(()) => Err(start_err),
+                Err(cleanup_err) => anyhow::bail!(
+                    "Failed to start execution algorithm {exec_algorithm_id}: {start_err:#}; \
+                     failed to roll back subscriptions: {cleanup_err:#}"
+                ),
+            };
+        }
+
+        Ok(true)
+    }
+
+    fn restore_exec_algorithm_subscriptions(
+        &mut self,
+        exec_algorithm_id: ExecAlgorithmId,
+    ) -> anyhow::Result<()> {
+        if let Some(restore_fn) = self.exec_algorithm_restore_fns.get_mut(&exec_algorithm_id) {
+            restore_fn()?;
+        }
+        Ok(())
+    }
+
+    fn cleanup_exec_algorithm_subscriptions(
+        &mut self,
+        exec_algorithm_id: ExecAlgorithmId,
+    ) -> anyhow::Result<()> {
+        if let Some(cleanup_fn) = self.exec_algorithm_cleanup_fns.get_mut(&exec_algorithm_id) {
+            cleanup_fn()?;
+        }
+        Ok(())
+    }
+
+    fn cleanup_exec_algorithm_subscriptions_for(
+        &mut self,
+        exec_algorithm_ids: &[ExecAlgorithmId],
+    ) -> anyhow::Result<()> {
+        let mut errors = Vec::new();
+
+        for exec_algorithm_id in exec_algorithm_ids {
+            if let Err(e) = self.cleanup_exec_algorithm_subscriptions(*exec_algorithm_id) {
+                errors.push(format!("{exec_algorithm_id}: {e:#}"));
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!("{}", errors.join("; "))
+        }
+    }
+
+    fn exec_algorithm_start_error_with_rollback(
+        &mut self,
+        exec_algorithm_id: ExecAlgorithmId,
+        restored_exec_algorithm_ids: &[ExecAlgorithmId],
+        start_err: anyhow::Error,
+    ) -> anyhow::Error {
+        match self.cleanup_exec_algorithm_subscriptions_for(restored_exec_algorithm_ids) {
+            Ok(()) => start_err,
+            Err(cleanup_err) => anyhow::anyhow!(
+                "Failed while starting execution algorithm {exec_algorithm_id}: {start_err:#}; \
+                 failed to roll back restored subscriptions: {cleanup_err:#}"
+            ),
+        }
     }
 
     /// Stops all registered components.
@@ -1160,7 +1343,7 @@ impl Trader {
         }
     }
 
-    fn stop_components_after_start_failure(&self) -> anyhow::Result<()> {
+    fn stop_components_after_start_failure(&mut self) -> anyhow::Result<()> {
         let mut errors = Vec::new();
 
         for actor_id in &self.actor_ids {
@@ -1170,10 +1353,16 @@ impl Trader {
             }
         }
 
-        for exec_algorithm_id in &self.exec_algorithm_ids {
+        for exec_algorithm_id in self.exec_algorithm_ids.clone() {
             log::debug!("Stopping execution algorithm {exec_algorithm_id} after startup failure");
             if let Err(e) = Self::stop_component_if_active(exec_algorithm_id.inner()) {
                 errors.push(format!("execution algorithm {exec_algorithm_id}: {e:#}"));
+            }
+
+            if let Err(e) = self.cleanup_exec_algorithm_subscriptions(exec_algorithm_id) {
+                errors.push(format!(
+                    "execution algorithm {exec_algorithm_id} subscription cleanup: {e:#}"
+                ));
             }
         }
 
@@ -1221,8 +1410,9 @@ impl Trader {
             reset_component(&strategy_id.inner())?;
         }
 
-        for exec_algorithm_id in &self.exec_algorithm_ids {
+        for exec_algorithm_id in self.exec_algorithm_ids.clone() {
             log::debug!("Resetting execution algorithm {exec_algorithm_id}");
+            self.cleanup_exec_algorithm_subscriptions(exec_algorithm_id)?;
             reset_component(&exec_algorithm_id.inner())?;
         }
 
@@ -1249,8 +1439,9 @@ impl Trader {
                 .deregister(strategy_control_endpoint(*strategy_id));
         }
 
-        for exec_algorithm_id in &self.exec_algorithm_ids {
+        for exec_algorithm_id in self.exec_algorithm_ids.clone() {
             log::debug!("Disposing execution algorithm {exec_algorithm_id}");
+            self.cleanup_exec_algorithm_subscriptions(exec_algorithm_id)?;
             dispose_component(&exec_algorithm_id.inner())?;
             let endpoint: Ustr = format!("{exec_algorithm_id}.execute").into();
             msgbus::deregister_any(endpoint.into());
@@ -1265,6 +1456,8 @@ impl Trader {
         self.strategy_stop_fns.clear();
         self.strategy_handler_ids.clear();
         self.exec_algorithm_ids.clear();
+        self.exec_algorithm_restore_fns.clear();
+        self.exec_algorithm_cleanup_fns.clear();
         self.clocks.clear();
 
         Ok(())
@@ -1336,8 +1529,9 @@ impl Trader {
     ///
     /// Returns an error if any execution algorithm fails to dispose.
     pub fn clear_exec_algorithms(&mut self) -> anyhow::Result<()> {
-        for exec_algorithm_id in &self.exec_algorithm_ids {
+        for exec_algorithm_id in self.exec_algorithm_ids.clone() {
             log::debug!("Disposing execution algorithm {exec_algorithm_id}");
+            self.cleanup_exec_algorithm_subscriptions(exec_algorithm_id)?;
             dispose_component(&exec_algorithm_id.inner())?;
             let endpoint: Ustr = format!("{exec_algorithm_id}.execute").into();
             msgbus::deregister_any(endpoint.into());
@@ -1346,9 +1540,13 @@ impl Trader {
                 clock.borrow_mut().cancel_timers();
             }
             self.clocks.shift_remove(&component_id);
+            self.exec_algorithm_restore_fns.remove(&exec_algorithm_id);
+            self.exec_algorithm_cleanup_fns.remove(&exec_algorithm_id);
         }
 
         self.exec_algorithm_ids.clear();
+        self.exec_algorithm_restore_fns.clear();
+        self.exec_algorithm_cleanup_fns.clear();
 
         Ok(())
     }
@@ -1923,10 +2121,17 @@ mod tests {
     use nautilus_data::engine::{DataEngine, config::DataEngineConfig};
     use nautilus_execution::engine::{ExecutionEngine, config::ExecutionEngineConfig};
     use nautilus_model::{
-        events::OrderAccepted,
-        identifiers::{ActorId, ComponentId, TraderId},
-        orders::OrderAny,
+        enums::{OrderType, PositionAdjustmentType},
+        events::{
+            OrderAccepted, OrderFilled, OrderRejected, OrderUpdated, PositionAdjusted,
+            order::spec::{OrderFilledSpec, OrderRejectedSpec, OrderUpdatedSpec},
+        },
+        identifiers::{
+            AccountId, ActorId, ClientOrderId, ComponentId, InstrumentId, PositionId, TraderId,
+        },
+        orders::{OrderAny, OrderTestBuilder},
         stubs::TestDefault,
+        types::Quantity,
     };
     use nautilus_portfolio::portfolio::Portfolio;
     use nautilus_risk::engine::{RiskEngine, config::RiskEngineConfig};
@@ -1962,23 +2167,96 @@ mod tests {
     #[derive(Debug)]
     struct TestExecAlgorithm {
         core: ExecutionAlgorithmCore,
+        fail_start: bool,
+        rejected_events: usize,
+        updated_events: usize,
+        filled_events: usize,
+        position_events: usize,
     }
 
     impl TestExecAlgorithm {
         fn new(config: ExecutionAlgorithmConfig) -> Self {
             Self {
                 core: ExecutionAlgorithmCore::new(config),
+                fail_start: false,
+                rejected_events: 0,
+                updated_events: 0,
+                filled_events: 0,
+                position_events: 0,
             }
         }
     }
 
-    impl DataActor for TestExecAlgorithm {}
+    impl DataActor for TestExecAlgorithm {
+        fn on_start(&mut self) -> anyhow::Result<()> {
+            if self.fail_start {
+                anyhow::bail!("test execution algorithm start failure");
+            }
+            Ok(())
+        }
+    }
 
     nautilus_execution_algorithm!(TestExecAlgorithm, {
         fn on_order(&mut self, _order: OrderAny) -> anyhow::Result<()> {
             Ok(())
         }
+
+        fn on_order_rejected(&mut self, _event: OrderRejected) {
+            self.rejected_events += 1;
+        }
+
+        fn on_order_updated(&mut self, _event: OrderUpdated) {
+            self.updated_events += 1;
+        }
+
+        fn on_algo_order_filled(&mut self, _event: OrderFilled) {
+            self.filled_events += 1;
+        }
+
+        fn on_position_event(&mut self, _event: PositionEvent) {
+            self.position_events += 1;
+        }
     });
+
+    fn add_cached_exec_order(
+        cache: &Rc<RefCell<Cache>>,
+        client_order_id: ClientOrderId,
+        strategy_id: StrategyId,
+        exec_algorithm_id: Option<ExecAlgorithmId>,
+        is_terminal: bool,
+    ) -> OrderAny {
+        let mut builder = OrderTestBuilder::new(OrderType::Market);
+        builder
+            .client_order_id(client_order_id)
+            .strategy_id(strategy_id)
+            .instrument_id(InstrumentId::test_default())
+            .quantity(Quantity::from(1));
+
+        if let Some(exec_algorithm_id) = exec_algorithm_id {
+            builder.exec_algorithm_id(exec_algorithm_id);
+        }
+        let order = builder.build();
+        cache
+            .borrow_mut()
+            .add_order(order.clone(), None, None, false)
+            .unwrap();
+
+        if is_terminal {
+            let event = OrderEventAny::Rejected(
+                OrderRejectedSpec::builder()
+                    .trader_id(order.trader_id())
+                    .strategy_id(order.strategy_id())
+                    .instrument_id(order.instrument_id())
+                    .client_order_id(order.client_order_id())
+                    .account_id(AccountId::test_default())
+                    .reason("TEST_TERMINAL".into())
+                    .build(),
+            );
+            cache.borrow_mut().update_order(&event).unwrap();
+        }
+
+        order
+    }
 
     // Simple Strategy wrapper for testing
     #[derive(Debug)]
@@ -2499,6 +2777,296 @@ mod tests {
         assert_eq!(trader.exec_algorithm_count(), 1);
         assert_eq!(trader.component_count(), 1);
         assert!(trader.exec_algorithm_ids().contains(&exec_algorithm_id));
+    }
+
+    #[rstest]
+    fn test_exec_algorithm_restores_cached_strategy_subscriptions_on_start_and_restart() {
+        let (_msgbus, cache, portfolio, _data_engine, _risk_engine, _exec_engine, clock_factory) =
+            create_trader_components();
+        let trader_id = TraderId::test_default();
+        let instance_id = UUID4::new();
+        let unique = UUID4::new();
+        let exec_algorithm_id = ExecAlgorithmId::from(format!("RECOVERY-{unique}"));
+        let other_algorithm_id = ExecAlgorithmId::from(format!("OTHER-{unique}"));
+        let strategy_a = StrategyId::from(format!("RecoveryA-{unique}"));
+        let strategy_b = StrategyId::from(format!("RecoveryB-{unique}"));
+        let terminal_strategy = StrategyId::from(format!("Terminal-{unique}"));
+        let external_strategy = StrategyId::external();
+
+        let order_a = add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-A1-{unique}")),
+            strategy_a,
+            Some(exec_algorithm_id),
+            false,
+        );
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-A2-{unique}")),
+            strategy_a,
+            Some(exec_algorithm_id),
+            false,
+        );
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-B-{unique}")),
+            strategy_b,
+            Some(exec_algorithm_id),
+            false,
+        );
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-TERMINAL-{unique}")),
+            terminal_strategy,
+            Some(exec_algorithm_id),
+            true,
+        );
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-OTHER-{unique}")),
+            StrategyId::from(format!("Other-{unique}")),
+            Some(other_algorithm_id),
+            false,
+        );
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-EXTERNAL-{unique}")),
+            external_strategy,
+            None,
+            false,
+        );
+
+        let mut trader = Trader::new(
+            trader_id,
+            instance_id,
+            Environment::Backtest,
+            clock_factory,
+            cache,
+            portfolio,
+        );
+        let config = ExecutionAlgorithmConfig {
+            exec_algorithm_id: Some(exec_algorithm_id),
+            ..Default::default()
+        };
+        trader
+            .add_exec_algorithm(TestExecAlgorithm::new(config))
+            .unwrap();
+
+        trader.start_components().unwrap();
+
+        {
+            let registered = get_actor_unchecked::<TestExecAlgorithm>(&exec_algorithm_id.inner());
+            assert!(registered.core.is_strategy_subscribed(&strategy_a));
+            assert!(registered.core.is_strategy_subscribed(&strategy_b));
+            assert!(!registered.core.is_strategy_subscribed(&terminal_strategy));
+            assert!(!registered.core.is_strategy_subscribed(&external_strategy));
+        }
+
+        let rejected = OrderEventAny::Rejected(
+            OrderRejectedSpec::builder()
+                .trader_id(order_a.trader_id())
+                .strategy_id(strategy_a)
+                .instrument_id(order_a.instrument_id())
+                .client_order_id(order_a.client_order_id())
+                .account_id(AccountId::test_default())
+                .reason("TEST_REJECTED".into())
+                .build(),
+        );
+        let updated = OrderEventAny::Updated(
+            OrderUpdatedSpec::builder()
+                .trader_id(order_a.trader_id())
+                .strategy_id(strategy_a)
+                .instrument_id(order_a.instrument_id())
+                .client_order_id(order_a.client_order_id())
+                .build(),
+        );
+        let filled = OrderEventAny::Filled(
+            OrderFilledSpec::builder()
+                .trader_id(order_a.trader_id())
+                .strategy_id(strategy_a)
+                .instrument_id(order_a.instrument_id())
+                .client_order_id(order_a.client_order_id())
+                .build(),
+        );
+        let position = PositionEvent::PositionAdjusted(PositionAdjusted::new(
+            trader_id,
+            strategy_a,
+            InstrumentId::test_default(),
+            PositionId::from(format!("P-{unique}")),
+            AccountId::test_default(),
+            PositionAdjustmentType::Funding,
+            None,
+            None,
+            None,
+            UUID4::new(),
+            0.into(),
+            0.into(),
+        ));
+
+        let order_topic = format!("events.order.{strategy_a}");
+        msgbus::publish_order_event(order_topic.clone().into(), &rejected);
+        msgbus::publish_order_event(order_topic.clone().into(), &updated);
+        msgbus::publish_order_event(order_topic.into(), &filled);
+        msgbus::publish_position_event(format!("events.position.{strategy_a}").into(), &position);
+
+        {
+            let registered = get_actor_unchecked::<TestExecAlgorithm>(&exec_algorithm_id.inner());
+            assert_eq!(registered.rejected_events, 1);
+            assert_eq!(registered.updated_events, 1);
+            assert_eq!(registered.filled_events, 1);
+            assert_eq!(registered.position_events, 1);
+        }
+
+        trader.stop_components().unwrap();
+        trader.reset_components().unwrap();
+        {
+            let registered = get_actor_unchecked::<TestExecAlgorithm>(&exec_algorithm_id.inner());
+            assert!(!registered.core.is_strategy_subscribed(&strategy_a));
+            assert!(!registered.core.is_strategy_subscribed(&strategy_b));
+        }
+
+        trader.start_components().unwrap();
+        {
+            let registered = get_actor_unchecked::<TestExecAlgorithm>(&exec_algorithm_id.inner());
+            assert!(registered.core.is_strategy_subscribed(&strategy_a));
+            assert!(registered.core.is_strategy_subscribed(&strategy_b));
+        }
+
+        trader.stop_components().unwrap();
+        trader.clear_exec_algorithms().unwrap();
+        assert!(trader.exec_algorithm_restore_fns.is_empty());
+        assert!(trader.exec_algorithm_cleanup_fns.is_empty());
+    }
+
+    #[rstest]
+    fn test_exec_algorithm_start_failure_cleans_all_restored_subscriptions() {
+        let (_msgbus, cache, portfolio, _data_engine, _risk_engine, _exec_engine, clock_factory) =
+            create_trader_components();
+        let trader_id = TraderId::test_default();
+        let instance_id = UUID4::new();
+        let unique = UUID4::new();
+        let running_algorithm_id = ExecAlgorithmId::from(format!("RUNNING-{unique}"));
+        let failing_algorithm_id = ExecAlgorithmId::from(format!("FAIL-{unique}"));
+        let running_strategy_id = StrategyId::from(format!("Running-{unique}"));
+        let failing_strategy_id = StrategyId::from(format!("Failing-{unique}"));
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-RUNNING-{unique}")),
+            running_strategy_id,
+            Some(running_algorithm_id),
+            false,
+        );
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-FAILING-{unique}")),
+            failing_strategy_id,
+            Some(failing_algorithm_id),
+            false,
+        );
+
+        let mut trader = Trader::new(
+            trader_id,
+            instance_id,
+            Environment::Backtest,
+            clock_factory,
+            cache,
+            portfolio,
+        );
+        let running_config = ExecutionAlgorithmConfig {
+            exec_algorithm_id: Some(running_algorithm_id),
+            ..Default::default()
+        };
+        trader
+            .add_exec_algorithm(TestExecAlgorithm::new(running_config))
+            .unwrap();
+        let failing_config = ExecutionAlgorithmConfig {
+            exec_algorithm_id: Some(failing_algorithm_id),
+            ..Default::default()
+        };
+        let mut failing_algorithm = TestExecAlgorithm::new(failing_config);
+        failing_algorithm.fail_start = true;
+        trader.add_exec_algorithm(failing_algorithm).unwrap();
+        trader.initialize().unwrap();
+        let trader = Rc::new(RefCell::new(trader));
+
+        let error = Trader::start_with_component_callbacks(&trader).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("test execution algorithm start failure")
+        );
+        {
+            let running = get_actor_unchecked::<TestExecAlgorithm>(&running_algorithm_id.inner());
+            let failing = get_actor_unchecked::<TestExecAlgorithm>(&failing_algorithm_id.inner());
+            assert!(!running.core.is_strategy_subscribed(&running_strategy_id));
+            assert!(!failing.core.is_strategy_subscribed(&failing_strategy_id));
+        }
+
+        trader.borrow_mut().stop_after_start_failure().unwrap();
+
+        let running = get_actor_unchecked::<TestExecAlgorithm>(&running_algorithm_id.inner());
+        assert!(!running.core.is_strategy_subscribed(&running_strategy_id));
+    }
+
+    #[rstest]
+    fn test_start_components_failure_cleans_previously_restored_subscriptions() {
+        let (_msgbus, cache, portfolio, _data_engine, _risk_engine, _exec_engine, clock_factory) =
+            create_trader_components();
+        let trader_id = TraderId::test_default();
+        let instance_id = UUID4::new();
+        let unique = UUID4::new();
+        let running_algorithm_id = ExecAlgorithmId::from(format!("DIRECT-RUNNING-{unique}"));
+        let failing_algorithm_id = ExecAlgorithmId::from(format!("DIRECT-FAIL-{unique}"));
+        let running_strategy_id = StrategyId::from(format!("DirectRunning-{unique}"));
+        let failing_strategy_id = StrategyId::from(format!("DirectFailing-{unique}"));
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-DIRECT-RUNNING-{unique}")),
+            running_strategy_id,
+            Some(running_algorithm_id),
+            false,
+        );
+        add_cached_exec_order(
+            &cache,
+            ClientOrderId::from(format!("O-DIRECT-FAILING-{unique}")),
+            failing_strategy_id,
+            Some(failing_algorithm_id),
+            false,
+        );
+
+        let mut trader = Trader::new(
+            trader_id,
+            instance_id,
+            Environment::Backtest,
+            clock_factory,
+            cache,
+            portfolio,
+        );
+        trader
+            .add_exec_algorithm(TestExecAlgorithm::new(ExecutionAlgorithmConfig {
+                exec_algorithm_id: Some(running_algorithm_id),
+                ..Default::default()
+            }))
+            .unwrap();
+        let mut failing_algorithm = TestExecAlgorithm::new(ExecutionAlgorithmConfig {
+            exec_algorithm_id: Some(failing_algorithm_id),
+            ..Default::default()
+        });
+        failing_algorithm.fail_start = true;
+        trader.add_exec_algorithm(failing_algorithm).unwrap();
+
+        let error = trader.start_components().unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("test execution algorithm start failure")
+        );
+        let running = get_actor_unchecked::<TestExecAlgorithm>(&running_algorithm_id.inner());
+        let failing = get_actor_unchecked::<TestExecAlgorithm>(&failing_algorithm_id.inner());
+        assert!(!running.core.is_strategy_subscribed(&running_strategy_id));
+        assert!(!failing.core.is_strategy_subscribed(&failing_strategy_id));
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and followed the established practices
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Restores execution algorithm order and position event subscriptions from cached non-terminal orders before each algorithm starts. This allows algorithms to continue receiving events after a cache-backed restart even when no new `SubmitOrder` command is emitted, while preserving exact execution-algorithm ownership filtering and idempotent subscriptions.

## Related issues/PRs

None.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs-v2` and committed the generated output

No public API, PyO3 binding, configuration, or documentation changes are included.

## Testing

**Ensure new or changed logic is covered by tests.** Check at least one:

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added Rust tests covering cached multi-order and multi-strategy restoration, strategy deduplication, terminal and unrelated order exclusion, order and position event delivery, reset/restart behavior, cleanup, and partial startup failure rollback through both Trader start paths.

Local lightweight validation:

- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Full Rust build, tests, Clippy, documentation checks, and pre-commit validation are delegated to the repository GitHub Actions workflows.