### PR TITLE
Enforce venue order ID ownership in the cache

### DIFF
--- a/crates/backtest/tests/netting_fill_void.rs
+++ b/crates/backtest/tests/netting_fill_void.rs
@@ -237,9 +237,14 @@ fn process_filled_order(
         VenueOrderId::from(fill.venue_order_id),
     ));
 
+    let accepted_order = execution_engine
+        .cache()
+        .borrow()
+        .order_owned(&order.client_order_id())
+        .expect("accepted order");
     let instrument_any: InstrumentAny = instrument.clone().into();
     execution_engine.process(&TestOrderEventStubs::filled(
-        &order,
+        &accepted_order,
         &instrument_any,
         Some(TradeId::new(fill.trade_id)),
         Some(position_id),

--- a/crates/common/src/cache/error.rs
+++ b/crates/common/src/cache/error.rs
@@ -14,7 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use nautilus_model::identifiers::{
-    AccountId, ClientOrderId, InstrumentId, OrderListId, PositionId,
+    AccountId, ClientOrderId, InstrumentId, OrderListId, PositionId, VenueOrderId,
 };
 use thiserror::Error;
 use ustr::Ustr;
@@ -45,6 +45,21 @@ pub const ORDER_LIST_NOT_FOUND: &str = "order list not found in cache";
 
 /// Message used for a missing position lookup.
 pub const POSITION_NOT_FOUND: &str = "position not found in cache";
+
+/// Error returned when a venue order ID is already owned by another client order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error(
+    "Venue order ID {venue_order_id} is already owned by client order \
+     {existing_client_order_id} and cannot be claimed by {claimant_client_order_id}"
+)]
+pub struct VenueOrderIdOwnershipError {
+    /// The venue order ID whose ownership conflicts.
+    pub venue_order_id: VenueOrderId,
+    /// The client order which already owns the venue order ID.
+    pub existing_client_order_id: ClientOrderId,
+    /// The client order attempting to claim the venue order ID.
+    pub claimant_client_order_id: ClientOrderId,
+}
 
 /// Error returned when an account cannot be resolved from a cache or store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -49,7 +49,7 @@ pub use error::{
     INSTRUMENT_NOT_FOUND, InstrumentLookupError, ORDER_BOOK_NOT_FOUND, ORDER_LIST_NOT_FOUND,
     ORDER_NOT_FOUND, OWN_ORDER_BOOK_NOT_FOUND, OrderBookLookupError, OrderListLookupError,
     OrderLookupError, OwnOrderBookLookupError, POSITION_NOT_FOUND, PositionLookupError,
-    SYNTHETIC_INSTRUMENT_NOT_FOUND, SyntheticInstrumentLookupError,
+    SYNTHETIC_INSTRUMENT_NOT_FOUND, SyntheticInstrumentLookupError, VenueOrderIdOwnershipError,
 };
 use index::CacheIndex;
 use nautilus_core::{
@@ -4233,13 +4233,34 @@ impl Cache {
     ///
     /// # Errors
     ///
-    /// Returns an error if the existing venue order ID conflicts and overwrite is false.
+    /// Returns an error if the client already has a different venue order ID and `overwrite` is
+    /// false, or if the venue order ID is owned by a different client order.
     pub fn add_venue_order_id(
         &mut self,
         client_order_id: &ClientOrderId,
         venue_order_id: &VenueOrderId,
         overwrite: bool,
     ) -> anyhow::Result<()> {
+        self.validate_venue_order_id_claim(client_order_id, venue_order_id, overwrite)?;
+
+        self.index
+            .client_order_ids
+            .insert(*client_order_id, *venue_order_id);
+        self.index
+            .venue_order_ids
+            .insert(*venue_order_id, *client_order_id);
+
+        Ok(())
+    }
+
+    fn validate_venue_order_id_claim(
+        &self,
+        client_order_id: &ClientOrderId,
+        venue_order_id: &VenueOrderId,
+        overwrite: bool,
+    ) -> anyhow::Result<()> {
+        self.validate_venue_order_id_ownership(client_order_id, venue_order_id)?;
+
         if let Some(existing_venue_order_id) = self.index.client_order_ids.get(client_order_id)
             && !overwrite
             && existing_venue_order_id != venue_order_id
@@ -4252,12 +4273,24 @@ impl Cache {
             );
         }
 
-        self.index
-            .client_order_ids
-            .insert(*client_order_id, *venue_order_id);
-        self.index
-            .venue_order_ids
-            .insert(*venue_order_id, *client_order_id);
+        Ok(())
+    }
+
+    fn validate_venue_order_id_ownership(
+        &self,
+        client_order_id: &ClientOrderId,
+        venue_order_id: &VenueOrderId,
+    ) -> anyhow::Result<()> {
+        if let Some(existing_client_order_id) = self.index.venue_order_ids.get(venue_order_id)
+            && existing_client_order_id != client_order_id
+        {
+            return Err(VenueOrderIdOwnershipError {
+                venue_order_id: *venue_order_id,
+                existing_client_order_id: *existing_client_order_id,
+                claimant_client_order_id: *client_order_id,
+            }
+            .into());
+        }
 
         Ok(())
     }
@@ -4745,6 +4778,14 @@ impl Cache {
         // post-event value back into the cell so subsequent reads see the new state.
         let mut snapshot = order_cell.borrow().clone();
         snapshot.apply(event.clone())?;
+
+        // Preflight only reverse ownership. A same-client forward mismatch remains a logged
+        // refresh inconsistency, while other refresh failures, such as a backing database error,
+        // remain logged after the canonical state is committed.
+        if let Some(venue_order_id) = snapshot.venue_order_id() {
+            self.validate_venue_order_id_ownership(&client_order_id, &venue_order_id)?;
+        }
+
         *order_cell.borrow_mut() = snapshot.clone();
 
         if let Err(e) = self.refresh_order(&snapshot) {
@@ -4757,24 +4798,22 @@ impl Cache {
     fn refresh_order(&mut self, order: &OrderAny) -> anyhow::Result<()> {
         let client_order_id = order.client_order_id();
 
+        // Claim the venue order ID before mutating any other derived state. An updated event may
+        // change the current ID for the same client order, while historical reverse aliases remain.
+        if let Some(venue_order_id) = order.venue_order_id() {
+            let overwrite = matches!(order.last_event(), OrderEventAny::Updated(_));
+            if let Err(e) = self.add_venue_order_id(&client_order_id, &venue_order_id, overwrite) {
+                if e.is::<VenueOrderIdOwnershipError>() {
+                    return Err(e);
+                }
+                log::error!("Error indexing venue order ID in cache: {e}");
+            }
+        }
+
         if order.is_active_local() {
             self.index.orders_active_local.insert(client_order_id);
         } else {
             self.index.orders_active_local.remove(&client_order_id);
-        }
-
-        // Update venue order ID
-        if let Some(venue_order_id) = order.venue_order_id() {
-            // If the order is being modified then we allow a changing `VenueOrderId` to accommodate
-            // venues which use a cancel+replace update strategy.
-            if !self.index.venue_order_ids.contains_key(&venue_order_id) {
-                let overwrite = matches!(order.last_event(), OrderEventAny::Updated(_));
-                if let Err(e) =
-                    self.add_venue_order_id(&order.client_order_id(), &venue_order_id, overwrite)
-                {
-                    log::error!("Error indexing venue order ID in cache: {e}");
-                }
-            }
         }
 
         // Update in-flight state

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -74,7 +74,7 @@ use crate::{
         ORDER_BOOK_NOT_FOUND, ORDER_LIST_NOT_FOUND, ORDER_NOT_FOUND, OWN_ORDER_BOOK_NOT_FOUND,
         OrderBookLookupError, OrderListLookupError, OrderLookupError, OrderRef,
         OwnOrderBookLookupError, POSITION_NOT_FOUND, PositionLookupError,
-        SYNTHETIC_INSTRUMENT_NOT_FOUND, SyntheticInstrumentLookupError,
+        SYNTHETIC_INSTRUMENT_NOT_FOUND, SyntheticInstrumentLookupError, VenueOrderIdOwnershipError,
         database::{CacheDatabaseAdapter, CacheMap},
     },
     signal::Signal,
@@ -506,6 +506,7 @@ fn test_cache_positions_skips_malformed_position_oms() {
         )]),
         positions: AHashMap::from([(position_id, position)]),
         fail_add: false,
+        fail_update_order: false,
     };
     let mut cache = Cache::default();
     cache.set_database(Box::new(database));
@@ -1105,6 +1106,102 @@ fn test_update_order_returns_not_found_for_missing_order(mut cache: Cache) {
 }
 
 #[rstest]
+fn test_add_venue_order_id_rejects_cross_order_claim_and_retains_historical_alias(
+    mut cache: Cache,
+) {
+    let client_order_id1 = ClientOrderId::new("O-1");
+    let client_order_id2 = ClientOrderId::new("O-2");
+    let venue_order_id1 = VenueOrderId::new("V-1");
+    let venue_order_id2 = VenueOrderId::new("V-2");
+
+    cache
+        .add_venue_order_id(&client_order_id1, &venue_order_id1, false)
+        .unwrap();
+    cache
+        .add_venue_order_id(&client_order_id1, &venue_order_id2, true)
+        .unwrap();
+
+    let client_order_ids = cache.index.client_order_ids.clone();
+    let venue_order_ids = cache.index.venue_order_ids.clone();
+    let error = cache
+        .add_venue_order_id(&client_order_id2, &venue_order_id2, false)
+        .unwrap_err();
+
+    assert_eq!(
+        error.downcast_ref::<VenueOrderIdOwnershipError>(),
+        Some(&VenueOrderIdOwnershipError {
+            venue_order_id: venue_order_id2,
+            existing_client_order_id: client_order_id1,
+            claimant_client_order_id: client_order_id2,
+        })
+    );
+    let message = error.to_string();
+    assert!(message.contains("V-2"));
+    assert!(message.contains("O-1"));
+    assert!(message.contains("O-2"));
+    assert_eq!(cache.index.client_order_ids, client_order_ids);
+    assert_eq!(cache.index.venue_order_ids, venue_order_ids);
+    assert_eq!(
+        cache.client_order_id(&venue_order_id1),
+        Some(&client_order_id1)
+    );
+    assert_eq!(
+        cache.client_order_id(&venue_order_id2),
+        Some(&client_order_id1)
+    );
+    assert_eq!(
+        cache.venue_order_id(&client_order_id1),
+        Some(&venue_order_id2)
+    );
+    assert_eq!(cache.venue_order_id(&client_order_id2), None);
+}
+
+#[rstest]
+fn test_update_order_rejects_cross_order_venue_id_claim_atomically(
+    mut cache: Cache,
+    audusd_sim: CurrencyPair,
+) {
+    let venue_order_id = VenueOrderId::new("V-SHARED");
+    let owner_id = ClientOrderId::new("O-OWNER");
+    cache
+        .add_venue_order_id(&owner_id, &venue_order_id, false)
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .client_order_id(ClientOrderId::new("O-CLAIMANT"))
+        .instrument_id(audusd_sim.id())
+        .quantity(Quantity::from(100_000))
+        .price(Price::from("1.00000"))
+        .build();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+
+    let submitted = TestOrderEventStubs::submitted(&order, AccountId::new("SIM-001"));
+    let submitted_order = cache.update_order(&submitted).unwrap();
+    let canonical_before = cache
+        .order(&submitted_order.client_order_id())
+        .unwrap()
+        .clone();
+    let accepted =
+        TestOrderEventStubs::accepted(&submitted_order, AccountId::new("SIM-001"), venue_order_id);
+
+    let error = cache.update_order(&accepted).unwrap_err();
+
+    assert!(error.to_string().contains("already owned"));
+    assert_eq!(
+        cache
+            .order(&submitted_order.client_order_id())
+            .unwrap()
+            .clone(),
+        canonical_before
+    );
+    assert_eq!(cache.client_order_id(&venue_order_id), Some(&owner_id));
+    assert_eq!(
+        cache.venue_order_id(&submitted_order.client_order_id()),
+        None
+    );
+}
+
+#[rstest]
 fn test_update_order_rejects_invalid_transition_without_mutating(
     mut cache: Cache,
     audusd_sim: CurrencyPair,
@@ -1269,6 +1366,40 @@ fn test_replace_order_overwrites_value(mut cache: Cache, audusd_sim: CurrencyPai
         cache.order(&client_order_id).unwrap().position_id(),
         Some(PositionId::from("P-REPLACED"))
     );
+}
+
+#[rstest]
+fn test_replace_order_rejects_reverse_venue_id_conflict_before_commit(
+    mut cache: Cache,
+    audusd_sim: CurrencyPair,
+) {
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(audusd_sim.id)
+        .client_order_id(ClientOrderId::new("O-CLAIMANT"))
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00000"))
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+    let owner_id = ClientOrderId::new("O-OWNER");
+    let venue_order_id = VenueOrderId::new("V-OWNED");
+    cache
+        .add_venue_order_id(&owner_id, &venue_order_id, false)
+        .unwrap();
+    let mut replacement = order.clone();
+    let submitted = TestOrderEventStubs::submitted(&replacement, AccountId::new("SIM-001"));
+    replacement.apply(submitted).unwrap();
+    let accepted =
+        TestOrderEventStubs::accepted(&replacement, AccountId::new("SIM-001"), venue_order_id);
+    replacement.apply(accepted).unwrap();
+
+    let error = cache.replace_order(&replacement).unwrap_err();
+
+    assert!(error.is::<VenueOrderIdOwnershipError>());
+    assert_eq!(cache.order(&client_order_id).unwrap(), &order);
+    assert_eq!(cache.client_order_id(&venue_order_id), Some(&owner_id));
+    assert_eq!(cache.venue_order_id(&client_order_id), None);
 }
 
 #[rstest]
@@ -5866,7 +5997,7 @@ fn test_update_order_removes_closed_ioc_from_existing_own_book(mut cache: Cache)
 }
 
 #[rstest]
-fn test_update_order_venue_id_conflict_still_removes_closed_from_own_book(mut cache: Cache) {
+fn test_update_order_applies_fill_with_stale_unowned_venue_id(mut cache: Cache) {
     let audusd_sim = audusd_sim();
     cache
         .add_instrument(InstrumentAny::CurrencyPair(audusd_sim.clone()))
@@ -5921,10 +6052,11 @@ fn test_update_order_venue_id_conflict_still_removes_closed_from_own_book(mut ca
         Some(PositionId::new("P-CONFLICT")),
         Some(Money::from("0 USD")),
     );
-    update_order_with_event(&mut cache, &mut live_order, OrderEventAny::Filled(filled));
+    let updated = cache.update_order(&OrderEventAny::Filled(filled)).unwrap();
 
     let own_book = cache.own_order_book(&audusd_sim.id()).unwrap();
-    assert!(live_order.is_closed());
+    assert!(updated.is_closed());
+    assert!(live_order.is_open());
     assert_eq!(own_book.bids().count(), 0);
     assert!(
         !cache
@@ -5937,6 +6069,92 @@ fn test_update_order_venue_id_conflict_still_removes_closed_from_own_book(mut ca
             .index
             .orders_closed
             .contains(&live_order.client_order_id())
+    );
+    assert_eq!(
+        cache
+            .order(&live_order.client_order_id())
+            .unwrap()
+            .venue_order_id(),
+        Some(VenueOrderId::new("V-CONFLICT"))
+    );
+    assert_eq!(
+        cache.venue_order_id(&live_order.client_order_id()),
+        Some(&VenueOrderId::new("V-ORIGINAL"))
+    );
+    assert_eq!(
+        cache.client_order_id(&VenueOrderId::new("V-CONFLICT")),
+        None
+    );
+}
+
+#[rstest]
+fn test_update_order_rejects_fill_with_venue_id_owned_by_another_order_atomically(
+    mut cache: Cache,
+) {
+    let audusd_sim = audusd_sim();
+    let owner_id = ClientOrderId::new("O-OWNER");
+    let owned_venue_order_id = VenueOrderId::new("V-OWNED");
+    cache
+        .add_venue_order_id(&owner_id, &owned_venue_order_id, false)
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(audusd_sim.id())
+        .client_order_id(ClientOrderId::new("O-CLAIMANT"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .price(Price::from("1.00000"))
+        .build();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+    let submitted = TestOrderEventStubs::submitted(&order, AccountId::new("SIM-001"));
+    let submitted_order = cache.update_order(&submitted).unwrap();
+    let accepted = TestOrderEventStubs::accepted(
+        &submitted_order,
+        AccountId::new("SIM-001"),
+        VenueOrderId::new("V-ACCEPTED"),
+    );
+    let accepted_order = cache.update_order(&accepted).unwrap();
+    let canonical_before = cache
+        .order(&accepted_order.client_order_id())
+        .unwrap()
+        .clone();
+    let filled = build_order_filled(
+        accepted_order.trader_id(),
+        accepted_order.strategy_id(),
+        audusd_sim.id(),
+        accepted_order.client_order_id(),
+        owned_venue_order_id,
+        AccountId::new("SIM-001"),
+        TradeId::new("T-CONFLICT"),
+        accepted_order.order_side(),
+        accepted_order.order_type(),
+        accepted_order.quantity(),
+        Price::from("1.00000"),
+        audusd_sim.quote_currency(),
+        LiquiditySide::Maker,
+        Some(PositionId::new("P-CONFLICT")),
+        Some(Money::from("0 USD")),
+    );
+
+    let error = cache
+        .update_order(&OrderEventAny::Filled(filled))
+        .unwrap_err();
+
+    assert!(error.is::<VenueOrderIdOwnershipError>());
+    assert_eq!(
+        cache
+            .order(&accepted_order.client_order_id())
+            .unwrap()
+            .clone(),
+        canonical_before
+    );
+    assert_eq!(
+        cache.venue_order_id(&accepted_order.client_order_id()),
+        Some(&VenueOrderId::new("V-ACCEPTED"))
+    );
+    assert_eq!(
+        cache.client_order_id(&owned_venue_order_id),
+        Some(&owner_id)
     );
 }
 
@@ -5992,6 +6210,10 @@ fn test_update_order_allows_venue_id_change_for_order_updated(mut cache: Cache) 
     );
     assert_eq!(
         cache.client_order_id(&new_venue_order_id),
+        Some(&live_order.client_order_id())
+    );
+    assert_eq!(
+        cache.client_order_id(&original_venue_order_id),
         Some(&live_order.client_order_id())
     );
 }
@@ -6444,6 +6666,7 @@ struct SnapshotBlobTestDatabase {
     general: AHashMap<String, Bytes>,
     positions: AHashMap<PositionId, Position>,
     fail_add: bool,
+    fail_update_order: bool,
 }
 
 impl SnapshotBlobTestDatabase {
@@ -6454,6 +6677,7 @@ impl SnapshotBlobTestDatabase {
             general,
             positions: AHashMap::new(),
             fail_add: false,
+            fail_update_order: false,
         }
     }
 
@@ -6468,6 +6692,7 @@ impl SnapshotBlobTestDatabase {
             general,
             positions,
             fail_add: false,
+            fail_update_order: false,
         }
     }
 
@@ -6476,6 +6701,14 @@ impl SnapshotBlobTestDatabase {
             general: AHashMap::new(),
             positions: AHashMap::new(),
             fail_add: true,
+            fail_update_order: false,
+        }
+    }
+
+    fn fail_update_order() -> Self {
+        Self {
+            fail_update_order: true,
+            ..Default::default()
         }
     }
 }
@@ -6736,6 +6969,9 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
     }
 
     fn update_order(&self, _order_event: &OrderEventAny) -> anyhow::Result<()> {
+        if self.fail_update_order {
+            anyhow::bail!("update order failed");
+        }
         Ok(())
     }
 
@@ -6759,6 +6995,27 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
     fn heartbeat(&self, _timestamp: UnixNanos) -> anyhow::Result<()> {
         Ok(())
     }
+}
+
+#[rstest]
+fn test_update_order_commits_canonical_state_when_database_update_fails() {
+    let database = SnapshotBlobTestDatabase::fail_update_order();
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim().id())
+        .client_order_id(ClientOrderId::from("O-DATABASE-FAILURE"))
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+    let submitted = TestOrderEventStubs::submitted(&order, AccountId::from("SIM-001"));
+
+    let updated = cache.update_order(&submitted);
+
+    assert!(updated.is_ok());
+    let canonical = cache.order(&client_order_id).unwrap();
+    assert_eq!(canonical.status(), OrderStatus::Submitted);
+    assert_eq!(canonical.last_event(), &submitted);
 }
 
 #[rstest]

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -1289,13 +1289,14 @@ impl ExecutionEngine {
 
         {
             let mut cache = self.cache.borrow_mut();
-            if let Err(e) = cache.add_order(order.clone(), None, None, false) {
-                log::error!("Failed to add external order to cache: {e}");
+            if let Err(e) = cache.add_venue_order_id(&client_order_id, &venue_order_id, false) {
+                log::warn!("Failed to claim venue order ID for external order: {e}");
                 return None;
             }
 
-            if let Err(e) = cache.add_venue_order_id(&client_order_id, &venue_order_id, false) {
-                log::warn!("Failed to add venue order ID index: {e}");
+            if let Err(e) = cache.add_order(order.clone(), None, None, false) {
+                log::error!("Failed to add external order to cache: {e}");
+                return None;
             }
         }
 
@@ -4019,11 +4020,13 @@ impl ExecutionEngine {
 
 #[cfg(test)]
 mod tests {
+    use nautilus_common::clock::TestClock;
     use nautilus_model::{
-        enums::{LiquiditySide, OrderSide, PositionSideSpecified},
+        enums::{LiquiditySide, OrderSide, OrderType, PositionSideSpecified},
         events::order::spec::OrderFilledSpec,
         identifiers::{AccountId, ClientOrderId, TradeId, VenueOrderId},
         instruments::{InstrumentAny, stubs::audusd_sim},
+        orders::builder::OrderTestBuilder,
         types::Price,
     };
     use rstest::*;
@@ -4139,6 +4142,52 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    #[rstest]
+    fn materialize_external_order_rejects_venue_id_owned_by_another_order() {
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let venue_order_id = VenueOrderId::from("V-SHARED");
+        let owner_id = ClientOrderId::from("O-OWNER");
+        cache
+            .borrow_mut()
+            .add_venue_order_id(&owner_id, &venue_order_id, false)
+            .unwrap();
+        let engine = ExecutionEngine::new(
+            Rc::new(RefCell::new(TestClock::new())),
+            Rc::clone(&cache),
+            None,
+        );
+        let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+        let claimant_id = ClientOrderId::from("O-CLAIMANT");
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .instrument_id(instrument.id())
+            .client_order_id(claimant_id)
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from(100_000))
+            .price(Price::from("1.00000"))
+            .build();
+        let OrderEventAny::Initialized(initialized) = order.last_event().clone() else {
+            panic!("Expected initialized order");
+        };
+
+        let result = engine.materialize_external_order(
+            initialized,
+            claimant_id,
+            venue_order_id,
+            instrument.id(),
+            order.strategy_id(),
+            UnixNanos::default(),
+            None,
+        );
+
+        assert!(result.is_none());
+        assert!(!cache.borrow().order_exists(&claimant_id));
+        assert_eq!(
+            cache.borrow().client_order_id(&venue_order_id),
+            Some(&owner_id)
+        );
+        assert_eq!(cache.borrow().venue_order_id(&claimant_id), None);
     }
 
     fn position_for_account(

--- a/crates/execution/src/matching_engine/engine.rs
+++ b/crates/execution/src/matching_engine/engine.rs
@@ -7054,6 +7054,86 @@ mod tests {
         assert!(events.borrow().is_empty());
     }
 
+    fn collision_engine() -> (OrderMatchingEngine, Rc<RefCell<Cache>>, VenueOrderId) {
+        let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let venue_order_id = VenueOrderId::from(format!("{}-1-1", instrument.id().venue));
+        cache
+            .borrow_mut()
+            .add_venue_order_id(&ClientOrderId::from("O-OWNER"), &venue_order_id, false)
+            .unwrap();
+        let engine = OrderMatchingEngine::new(
+            instrument,
+            1,
+            FillModelHandle::default(),
+            FeeModelAny::default().into(),
+            BookType::L1_MBP,
+            OmsType::Netting,
+            AccountType::Margin,
+            Rc::new(RefCell::new(TestClock::new())),
+            Rc::clone(&cache),
+            Default::default(),
+        );
+
+        (engine, cache, venue_order_id)
+    }
+
+    #[rstest]
+    #[case(OrderType::Market)]
+    #[case(OrderType::MarketToLimit)]
+    fn test_market_collision_probes_and_fills_with_default_ack_config(
+        #[case] order_type: OrderType,
+    ) {
+        let (mut engine, cache, venue_order_id) = collision_engine();
+        assert!(!engine.config.use_market_order_acks);
+        let quote = QuoteTick::new(
+            engine.instrument.id(),
+            Price::from("1499.00"),
+            Price::from("1500.00"),
+            Quantity::from("10.000"),
+            Quantity::from("10.000"),
+            UnixNanos::default(),
+            UnixNanos::default(),
+        );
+        engine.process_quote_tick(&quote);
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let events_handler = Rc::clone(&events);
+        engine.set_event_handler(Rc::new(move |event| {
+            events_handler.borrow_mut().push(event);
+        }));
+        let mut order = OrderTestBuilder::new(order_type)
+            .instrument_id(engine.instrument.id())
+            .client_order_id(ClientOrderId::from("O-CLAIMANT"))
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1.000"))
+            .submit(true)
+            .build();
+
+        engine.process_order(&mut order, AccountId::from("ACCOUNT-001"));
+
+        assert!(
+            !events
+                .borrow()
+                .iter()
+                .any(|event| matches!(event, OrderEventAny::Rejected(_)))
+        );
+        assert!(
+            events
+                .borrow()
+                .iter()
+                .any(|event| matches!(event, OrderEventAny::Filled(_)))
+        );
+        assert!(cache.borrow().order_exists(&order.client_order_id()));
+        assert_eq!(
+            cache.borrow().client_order_id(&venue_order_id),
+            Some(&ClientOrderId::from("O-OWNER"))
+        );
+        assert_eq!(
+            cache.borrow().venue_order_id(&order.client_order_id()),
+            Some(&VenueOrderId::from(format!("{}-1-2", engine.venue)))
+        );
+    }
+
     struct RecordingFeeModel {
         calls: Rc<Cell<u32>>,
         commission: Money,

--- a/crates/execution/src/matching_engine/ids_generator.rs
+++ b/crates/execution/src/matching_engine/ids_generator.rs
@@ -15,7 +15,7 @@
 
 use std::{cell::RefCell, fmt::Debug, rc::Rc};
 
-use nautilus_common::cache::Cache;
+use nautilus_common::cache::{Cache, VenueOrderIdOwnershipError};
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
     enums::OmsType,
@@ -92,13 +92,45 @@ impl IdsGenerator {
             return Ok(venue_order_id.to_owned());
         }
 
-        let venue_order_id = self.generate_venue_order_id();
-        self.cache.borrow_mut().add_venue_order_id(
-            &order.client_order_id(),
-            &venue_order_id,
-            false,
-        )?;
-        Ok(venue_order_id)
+        let client_order_id = order.client_order_id();
+        let mut conflict_count = 0_usize;
+
+        loop {
+            let venue_order_id = self.try_generate_venue_order_id()?;
+            let claim_result = self.cache.borrow_mut().add_venue_order_id(
+                &client_order_id,
+                &venue_order_id,
+                false,
+            );
+
+            match claim_result {
+                Ok(()) => {
+                    if conflict_count > 0 {
+                        log::info!(
+                            "Allocated venue order ID {venue_order_id} for {client_order_id} after \
+                             probing past {conflict_count} ownership conflicts"
+                        );
+                    }
+                    return Ok(venue_order_id);
+                }
+                Err(e) => {
+                    let Some(conflict) = e.downcast_ref::<VenueOrderIdOwnershipError>() else {
+                        return Err(e);
+                    };
+
+                    if conflict_count == 0 {
+                        log::error!(
+                            "Generated venue order ID conflict: candidate={}, existing_owner={}, \
+                             claimant={}",
+                            conflict.venue_order_id,
+                            conflict.existing_client_order_id,
+                            conflict.claimant_client_order_id,
+                        );
+                    }
+                    conflict_count += 1;
+                }
+            }
+        }
     }
 
     /// Retrieves or generates a position ID for the given order.
@@ -172,15 +204,28 @@ impl IdsGenerator {
         }
     }
 
+    /// Generates a venue order ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the deterministic order counter is exhausted.
     pub fn generate_venue_order_id(&mut self) -> VenueOrderId {
-        self.order_count += 1;
+        self.try_generate_venue_order_id()
+            .expect("Venue order ID counter exhausted")
+    }
+
+    fn try_generate_venue_order_id(&mut self) -> anyhow::Result<VenueOrderId> {
+        self.order_count = self
+            .order_count
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("Venue order ID counter exhausted"))?;
 
         if self.use_random_ids {
-            VenueOrderId::new(UUID4::new().to_string())
+            Ok(VenueOrderId::new(UUID4::new().to_string()))
         } else {
-            VenueOrderId::new(
+            Ok(VenueOrderId::new(
                 format!("{}-{}-{}", self.venue, self.raw_id, self.order_count).as_str(),
-            )
+            ))
         }
     }
 }
@@ -207,7 +252,7 @@ fn fnv1a_trade_id_hash(venue: Venue, raw_id: u32, ts_init_ns: u64) -> u64 {
 mod tests {
     use std::{cell::RefCell, rc::Rc};
 
-    use nautilus_common::cache::Cache;
+    use nautilus_common::cache::{Cache, VenueOrderIdOwnershipError};
     use nautilus_core::UnixNanos;
     use nautilus_model::{
         enums::{OmsType, OrderSide, OrderType},
@@ -219,7 +264,7 @@ mod tests {
         instruments::{
             CryptoPerpetual, Instrument, InstrumentAny, stubs::crypto_perpetual_ethusdt,
         },
-        orders::{Order, OrderAny, OrderTestBuilder},
+        orders::{Order, OrderAny, OrderTestBuilder, stubs::TestOrderEventStubs},
         position::Position,
         types::{Price, Quantity},
     };
@@ -431,6 +476,99 @@ mod tests {
         // check if venue order id is cached again
         let venue_order_id3 = ids_generator.get_venue_order_id(&market_order_buy).unwrap();
         assert_eq!(venue_order_id3, VenueOrderId::from("BINANCE-1-1"));
+    }
+
+    #[rstest]
+    fn test_get_venue_order_id_probes_past_preclaimed_candidates(market_order_buy: OrderAny) {
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let owner_id = ClientOrderId::from("O-OWNER");
+
+        for suffix in 1..=3 {
+            cache
+                .borrow_mut()
+                .add_venue_order_id(
+                    &owner_id,
+                    &VenueOrderId::from(format!("BINANCE-1-{suffix}")),
+                    true,
+                )
+                .unwrap();
+        }
+        let mut ids_generator = get_ids_generator(Rc::clone(&cache), true, OmsType::Netting);
+
+        let venue_order_id = ids_generator.get_venue_order_id(&market_order_buy).unwrap();
+
+        assert_eq!(venue_order_id, VenueOrderId::from("BINANCE-1-4"));
+        assert_eq!(
+            cache
+                .borrow()
+                .venue_order_id(&market_order_buy.client_order_id()),
+            Some(&venue_order_id)
+        );
+
+        for suffix in 1..=3 {
+            assert_eq!(
+                cache
+                    .borrow()
+                    .client_order_id(&VenueOrderId::from(format!("BINANCE-1-{suffix}"))),
+                Some(&owner_id)
+            );
+        }
+    }
+
+    #[rstest]
+    fn test_get_venue_order_id_fails_when_counter_is_exhausted(market_order_buy: OrderAny) {
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let mut ids_generator = get_ids_generator(Rc::clone(&cache), true, OmsType::Netting);
+        ids_generator.order_count = usize::MAX;
+
+        let error = ids_generator
+            .get_venue_order_id(&market_order_buy)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("counter exhausted"));
+        assert_eq!(
+            cache
+                .borrow()
+                .venue_order_id(&market_order_buy.client_order_id()),
+            None
+        );
+    }
+
+    #[rstest]
+    fn test_get_venue_order_id_does_not_replace_authoritative_id(mut market_order_buy: OrderAny) {
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let venue_order_id = VenueOrderId::from("V-AUTHORITATIVE");
+        let owner_id = ClientOrderId::from("O-OWNER");
+        cache
+            .borrow_mut()
+            .add_venue_order_id(&owner_id, &venue_order_id, false)
+            .unwrap();
+        let accepted = TestOrderEventStubs::accepted(
+            &market_order_buy,
+            AccountId::from("ACCOUNT-001"),
+            venue_order_id,
+        );
+        market_order_buy.apply(accepted).unwrap();
+        let mut ids_generator = get_ids_generator(Rc::clone(&cache), true, OmsType::Netting);
+
+        let returned_id = ids_generator.get_venue_order_id(&market_order_buy).unwrap();
+        let error = cache
+            .borrow_mut()
+            .add_venue_order_id(&market_order_buy.client_order_id(), &returned_id, false)
+            .unwrap_err();
+
+        assert_eq!(returned_id, venue_order_id);
+        assert!(error.is::<VenueOrderIdOwnershipError>());
+        assert_eq!(
+            cache.borrow().client_order_id(&venue_order_id),
+            Some(&owner_id)
+        );
+        assert_eq!(
+            cache
+                .borrow()
+                .venue_order_id(&market_order_buy.client_order_id()),
+            None
+        );
     }
 
     fn build_ids_generator(venue: Venue, raw_id: u32) -> IdsGenerator {

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -221,6 +221,14 @@ fn build_order_canceled(
         .build()
 }
 
+fn cached_order_or(execution_engine: &ExecutionEngine, order: &OrderAny) -> OrderAny {
+    execution_engine
+        .cache()
+        .borrow()
+        .order(&order.client_order_id())
+        .map_or_else(|| order.clone(), |cached| cached.clone())
+}
+
 fn build_order_expired(
     trader_id: TraderId,
     strategy_id: StrategyId,
@@ -1713,7 +1721,7 @@ fn test_fill_void_position_validation_failure_leaves_order_unchanged(
         order.strategy_id(),
         instrument.id(),
         order.client_order_id(),
-        VenueOrderId::from("V-MISSING-FRAGMENT"),
+        VenueOrderId::from("V-001"),
         AccountId::test_default(),
         trade_id,
         order.order_side(),
@@ -1746,7 +1754,7 @@ fn test_fill_void_position_validation_failure_leaves_order_unchanged(
             .strategy_id(order.strategy_id())
             .instrument_id(instrument.id())
             .client_order_id(order.client_order_id())
-            .venue_order_id(VenueOrderId::from("V-MISSING-FRAGMENT"))
+            .venue_order_id(VenueOrderId::from("V-001"))
             .account_id(AccountId::test_default())
             .trade_id(trade_id)
             .voided_qty(order.quantity())
@@ -2936,6 +2944,7 @@ fn prepare_accepted_order_with_account(
     );
     execution_engine.process(&accepted);
 
+    let order = cached_order_or(execution_engine, &order);
     (instrument, order)
 }
 
@@ -3815,7 +3824,7 @@ fn test_when_applying_event_to_order_with_invalid_state_trigger_logs(
 
     // Try to fill order before it's been accepted (invalid state transition)
     let order_filled_event = TestOrderEventStubs::filled(
-        &order,
+        &cached_order_or(&execution_engine, &order),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001")),
         None,
@@ -3866,7 +3875,7 @@ fn test_order_filled_event_when_order_not_found_in_cache_logs(
         "Order should not exist in cache"
     );
     let order_filled_event = TestOrderEventStubs::filled(
-        &order,
+        &cached_order_or(&execution_engine, &order),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001")),
         None,
@@ -4756,7 +4765,7 @@ fn test_handle_order_fill_event_with_no_position_id_correctly_handles_fill(
     execution_engine.process(&order_submitted_event);
 
     let order_filled_event = TestOrderEventStubs::filled(
-        &order,
+        &cached_order_or(&execution_engine, &order),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001")), // Provide unique trade_id
         None,                                            // position_id
@@ -5479,7 +5488,7 @@ fn test_handle_position_opening_with_position_id_none(mut execution_engine: Exec
     execution_engine.process(&order_accepted_event);
 
     let order_filled_event = TestOrderEventStubs::filled(
-        &order,
+        &cached_order_or(&execution_engine, &order),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001")),
         None,                            // position_id = None (let engine generate it)
@@ -5609,6 +5618,7 @@ fn test_add_to_existing_position_on_order_fill(mut execution_engine: ExecutionEn
         .trader_id(trader_id)
         .strategy_id(strategy_id)
         .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-ADD-1"))
         .quantity(Quantity::from(100_000))
         .build();
 
@@ -5630,7 +5640,7 @@ fn test_add_to_existing_position_on_order_fill(mut execution_engine: ExecutionEn
 
     // Fill first order to create a position
     let order1_filled_event = TestOrderEventStubs::filled(
-        &order1,
+        &cached_order_or(&execution_engine, &order1),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         None,                            // Let system generate position ID
@@ -5660,6 +5670,7 @@ fn test_add_to_existing_position_on_order_fill(mut execution_engine: ExecutionEn
         .trader_id(trader_id)
         .strategy_id(strategy_id)
         .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-ADD-2"))
         .quantity(Quantity::from(100_000))
         .build();
 
@@ -5680,7 +5691,7 @@ fn test_add_to_existing_position_on_order_fill(mut execution_engine: ExecutionEn
     execution_engine.process(&order2_accepted_event);
 
     let order2_filled_event = TestOrderEventStubs::filled(
-        &order2,
+        &cached_order_or(&execution_engine, &order2),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-2")),
         Some(expected_position_id),      // Specify existing position ID
@@ -5827,6 +5838,7 @@ fn test_close_position_on_order_fill(mut execution_engine: ExecutionEngine) {
         .trader_id(trader_id)
         .strategy_id(strategy_id)
         .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-CLOSE-1"))
         .side(OrderSide::Buy)
         .quantity(Quantity::from(100_000))
         .trigger_price(Price::from_str("1.00000").unwrap())
@@ -5853,7 +5865,7 @@ fn test_close_position_on_order_fill(mut execution_engine: ExecutionEngine) {
 
     // Fill first order to open position
     let order1_filled_event = TestOrderEventStubs::filled(
-        &order1,
+        &cached_order_or(&execution_engine, &order1),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         None,
@@ -5886,6 +5898,7 @@ fn test_close_position_on_order_fill(mut execution_engine: ExecutionEngine) {
         .trader_id(trader_id)
         .strategy_id(strategy_id)
         .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-CLOSE-2"))
         .side(OrderSide::Sell)
         .quantity(Quantity::from(100_000))
         .trigger_price(Price::from_str("1.00000").unwrap())
@@ -5908,7 +5921,7 @@ fn test_close_position_on_order_fill(mut execution_engine: ExecutionEngine) {
     execution_engine.process(&order2_accepted_event);
 
     let order2_filled_event = TestOrderEventStubs::filled(
-        &order2,
+        &cached_order_or(&execution_engine, &order2),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001-2")),
         None,
@@ -6062,7 +6075,7 @@ fn test_multiple_strategy_positions_opened(mut execution_engine: ExecutionEngine
     execution_engine.process(&order1_accepted_event);
 
     let order1_filled_event = TestOrderEventStubs::filled(
-        &order1,
+        &cached_order_or(&execution_engine, &order1),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         None,
@@ -6086,7 +6099,7 @@ fn test_multiple_strategy_positions_opened(mut execution_engine: ExecutionEngine
     execution_engine.process(&order2_accepted_event);
 
     let order2_filled_event = TestOrderEventStubs::filled(
-        &order2,
+        &cached_order_or(&execution_engine, &order2),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-2")),
         None,
@@ -6370,7 +6383,7 @@ fn test_flip_position_on_opposite_filled_same_position_sell(mut execution_engine
     execution_engine.process(&order1_accepted_event);
 
     let order1_filled_event = TestOrderEventStubs::filled(
-        &order1,
+        &cached_order_or(&execution_engine, &order1),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         Some(position_id),
@@ -6414,7 +6427,7 @@ fn test_flip_position_on_opposite_filled_same_position_sell(mut execution_engine
     execution_engine.process(&order2_accepted_event);
 
     let order2_filled_event = TestOrderEventStubs::filled(
-        &order2,
+        &cached_order_or(&execution_engine, &order2),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-2")),
         Some(position_id), // Fill against the same position
@@ -6624,7 +6637,7 @@ fn test_flip_position_on_opposite_filled_same_position_buy(mut execution_engine:
     execution_engine.process(&order1_accepted_event);
 
     let order1_filled_event = TestOrderEventStubs::filled(
-        &order1,
+        &cached_order_or(&execution_engine, &order1),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         Some(position_id),
@@ -6672,7 +6685,7 @@ fn test_flip_position_on_opposite_filled_same_position_buy(mut execution_engine:
     execution_engine.process(&order2_accepted_event);
 
     let order2_filled_event = TestOrderEventStubs::filled(
-        &order2,
+        &cached_order_or(&execution_engine, &order2),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-2")),
         Some(position_id), // Fill against the same position
@@ -6872,7 +6885,7 @@ fn test_flip_position_on_flat_position_then_filled_reusing_position_id(
     execution_engine.process(&order1_accepted_event);
 
     let order1_filled_event = TestOrderEventStubs::filled(
-        &order1,
+        &cached_order_or(&execution_engine, &order1),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         Some(position_id),
@@ -6920,7 +6933,7 @@ fn test_flip_position_on_flat_position_then_filled_reusing_position_id(
     execution_engine.process(&order2_accepted_event);
 
     let order2_filled_event = TestOrderEventStubs::filled(
-        &order2,
+        &cached_order_or(&execution_engine, &order2),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001-2")),
         Some(position_id), // Fill against the same position
@@ -7034,7 +7047,7 @@ fn test_cached_position_id_used_for_netting_fill(mut execution_engine: Execution
 
     // Fill with position_id = None; engine should use cached value
     let order_filled_event = TestOrderEventStubs::filled(
-        &order,
+        &cached_order_or(&execution_engine, &order),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         None,
@@ -7134,7 +7147,7 @@ fn test_cached_position_id_used_for_hedging_fill(mut execution_engine: Execution
 
     // Fill with position_id = None; engine should use cached value
     let order_filled_event = TestOrderEventStubs::filled(
-        &order,
+        &cached_order_or(&execution_engine, &order),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         None,
@@ -7233,7 +7246,7 @@ fn test_cached_position_id_overrides_fill_position_id(mut execution_engine: Exec
     // Fill with a DIFFERENT position_id (venue-supplied); cached should take precedence
     let venue_position_id = PositionId::from("VENUE-POS");
     let order_filled_event = TestOrderEventStubs::filled(
-        &order,
+        &cached_order_or(&execution_engine, &order),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         Some(venue_position_id),
@@ -7353,7 +7366,7 @@ fn test_exec_algorithm_position_id_propagates_to_primary_order(
 
     // Fill the child order with no position_id; engine should generate one and propagate
     let child_filled_event = TestOrderEventStubs::filled(
-        &child_order,
+        &cached_order_or(&execution_engine, &child_order),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         None,
@@ -7493,7 +7506,7 @@ fn test_exec_algorithm_does_not_overwrite_primary_cached_position_id(
     execution_engine.process(&child_accepted_event);
 
     let child_filled_event = TestOrderEventStubs::filled(
-        &child_order,
+        &cached_order_or(&execution_engine, &child_order),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         None,
@@ -7592,7 +7605,7 @@ fn test_flip_position_when_netting_oms(mut execution_engine: ExecutionEngine) {
     execution_engine.process(&order1_accepted_event);
 
     let order1_filled_event = TestOrderEventStubs::filled(
-        &order1,
+        &cached_order_or(&execution_engine, &order1),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-001-1")),
         None,
@@ -7640,7 +7653,7 @@ fn test_flip_position_when_netting_oms(mut execution_engine: ExecutionEngine) {
     execution_engine.process(&order2_accepted_event);
 
     let order2_filled_event = TestOrderEventStubs::filled(
-        &order2,
+        &cached_order_or(&execution_engine, &order2),
         &instrument.into(),
         Some(TradeId::new("E-19700101-000000-001-001-2")),
         None,
@@ -7771,7 +7784,7 @@ fn test_reduce_only_netting_fill_does_not_open_opposite_position(
     execution_engine.process(&accepted_event);
 
     let filled_event = TestOrderEventStubs::filled(
-        &reduce_only_order,
+        &cached_order_or(&execution_engine, &reduce_only_order),
         &instrument.clone().into(),
         Some(TradeId::new("E-19700101-000000-001-998-1")),
         None,
@@ -8194,7 +8207,8 @@ fn add_order_and_process_fill(
         TestOrderEventStubs::accepted(order, account_id, VenueOrderId::from(venue_order_id));
     execution_engine.process(&accepted_event);
 
-    let filled_event = OrderFilledTestBuilder::new(order, &instrument.clone().into())
+    let cached_order = cached_order_or(execution_engine, order);
+    let filled_event = OrderFilledTestBuilder::new(&cached_order, &instrument.clone().into())
         .trade_id(TradeId::new(trade_id))
         .account_id(account_id)
         .without_position_id()
@@ -11902,8 +11916,9 @@ fn process_filled_order(
     ));
 
     let instrument_any: InstrumentAny = instrument.clone().into();
+    let cached_order = cached_order_or(execution_engine, &order);
     execution_engine.process(&TestOrderEventStubs::filled(
-        &order,
+        &cached_order,
         &instrument_any,
         Some(TradeId::new(trade_id)),
         Some(position_id),

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -2579,7 +2579,9 @@ mod tests {
             .apply(TestOrderEventStubs::accepted(
                 &order,
                 account_id,
-                VenueOrderId::test_default(),
+                // Derived per order: a venue order ID has a single owning client order, so
+                // batch tests holding two accepted orders cannot share the default.
+                VenueOrderId::from(client_order_id),
             ))
             .unwrap();
         order
@@ -2621,7 +2623,8 @@ mod tests {
             .apply(TestOrderEventStubs::accepted(
                 &order,
                 account_id,
-                VenueOrderId::test_default(),
+                // Derived per order, as above.
+                VenueOrderId::from(client_order_id),
             ))
             .unwrap();
         order


### PR DESCRIPTION
A follow-up to the purge and index integrity work in #4569, covering the ownership half of the same index family.

## Venue order ID ownership was never enforced

`Cache::add_venue_order_id` maintains two maps, `index.client_order_ids` and `index.venue_order_ids`, but validated only one direction: whether the client order already had a different venue order ID. Nothing checked whether the incoming venue order ID was already owned by a *different* client order, so the reverse entry was rebound unconditionally. The first owner kept its forward mapping while the reverse entry named the claimant, and every lookup by venue order ID - order resolution on a venue report, reconciliation matching - resolved to the wrong order.

`refresh_order` had the complementary defect from the other side. Its guard tested `venue_order_ids.contains_key(..)`, that is existence rather than ownership, so when the key existed under another client order it did nothing at all: the order was left unindexed in both directions while the reverse entry continued to name the first owner.

The claim now validates both directions before mutating either map, and returns a typed `VenueOrderIdOwnershipError` naming the venue order ID, the existing owner and the claimant. On conflict neither map changes. `refresh_order` always performs the checked claim, which also repairs a missing forward entry when the reverse owner is already correct, and propagates an ownership conflict rather than logging it, so `replace_order` cannot commit a canonical snapshot that claims another order's venue order ID.

`Cache::update_order` preflights ownership only. A venue order ID owned by a different client order is rejected before the canonical order is committed, so a rejected event leaves the order in its prior state; a same-client forward mismatch remains the logged refresh inconsistency it was before this change. That distinction is load-bearing: enforcing the forward rule at the preflight too would reject a fill outright whenever its venue order ID disagreed with the acceptance, so an adapter emitting a stale or defaulted identifier on a fill would lose the fill entirely.

The two maps are deliberately not strict inverses and this change does not make them so. A cancel-replace legitimately retains the historical `V_old -> C` alias with no forward entry; the invariant enforced here is that a venue order ID has at most one owner, and that every current forward entry has a matching reverse entry. `overwrite` continues to permit the same client order changing its own venue order ID, and never permits taking one from another client.

## Generated IDs probe past a conflict rather than failing

Enforcing ownership makes the claim in `IdsGenerator::get_venue_order_id` fallible, and that path feeds the simulated matching engine, where a failure would surface in the middle of order lifecycles that assume ID allocation cannot fail. A freshly generated candidate has no external identity yet, so choosing a different one is the allocator's job rather than a failure the lifecycle must absorb. On an ownership conflict the generator now probes for the next free candidate, and only an ownership conflict is retried - every other error remains terminal. The first conflict is logged with the candidate, the existing owner and the claimant, and a count is logged when allocation succeeds, so a duplicate raw-ID namespace stays visible without producing a log entry per collision.

This changes collision policy, not the generated ID format: `{venue}-{raw_id}-{order_count}` is unchanged, and allocation on a clean cache produces exactly the same sequence as before.

Externally supplied and previously assigned venue order IDs are authoritative and are never replaced. They continue to fail fast at the cache boundary, and the execution engine no longer publishes or registers an externally materialized order whose claim was rejected.

## What this does not cover

Duplicate raw-ID namespaces become recoverable by probing rather than prevented; the error log is what makes the misconfiguration visible.

Counter exhaustion remains terminal, and the simulated matching engine unwraps it. Probing walks past a persisted prefix, so exhaustion means the counter itself is spent rather than a collision being unresolvable, but generated-ID allocation is not infallible.

`get_venue_order_id` returns an ID already present on the order or in the forward cache without revalidating its ownership; those IDs are trusted because they have already crossed the checked cache boundary.

A same-client forward mismatch stays logged rather than enforced. A fill carrying a stale venue order ID that no other order owns is applied while `index.client_order_ids` still holds the accepted one, which is the pre-existing logged inconsistency rather than cross-order corruption; if that identifier belongs to another client order, the ownership check still rejects it atomically.

`build_index` is unchanged. It rebuilds only reverse entries and overwrites duplicates in iteration order, so this change does not establish that a persisted cache is globally free of duplicate ownership, nor does `check_integrity` detect every such conflict.

Synthetic option-settlement IDs remain a best-effort legacy path outside this change: if one collides, cache ownership is preserved but that leg's accepted and filled events may be rejected, leaving settlement incomplete. That path derives both its client and venue identifiers from the same truncated UUID and registers its legs non-atomically, which needs its own change rather than being folded in here.

## Testing

The cache tests pin the invariant directly: a second client order claiming an owned venue order ID is rejected with both maps unchanged; an accepted or updated event carrying another client's venue order ID is rejected before the canonical order is modified; and a same-client cancel-replace still succeeds while retaining the historical reverse alias, which is the case that fails if an implementation "repairs" the maps into strict inverses.

`test_update_order_commits_canonical_state_when_database_update_fails` pins the preflight boundary specifically. Only a cross-order ownership conflict propagates; a backing-database failure is still logged after the canonical order is committed, so the ordering cannot regress into aborting an update with derived state already changed. A companion pair pins the narrowed semantics from both sides: a fill carrying a stale venue order ID owned by nobody is applied with the forward mismatch logged, while a fill carrying one owned by another client order is still rejected atomically.

On the allocator side, a matching engine whose next deterministic candidate is already owned probes past it and fills normally, parameterised over market and market-to-limit and asserted at the default acknowledgement configuration rather than only the non-default one.

All of these were verified to fail against the unfixed implementation. Several existing execution tests changed because they built fill events from local order objects that never received their acceptance, so `OrderFilledTestBuilder` fell back to a shared default venue order ID and multiple distinct client orders in one test claimed the same one; they now use the cached order, and two of them additionally needed distinct client order IDs that they had previously shared by default.
