### PR TITLE
Align Eq and Ord on ScheduledTimeEvent and OwnBookOrder

### DIFF
--- a/crates/common/src/timer.rs
+++ b/crates/common/src/timer.rs
@@ -125,7 +125,13 @@ impl PartialOrd for ScheduledTimeEvent {
 impl Ord for ScheduledTimeEvent {
     fn cmp(&self, other: &Self) -> Ordering {
         // Reverse order for max heap: earlier timestamps have higher priority
-        other.0.ts_event.cmp(&self.0.ts_event)
+        other
+            .0
+            .ts_event
+            .cmp(&self.0.ts_event)
+            .then_with(|| other.0.name.cmp(&self.0.name))
+            .then_with(|| other.0.ts_init.cmp(&self.0.ts_init))
+            .then_with(|| other.0.event_id.as_str().cmp(self.0.event_id.as_str()))
     }
 }
 
@@ -563,7 +569,7 @@ impl Iterator for TestTimer {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, num::NonZeroU64, rc::Rc};
+    use std::{cell::RefCell, collections::BinaryHeap, num::NonZeroU64, rc::Rc};
 
     use nautilus_core::{UUID4, UnixNanos};
     #[cfg(feature = "python")]
@@ -577,7 +583,10 @@ mod tests {
     use rstest::*;
     use ustr::Ustr;
 
-    use super::{TestTimer, TimeEvent, TimeEventCallback, TimeEventHandler, create_valid_interval};
+    use super::{
+        ScheduledTimeEvent, TestTimer, TimeEvent, TimeEventCallback, TimeEventHandler,
+        create_valid_interval,
+    };
     use crate::msgbus::{
         BusTap, Endpoint, MStr, MessagingSwitchboard, Topic, clear_bus_tap, set_bus_tap,
     };
@@ -785,6 +794,97 @@ mod tests {
         assert!(earlier_name < later_init);
         assert!(earlier_name < later_id);
         assert_ne!(earlier_name, later_id);
+    }
+
+    #[rstest]
+    fn test_scheduled_time_event_ordering_laws() {
+        let base = ScheduledTimeEvent::new(TimeEvent::new(
+            Ustr::from("ALPHA"),
+            UUID4::from("00000000-0000-4000-8000-000000000001"),
+            100.into(),
+            10.into(),
+        ));
+        let variants = [
+            base.clone(),
+            ScheduledTimeEvent::new(TimeEvent::new(
+                Ustr::from("BETA"),
+                base.0.event_id,
+                base.0.ts_event,
+                base.0.ts_init,
+            )),
+            ScheduledTimeEvent::new(TimeEvent::new(
+                base.0.name,
+                UUID4::from("00000000-0000-4000-8000-000000000002"),
+                base.0.ts_event,
+                base.0.ts_init,
+            )),
+            ScheduledTimeEvent::new(TimeEvent::new(
+                base.0.name,
+                base.0.event_id,
+                101.into(),
+                base.0.ts_init,
+            )),
+            ScheduledTimeEvent::new(TimeEvent::new(
+                base.0.name,
+                base.0.event_id,
+                base.0.ts_event,
+                11.into(),
+            )),
+        ];
+
+        for a in &variants {
+            for b in &variants {
+                assert_eq!(a == b, a.cmp(b).is_eq());
+                assert_eq!(a.partial_cmp(b), Some(a.cmp(b)));
+                assert_eq!(a.cmp(b), b.cmp(a).reverse());
+            }
+        }
+    }
+
+    #[rstest]
+    fn test_scheduled_time_event_heap_ordering() {
+        let expected = [
+            TimeEvent::new(
+                Ustr::from("ALPHA"),
+                UUID4::from("00000000-0000-4000-8000-000000000001"),
+                100.into(),
+                10.into(),
+            ),
+            TimeEvent::new(
+                Ustr::from("ALPHA"),
+                UUID4::from("00000000-0000-4000-8000-000000000002"),
+                100.into(),
+                10.into(),
+            ),
+            TimeEvent::new(
+                Ustr::from("ALPHA"),
+                UUID4::from("00000000-0000-4000-8000-000000000003"),
+                100.into(),
+                11.into(),
+            ),
+            TimeEvent::new(
+                Ustr::from("BETA"),
+                UUID4::from("00000000-0000-4000-8000-000000000004"),
+                100.into(),
+                10.into(),
+            ),
+            TimeEvent::new(
+                Ustr::from("ALPHA"),
+                UUID4::from("00000000-0000-4000-8000-000000000005"),
+                101.into(),
+                10.into(),
+            ),
+        ];
+        let insertion_order = [4, 1, 3, 0, 2];
+        let mut heap = BinaryHeap::new();
+
+        for index in insertion_order {
+            heap.push(ScheduledTimeEvent::new(expected[index].clone()));
+        }
+
+        let popped = std::iter::from_fn(|| heap.pop().map(ScheduledTimeEvent::into_inner))
+            .collect::<Vec<_>>();
+        assert_eq!(popped, expected);
     }
 
     #[cfg(feature = "python")]

--- a/crates/model/src/orderbook/own.rs
+++ b/crates/model/src/orderbook/own.rs
@@ -141,9 +141,7 @@ impl OwnBookOrder {
 
 impl Ord for OwnBookOrder {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.ts_init
-            .cmp(&other.ts_init)
-            .then_with(|| self.client_order_id.cmp(&other.client_order_id))
+        self.client_order_id.cmp(&other.client_order_id)
     }
 }
 

--- a/crates/model/src/orderbook/tests.rs
+++ b/crates/model/src/orderbook/tests.rs
@@ -13,7 +13,10 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, hash_map::DefaultHasher},
+    hash::{Hash, Hasher},
+};
 
 use ahash::AHashSet;
 use indexmap::IndexMap;
@@ -3737,6 +3740,50 @@ fn own_order() -> OwnBookOrder {
         ts_submitted,
         ts_init,
     )
+}
+
+#[rstest]
+fn test_own_order_ordering_laws(own_order: OwnBookOrder) {
+    let mut updated = own_order;
+    updated.price = Price::from("101.00");
+    updated.size = Quantity::from("5");
+    updated.status = OrderStatus::Accepted;
+    updated.ts_last = 20.into();
+    updated.ts_accepted = 15.into();
+    updated.ts_init = 10.into();
+
+    assert_eq!(own_order, updated);
+    assert_eq!(own_order.cmp(&updated), std::cmp::Ordering::Equal);
+
+    let mut original_hasher = DefaultHasher::new();
+    own_order.hash(&mut original_hasher);
+    let mut updated_hasher = DefaultHasher::new();
+    updated.hash(&mut updated_hasher);
+    assert_eq!(original_hasher.finish(), updated_hasher.finish());
+
+    let mut lower_id_later_timestamp = own_order;
+    lower_id_later_timestamp.client_order_id = ClientOrderId::from("O-100");
+    lower_id_later_timestamp.ts_init = 200.into();
+    let mut higher_id_earlier_timestamp = own_order;
+    higher_id_earlier_timestamp.client_order_id = ClientOrderId::from("O-200");
+    higher_id_earlier_timestamp.ts_init = 100.into();
+
+    assert!(lower_id_later_timestamp < higher_id_earlier_timestamp);
+
+    let variants = [
+        own_order,
+        updated,
+        lower_id_later_timestamp,
+        higher_id_earlier_timestamp,
+    ];
+
+    for a in &variants {
+        for b in &variants {
+            assert_eq!(a == b, a.cmp(b).is_eq());
+            assert_eq!(a.partial_cmp(b), Some(a.cmp(b)));
+            assert_eq!(a.cmp(b), b.cmp(a).reverse());
+        }
+    }
 }
 
 #[rstest]


### PR DESCRIPTION
A follow-up to the identity-invariant work in #4592 and #4597, covering two types whose `Eq` and `Ord` implementations disagree.

Both are contract repairs with no demonstrated in-tree consequence. `Ord` requires that `a == b` exactly when `a.cmp(&b)` is `Equal`, and neither type satisfies that today, but no container in the tree combines the two relations: nothing deduplicates on `Equal`, and nothing sorts or searches these values. They are worth fixing because the contracts are wrong, not because something observable is broken.

## `ScheduledTimeEvent` compares equal on equal timestamps alone

`ScheduledTimeEvent` derives full-field equality over the inner `TimeEvent`, while its `Ord` compares only `ts_event`, reversed so the `BinaryHeap` yields the earliest timestamp first. Two events scheduled at the same instant therefore compare `Equal` while differing in name, event ID or `ts_init`.

The comparator now orders by `(ts_event, name, ts_init, event_id)` with every component reversed. That is not a newly invented key: `TimeEventHandler::cmp_event` already orders by exactly those four fields in the same sequence, so this is the existing tie-break reversed for heap use, and its first two components match the `(ts_event, name)` sort `TestClock::advance_time` applies to the events it returns.

Equal-timestamp entries now follow that tie-break instead of comparing `Equal`; earliest timestamps remain highest priority, and `TestClock::advance_time` continues to return events ordered by `(ts_event, name)`. Note that `TestTimer::next` mints a fresh `UUID4` per event as it iterates, so a changed processing order among simultaneous timers can change which opaque event ID accompanies which event. No consumer relies on that association and UUID allocation has no ordering contract, but the change is not literally invisible.

## `OwnBookOrder` orders by a field its identity ignores

`OwnBookOrder` compares equal on `client_order_id` alone and hashes on the same field, so equality and hashing agree. Its `Ord` compares `(ts_init, client_order_id)`, so two snapshots of the same order taken at different initialization times are equal yet order as `Less` or `Greater`.

`Ord` is the implementation that drifted. `3dfb7e0858` deliberately narrowed equality to `client_order_id`, removing `status` and `ts_last`, and in the same commit added `client_order_id` as an ordering tie-break while leaving `ts_init` primary. Identity is the client order ID everywhere else too: the ladder stores orders in an `IndexMap` keyed by `ClientOrderId`, and updates change status, price, size and timestamps without changing which order a record refers to.

The comparator is now `client_order_id` alone, leaving `PartialEq`, `Eq` and `Hash` untouched. The alternative, widening equality and hashing to include `ts_init`, would preserve the current sort order at the cost of changing what identity means for a type whose storage, and whose Python `__eq__` and `__hash__`, already treat the ID as identity.

External Rust callers that sort `OwnBookOrder` move from chronological to client-order-ID ordering. There is no such caller in this repository.

## Testing

`test_scheduled_time_event_ordering_laws` and `test_own_order_ordering_laws` assert the law directly over a sample that varies each participating field independently: `a == b` matches `a.cmp(&b).is_eq()`, `partial_cmp` delegates to `cmp`, and comparison is antisymmetric. The own-order test additionally pins that equal orders hash equally, and compares two orders whose timestamp order is deliberately opposed to their ID order, which is what proves `ts_init` has left the ordering.

`test_scheduled_time_event_heap_ordering` pins the heap direction with fixed UUIDs, asserting the full pop sequence for events differing by timestamp, name, `ts_init` and event ID. Entries are pushed in a different order than they are expected to pop, so the test proves the comparator rather than insertion stability.

All three were verified to fail against the unfixed implementations: the two law tests because same-timestamp and same-ID values compare `Equal` while being unequal, and the heap test because equal-timestamp ordering was previously undefined.

No test asserts a container-level divergence, because there is no such consumer to exercise.
