### PR TITLE
Fix Clippy findings in kernel and Derive bins

### DIFF
--- a/crates/adapters/derive/bin/flatten.rs
+++ b/crates/adapters/derive/bin/flatten.rs
@@ -125,7 +125,7 @@ async fn main() -> anyhow::Result<()> {
     )?;
     let domain_separator = parse_b256(domain_separator_for(environment), "domain_separator")?;
     let action_typehash_bytes = parse_b256(ACTION_TYPEHASH, "ACTION_TYPEHASH")?;
-    let nonce_manager = NonceManager::default();
+    let nonce_manager = NonceManager;
 
     cancel_all_orders(&client, subaccount_id).await?;
     verify_no_open_orders(&client, subaccount_id).await?;

--- a/crates/adapters/derive/bin/spot_research.rs
+++ b/crates/adapters/derive/bin/spot_research.rs
@@ -124,7 +124,7 @@ async fn main() -> anyhow::Result<()> {
     let action_typehash: B256 = ACTION_TYPEHASH
         .parse()
         .map_err(|e| anyhow::anyhow!("failed to parse ACTION_TYPEHASH: {e}"))?;
-    let nonce_manager = NonceManager::default();
+    let nonce_manager = NonceManager;
 
     let instruments = client
         .get_instruments("ETH", DeriveInstrumentType::Erc20, false)

--- a/crates/system/src/kernel.rs
+++ b/crates/system/src/kernel.rs
@@ -740,8 +740,10 @@ impl NautilusKernel {
     /// # Errors
     ///
     /// Returns an error if actor or strategy state cannot be saved.
+    #[allow(unknown_lints, reason = "Clippy lint is unavailable on Rust 1.97")]
     #[expect(
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "keeps the public async kernel API shape stable"
     )]
     pub async fn finalize_stop(&mut self) -> anyhow::Result<()> {


### PR DESCRIPTION
Three findings from a workspace-wide `cargo clippy --all-targets` sweep that no current CI lane reaches: one from clippy 1.98's new lints, following the nightly Clippy fixes in `88901da1a0`, and two stable-clippy findings introduced by `99f56028bc`.

## Suppress `unused_async_trait_impl` on `NautilusKernel::finalize_stop`

Clippy 1.98 adds `unused_async_trait_impl` as a sibling of `unused_async`, and its `check_impl_item` pass examines every `async fn` in an impl block without checking whether the impl implements a trait - so it also fires on the inherent `finalize_stop`, which already carries `#[expect(clippy::unused_async)]` for the same underlying condition. The fix applies the same idiom `88901da1a0` introduced for `reconcile_execution_mass_status` and the two websocket client sites: `#[allow(unknown_lints)]` (the lint id is unknown to 1.97) above an expect naming both lints. The `async` signature is unchanged.

## Construct `NonceManager` directly in the derive bins

`default_constructed_unit_structs` fires on `NonceManager::default()` in `bin/flatten.rs` and `bin/spot_research.rs`: `99f56028bc` made `NonceManager` a process-wide unit struct but left the two bins constructing it via `default()`. The lint is stable and warn-by-default, and went unseen because those files were not part of that change, so changed-files linting never revisited them. Both sites now use the unit-struct literal.

## Testing

No test changes - nothing behavioral changes. The differential is Clippy itself: a workspace `cargo clippy --all-targets` sweep reports exactly these three errors without the change and none with it. The two `default_constructed_unit_structs` findings are visible to the pinned 1.97.1 under the same sweep; `unused_async_trait_impl` is new in clippy 1.98, and on 1.97.1 the kernel attribute is inert (`unknown_lints` allowed, and the unit-struct literal is idiomatic under both).
