### PR TITLE
Remove wall-clock dependency from own-book filtering

### DIFF
--- a/crates/model/src/orderbook/book.rs
+++ b/crates/model/src/orderbook/book.rs
@@ -642,8 +642,13 @@ impl OrderBook {
     /// Maps bid prices to total public size per level, excluding own orders up to a depth limit.
     ///
     /// With `own_book`, subtracts own order sizes, filtered by `status` if provided.
-    /// Uses `accepted_buffer_ns` to include only orders accepted at least that many
-    /// nanoseconds before `now` (defaults to now).
+    /// When `now` is provided, only subtracts orders whose acceptance time plus
+    /// `accepted_buffer_ns` is at or before `now`. When `now` is `None`, acceptance-time
+    /// filtering is disabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `own_book` is `Some`, `accepted_buffer_ns` is positive, and `now` is `None`.
     #[must_use]
     pub fn bids_filtered_as_map(
         &self,
@@ -671,8 +676,13 @@ impl OrderBook {
     /// Maps ask prices to total public size per level, excluding own orders up to a depth limit.
     ///
     /// With `own_book`, subtracts own order sizes, filtered by `status` if provided.
-    /// Uses `accepted_buffer_ns` to include only orders accepted at least that many
-    /// nanoseconds before `now` (defaults to now).
+    /// When `now` is provided, only subtracts orders whose acceptance time plus
+    /// `accepted_buffer_ns` is at or before `now`. When `now` is `None`, acceptance-time
+    /// filtering is disabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `own_book` is `Some`, `accepted_buffer_ns` is positive, and `now` is `None`.
     #[must_use]
     pub fn asks_filtered_as_map(
         &self,
@@ -702,6 +712,7 @@ impl OrderBook {
     /// # Panics
     ///
     /// Panics if `self` and `own_book` have different instrument IDs.
+    /// Panics if `own_book` is `Some`, `accepted_buffer_ns` is positive, and `now` is `None`.
     ///
     /// [`Self::filtered_view_checked`] for fallible construction.
     #[must_use]
@@ -726,6 +737,7 @@ impl OrderBook {
     ///
     /// # Panics
     ///
+    /// Panics if `own_book` is `Some`, `accepted_buffer_ns` is positive, and `now` is `None`.
     /// Panics if `Price::from_decimal` or `Quantity::from_decimal` fails when
     /// reconstructing filtered levels.
     pub fn filtered_view_checked(
@@ -795,8 +807,13 @@ impl OrderBook {
     /// Groups bid quantities into price buckets, truncating to a maximum depth, excluding own orders.
     ///
     /// With `own_book`, subtracts own order sizes, filtered by `status` if provided.
-    /// Uses `accepted_buffer_ns` to include only orders accepted at least that many
-    /// nanoseconds before `now` (defaults to now).
+    /// When `now` is provided, only subtracts orders whose acceptance time plus
+    /// `accepted_buffer_ns` is at or before `now`. When `now` is `None`, acceptance-time
+    /// filtering is disabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `own_book` is `Some`, `accepted_buffer_ns` is positive, and `now` is `None`.
     #[must_use]
     pub fn group_bids_filtered(
         &self,
@@ -822,8 +839,13 @@ impl OrderBook {
     /// Groups ask quantities into price buckets, truncating to a maximum depth, excluding own orders.
     ///
     /// With `own_book`, subtracts own order sizes, filtered by `status` if provided.
-    /// Uses `accepted_buffer_ns` to include only orders accepted at least that many
-    /// nanoseconds before `now` (defaults to now).
+    /// When `now` is provided, only subtracts orders whose acceptance time plus
+    /// `accepted_buffer_ns` is at or before `now`. When `now` is `None`, acceptance-time
+    /// filtering is disabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `own_book` is `Some`, `accepted_buffer_ns` is positive, and `now` is `None`.
     #[must_use]
     pub fn group_asks_filtered(
         &self,

--- a/crates/model/src/orderbook/display.rs
+++ b/crates/model/src/orderbook/display.rs
@@ -139,6 +139,7 @@ pub(crate) fn pprint_own_book(
     group_size: Option<Decimal>,
 ) -> String {
     let data: Vec<BookLevelDisplay> = if let Some(group_size) = group_size {
+        // Rendering is membership-neutral, so acceptance-time filtering stays disabled.
         let bid_quantities =
             own_order_book.bid_quantity(None, Some(num_levels), Some(group_size), None, None);
         let ask_quantities =

--- a/crates/model/src/orderbook/own.rs
+++ b/crates/model/src/orderbook/own.rs
@@ -26,7 +26,7 @@ use std::{
 
 use ahash::AHashSet;
 use indexmap::IndexMap;
-use nautilus_core::{UnixNanos, time::nanos_since_unix_epoch};
+use nautilus_core::UnixNanos;
 use rust_decimal::Decimal;
 
 use super::{BookViewError, OwnBookError, display::pprint_own_book};
@@ -357,8 +357,13 @@ impl OwnOrderBook {
 
     /// Maps bid price levels to their own orders, excluding empty levels after filtering.
     ///
-    /// Filters by `status` if provided. With `accepted_buffer_ns`, only includes orders accepted
-    /// at least that many nanoseconds before `ts_now` (defaults to now).
+    /// Filters by `status` if provided. When `ts_now` is provided, only includes orders whose
+    /// acceptance time plus `accepted_buffer_ns` is at or before `ts_now`. When `ts_now` is
+    /// `None`, acceptance-time filtering is disabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `accepted_buffer_ns` is positive and `ts_now` is `None`.
     #[must_use]
     pub fn bids_as_map(
         &self,
@@ -371,8 +376,13 @@ impl OwnOrderBook {
 
     /// Maps ask price levels to their own orders, excluding empty levels after filtering.
     ///
-    /// Filters by `status` if provided. With `accepted_buffer_ns`, only includes orders accepted
-    /// at least that many nanoseconds before `ts_now` (defaults to now).
+    /// Filters by `status` if provided. When `ts_now` is provided, only includes orders whose
+    /// acceptance time plus `accepted_buffer_ns` is at or before `ts_now`. When `ts_now` is
+    /// `None`, acceptance-time filtering is disabled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `accepted_buffer_ns` is positive and `ts_now` is `None`.
     #[must_use]
     pub fn asks_as_map(
         &self,
@@ -385,11 +395,16 @@ impl OwnOrderBook {
 
     /// Aggregates own bid quantities per price level, omitting zero-quantity levels.
     ///
-    /// Filters by `status` if provided, including only matching orders. With `accepted_buffer_ns`,
-    /// only includes orders accepted at least that many nanoseconds before `ts_now` (defaults to now).
+    /// Filters by `status` if provided, including only matching orders. When `ts_now` is provided,
+    /// only includes orders whose acceptance time plus `accepted_buffer_ns` is at or before
+    /// `ts_now`. When `ts_now` is `None`, acceptance-time filtering is disabled.
     ///
     /// If `group_size` is provided, groups quantities into price buckets.
     /// If `depth` is provided, limits the number of price levels returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `accepted_buffer_ns` is positive and `ts_now` is `None`.
     #[must_use]
     pub fn bid_quantity(
         &self,
@@ -417,11 +432,16 @@ impl OwnOrderBook {
 
     /// Aggregates own ask quantities per price level, omitting zero-quantity levels.
     ///
-    /// Filters by `status` if provided, including only matching orders. With `accepted_buffer_ns`,
-    /// only includes orders accepted at least that many nanoseconds before `ts_now` (defaults to now).
+    /// Filters by `status` if provided, including only matching orders. When `ts_now` is provided,
+    /// only includes orders whose acceptance time plus `accepted_buffer_ns` is at or before
+    /// `ts_now`. When `ts_now` is `None`, acceptance-time filtering is disabled.
     ///
     /// If `group_size` is provided, groups quantities into price buckets.
     /// If `depth` is provided, limits the number of price levels returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `accepted_buffer_ns` is positive and `ts_now` is `None`.
     #[must_use]
     pub fn ask_quantity(
         &self,
@@ -554,6 +574,22 @@ fn transform_opposite_order(order: OwnBookOrder, side: OrderSideSpecified) -> Ow
     )
 }
 
+/// Validates the acceptance-time filter arguments.
+///
+/// # Errors
+///
+/// Returns an error if `accepted_buffer_ns` is positive and `ts_now` is `None`.
+pub(crate) fn validate_accepted_buffer(
+    accepted_buffer_ns: Option<u64>,
+    ts_now: Option<u64>,
+) -> Result<(), &'static str> {
+    if accepted_buffer_ns.is_some_and(|buffer| buffer > 0) && ts_now.is_none() {
+        Err("ts_now must be provided when accepted_buffer_ns > 0")
+    } else {
+        Ok(())
+    }
+}
+
 /// Filters orders by status and accepted timestamp.
 ///
 /// `accepted_buffer_ns` acts as a grace period after `ts_accepted`. Orders whose
@@ -562,21 +598,33 @@ fn transform_opposite_order(order: OwnBookOrder, side: OrderSideSpecified) -> Ow
 /// they have not been venue-acknowledged yet. Callers that want to hide inflight
 /// orders must additionally filter by `OrderStatus` (for example, include only
 /// `ACCEPTED` / `PARTIALLY_FILLED`).
+///
+/// # Panics
+///
+/// Panics if `accepted_buffer_ns` is positive and `ts_now` is `None`.
 fn filter_orders<'a>(
     levels: impl Iterator<Item = &'a OwnBookLevel>,
     status: Option<&AHashSet<OrderStatus>>,
     accepted_buffer_ns: Option<u64>,
     ts_now: Option<u64>,
 ) -> IndexMap<Decimal, Vec<OwnBookOrder>> {
+    validate_accepted_buffer(accepted_buffer_ns, ts_now).unwrap_or_else(|e| panic!("{e}"));
     let accepted_buffer_ns = accepted_buffer_ns.unwrap_or(0);
-    let ts_now = ts_now.unwrap_or_else(nanos_since_unix_epoch);
+
     levels
         .map(|level| {
             let orders = level
                 .orders
                 .values()
                 .filter(|order| status.is_none_or(|f| f.contains(&order.status)))
-                .filter(|order| order.ts_accepted + accepted_buffer_ns <= ts_now)
+                .filter(|order| {
+                    ts_now.is_none_or(|ts_now| {
+                        order
+                            .ts_accepted
+                            .checked_add(accepted_buffer_ns)
+                            .is_some_and(|eligible_at| eligible_at.as_u64() <= ts_now)
+                    })
+                })
                 .copied()
                 .collect::<Vec<OwnBookOrder>>();
 

--- a/crates/model/src/orderbook/tests.rs
+++ b/crates/model/src/orderbook/tests.rs
@@ -4706,6 +4706,100 @@ fn test_own_order_book_bids_and_asks_as_map() {
 }
 
 #[rstest]
+fn test_own_order_book_missing_ts_now_skips_acceptance_filter() {
+    let instrument_id = InstrumentId::from("AAPL.XNAS");
+    let mut book = OwnOrderBook::new(instrument_id);
+    let order = OwnBookOrder::new(
+        TraderId::test_default(),
+        ClientOrderId::from("O-1"),
+        Some(VenueOrderId::from("1")),
+        OrderSideSpecified::Buy,
+        Price::from("100.00"),
+        Quantity::from("10"),
+        OrderType::Limit,
+        TimeInForce::Gtc,
+        OrderStatus::Accepted,
+        UnixNanos::default(),
+        UnixNanos::max(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    );
+    book.add(order);
+
+    // `ts_accepted` is deliberately `UnixNanos::max()` rather than a value derived from
+    // the current wall clock, so the assertion cannot pass by accident of when it runs.
+    let unfiltered = book.bids_as_map(None, None, None);
+    let filtered = book.bids_as_map(None, None, Some(0));
+
+    assert_eq!(unfiltered.get(&dec!(100.00)), Some(&vec![order]));
+    assert!(filtered.is_empty());
+}
+
+#[rstest]
+fn test_own_order_book_acceptance_buffer_overflow_excludes_order() {
+    let instrument_id = InstrumentId::from("AAPL.XNAS");
+    let mut book = OwnOrderBook::new(instrument_id);
+    let order = OwnBookOrder::new(
+        TraderId::test_default(),
+        ClientOrderId::from("O-1"),
+        Some(VenueOrderId::from("1")),
+        OrderSideSpecified::Buy,
+        Price::from("100.00"),
+        Quantity::from("10"),
+        OrderType::Limit,
+        TimeInForce::Gtc,
+        OrderStatus::Accepted,
+        UnixNanos::default(),
+        UnixNanos::max(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    );
+    book.add(order);
+
+    // `ts_accepted + accepted_buffer_ns` overflows, so the order can never become
+    // eligible and is excluded rather than panicking on the addition.
+    let overflowed = book.bids_as_map(None, Some(1), Some(u64::MAX));
+
+    assert!(overflowed.is_empty());
+}
+
+#[rstest]
+#[should_panic(expected = "ts_now must be provided when accepted_buffer_ns > 0")]
+fn test_own_order_book_positive_accepted_buffer_without_ts_now_panics() {
+    let instrument_id = InstrumentId::from("AAPL.XNAS");
+    let book = OwnOrderBook::new(instrument_id);
+
+    let _ = book.bids_as_map(None, Some(1), None);
+}
+
+#[rstest]
+fn test_own_book_grouped_pprint_includes_future_accepted_order() {
+    let instrument_id = InstrumentId::from("AAPL.XNAS");
+    let mut book = OwnOrderBook::new(instrument_id);
+    let order = OwnBookOrder::new(
+        TraderId::test_default(),
+        ClientOrderId::from("O-1"),
+        Some(VenueOrderId::from("1")),
+        OrderSideSpecified::Buy,
+        Price::from("123.45"),
+        Quantity::from("17"),
+        OrderType::Limit,
+        TimeInForce::Gtc,
+        OrderStatus::Accepted,
+        UnixNanos::default(),
+        UnixNanos::max(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    );
+    book.add(order);
+
+    let output = book.pprint(3, Some(dec!(0.01)));
+
+    assert!(output.contains("123.45"));
+    assert!(output.contains("17"));
+}
+
+#[rstest]
 fn test_own_order_book_quantity_empty_levels() {
     let instrument_id = InstrumentId::from("AAPL.XNAS");
     let book = OwnOrderBook::new(instrument_id);
@@ -6657,10 +6751,14 @@ fn own_order_passes_filter(
     ts_now: Option<u64>,
 ) -> bool {
     let accepted_buffer_ns = accepted_buffer_ns.unwrap_or(0);
-    let ts_now = ts_now.unwrap_or(u64::MAX);
 
     status.is_none_or(|filter| filter.contains(&order.status))
-        && order.ts_accepted + accepted_buffer_ns <= ts_now
+        && ts_now.is_none_or(|ts_now| {
+            order
+                .ts_accepted
+                .checked_add(accepted_buffer_ns)
+                .is_some_and(|eligible_at| eligible_at.as_u64() <= ts_now)
+        })
 }
 
 fn test_own_book_with_operations(operations: Vec<OwnBookOperation>) {

--- a/crates/model/src/python/orderbook/book.rs
+++ b/crates/model/src/python/orderbook/book.rs
@@ -23,7 +23,11 @@ use crate::{
     data::{BookOrder, OrderBookDelta, OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick},
     enums::{BookType, OrderSide, OrderStatus},
     identifiers::InstrumentId,
-    orderbook::{BookLevel, OrderBook, analysis::book_check_integrity, own::OwnOrderBook},
+    orderbook::{
+        BookLevel, OrderBook,
+        analysis::book_check_integrity,
+        own::{OwnOrderBook, validate_accepted_buffer},
+    },
     types::{Price, Quantity},
 };
 
@@ -262,15 +266,16 @@ impl OrderBook {
         status: Option<std::collections::HashSet<OrderStatus>>,
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
-    ) -> IndexMap<Decimal, Decimal> {
+    ) -> PyResult<IndexMap<Decimal, Decimal>> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
-        self.bids_filtered_as_map(
+        Ok(self.bids_filtered_as_map(
             depth,
             own_book,
             status_set.as_ref(),
             accepted_buffer_ns,
             ts_now,
-        )
+        ))
     }
 
     #[pyo3(name = "asks_filtered_to_dict")]
@@ -282,15 +287,16 @@ impl OrderBook {
         status: Option<std::collections::HashSet<OrderStatus>>,
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
-    ) -> IndexMap<Decimal, Decimal> {
+    ) -> PyResult<IndexMap<Decimal, Decimal>> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
-        self.asks_filtered_as_map(
+        Ok(self.asks_filtered_as_map(
             depth,
             own_book,
             status_set.as_ref(),
             accepted_buffer_ns,
             ts_now,
-        )
+        ))
     }
 
     #[pyo3(name = "group_bids_filtered")]
@@ -303,23 +309,25 @@ impl OrderBook {
         status: Option<std::collections::HashSet<OrderStatus>>,
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
-    ) -> IndexMap<Decimal, Decimal> {
+    ) -> PyResult<IndexMap<Decimal, Decimal>> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
-        self.group_bids_filtered(
+        Ok(self.group_bids_filtered(
             group_size,
             depth,
             own_book,
             status_set.as_ref(),
             accepted_buffer_ns,
             ts_now,
-        )
+        ))
     }
 
     /// Groups ask quantities into price buckets, truncating to a maximum depth, excluding own orders.
     ///
     /// With `own_book`, subtracts own order sizes, filtered by `status` if provided.
-    /// Uses `accepted_buffer_ns` to include only orders accepted at least that many
-    /// nanoseconds before `now` (defaults to now).
+    /// When `now` is provided, only subtracts orders whose acceptance time plus
+    /// `accepted_buffer_ns` is at or before `now`. When `now` is `None`, acceptance-time
+    /// filtering is disabled.
     #[pyo3(name = "group_asks_filtered")]
     #[pyo3(signature = (group_size, depth=None, own_book=None, status=None, accepted_buffer_ns=None, ts_now=None))]
     fn py_group_asks_filtered(
@@ -330,16 +338,17 @@ impl OrderBook {
         status: Option<std::collections::HashSet<OrderStatus>>,
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
-    ) -> IndexMap<Decimal, Decimal> {
+    ) -> PyResult<IndexMap<Decimal, Decimal>> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
-        self.group_asks_filtered(
+        Ok(self.group_asks_filtered(
             group_size,
             depth,
             own_book,
             status_set.as_ref(),
             accepted_buffer_ns,
             ts_now,
-        )
+        ))
     }
 
     /// Returns a filtered `OrderBook` view with own sizes subtracted from public levels.
@@ -353,6 +362,7 @@ impl OrderBook {
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
     ) -> PyResult<Self> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
         self.filtered_view_checked(
             own_book,

--- a/crates/model/src/python/orderbook/mod.rs
+++ b/crates/model/src/python/orderbook/mod.rs
@@ -18,3 +18,121 @@
 pub mod book;
 pub mod level;
 pub mod own;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Once;
+
+    use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
+    use rstest::rstest;
+    use rust_decimal::Decimal;
+
+    use crate::{
+        enums::BookType,
+        identifiers::InstrumentId,
+        orderbook::{OrderBook, own::OwnOrderBook},
+    };
+
+    fn ensure_python_initialized() {
+        static INIT: Once = Once::new();
+        INIT.call_once(Python::initialize);
+    }
+
+    #[rstest]
+    #[case::own_bids_to_dict("bids_to_dict", false, false)]
+    #[case::own_asks_to_dict("asks_to_dict", false, false)]
+    #[case::own_bid_quantity("bid_quantity", false, false)]
+    #[case::own_ask_quantity("ask_quantity", false, false)]
+    #[case::book_bids_filtered_to_dict("bids_filtered_to_dict", true, false)]
+    #[case::book_asks_filtered_to_dict("asks_filtered_to_dict", true, false)]
+    #[case::book_group_bids_filtered("group_bids_filtered", true, true)]
+    #[case::book_group_asks_filtered("group_asks_filtered", true, true)]
+    #[case::book_filtered_view("filtered_view", true, false)]
+    fn test_python_acceptance_filter_requires_ts_now(
+        #[case] method_name: &str,
+        #[case] filtered_book_method: bool,
+        #[case] requires_group_size: bool,
+    ) {
+        ensure_python_initialized();
+
+        Python::attach(|py| {
+            let instrument_id = InstrumentId::from("AAPL.XNAS");
+            let own_book = Py::new(py, OwnOrderBook::new(instrument_id)).unwrap();
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("accepted_buffer_ns", 1).unwrap();
+
+            let py_err = if filtered_book_method {
+                kwargs.set_item("own_book", own_book.bind(py)).unwrap();
+                let book = Py::new(py, OrderBook::new(instrument_id, BookType::L2_MBP)).unwrap();
+                let result = if requires_group_size {
+                    book.bind(py)
+                        .call_method(method_name, (Decimal::ONE,), Some(&kwargs))
+                } else {
+                    book.bind(py).call_method(method_name, (), Some(&kwargs))
+                };
+                result.unwrap_err()
+            } else {
+                own_book
+                    .bind(py)
+                    .call_method(method_name, (), Some(&kwargs))
+                    .unwrap_err()
+            };
+
+            assert!(
+                py_err.is_instance_of::<PyValueError>(py),
+                "expected PyValueError, received {}",
+                py_err.get_type(py).name().unwrap().to_str().unwrap()
+            );
+            assert_eq!(
+                py_err.value(py).to_string(),
+                "ts_now must be provided when accepted_buffer_ns > 0"
+            );
+        });
+    }
+
+    /// The filtered-book methods reject the invalid pair even with no own book.
+    ///
+    /// Without `own_book` the underlying Rust method never filters own orders, so
+    /// it never reaches the assertion and could not panic. The Python boundary is
+    /// deliberately stricter, treating the arguments as an invalid pair in their
+    /// own right; this pins that decision, which the cases above cannot because
+    /// they all supply an own book.
+    #[rstest]
+    #[case::bids_filtered_to_dict("bids_filtered_to_dict", false)]
+    #[case::asks_filtered_to_dict("asks_filtered_to_dict", false)]
+    #[case::group_bids_filtered("group_bids_filtered", true)]
+    #[case::group_asks_filtered("group_asks_filtered", true)]
+    #[case::filtered_view("filtered_view", false)]
+    fn test_python_filtered_book_requires_ts_now_without_own_book(
+        #[case] method_name: &str,
+        #[case] requires_group_size: bool,
+    ) {
+        ensure_python_initialized();
+
+        Python::attach(|py| {
+            let instrument_id = InstrumentId::from("AAPL.XNAS");
+            let book = Py::new(py, OrderBook::new(instrument_id, BookType::L2_MBP)).unwrap();
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("accepted_buffer_ns", 1).unwrap();
+
+            let result = if requires_group_size {
+                book.bind(py)
+                    .call_method(method_name, (Decimal::ONE,), Some(&kwargs))
+            } else {
+                book.bind(py).call_method(method_name, (), Some(&kwargs))
+            };
+
+            let py_err = result.unwrap_err();
+
+            assert!(
+                py_err.is_instance_of::<PyValueError>(py),
+                "expected PyValueError, received {}",
+                py_err.get_type(py).name().unwrap().to_str().unwrap()
+            );
+            assert_eq!(
+                py_err.value(py).to_string(),
+                "ts_now must be provided when accepted_buffer_ns > 0"
+            );
+        });
+    }
+}

--- a/crates/model/src/python/orderbook/own.rs
+++ b/crates/model/src/python/orderbook/own.rs
@@ -27,7 +27,10 @@ use rust_decimal::Decimal;
 use crate::{
     enums::{OrderSide, OrderStatus, OrderType, TimeInForce},
     identifiers::{ClientOrderId, InstrumentId, TraderId, VenueOrderId},
-    orderbook::{OwnBookOrder, own::OwnOrderBook},
+    orderbook::{
+        OwnBookOrder,
+        own::{OwnOrderBook, validate_accepted_buffer},
+    },
     types::{Price, Quantity},
 };
 
@@ -291,9 +294,10 @@ impl OwnOrderBook {
         status: Option<HashSet<OrderStatus>>,
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
-    ) -> IndexMap<Decimal, Vec<OwnBookOrder>> {
+    ) -> PyResult<IndexMap<Decimal, Vec<OwnBookOrder>>> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
-        self.bids_as_map(status_set.as_ref(), accepted_buffer_ns, ts_now)
+        Ok(self.bids_as_map(status_set.as_ref(), accepted_buffer_ns, ts_now))
     }
 
     #[pyo3(name = "asks_to_dict")]
@@ -303,15 +307,17 @@ impl OwnOrderBook {
         status: Option<HashSet<OrderStatus>>,
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
-    ) -> IndexMap<Decimal, Vec<OwnBookOrder>> {
+    ) -> PyResult<IndexMap<Decimal, Vec<OwnBookOrder>>> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
-        self.asks_as_map(status_set.as_ref(), accepted_buffer_ns, ts_now)
+        Ok(self.asks_as_map(status_set.as_ref(), accepted_buffer_ns, ts_now))
     }
 
     /// Aggregates own bid quantities per price level, omitting zero-quantity levels.
     ///
-    /// Filters by `status` if provided, including only matching orders. With `accepted_buffer_ns`,
-    /// only includes orders accepted at least that many nanoseconds before `ts_now` (defaults to now).
+    /// Filters by `status` if provided, including only matching orders. When `ts_now` is provided,
+    /// only includes orders whose acceptance time plus `accepted_buffer_ns` is at or before
+    /// `ts_now`. When `ts_now` is `None`, acceptance-time filtering is disabled.
     ///
     /// If `group_size` is provided, groups quantities into price buckets.
     /// If `depth` is provided, limits the number of price levels returned.
@@ -324,21 +330,23 @@ impl OwnOrderBook {
         group_size: Option<Decimal>,
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
-    ) -> IndexMap<Decimal, Decimal> {
+    ) -> PyResult<IndexMap<Decimal, Decimal>> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
-        self.bid_quantity(
+        Ok(self.bid_quantity(
             status_set.as_ref(),
             depth,
             group_size,
             accepted_buffer_ns,
             ts_now,
-        )
+        ))
     }
 
     /// Aggregates own ask quantities per price level, omitting zero-quantity levels.
     ///
-    /// Filters by `status` if provided, including only matching orders. With `accepted_buffer_ns`,
-    /// only includes orders accepted at least that many nanoseconds before `ts_now` (defaults to now).
+    /// Filters by `status` if provided, including only matching orders. When `ts_now` is provided,
+    /// only includes orders whose acceptance time plus `accepted_buffer_ns` is at or before
+    /// `ts_now`. When `ts_now` is `None`, acceptance-time filtering is disabled.
     ///
     /// If `group_size` is provided, groups quantities into price buckets.
     /// If `depth` is provided, limits the number of price levels returned.
@@ -351,15 +359,16 @@ impl OwnOrderBook {
         group_size: Option<Decimal>,
         accepted_buffer_ns: Option<u64>,
         ts_now: Option<u64>,
-    ) -> IndexMap<Decimal, Decimal> {
+    ) -> PyResult<IndexMap<Decimal, Decimal>> {
+        validate_accepted_buffer(accepted_buffer_ns, ts_now).map_err(to_pyvalue_err)?;
         let status_set: Option<AHashSet<OrderStatus>> = status.map(|s| s.into_iter().collect());
-        self.ask_quantity(
+        Ok(self.ask_quantity(
             status_set.as_ref(),
             depth,
             group_size,
             accepted_buffer_ns,
             ts_now,
-        )
+        ))
     }
 
     /// Returns a new own book containing this books orders plus parity-transformed opposite orders.

--- a/docs/concepts/order_book.md
+++ b/docs/concepts/order_book.md
@@ -221,8 +221,9 @@ let filtered = book.filtered_view(Some(&own_book), None, status, None, None);
 The `accepted_buffer_ns` parameter provides a grace period: when set, only orders
 where `ts_accepted + buffer <= now` are included. This excludes recently accepted
 orders that may not yet appear in the public book feed. The buffer applies to the
-`ts_accepted` field regardless of order status. Combine with a status filter to
-also exclude non-accepted orders.
+`ts_accepted` field regardless of order status. Omitting `ts_now` disables
+acceptance-time filtering, and a positive `accepted_buffer_ns` requires `ts_now`.
+Combine with a status filter to also exclude non-accepted orders.
 
 ```rust
 // Only subtract orders accepted at least 500ms ago


### PR DESCRIPTION
A follow-up to the `DataType` identity work in #4592, covering another invariant in the same family: a query result that depends on when it was asked.

## Own-book filtering compared engine timestamps against the machine wall clock

`filter_orders` in `crates/model/src/orderbook/own.rs` substituted `nanos_since_unix_epoch` for a missing `ts_now`, then applied `ts_accepted + accepted_buffer_ns <= ts_now` unconditionally. The predicate was not gated on a buffer having been requested, so with `accepted_buffer_ns` absent it degraded to `ts_accepted <= wall_clock` and still consulted the system clock. Every caller that omitted `ts_now` was therefore wall-clock dependent, not only those asking for a grace period, and `bids_as_map`, `asks_as_map`, `bid_quantity` and `ask_quantity` all funnel through it.

Nothing else on this path is wall-clock driven. Backtests run on a simulated clock and `ts_accepted` values originate there, so the comparison mixed two unrelated time bases: an own-order query could include or exclude an order based on the machine clock at the moment it ran.

The tree already recorded the intended meaning in two places. The property-test reference implementation substituted `u64::MAX` for a missing `ts_now`, that is "no filtering", and the execution-engine tests' own comments describe `None, None` as "no filter". The oracle and the implementation had disagreed since the parameter was introduced.

`ts_now` is now the switch that controls acceptance-time filtering. With no time source the acceptance time is not inspected at all; with `Some(t)` the order must satisfy `ts_accepted + accepted_buffer_ns <= t`. A positive buffer with no `ts_now` is a caller error rather than a silently ignored request, matching the existing higher-level cache API which already rejects that combination. The addition is checked, so a buffer that would push eligibility past `u64::MAX` excludes the order instead of overflowing; saturating would wrongly admit it at `ts_now == u64::MAX` and wrapping would admit it near zero.

`nanos_since_unix_epoch` is no longer imported by the module.

## Grouped own-book rendering inherited the same dependency

`pprint_own_book` requests grouped quantities with no status, no buffer and no time. Under the previous semantics that still applied the wall-clock predicate, so grouped rendering could omit orders while the ungrouped branch, which walks the ladders directly, always showed them. The two branches disagreed about membership.

The new contract resolves this at the source: passing no time source performs no acceptance filtering, so grouped and ungrouped rendering now agree, and grouping changes bucketing and depth rather than which orders exist in the view. Rust `Display` never routed through this path and is unchanged.

## Testing

`test_own_order_book_missing_ts_now_skips_acceptance_filter` pins the core semantics with an order accepted at `UnixNanos::max()`: it is present with no time source and absent with an explicit `ts_now` of zero. The timestamp is deliberately `UnixNanos::max()` rather than a value derived from the current wall clock, so the assertion cannot pass by accident of when the suite runs.

`test_own_order_book_acceptance_buffer_overflow_excludes_order` covers the overflow boundary separately, and `test_own_order_book_positive_accepted_buffer_without_ts_now_panics` pins the caller error. `test_own_book_grouped_pprint_includes_future_accepted_order` asserts the future-dated order's price and quantity appear in grouped output, which protects the rendering path specifically; the map-level assertions alone would not prove rendering is membership-neutral.

Each was verified to fail against the unfixed implementation, and each fails for the mechanism it names: the first at its own membership assertion, the second on the overflow panic in the unchecked addition. These began as one test, which failed against the unfixed code only at the overflow call and so never exercised the wall-clock comparison; they were split so the differential evidence is unambiguous.

The 49 existing call sites in `crates/execution/tests/exec_engine.rs` that pass no buffer and no time are unmodified and their expected results are unchanged. Those tests use zero-based test clocks that are never advanced, so their acceptance timestamps sat far below the wall clock and the previous predicate already admitted the orders; the change removes a condition they were never asserting.

The property-test reference implementation was updated to match the new contract, replacing its `u64::MAX` approximation of "no filtering" with the same absent-time semantics.
