### PR TITLE
Select Nautilus test data fixtures by the model's resolved precision

### DIFF
--- a/crates/testkit/Cargo.toml
+++ b/crates/testkit/Cargo.toml
@@ -125,6 +125,10 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [[test]]
+name = "common"
+required-features = ["datasets"]
+
+[[test]]
 name = "large_data"
 required-features = ["datasets"]
 

--- a/crates/testkit/src/common.rs
+++ b/crates/testkit/src/common.rs
@@ -23,6 +23,7 @@ use nautilus_core::paths::get_test_data_path;
 use nautilus_model::{
     data::OrderBookDelta,
     instruments::{InstrumentAny, stubs::equity_aapl_itch},
+    types::fixed::PRECISION_BYTES,
 };
 use nautilus_serialization::arrow::DecodeFromRecordBatch;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -49,18 +50,11 @@ pub fn get_test_data_file_path(path: &str) -> String {
 ///
 /// Panics if the computed path cannot be represented as a valid UTF-8 string.
 #[must_use]
-#[allow(unused_mut)]
 pub fn get_nautilus_test_data_file_path(filename: &str) -> String {
-    let mut path = get_test_data_path().join("nautilus");
-
-    #[cfg(feature = "high-precision")]
-    {
-        path = path.join("128-bit");
-    }
-    #[cfg(not(feature = "high-precision"))]
-    {
-        path = path.join("64-bit");
-    }
+    let precision_directory = format!("{}-bit", PRECISION_BYTES * 8);
+    let path = get_test_data_path()
+        .join("nautilus")
+        .join(precision_directory);
 
     path.join(filename).to_str().unwrap().to_string()
 }

--- a/crates/testkit/tests/common.rs
+++ b/crates/testkit/tests/common.rs
@@ -1,0 +1,41 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::{fs::File, mem::size_of};
+
+use arrow::datatypes::DataType;
+use nautilus_model::types::{price::PriceRaw, quantity::QuantityRaw};
+use nautilus_testkit::common::get_nautilus_test_data_file_path;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use rstest::rstest;
+
+#[rstest]
+fn selected_fixture_fixed_widths_match_model_raw_types() {
+    let filepath = get_nautilus_test_data_file_path("quotes.parquet");
+    let file = File::open(filepath).unwrap();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+    let schema = builder.schema();
+
+    assert_eq!(
+        schema.field_with_name("bid_price").unwrap().data_type(),
+        &DataType::FixedSizeBinary(i32::try_from(size_of::<PriceRaw>()).unwrap()),
+        "selected fixture price width must match PriceRaw",
+    );
+    assert_eq!(
+        schema.field_with_name("bid_size").unwrap().data_type(),
+        &DataType::FixedSizeBinary(i32::try_from(size_of::<QuantityRaw>()).unwrap()),
+        "selected fixture quantity width must match QuantityRaw",
+    );
+}


### PR DESCRIPTION
`get_nautilus_test_data_file_path` selected the 64-bit or 128-bit fixture directory from testkit's own `high-precision` feature, which cargo feature unification can leave disagreeing with the width the model actually compiled.

## Key fixture selection on the resolved width, not testkit's cfg

`defi` implies `high-precision` in `nautilus-model`, widening `PriceRaw`/`QuantityRaw` to `i128` - but enabling `nautilus-model/defi` (which any workspace build pulling `nautilus-blockchain` does) enables nothing on `nautilus-testkit`, so the helper keeps handing 64-bit fixtures to a 128-bit decoder. Arrow validation rejects the 8-byte column (`serialization/src/arrow/mod.rs:536`) and the decode error is unwrapped inside the spawned stream task (`persistence/src/backend/session.rs:253`), so the failure surfaces as silently empty query results: six `test_catalog` tests fail with len-0/index-out-of-bounds under `cargo test -p nautilus-persistence --features nautilus-model/defi`. Default and CI builds keep the two widths agreeing, which is why the desync is invisible there.

The helper now derives the directory from `nautilus_model::types::fixed::PRECISION_BYTES` - the same width contract the Arrow encoders and decoders of these fixtures follow - so selection tracks the resolved width under every unification. The `common` module compiles only under testkit's `datasets` feature, which enables `nautilus-model`, so the dependency is always present. Testkit's `high-precision` feature keeps its remaining roles: forwarding width to model/serialization and gating the 128-bit-only order book integration tests.

## Testing

New `selected_fixture_fixed_widths_match_model_raw_types` in `crates/testkit/tests/common.rs` (guarded by `required-features = ["datasets"]` like the crate's other integration tests): it opens the parquet schema of the file the helper actually selects and asserts the `FixedSizeBinary` widths of `bid_price` and `bid_size` equal `size_of::<PriceRaw>()` and `size_of::<QuantityRaw>()` - deliberately a different oracle from the production selector. The assertion was verified to fail against the unfixed helper under `--features nautilus-model/defi` (8-byte schema selected while `PriceRaw` is 16 bytes) and to pass under both the defi and standard-width shapes with the fix; the previously failing persistence catalog queries pass under `nautilus-model/defi`.
