### PR TITLE
Align Subscription equality and ordering and name the delivery comparator

### DIFF
--- a/crates/common/src/msgbus/api.rs
+++ b/crates/common/src/msgbus/api.rs
@@ -258,7 +258,7 @@ pub fn subscribe_any(
     for (topic, subs) in &mut msgbus_ref_mut.topics {
         if is_matching_backtracking(*topic, sub.pattern) {
             subs.push(sub.clone());
-            subs.sort();
+            subs.sort_by(Subscription::delivery_order);
             log::debug!("Added subscription for '{topic}'");
         }
     }

--- a/crates/common/src/msgbus/core.rs
+++ b/crates/common/src/msgbus/core.rs
@@ -165,6 +165,14 @@ impl Subscription {
             priority: priority.unwrap_or(0),
         }
     }
+
+    pub(crate) fn delivery_order(&self, other: &Self) -> std::cmp::Ordering {
+        other
+            .priority
+            .cmp(&self.priority)
+            .then_with(|| self.pattern.cmp(&other.pattern))
+            .then_with(|| self.handler_id.cmp(&other.handler_id))
+    }
 }
 
 impl PartialEq<Self> for Subscription {
@@ -183,10 +191,8 @@ impl PartialOrd for Subscription {
 
 impl Ord for Subscription {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        other
-            .priority
-            .cmp(&self.priority)
-            .then_with(|| self.pattern.cmp(&other.pattern))
+        self.pattern
+            .cmp(&other.pattern)
             .then_with(|| self.handler_id.cmp(&other.handler_id))
     }
 }
@@ -752,7 +758,7 @@ impl MessageBus {
     pub(crate) fn inner_matching_subscriptions(&mut self, topic: MStr<Topic>) -> Vec<Subscription> {
         self.topics.get(&topic).cloned().unwrap_or_else(|| {
             let mut matches = self.find_topic_matches(topic);
-            matches.sort();
+            matches.sort_by(Subscription::delivery_order);
             self.topics.insert(topic, matches.clone());
             matches
         })
@@ -770,7 +776,7 @@ impl MessageBus {
             }
         } else {
             let mut matches = self.find_topic_matches(topic);
-            matches.sort();
+            matches.sort_by(Subscription::delivery_order);
 
             for sub in &matches {
                 buf.push(sub.handler.clone());
@@ -802,17 +808,97 @@ impl MessageBus {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        any::Any,
+        cell::RefCell,
+        collections::hash_map::DefaultHasher,
+        fmt::Debug,
+        hash::{Hash, Hasher},
+        rc::Rc,
+    };
+
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use rstest::rstest;
     use ustr::Ustr;
 
     use super::*;
     use crate::msgbus::{
-        self, ShareableMessageHandler, get_message_bus,
+        self, Handler, ShareableMessageHandler, get_message_bus,
         matching::is_matching_backtracking,
         stubs::{get_any_saving_handler, get_call_check_handler, get_stub_shareable_handler},
         subscriptions_count_any,
+        typed_handler::shareable_handler,
     };
+
+    #[derive(Debug)]
+    struct RecordingAnyHandler {
+        id: Ustr,
+        label: &'static str,
+        order: Rc<RefCell<Vec<&'static str>>>,
+    }
+
+    impl Handler<dyn Any> for RecordingAnyHandler {
+        fn id(&self) -> Ustr {
+            self.id
+        }
+
+        fn handle(&self, _message: &dyn Any) {
+            self.order.borrow_mut().push(self.label);
+        }
+    }
+
+    fn recording_any_handler(
+        id: &'static str,
+        label: &'static str,
+        order: Rc<RefCell<Vec<&'static str>>>,
+    ) -> ShareableMessageHandler {
+        shareable_handler(Rc::new(RecordingAnyHandler {
+            id: Ustr::from(id),
+            label,
+            order,
+        }))
+    }
+
+    #[rstest]
+    fn test_subscription_ordering_laws() {
+        let handler = get_stub_shareable_handler(Some(Ustr::from("handler-b")));
+        let base = Subscription::new("pattern-b".into(), handler.clone(), Some(1));
+        let different_priority = Subscription::new("pattern-b".into(), handler, Some(2));
+        let different_pattern = Subscription::new(
+            "pattern-a".into(),
+            get_stub_shareable_handler(Some(Ustr::from("handler-b"))),
+            Some(1),
+        );
+        let different_handler = Subscription::new(
+            "pattern-b".into(),
+            get_stub_shareable_handler(Some(Ustr::from("handler-a"))),
+            Some(1),
+        );
+
+        assert_eq!(base, different_priority);
+        assert_eq!(base.cmp(&different_priority), std::cmp::Ordering::Equal);
+
+        let mut base_hasher = DefaultHasher::new();
+        base.hash(&mut base_hasher);
+        let mut different_priority_hasher = DefaultHasher::new();
+        different_priority.hash(&mut different_priority_hasher);
+        assert_eq!(base_hasher.finish(), different_priority_hasher.finish());
+
+        let variants = [
+            base,
+            different_priority,
+            different_pattern,
+            different_handler,
+        ];
+
+        for a in &variants {
+            for b in &variants {
+                assert_eq!(a == b, a.cmp(b).is_eq());
+                assert_eq!(a.partial_cmp(b), Some(a.cmp(b)));
+                assert_eq!(a.cmp(b), b.cmp(a).reverse());
+            }
+        }
+    }
 
     #[rstest]
     fn test_new() {
@@ -1212,6 +1298,121 @@ mod tests {
         assert_eq!(subs[1].handler_id, handler_id3);
         assert_eq!(subs[2].handler_id, handler_id1);
         assert_eq!(subs[3].handler_id, handler_id2);
+    }
+
+    #[rstest]
+    fn test_matching_subscriptions_orders_by_full_delivery_key_on_cache_miss() {
+        MessageBus::default().register_message_bus();
+        let order = Rc::new(RefCell::new(Vec::new()));
+
+        msgbus::subscribe_any(
+            "delivery.*".into(),
+            recording_any_handler("handler-z", "low-z", order.clone()),
+            Some(1),
+        );
+        msgbus::subscribe_any(
+            "delivery.topic".into(),
+            recording_any_handler("handler-b", "exact-b", order.clone()),
+            Some(10),
+        );
+        msgbus::subscribe_any(
+            "delivery.topic".into(),
+            recording_any_handler("handler-a", "exact-a", order.clone()),
+            Some(10),
+        );
+        msgbus::subscribe_any(
+            "delivery.*".into(),
+            recording_any_handler("handler-b", "wildcard-b", order),
+            Some(10),
+        );
+
+        let subscriptions = get_message_bus()
+            .borrow_mut()
+            .matching_subscriptions("delivery.topic");
+        let actual = subscriptions
+            .iter()
+            .map(|sub| (sub.priority, sub.pattern.as_str(), sub.handler_id.as_str()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                (10, "delivery.*", "handler-b"),
+                (10, "delivery.topic", "handler-a"),
+                (10, "delivery.topic", "handler-b"),
+                (1, "delivery.*", "handler-z"),
+            ]
+        );
+    }
+
+    #[rstest]
+    fn test_first_uncached_publish_any_orders_by_full_delivery_key() {
+        MessageBus::default().register_message_bus();
+        let order = Rc::new(RefCell::new(Vec::new()));
+
+        msgbus::subscribe_any(
+            "delivery.*".into(),
+            recording_any_handler("handler-z", "low-z", order.clone()),
+            Some(1),
+        );
+        msgbus::subscribe_any(
+            "delivery.topic".into(),
+            recording_any_handler("handler-b", "exact-b", order.clone()),
+            Some(10),
+        );
+        msgbus::subscribe_any(
+            "delivery.topic".into(),
+            recording_any_handler("handler-a", "exact-a", order.clone()),
+            Some(10),
+        );
+        msgbus::subscribe_any(
+            "delivery.*".into(),
+            recording_any_handler("handler-b", "wildcard-b", order.clone()),
+            Some(10),
+        );
+
+        msgbus::publish_any("delivery.topic".into(), &());
+
+        assert_eq!(
+            *order.borrow(),
+            vec!["wildcard-b", "exact-a", "exact-b", "low-z"]
+        );
+    }
+
+    #[rstest]
+    fn test_late_subscription_orders_cached_any_topic_by_full_delivery_key() {
+        MessageBus::default().register_message_bus();
+        let order = Rc::new(RefCell::new(Vec::new()));
+
+        msgbus::subscribe_any(
+            "delivery.*".into(),
+            recording_any_handler("handler-z", "low-z", order.clone()),
+            Some(1),
+        );
+        msgbus::subscribe_any(
+            "delivery.topic".into(),
+            recording_any_handler("handler-b", "exact-b", order.clone()),
+            Some(10),
+        );
+        msgbus::subscribe_any(
+            "delivery.topic".into(),
+            recording_any_handler("handler-a", "exact-a", order.clone()),
+            Some(10),
+        );
+        msgbus::publish_any("delivery.topic".into(), &());
+        order.borrow_mut().clear();
+
+        msgbus::subscribe_any(
+            "delivery.*".into(),
+            recording_any_handler("handler-b", "wildcard-b", order.clone()),
+            Some(10),
+        );
+        msgbus::publish_any("delivery.topic".into(), &());
+
+        assert_eq!(
+            *order.borrow(),
+            vec!["wildcard-b", "exact-a", "exact-b", "low-z"]
+        );
     }
 
     #[rstest]

--- a/crates/common/src/msgbus/typed_router.rs
+++ b/crates/common/src/msgbus/typed_router.rs
@@ -60,6 +60,14 @@ impl<T: 'static> TypedSubscription<T> {
             priority: priority.unwrap_or(0),
         }
     }
+
+    fn delivery_order(&self, other: &Self) -> Ordering {
+        other
+            .priority
+            .cmp(&self.priority)
+            .then_with(|| self.pattern.cmp(&other.pattern))
+            .then_with(|| self.handler_id.cmp(&other.handler_id))
+    }
 }
 
 impl<T: 'static> Debug for TypedSubscription<T> {
@@ -89,11 +97,8 @@ impl<T: 'static> PartialOrd for TypedSubscription<T> {
 
 impl<T: 'static> Ord for TypedSubscription<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Higher priority first (descending)
-        other
-            .priority
-            .cmp(&self.priority)
-            .then_with(|| self.pattern.cmp(&other.pattern))
+        self.pattern
+            .cmp(&other.pattern)
             .then_with(|| self.handler_id.cmp(&other.handler_id))
     }
 }
@@ -183,9 +188,10 @@ impl<T: 'static> TopicRouter<T> {
 
         self.subscriptions.push(sub);
 
-        // Re-sort by priority (descending), then clear index cache
-        // since sort can rearrange all indices
-        self.subscriptions.sort();
+        // Re-sort by priority descending, pattern ascending, then handler ID ascending.
+        // Clear the index cache since sorting can rearrange all indices.
+        self.subscriptions
+            .sort_by(TypedSubscription::delivery_order);
         self.topic_cache.clear();
     }
 
@@ -377,11 +383,57 @@ impl<T: 'static> TopicRouter<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc};
+    use std::{
+        cell::RefCell,
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+        rc::Rc,
+    };
 
     use rstest::rstest;
 
     use super::*;
+
+    #[rstest]
+    fn test_typed_subscription_ordering_laws() {
+        let handler = TypedHandler::from_with_id("handler-b", |_: &i32| {});
+        let base = TypedSubscription::new("pattern-b".into(), handler.clone(), Some(1));
+        let different_priority = TypedSubscription::new("pattern-b".into(), handler, Some(2));
+        let different_pattern = TypedSubscription::new(
+            "pattern-a".into(),
+            TypedHandler::from_with_id("handler-b", |_: &i32| {}),
+            Some(1),
+        );
+        let different_handler = TypedSubscription::new(
+            "pattern-b".into(),
+            TypedHandler::from_with_id("handler-a", |_: &i32| {}),
+            Some(1),
+        );
+
+        assert_eq!(base, different_priority);
+        assert_eq!(base.cmp(&different_priority), Ordering::Equal);
+
+        let mut base_hasher = DefaultHasher::new();
+        base.hash(&mut base_hasher);
+        let mut different_priority_hasher = DefaultHasher::new();
+        different_priority.hash(&mut different_priority_hasher);
+        assert_eq!(base_hasher.finish(), different_priority_hasher.finish());
+
+        let variants = [
+            base,
+            different_priority,
+            different_pattern,
+            different_handler,
+        ];
+
+        for a in &variants {
+            for b in &variants {
+                assert_eq!(a == b, a.cmp(b).is_eq());
+                assert_eq!(a.partial_cmp(b), Some(a.cmp(b)));
+                assert_eq!(a.cmp(b), b.cmp(a).reverse());
+            }
+        }
+    }
 
     #[rstest]
     fn test_topic_router_subscribe_and_publish() {
@@ -403,29 +455,39 @@ mod tests {
     }
 
     #[rstest]
-    fn test_topic_router_priority_ordering() {
+    fn test_topic_router_publish_orders_by_full_delivery_key() {
         let mut router = TopicRouter::<i32>::new();
         let order = Rc::new(RefCell::new(Vec::new()));
 
-        let order1 = order.clone();
-        let handler1 = TypedHandler::from_with_id("low", move |_: &i32| {
-            order1.borrow_mut().push("low");
+        let low_order = order.clone();
+        let low = TypedHandler::from_with_id("handler-z", move |_: &i32| {
+            low_order.borrow_mut().push("low-z");
+        });
+        let exact_b_order = order.clone();
+        let exact_b = TypedHandler::from_with_id("handler-b", move |_: &i32| {
+            exact_b_order.borrow_mut().push("exact-b");
+        });
+        let exact_a_order = order.clone();
+        let exact_a = TypedHandler::from_with_id("handler-a", move |_: &i32| {
+            exact_a_order.borrow_mut().push("exact-a");
+        });
+        let wildcard_b_order = order.clone();
+        let wildcard_b = TypedHandler::from_with_id("handler-b", move |_: &i32| {
+            wildcard_b_order.borrow_mut().push("wildcard-b");
         });
 
-        let order2 = order.clone();
-        let handler2 = TypedHandler::from_with_id("high", move |_: &i32| {
-            order2.borrow_mut().push("high");
-        });
+        router.subscribe("delivery.*".into(), low, 1);
+        router.subscribe("delivery.topic".into(), exact_b, 10);
+        router.subscribe("delivery.topic".into(), exact_a, 10);
+        router.subscribe("delivery.*".into(), wildcard_b, 10);
 
-        // Subscribe low priority first, high priority second
-        router.subscribe("test.*".into(), handler1, 5);
-        router.subscribe("test.*".into(), handler2, 10);
-
-        let topic: MStr<Topic> = "test.topic".into();
+        let topic: MStr<Topic> = "delivery.topic".into();
         router.publish(topic, &42);
 
-        // High priority should be called first
-        assert_eq!(*order.borrow(), vec!["high", "low"]);
+        assert_eq!(
+            *order.borrow(),
+            vec!["wildcard-b", "exact-a", "exact-b", "low-z"]
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
Extends the `Eq`/`Ord` agreement work merged in #4598 to the message bus subscription types, where the misaligned key is also the delivery-order mechanism.

## Align `Ord` with identity on both subscription types

`Subscription` and `TypedSubscription` define equality and hashing from `(pattern, handler_id)` but ordered on reversed `priority` first, so two subscriptions differing only in priority were `==` while `cmp` returned `Less`/`Greater` - violating the requirement that `a == b` exactly when `a.cmp(&b) == Ordering::Equal`. Both `Ord` implementations now compare `pattern` then `handler_id`, agreeing with `PartialEq`/`Eq`/`Hash`, which stay untouched: priority deliberately does not participate in identity, since duplicate registration ignores it and the first registration wins. The impls remain manual (`MStr` does not derive `Ord` and the handler is not orderable).

## Move delivery order to a named comparator

Delivery order lived implicitly in the old `Ord`, consumed by four bare `.sort()` calls (`MessageBus::inner_matching_subscriptions`, the uncached `publish_any` path, `subscribe_any`'s backfill into already-cached topics, and `TopicRouter::subscribe`). Each now uses an explicit `delivery_order` comparator carrying the exact previous key - priority descending, then pattern, then handler ID - so delivery semantics are byte-for-byte unchanged, including tie order among equal-priority handlers. Keeping the full key matters: a priority-only comparator under a stable sort would resolve equal-priority ties by input order, which differs per path (insertion order in the typed router, prior cache order in the backfill, hash-set iteration order in fresh matching) and would make delivery path-dependent.

## Testing

`test_subscription_ordering_laws` and `test_typed_subscription_ordering_laws` pin the contract over a variant matrix (same identity with different priorities is equal, hashes equal, and compares `Equal`; `partial_cmp` agrees with `cmp`; comparison is antisymmetric) - both fail against the previous implementations. Four delivery-path tests cover each former sort site with mixed and equal priorities inserted in reverse of the expected order, asserting the full delivery sequence: cache-miss `matching_subscriptions`, first uncached `publish_any`, a late subscription backfilled into an already-cached topic, and typed-router publish. The sequence assertions were verified to fail against a priority-only comparator variant, and the cached late-subscription case rejects that variant deterministically.

NB: The legacy Cython `Subscription` in `common/component.pyx` carries the analogous priority-in-comparison arrangement and is deliberately not touched here.
