### PR TITLE
Fix simulated venue liquidation, rollover, and reset state handling

### DIFF
--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -1470,6 +1470,10 @@ impl SimulatedExchange {
     /// Must be called once per time step after all command queues have fully
     /// settled, not inside the settle loop.
     pub fn process_modules(&mut self, ts_now: UnixNanos) {
+        if self.frozen_account || self.exec_client.is_none() {
+            return;
+        }
+
         let results = {
             let cache = self.cache.borrow();
             let ctx = ExchangeContext {

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -60,7 +60,10 @@ use ustr::Ustr;
 
 use crate::{
     config::SimulatedVenueConfig,
-    modules::{ExchangeContext, SimulationModule},
+    modules::{
+        AccountAdjustmentError, AccountAdjustmentOutcome, ExchangeContext, SimulationModule,
+        SimulationModuleResult,
+    },
 };
 
 /// Represents commands with simulated network latency in a min-heap priority queue.
@@ -561,26 +564,44 @@ impl SimulatedExchange {
         }
 
         if let Some(exec_client) = &self.exec_client {
+            log::debug!("Adjusting account for venue {}", exec_client.venue());
+        }
+
+        match self.try_adjust_account(adjustment) {
+            Ok(()) => true,
+            Err(e) => {
+                log::error!("{e}");
+                false
+            }
+        }
+    }
+
+    /// Tries to adjust the account balance by the given amount without logging failures.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the account or currency balance is unavailable, the
+    /// resulting balance exceeds [`Money`] bounds, or account state generation fails.
+    pub fn try_adjust_account(&mut self, adjustment: Money) -> Result<(), AccountAdjustmentError> {
+        if self.frozen_account {
+            // Nothing to adjust
+            return Ok(());
+        }
+
+        if let Some(exec_client) = &self.exec_client {
             let venue = exec_client.venue();
-            log::debug!("Adjusting account for venue {venue}");
             let account_state = {
                 let cache = self.cache.borrow();
                 if let Some(account) = cache.account_for_venue(&venue) {
                     if let Some(balance) = account.balance(Some(adjustment.currency)) {
                         let mut current_balance = *balance;
                         let Some(total) = current_balance.total.checked_add(adjustment) else {
-                            log::error!(
-                                "Cannot adjust account: {} total exceeds Money bounds",
-                                adjustment.currency
-                            );
-                            return false;
+                            return Err(AccountAdjustmentError::TotalOverflow(adjustment.currency));
                         };
                         let Some(free) = current_balance.free.checked_add(adjustment) else {
-                            log::error!(
-                                "Cannot adjust account: {} free balance exceeds Money bounds",
-                                adjustment.currency
-                            );
-                            return false;
+                            return Err(AccountAdjustmentError::FreeBalanceOverflow(
+                                adjustment.currency,
+                            ));
                         };
                         current_balance.total = total;
                         current_balance.free = free;
@@ -596,30 +617,20 @@ impl SimulatedExchange {
                             self.clock.borrow().timestamp_ns(),
                         ))
                     } else {
-                        log::error!(
-                            "Cannot adjust account: no balance for currency {}",
-                            adjustment.currency
-                        );
-                        None
+                        return Err(AccountAdjustmentError::MissingBalance(adjustment.currency));
                     }
                 } else {
-                    log::error!("Cannot adjust account: no account for venue {venue}");
-                    None
+                    return Err(AccountAdjustmentError::MissingAccount(venue));
                 }
             };
 
             if let Some((balances, margins, ts_event)) = account_state {
-                if let Err(e) =
-                    exec_client.generate_account_state(balances, margins, true, ts_event)
-                {
-                    log::error!("Cannot adjust account: failed to generate account state: {e}");
-                    return false;
-                }
-            } else {
-                return false;
+                exec_client
+                    .generate_account_state(balances, margins, true, ts_event)
+                    .map_err(|e| AccountAdjustmentError::AccountStateGeneration(e.to_string()))?;
             }
         }
-        true
+        Ok(())
     }
 
     /// Returns whether there are pending commands at or before `ts_now`.
@@ -1459,7 +1470,7 @@ impl SimulatedExchange {
     /// Must be called once per time step after all command queues have fully
     /// settled, not inside the settle loop.
     pub fn process_modules(&mut self, ts_now: UnixNanos) {
-        let adjustments = {
+        let results = {
             let cache = self.cache.borrow();
             let ctx = ExchangeContext {
                 venue: self.id,
@@ -1470,12 +1481,22 @@ impl SimulatedExchange {
             };
             self.modules
                 .iter()
-                .flat_map(|m| m.process(ts_now, &ctx))
-                .collect::<Vec<Money>>()
+                .enumerate()
+                .map(|(module_index, module)| (module_index, module.process(ts_now, &ctx)))
+                .collect::<Vec<_>>()
         };
 
-        for adjustment in adjustments {
-            self.adjust_account(adjustment);
+        for (module_index, result) in results {
+            if let SimulationModuleResult::Completed(adjustments) = result {
+                let outcomes = adjustments
+                    .into_iter()
+                    .map(|adjustment| match self.try_adjust_account(adjustment) {
+                        Ok(()) => AccountAdjustmentOutcome::Applied,
+                        Err(e) => AccountAdjustmentOutcome::Failed(e),
+                    })
+                    .collect::<Vec<_>>();
+                self.modules[module_index].acknowledge(&outcomes);
+            }
         }
     }
 

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -1440,6 +1440,7 @@ impl SimulatedExchange {
         self.funding_settled_through.clear();
         self.message_queue.clear();
         self.inflight_queue.clear();
+        self.inflight_counter.clear();
 
         log::info!("Resetting exchange state");
     }
@@ -1561,8 +1562,6 @@ impl SimulatedExchange {
                     currency,
                 );
             }
-
-            break;
         }
     }
 
@@ -1773,13 +1772,17 @@ impl SimulatedExchange {
 
 #[cfg(test)]
 mod tests {
-    use nautilus_common::messages::execution::{QueryAccount, QueryOrder};
+    use nautilus_common::messages::execution::{QueryAccount, QueryOrder, SubmitOrder};
     use nautilus_execution::models::latency::StaticLatencyModel;
     use nautilus_model::{
-        enums::{AccountType, BookType},
+        accounts::MarginAccount,
+        enums::{AccountType, BookType, OrderSide, OrderType},
+        events::AccountState,
         identifiers::{ClientOrderId, StrategyId, TraderId},
         instruments::{CurrencyPair, InstrumentAny, stubs::audusd_sim},
+        orders::{OrderTestBuilder, stubs::TestOrderEventStubs},
         stubs::TestDefault,
+        types::AccountBalance,
     };
     use rstest::rstest;
 
@@ -1888,5 +1891,74 @@ mod tests {
         assert!(exchange.instruments.is_empty());
         assert!(exchange.matching_engines.is_empty());
         assert_eq!(exchange.last_raw_id, u32::MAX);
+    }
+
+    #[rstest]
+    fn test_reset_clears_inflight_counter() {
+        let mut exchange = setup_exchange(Dispatch::Latency);
+        let account = MarginAccount::new(
+            AccountState::new(
+                AccountId::test_default(),
+                AccountType::Margin,
+                vec![AccountBalance::new(
+                    Money::from("1000 USD"),
+                    Money::from("0 USD"),
+                    Money::from("1000 USD"),
+                )],
+                vec![],
+                false,
+                UUID4::default(),
+                UnixNanos::default(),
+                UnixNanos::default(),
+                None,
+            ),
+            false,
+        );
+        exchange
+            .cache
+            .borrow_mut()
+            .add_account(AccountAny::Margin(account))
+            .unwrap();
+
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+            .client_order_id(ClientOrderId::from("O-RESET"))
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1"))
+            .price(Price::from("1.00000"))
+            .build();
+        exchange
+            .cache
+            .borrow_mut()
+            .add_order(order.clone(), None, None, false)
+            .unwrap();
+        exchange
+            .cache
+            .borrow_mut()
+            .update_order(&TestOrderEventStubs::submitted(
+                &order,
+                AccountId::test_default(),
+            ))
+            .unwrap();
+        exchange.send(TradingCommand::SubmitOrder(SubmitOrder::new(
+            TraderId::test_default(),
+            None,
+            StrategyId::test_default(),
+            order.instrument_id(),
+            order.client_order_id(),
+            order.init_event().clone(),
+            None,
+            None,
+            None,
+            UUID4::default(),
+            UnixNanos::from(100),
+            None,
+        )));
+
+        assert_eq!(exchange.inflight_counter.len(), 1);
+
+        exchange.reset();
+
+        assert!(exchange.inflight_counter.is_empty());
     }
 }

--- a/crates/backtest/src/modules/fx_rollover.rs
+++ b/crates/backtest/src/modules/fx_rollover.rs
@@ -204,16 +204,23 @@ pub struct FXRolloverInterestModule {
     rollover_completed: Cell<bool>,
     rollover_day: RefCell<Option<RolloverDayState>>,
     rollover_totals: RefCell<AHashMap<Currency, f64>>,
+    unapplied_rollover_totals: RefCell<AHashMap<Currency, f64>>,
 }
 
 #[derive(Debug, Clone)]
 struct RolloverDayState {
     date: NaiveDate,
-    scheduled_time_ns: u64,
-    warned_failures: AHashSet<(InstrumentId, RolloverFailureKind)>,
-    warned_adjustment_failures: AHashSet<(Currency, AccountAdjustmentFailureKind)>,
-    pending_adjustments: Option<Vec<Money>>,
+    warned_failures: AHashSet<(NaiveDate, InstrumentId, RolloverFailureKind)>,
+    warned_adjustment_failures: AHashSet<(NaiveDate, Currency, AccountAdjustmentFailureKind)>,
+    pending_adjustments: Option<Vec<RolloverAdjustment>>,
+    pending_end_date: Option<NaiveDate>,
     attempt_time: Option<UnixNanos>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RolloverAdjustment {
+    booking_date: NaiveDate,
+    amount: Money,
 }
 
 enum RolloverCalculationOutcome {
@@ -225,6 +232,12 @@ enum RolloverCalculationOutcome {
 enum RolloverFailureDisposition {
     RetryDay,
     SkipInstrument,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AccountAdjustmentFailureDisposition {
+    Retry,
+    RecordUnapplied,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -266,6 +279,19 @@ impl From<&AccountAdjustmentError> for AccountAdjustmentFailureKind {
     }
 }
 
+impl AccountAdjustmentFailureKind {
+    const fn disposition(self) -> AccountAdjustmentFailureDisposition {
+        match self {
+            Self::TotalOverflow | Self::FreeBalanceOverflow | Self::AccountStateGeneration => {
+                AccountAdjustmentFailureDisposition::Retry
+            }
+            Self::MissingBalance | Self::MissingAccount => {
+                AccountAdjustmentFailureDisposition::RecordUnapplied
+            }
+        }
+    }
+}
+
 impl FXRolloverInterestModule {
     /// Creates a new FX rollover interest module.
     ///
@@ -280,41 +306,60 @@ impl FXRolloverInterestModule {
             rollover_completed: Cell::new(false),
             rollover_day: RefCell::new(None),
             rollover_totals: RefCell::new(AHashMap::new()),
+            unapplied_rollover_totals: RefCell::new(AHashMap::new()),
         })
     }
 
     fn initialize_rollover_day(&self, date: NaiveDate) {
-        let rollover_eastern =
-            date.and_time(NaiveTime::from_hms_opt(17, 0, 0).expect("valid rollover time"));
-        let rollover_utc = Eastern
-            .from_local_datetime(&rollover_eastern)
-            .single()
-            .expect("unambiguous rollover time")
-            .naive_utc();
-        let scheduled_time_ns = rollover_utc
-            .and_utc()
-            .timestamp_nanos_opt()
-            .expect("rollover timestamp in range")
-            .cast_unsigned();
-
         self.rollover_day.replace(Some(RolloverDayState {
             date,
-            scheduled_time_ns,
             warned_failures: AHashSet::new(),
             warned_adjustment_failures: AHashSet::new(),
             pending_adjustments: None,
+            pending_end_date: None,
             attempt_time: None,
         }));
         self.rollover_completed.set(false);
     }
 
-    /// Logs a calculation failure at warn level once per (instrument, kind)
-    /// within the current rollover day, demoting repeats to debug: a `Retry`
-    /// outcome re-runs the calculation on every process call until it
-    /// completes, and repeating the identical warning per attempt would flood
-    /// the log. The set is cleared on a new day, on completion, and on reset.
+    fn rollover_time_ns(date: NaiveDate) -> u64 {
+        let rollover_eastern =
+            date.and_time(NaiveTime::from_hms_opt(17, 0, 0).expect("valid rollover time"));
+        Eastern
+            .from_local_datetime(&rollover_eastern)
+            .single()
+            .expect("unambiguous rollover time")
+            .timestamp_nanos_opt()
+            .expect("rollover timestamp in range")
+            .cast_unsigned()
+    }
+
+    fn weekday_on_or_before(mut date: NaiveDate) -> NaiveDate {
+        while date.weekday().number_from_monday() > 5 {
+            date = date.pred_opt().expect("previous rollover date in range");
+        }
+        date
+    }
+
+    fn next_weekday(mut date: NaiveDate) -> NaiveDate {
+        loop {
+            date = date.succ_opt().expect("next rollover date in range");
+            if date.weekday().number_from_monday() <= 5 {
+                return date;
+            }
+        }
+    }
+
+    /// Logs a calculation failure at warn level once per (booking date, instrument,
+    /// kind), demoting repeats to debug: a `Retry` outcome re-runs the calculation
+    /// on every process call until it completes, and repeating the identical
+    /// warning per attempt would flood the log. The booking date is part of the key
+    /// because one catch-up batch spans many dates, and a permanent per-instrument
+    /// skip must stay visible for each date it drops rather than warning only for
+    /// the first. The set is cleared on a new day, on completion, and on reset.
     fn log_calculation_failure(
         &self,
+        booking_date: NaiveDate,
         instrument_id: InstrumentId,
         kind: RolloverFailureKind,
         message: &str,
@@ -325,7 +370,7 @@ impl FXRolloverInterestModule {
             .as_mut()
             .expect("rollover day initialized")
             .warned_failures
-            .insert((instrument_id, kind));
+            .insert((booking_date, instrument_id, kind));
 
         if first_failure {
             log::warn!("{message}");
@@ -367,6 +412,7 @@ impl FXRolloverInterestModule {
                 Err(e) => {
                     let kind = RolloverFailureKind::Rate;
                     self.log_calculation_failure(
+                        date,
                         instrument_id,
                         kind,
                         &format!("Skipping rollover for {instrument_id} on {date}: {e}"),
@@ -383,6 +429,7 @@ impl FXRolloverInterestModule {
 
             let Some(matching_engine) = ctx.matching_engines.get(&instrument_id) else {
                 self.log_calculation_failure(
+                    date,
                     instrument_id,
                     RolloverFailureKind::Engine,
                     &format!("Cannot calculate rollover for {instrument_id}: no matching engine"),
@@ -398,6 +445,7 @@ impl FXRolloverInterestModule {
                 price.as_f64()
             } else {
                 self.log_calculation_failure(
+                    date,
                     instrument_id,
                     RolloverFailureKind::Price,
                     &format!("Cannot calculate rollover for {instrument_id}: no market price"),
@@ -427,6 +475,7 @@ impl FXRolloverInterestModule {
                     Ok(None) => None,
                     Err(e) => {
                         self.log_calculation_failure(
+                            date,
                             instrument_id,
                             RolloverFailureKind::Xrate,
                             &format!(
@@ -439,6 +488,7 @@ impl FXRolloverInterestModule {
                 };
                 let Some(xrate) = xrate else {
                     self.log_calculation_failure(
+                        date,
                         instrument_id,
                         RolloverFailureKind::Xrate,
                         &format!(
@@ -459,6 +509,7 @@ impl FXRolloverInterestModule {
                 Err(e) => {
                     let kind = RolloverFailureKind::Money;
                     self.log_calculation_failure(
+                        date,
                         instrument_id,
                         kind,
                         &format!(
@@ -493,9 +544,9 @@ impl SimulationModule for FXRolloverInterestModule {
         let initialize_date = {
             let day = self.rollover_day.borrow();
             match day.as_ref() {
-                None => Some(observed_date),
+                None => Some(Self::weekday_on_or_before(observed_date)),
                 Some(day) if self.rollover_completed.get() && day.date < observed_date => {
-                    day.date.succ_opt()
+                    Some(Self::next_weekday(day.date))
                 }
                 Some(_) => None,
             }
@@ -513,37 +564,73 @@ impl SimulationModule for FXRolloverInterestModule {
             let mut day = self.rollover_day.borrow_mut();
             let day = day.as_mut().expect("rollover day initialized");
             if let Some(adjustments) = &day.pending_adjustments {
-                let adjustments = adjustments.clone();
+                let adjustments = adjustments
+                    .iter()
+                    .map(|adjustment| adjustment.amount)
+                    .collect();
                 day.attempt_time = Some(ts_now);
                 return SimulationModuleResult::Completed(adjustments);
             }
         }
 
-        let (date, scheduled_time_ns) = {
+        let date = {
             let day = self.rollover_day.borrow();
             let day = day.as_ref().expect("rollover day initialized");
-            (day.date, day.scheduled_time_ns)
+            day.date
         };
 
-        if ts_now.as_u64() < scheduled_time_ns {
+        if ts_now.as_u64() < Self::rollover_time_ns(date) {
             return SimulationModuleResult::NotReady;
         }
 
-        let iso_weekday = date.weekday().number_from_monday();
-        match self.calculate_rollover_interest(date, iso_weekday, ctx) {
-            RolloverCalculationOutcome::Completed(adjustments) => {
-                let mut day = self.rollover_day.borrow_mut();
-                let day = day.as_mut().expect("rollover day initialized");
-                day.pending_adjustments = Some(adjustments.clone());
-                day.attempt_time = Some(ts_now);
-                SimulationModuleResult::Completed(adjustments)
+        // Drain every due weekday so sparse data cannot leave the booking cursor behind.
+        // This is complete by booked-day count, but uses the current positions, prices, and
+        // exchange rates for every date because historical cutoff snapshots are unavailable.
+        // Work is proportional to the gap length times the instrument count. This is a weekday
+        // calendar rather than a pair-specific business-day calendar. The existing Wednesday
+        // and Friday triple multipliers are retained for parity, even though standard spot FX
+        // usually applies the weekend triple on Wednesday only.
+        let mut booking_date = date;
+        let mut batch = Vec::new();
+        let batch_end_date = loop {
+            if booking_date > observed_date
+                || (booking_date == observed_date
+                    && ts_now.as_u64() < Self::rollover_time_ns(booking_date))
+            {
+                return SimulationModuleResult::NotReady;
             }
-            RolloverCalculationOutcome::Retry => SimulationModuleResult::NotReady,
-        }
+
+            let iso_weekday = booking_date.weekday().number_from_monday();
+            match self.calculate_rollover_interest(booking_date, iso_weekday, ctx) {
+                RolloverCalculationOutcome::Completed(adjustments) => {
+                    batch.extend(adjustments.into_iter().map(|amount| RolloverAdjustment {
+                        booking_date,
+                        amount,
+                    }));
+                }
+                RolloverCalculationOutcome::Retry => return SimulationModuleResult::NotReady,
+            }
+
+            let next = Self::next_weekday(booking_date);
+            if next > observed_date
+                || (next == observed_date && ts_now.as_u64() < Self::rollover_time_ns(next))
+            {
+                break booking_date;
+            }
+            booking_date = next;
+        };
+
+        let adjustments = batch.iter().map(|adjustment| adjustment.amount).collect();
+        let mut day = self.rollover_day.borrow_mut();
+        let day = day.as_mut().expect("rollover day initialized");
+        day.pending_adjustments = Some(batch);
+        day.pending_end_date = Some(batch_end_date);
+        day.attempt_time = Some(ts_now);
+        SimulationModuleResult::Completed(adjustments)
     }
 
     fn acknowledge(&self, outcomes: &[AccountAdjustmentOutcome]) {
-        let (adjustments, attempt_time, date, scheduled_time_ns) = {
+        let (adjustments, attempt_time, batch_end_date) = {
             let mut day = self.rollover_day.borrow_mut();
             let day = day.as_mut().expect("rollover day initialized");
             let adjustment_count = day
@@ -565,26 +652,21 @@ impl SimulationModule for FXRolloverInterestModule {
                 day.attempt_time
                     .take()
                     .expect("rollover attempt time recorded"),
-                day.date,
-                day.scheduled_time_ns,
+                day.pending_end_date
+                    .expect("rollover batch end date recorded"),
             )
         };
 
         let mut failed = Vec::new();
         {
             let mut totals = self.rollover_totals.borrow_mut();
+            let mut unapplied_totals = self.unapplied_rollover_totals.borrow_mut();
 
             for (adjustment, outcome) in adjustments.into_iter().zip(outcomes) {
                 match outcome {
                     AccountAdjustmentOutcome::Applied => {
-                        let total = totals.entry(adjustment.currency).or_insert(0.0);
-                        *total += adjustment.as_f64();
-                        self.rollover_day
-                            .borrow_mut()
-                            .as_mut()
-                            .expect("rollover day initialized")
-                            .warned_adjustment_failures
-                            .retain(|(currency, _)| *currency != adjustment.currency);
+                        let total = totals.entry(adjustment.amount.currency).or_insert(0.0);
+                        *total += adjustment.amount.as_f64();
                     }
                     AccountAdjustmentOutcome::Failed(error) => {
                         let kind = AccountAdjustmentFailureKind::from(error);
@@ -594,20 +676,45 @@ impl SimulationModule for FXRolloverInterestModule {
                             .as_mut()
                             .expect("rollover day initialized")
                             .warned_adjustment_failures
-                            .insert((adjustment.currency, kind));
+                            .insert((adjustment.booking_date, adjustment.amount.currency, kind));
 
-                        if first_failure {
-                            log::warn!(
-                                "Cannot apply rollover adjustment for {}: {error}",
-                                adjustment.currency
-                            );
-                        } else {
-                            log::debug!(
-                                "Cannot apply rollover adjustment for {}: {error}",
-                                adjustment.currency
-                            );
+                        match kind.disposition() {
+                            AccountAdjustmentFailureDisposition::Retry => {
+                                if first_failure {
+                                    log::warn!(
+                                        "Cannot apply rollover adjustment for {} on {}: {error}",
+                                        adjustment.amount.currency,
+                                        adjustment.booking_date
+                                    );
+                                } else {
+                                    log::debug!(
+                                        "Cannot apply rollover adjustment for {} on {}: {error}",
+                                        adjustment.amount.currency,
+                                        adjustment.booking_date
+                                    );
+                                }
+                                failed.push(adjustment);
+                            }
+                            AccountAdjustmentFailureDisposition::RecordUnapplied => {
+                                if first_failure {
+                                    log::warn!(
+                                        "Rollover adjustment for {} on {} failed with {kind:?} and is recorded as unapplied: {error}",
+                                        adjustment.amount,
+                                        adjustment.booking_date
+                                    );
+                                } else {
+                                    log::debug!(
+                                        "Rollover adjustment for {} on {} failed with {kind:?} and is recorded as unapplied: {error}",
+                                        adjustment.amount,
+                                        adjustment.booking_date
+                                    );
+                                }
+                                let total = unapplied_totals
+                                    .entry(adjustment.amount.currency)
+                                    .or_insert(0.0);
+                                *total += adjustment.amount.as_f64();
+                            }
                         }
-                        failed.push(adjustment);
                     }
                 }
             }
@@ -615,25 +722,18 @@ impl SimulationModule for FXRolloverInterestModule {
 
         if failed.is_empty() {
             self.rollover_completed.set(true);
-            self.rollover_day
-                .borrow_mut()
-                .as_mut()
-                .expect("rollover day initialized")
-                .warned_failures
-                .clear();
-            self.rollover_day
-                .borrow_mut()
-                .as_mut()
-                .expect("rollover day initialized")
-                .warned_adjustment_failures
-                .clear();
+            let mut day = self.rollover_day.borrow_mut();
+            let day = day.as_mut().expect("rollover day initialized");
+            day.date = batch_end_date;
+            day.pending_end_date = None;
+            day.warned_failures.clear();
 
             let attempt_eastern = Eastern.from_utc_datetime(&nanos_to_utc_datetime(attempt_time));
 
-            if attempt_eastern.date_naive() != date {
+            if attempt_eastern.date_naive() != batch_end_date {
                 log::warn!(
-                    "Rollover for {date}, scheduled at {}, booked late at {attempt_time}",
-                    UnixNanos::from(scheduled_time_ns)
+                    "Rollover batch through {batch_end_date}, scheduled through {}, booked late at {attempt_time}",
+                    UnixNanos::from(Self::rollover_time_ns(batch_end_date))
                 );
             }
         } else {
@@ -659,12 +759,30 @@ impl SimulationModule for FXRolloverInterestModule {
             })
             .collect();
         log::info!("Rollover interest (totals): {}", parts.join(", "));
+
+        let unapplied_totals = self.unapplied_rollover_totals.borrow();
+        let unapplied_parts: Vec<String> = unapplied_totals
+            .iter()
+            .filter_map(|(currency, total)| {
+                Money::new_checked(*total, *currency)
+                    .map(|money| money.to_string())
+                    .map_err(|e| {
+                        log::error!("Cannot report unapplied rollover total for {currency}: {e}");
+                    })
+                    .ok()
+            })
+            .collect();
+        log::info!(
+            "Rollover interest (unapplied totals): {}",
+            unapplied_parts.join(", ")
+        );
     }
 
     fn reset(&self) {
         self.rollover_completed.set(false);
         self.rollover_day.replace(None);
         self.rollover_totals.borrow_mut().clear();
+        self.unapplied_rollover_totals.borrow_mut().clear();
     }
 }
 
@@ -710,6 +828,13 @@ mod tests {
                 value: 1.55,
             },
         ]
+    }
+
+    fn rollover_adjustment(booking_date: NaiveDate, amount: &str) -> RolloverAdjustment {
+        RolloverAdjustment {
+            booking_date,
+            amount: Money::from(amount),
+        }
     }
 
     #[rstest]
@@ -777,12 +902,46 @@ mod tests {
             .rollover_totals
             .borrow_mut()
             .insert(Currency::USD(), 100.0);
+        module
+            .unapplied_rollover_totals
+            .borrow_mut()
+            .insert(Currency::AUD(), 20.0);
 
         module.reset();
 
         assert!(module.rollover_day.borrow().is_none());
         assert!(!module.rollover_completed.get());
         assert!(module.rollover_totals.borrow().is_empty());
+        assert!(module.unapplied_rollover_totals.borrow().is_empty());
+    }
+
+    #[rstest]
+    fn test_calculation_failure_dedupe_is_keyed_per_booking_date() {
+        let module = FXRolloverInterestModule::new(sample_records()).unwrap();
+        let date = NaiveDate::from_ymd_opt(2020, 1, 15).unwrap();
+        let next_date = NaiveDate::from_ymd_opt(2020, 1, 16).unwrap();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        module.initialize_rollover_day(date);
+
+        // A catch-up batch calculates many booking dates before the state is
+        // replaced, so a permanent per-instrument skip must stay visible for
+        // every date it drops rather than warning only for the first.
+        module.log_calculation_failure(date, instrument_id, RolloverFailureKind::Rate, "first");
+        module.log_calculation_failure(date, instrument_id, RolloverFailureKind::Rate, "repeat");
+        module.log_calculation_failure(next_date, instrument_id, RolloverFailureKind::Rate, "next");
+
+        assert_eq!(
+            module
+                .rollover_day
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .warned_failures,
+            AHashSet::from([
+                (date, instrument_id, RolloverFailureKind::Rate),
+                (next_date, instrument_id, RolloverFailureKind::Rate),
+            ])
+        );
     }
 
     #[rstest]
@@ -829,7 +988,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_partial_acknowledgement_retries_only_failed_adjustments() {
+    fn test_transient_adjustment_failure_retries_only_failed_adjustments() {
         let module = FXRolloverInterestModule::new(sample_records()).unwrap();
         let date = NaiveDate::from_ymd_opt(2020, 1, 15).unwrap();
         let attempt_time = UnixNanos::from(
@@ -844,16 +1003,19 @@ mod tests {
         {
             let mut day = module.rollover_day.borrow_mut();
             let day = day.as_mut().unwrap();
-            day.pending_adjustments =
-                Some(vec![Money::from("10.00 USD"), Money::from("20.00 AUD")]);
+            day.pending_adjustments = Some(vec![
+                rollover_adjustment(date, "10.00 USD"),
+                rollover_adjustment(date, "20.00 AUD"),
+            ]);
+            day.pending_end_date = Some(date);
             day.attempt_time = Some(attempt_time);
         }
 
         module.acknowledge(&[
             AccountAdjustmentOutcome::Applied,
-            AccountAdjustmentOutcome::Failed(AccountAdjustmentError::MissingBalance(
-                Currency::AUD(),
-            )),
+            AccountAdjustmentOutcome::Failed(
+                AccountAdjustmentError::TotalOverflow(Currency::AUD()),
+            ),
         ]);
 
         assert!(!module.rollover_completed.get());
@@ -864,7 +1026,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .pending_adjustments,
-            Some(vec![Money::from("20.00 AUD")])
+            Some(vec![rollover_adjustment(date, "20.00 AUD")])
         );
         assert_eq!(
             module.rollover_totals.borrow().get(&Currency::USD()),
@@ -902,7 +1064,7 @@ mod tests {
             SimulationModuleResult::Completed(vec![Money::from("20.00 AUD")])
         );
         module.acknowledge(&[AccountAdjustmentOutcome::Failed(
-            AccountAdjustmentError::MissingBalance(Currency::AUD()),
+            AccountAdjustmentError::TotalOverflow(Currency::AUD()),
         )]);
         assert_eq!(
             module
@@ -929,14 +1091,119 @@ mod tests {
             module.rollover_totals.borrow().get(&Currency::AUD()),
             Some(&20.0)
         );
-        assert!(
+        assert_eq!(
             module
                 .rollover_day
                 .borrow()
                 .as_ref()
                 .unwrap()
                 .warned_adjustment_failures
-                .is_empty()
+                .len(),
+            1
+        );
+    }
+
+    #[rstest]
+    fn test_permanent_adjustment_failure_completes_batch() {
+        let module = FXRolloverInterestModule::new(sample_records()).unwrap();
+        let date = NaiveDate::from_ymd_opt(2020, 1, 15).unwrap();
+        let attempt_time = UnixNanos::from(
+            date.and_hms_opt(22, 1, 0)
+                .unwrap()
+                .and_utc()
+                .timestamp_nanos_opt()
+                .unwrap()
+                .cast_unsigned(),
+        );
+        module.initialize_rollover_day(date);
+        let second_date = date.succ_opt().unwrap();
+        {
+            let mut day = module.rollover_day.borrow_mut();
+            let day = day.as_mut().unwrap();
+            day.pending_adjustments = Some(vec![
+                rollover_adjustment(date, "20.00 AUD"),
+                rollover_adjustment(second_date, "30.00 AUD"),
+            ]);
+            day.pending_end_date = Some(second_date);
+            day.attempt_time = Some(attempt_time);
+        }
+
+        module.acknowledge(&[
+            AccountAdjustmentOutcome::Failed(AccountAdjustmentError::MissingBalance(
+                Currency::AUD(),
+            )),
+            AccountAdjustmentOutcome::Failed(AccountAdjustmentError::MissingBalance(
+                Currency::AUD(),
+            )),
+        ]);
+
+        assert!(module.rollover_completed.get());
+        assert!(
+            module
+                .rollover_day
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .pending_adjustments
+                .is_none()
+        );
+        assert_eq!(
+            module
+                .unapplied_rollover_totals
+                .borrow()
+                .get(&Currency::AUD()),
+            Some(&50.0)
+        );
+        assert!(
+            !module
+                .rollover_totals
+                .borrow()
+                .contains_key(&Currency::AUD())
+        );
+        assert_eq!(
+            module
+                .rollover_day
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .warned_adjustment_failures,
+            AHashSet::from([
+                (
+                    date,
+                    Currency::AUD(),
+                    AccountAdjustmentFailureKind::MissingBalance,
+                ),
+                (
+                    second_date,
+                    Currency::AUD(),
+                    AccountAdjustmentFailureKind::MissingBalance,
+                ),
+            ])
+        );
+        let instruments = AHashMap::new();
+        let matching_engines = IndexMap::new();
+        let cache = Cache::default();
+        let ctx = ExchangeContext {
+            venue: Venue::new("SIM"),
+            base_currency: None,
+            instruments: &instruments,
+            matching_engines: &matching_engines,
+            cache: &cache,
+        };
+        let next_attempt = UnixNanos::from(
+            second_date
+                .succ_opt()
+                .unwrap()
+                .and_hms_opt(22, 1, 0)
+                .unwrap()
+                .and_utc()
+                .timestamp_nanos_opt()
+                .unwrap()
+                .cast_unsigned(),
+        );
+        assert_eq!(
+            module.process(next_attempt, &ctx),
+            SimulationModuleResult::Completed(Vec::new())
         );
     }
 
@@ -948,7 +1215,7 @@ mod tests {
         {
             let mut day = module.rollover_day.borrow_mut();
             let day = day.as_mut().unwrap();
-            day.pending_adjustments = Some(vec![Money::from("10.00 USD")]);
+            day.pending_adjustments = Some(vec![rollover_adjustment(date, "10.00 USD")]);
             day.attempt_time = Some(UnixNanos::from(1));
         }
 
@@ -964,7 +1231,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .pending_adjustments,
-            Some(vec![Money::from("10.00 USD")])
+            Some(vec![rollover_adjustment(date, "10.00 USD")])
         );
     }
 }

--- a/crates/backtest/src/modules/fx_rollover.rs
+++ b/crates/backtest/src/modules/fx_rollover.rs
@@ -201,7 +201,7 @@ impl RolloverInterestCalculator {
 )]
 pub struct FXRolloverInterestModule {
     calculator: RolloverInterestCalculator,
-    rollover_applied: Cell<bool>,
+    rollover_completed: Cell<bool>,
     rollover_day: RefCell<Option<RolloverDayState>>,
     rollover_totals: RefCell<AHashMap<Currency, f64>>,
 }
@@ -221,12 +221,28 @@ enum RolloverCalculationOutcome {
     Retry,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RolloverFailureDisposition {
+    RetryDay,
+    SkipInstrument,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum RolloverFailureKind {
     Engine,
+    Money,
     Price,
     Rate,
     Xrate,
+}
+
+impl RolloverFailureKind {
+    const fn disposition(self) -> RolloverFailureDisposition {
+        match self {
+            Self::Engine | Self::Price | Self::Xrate => RolloverFailureDisposition::RetryDay,
+            Self::Money | Self::Rate => RolloverFailureDisposition::SkipInstrument,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -261,7 +277,7 @@ impl FXRolloverInterestModule {
     pub fn new(records: Vec<InterestRateRecord>) -> anyhow::Result<Self> {
         Ok(Self {
             calculator: RolloverInterestCalculator::new(records)?,
-            rollover_applied: Cell::new(false),
+            rollover_completed: Cell::new(false),
             rollover_day: RefCell::new(None),
             rollover_totals: RefCell::new(AHashMap::new()),
         })
@@ -289,7 +305,7 @@ impl FXRolloverInterestModule {
             pending_adjustments: None,
             attempt_time: None,
         }));
-        self.rollover_applied.set(false);
+        self.rollover_completed.set(false);
     }
 
     /// Logs a calculation failure at warn level once per (instrument, kind)
@@ -343,6 +359,28 @@ impl FXRolloverInterestModule {
                 continue;
             }
 
+            // Look up the immutable rate data before any transient market
+            // inputs: a permanently missing rate must skip the instrument
+            // even when the engine or price would first retry the day.
+            let interest_rate = match self.calculator.calc_overnight_rate(instrument_id, date) {
+                Ok(rate) => rate,
+                Err(e) => {
+                    let kind = RolloverFailureKind::Rate;
+                    self.log_calculation_failure(
+                        instrument_id,
+                        kind,
+                        &format!("Skipping rollover for {instrument_id} on {date}: {e}"),
+                    );
+
+                    match kind.disposition() {
+                        RolloverFailureDisposition::RetryDay => {
+                            return RolloverCalculationOutcome::Retry;
+                        }
+                        RolloverFailureDisposition::SkipInstrument => continue,
+                    }
+                }
+            };
+
             let Some(matching_engine) = ctx.matching_engines.get(&instrument_id) else {
                 self.log_calculation_failure(
                     instrument_id,
@@ -365,18 +403,6 @@ impl FXRolloverInterestModule {
                     &format!("Cannot calculate rollover for {instrument_id}: no market price"),
                 );
                 return RolloverCalculationOutcome::Retry;
-            };
-
-            let interest_rate = match self.calculator.calc_overnight_rate(instrument_id, date) {
-                Ok(rate) => rate,
-                Err(e) => {
-                    self.log_calculation_failure(
-                        instrument_id,
-                        RolloverFailureKind::Rate,
-                        &format!("Cannot calculate rollover for {instrument_id}: {e}"),
-                    );
-                    return RolloverCalculationOutcome::Retry;
-                }
             };
 
             let net_qty: f64 = positions.iter().map(|p| p.signed_qty).sum();
@@ -428,8 +454,25 @@ impl FXRolloverInterestModule {
                 instrument.quote_currency()
             };
 
-            let Some(adjustment) = rollover_money(instrument_id, rollover, currency) else {
-                return RolloverCalculationOutcome::Retry;
+            let adjustment = match Money::new_checked(rollover, currency) {
+                Ok(adjustment) => adjustment,
+                Err(e) => {
+                    let kind = RolloverFailureKind::Money;
+                    self.log_calculation_failure(
+                        instrument_id,
+                        kind,
+                        &format!(
+                            "Skipping rollover for {instrument_id} on {date}: invalid adjustment: {e}"
+                        ),
+                    );
+
+                    match kind.disposition() {
+                        RolloverFailureDisposition::RetryDay => {
+                            return RolloverCalculationOutcome::Retry;
+                        }
+                        RolloverFailureDisposition::SkipInstrument => continue,
+                    }
+                }
             };
 
             adjustments.push(adjustment);
@@ -437,14 +480,6 @@ impl FXRolloverInterestModule {
 
         RolloverCalculationOutcome::Completed(adjustments)
     }
-}
-
-fn rollover_money(instrument_id: InstrumentId, value: f64, currency: Currency) -> Option<Money> {
-    Money::new_checked(value, currency)
-        .map_err(|e| {
-            log::error!("Skipping rollover for {instrument_id}: invalid adjustment: {e}");
-        })
-        .ok()
 }
 
 impl SimulationModule for FXRolloverInterestModule {
@@ -455,17 +490,22 @@ impl SimulationModule for FXRolloverInterestModule {
         let eastern_dt = Eastern.from_utc_datetime(&utc_dt);
         let observed_date = eastern_dt.date_naive();
 
-        let initialize = {
+        let initialize_date = {
             let day = self.rollover_day.borrow();
-            day.as_ref()
-                .is_none_or(|day| self.rollover_applied.get() && day.date != observed_date)
+            match day.as_ref() {
+                None => Some(observed_date),
+                Some(day) if self.rollover_completed.get() && day.date < observed_date => {
+                    day.date.succ_opt()
+                }
+                Some(_) => None,
+            }
         };
 
-        if initialize {
-            self.initialize_rollover_day(observed_date);
+        if let Some(date) = initialize_date {
+            self.initialize_rollover_day(date);
         }
 
-        if self.rollover_applied.get() {
+        if self.rollover_completed.get() {
             return SimulationModuleResult::NotReady;
         }
 
@@ -574,7 +614,7 @@ impl SimulationModule for FXRolloverInterestModule {
         }
 
         if failed.is_empty() {
-            self.rollover_applied.set(true);
+            self.rollover_completed.set(true);
             self.rollover_day
                 .borrow_mut()
                 .as_mut()
@@ -622,7 +662,7 @@ impl SimulationModule for FXRolloverInterestModule {
     }
 
     fn reset(&self) {
-        self.rollover_applied.set(false);
+        self.rollover_completed.set(false);
         self.rollover_day.replace(None);
         self.rollover_totals.borrow_mut().clear();
     }
@@ -732,7 +772,7 @@ mod tests {
     fn test_module_reset() {
         let module = FXRolloverInterestModule::new(sample_records()).unwrap();
         module.initialize_rollover_day(NaiveDate::from_ymd_opt(2020, 1, 15).unwrap());
-        module.rollover_applied.set(true);
+        module.rollover_completed.set(true);
         module
             .rollover_totals
             .borrow_mut()
@@ -741,7 +781,7 @@ mod tests {
         module.reset();
 
         assert!(module.rollover_day.borrow().is_none());
-        assert!(!module.rollover_applied.get());
+        assert!(!module.rollover_completed.get());
         assert!(module.rollover_totals.borrow().is_empty());
     }
 
@@ -789,14 +829,6 @@ mod tests {
     }
 
     #[rstest]
-    fn test_rollover_money_rejects_unrepresentable_adjustment() {
-        let adjustment =
-            rollover_money(InstrumentId::from("AUDUSD.SIM"), f64::MAX, Currency::USD());
-
-        assert_eq!(adjustment, None);
-    }
-
-    #[rstest]
     fn test_partial_acknowledgement_retries_only_failed_adjustments() {
         let module = FXRolloverInterestModule::new(sample_records()).unwrap();
         let date = NaiveDate::from_ymd_opt(2020, 1, 15).unwrap();
@@ -824,7 +856,7 @@ mod tests {
             )),
         ]);
 
-        assert!(!module.rollover_applied.get());
+        assert!(!module.rollover_completed.get());
         assert_eq!(
             module
                 .rollover_day
@@ -888,7 +920,7 @@ mod tests {
         );
         module.acknowledge(&[AccountAdjustmentOutcome::Applied]);
 
-        assert!(module.rollover_applied.get());
+        assert!(module.rollover_completed.get());
         assert_eq!(
             module.rollover_totals.borrow().get(&Currency::USD()),
             Some(&10.0)

--- a/crates/backtest/src/modules/fx_rollover.rs
+++ b/crates/backtest/src/modules/fx_rollover.rs
@@ -17,7 +17,7 @@
 
 use std::cell::{Cell, RefCell};
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, TimeZone};
 use chrono_tz::US::Eastern;
 use nautilus_core::UnixNanos;
@@ -178,8 +178,22 @@ pub struct FXRolloverInterestModule {
     calculator: RolloverInterestCalculator,
     rollover_time_ns: Cell<u64>,
     rollover_applied: Cell<bool>,
-    day_number: Cell<u32>,
+    rollover_date: Cell<Option<NaiveDate>>,
     rollover_totals: RefCell<AHashMap<Currency, f64>>,
+    warned_failures: RefCell<AHashSet<(InstrumentId, RolloverFailureKind)>>,
+}
+
+enum RolloverCalculationOutcome {
+    Completed(Vec<Money>),
+    Retry,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum RolloverFailureKind {
+    Engine,
+    Price,
+    Rate,
+    Xrate,
 }
 
 impl FXRolloverInterestModule {
@@ -190,47 +204,51 @@ impl FXRolloverInterestModule {
             calculator: RolloverInterestCalculator::new(records),
             rollover_time_ns: Cell::new(0),
             rollover_applied: Cell::new(false),
-            day_number: Cell::new(0),
+            rollover_date: Cell::new(None),
             rollover_totals: RefCell::new(AHashMap::new()),
+            warned_failures: RefCell::new(AHashSet::new()),
         }
     }
 
-    fn apply_rollover_interest(
+    /// Logs a calculation failure at warn level once per (instrument, kind)
+    /// within the current rollover day, demoting repeats to debug: a `Retry`
+    /// outcome re-runs the calculation on every process call until it
+    /// completes, and repeating the identical warning per attempt would flood
+    /// the log. The set is cleared on a new day, on completion, and on reset.
+    fn log_calculation_failure(
+        &self,
+        instrument_id: InstrumentId,
+        kind: RolloverFailureKind,
+        message: &str,
+    ) {
+        if self
+            .warned_failures
+            .borrow_mut()
+            .insert((instrument_id, kind))
+        {
+            log::warn!("{message}");
+        } else {
+            log::debug!("{message}");
+        }
+    }
+
+    fn calculate_rollover_interest(
         &self,
         date: NaiveDate,
         iso_weekday: u32,
         ctx: &ExchangeContext,
-    ) -> Vec<Money> {
+    ) -> RolloverCalculationOutcome {
+        let mut instrument_ids = ctx.instruments.keys().copied().collect::<Vec<_>>();
+        instrument_ids.sort_unstable();
         let mut adjustments = Vec::new();
 
-        let mut mid_prices: AHashMap<InstrumentId, f64> = AHashMap::new();
+        for instrument_id in instrument_ids {
+            let instrument = &ctx.instruments[&instrument_id];
 
-        for (instrument_id, instrument) in ctx.instruments {
             if instrument.asset_class() != AssetClass::FX {
                 continue;
             }
 
-            let Some(matching_engine) = ctx.matching_engines.get(instrument_id) else {
-                continue;
-            };
-
-            let book = matching_engine.get_book();
-            let mid = if let Some(m) = book.midpoint() {
-                m
-            } else if let Some(p) = book.best_bid_price() {
-                p.as_f64()
-            } else if let Some(p) = book.best_ask_price() {
-                p.as_f64()
-            } else {
-                continue;
-            };
-            mid_prices.insert(*instrument_id, mid);
-        }
-
-        let mut mid_prices = mid_prices.into_iter().collect::<Vec<_>>();
-        mid_prices.sort_unstable_by_key(|(instrument_id, _)| *instrument_id);
-
-        for (instrument_id, mid) in mid_prices {
             let positions =
                 ctx.cache
                     .positions_open(Some(&ctx.venue), Some(&instrument_id), None, None, None);
@@ -239,11 +257,39 @@ impl FXRolloverInterestModule {
                 continue;
             }
 
+            let Some(matching_engine) = ctx.matching_engines.get(&instrument_id) else {
+                self.log_calculation_failure(
+                    instrument_id,
+                    RolloverFailureKind::Engine,
+                    &format!("Cannot calculate rollover for {instrument_id}: no matching engine"),
+                );
+                return RolloverCalculationOutcome::Retry;
+            };
+            let book = matching_engine.get_book();
+            let mid = if let Some(mid) = book.midpoint() {
+                mid
+            } else if let Some(price) = book.best_bid_price() {
+                price.as_f64()
+            } else if let Some(price) = book.best_ask_price() {
+                price.as_f64()
+            } else {
+                self.log_calculation_failure(
+                    instrument_id,
+                    RolloverFailureKind::Price,
+                    &format!("Cannot calculate rollover for {instrument_id}: no market price"),
+                );
+                return RolloverCalculationOutcome::Retry;
+            };
+
             let interest_rate = match self.calculator.calc_overnight_rate(instrument_id, date) {
                 Ok(rate) => rate,
                 Err(e) => {
-                    log::warn!("Skipping rollover for {instrument_id}: {e}");
-                    continue;
+                    self.log_calculation_failure(
+                        instrument_id,
+                        RolloverFailureKind::Rate,
+                        &format!("Cannot calculate rollover for {instrument_id}: {e}"),
+                    );
+                    return RolloverCalculationOutcome::Retry;
                 }
             };
 
@@ -256,30 +302,33 @@ impl FXRolloverInterestModule {
                 rollover *= 3.0;
             }
 
-            let instrument = &ctx.instruments[&instrument_id];
             let currency = if let Some(base) = ctx.base_currency {
                 // Rollover math is still f64; convert the Decimal rate at the boundary
-                let xrate = ctx
+                let Some(xrate) = ctx
                     .cache
                     .get_xrate(ctx.venue, instrument.quote_currency(), base, PriceType::Mid)
                     .and_then(|rate| rate.to_f64())
-                    .unwrap_or(0.0);
+                else {
+                    self.log_calculation_failure(
+                        instrument_id,
+                        RolloverFailureKind::Xrate,
+                        &format!(
+                            "Cannot calculate rollover for {instrument_id}: no exchange rate from {} to {base}",
+                            instrument.quote_currency()
+                        ),
+                    );
+                    return RolloverCalculationOutcome::Retry;
+                };
                 rollover *= xrate;
                 base
             } else {
                 instrument.quote_currency()
             };
 
-            {
-                let mut totals = self.rollover_totals.borrow_mut();
-                let total = totals.entry(currency).or_insert(0.0);
-                *total += rollover;
-            }
-
             adjustments.push(Money::new(rollover, currency));
         }
 
-        adjustments
+        RolloverCalculationOutcome::Completed(adjustments)
     }
 }
 
@@ -289,11 +338,12 @@ impl SimulationModule for FXRolloverInterestModule {
     fn process(&self, ts_now: UnixNanos, ctx: &ExchangeContext) -> Vec<Money> {
         let utc_dt = nanos_to_utc_datetime(ts_now);
         let eastern_dt = Eastern.from_utc_datetime(&utc_dt);
-        let eastern_day = eastern_dt.ordinal();
+        let eastern_date = eastern_dt.date_naive();
 
-        if self.day_number.get() != eastern_day {
-            self.day_number.set(eastern_day);
+        if self.rollover_date.get() != Some(eastern_date) {
+            self.rollover_date.set(Some(eastern_date));
             self.rollover_applied.set(false);
+            self.warned_failures.borrow_mut().clear();
 
             let rollover_eastern = eastern_dt
                 .date_naive()
@@ -313,8 +363,19 @@ impl SimulationModule for FXRolloverInterestModule {
 
         if !self.rollover_applied.get() && ts_now.as_u64() >= self.rollover_time_ns.get() {
             let iso_weekday = eastern_dt.weekday().number_from_monday();
-            self.rollover_applied.set(true);
-            return self.apply_rollover_interest(eastern_dt.date_naive(), iso_weekday, ctx);
+
+            if let RolloverCalculationOutcome::Completed(adjustments) =
+                self.calculate_rollover_interest(eastern_date, iso_weekday, ctx)
+            {
+                let mut totals = self.rollover_totals.borrow_mut();
+                for adjustment in &adjustments {
+                    let total = totals.entry(adjustment.currency).or_insert(0.0);
+                    *total += adjustment.as_f64();
+                }
+                self.rollover_applied.set(true);
+                self.warned_failures.borrow_mut().clear();
+                return adjustments;
+            }
         }
 
         Vec::new()
@@ -335,8 +396,9 @@ impl SimulationModule for FXRolloverInterestModule {
     fn reset(&self) {
         self.rollover_time_ns.set(0);
         self.rollover_applied.set(false);
-        self.day_number.set(0);
+        self.rollover_date.set(None);
         self.rollover_totals.borrow_mut().clear();
+        self.warned_failures.borrow_mut().clear();
     }
 }
 
@@ -441,7 +503,9 @@ mod tests {
     #[rstest]
     fn test_module_reset() {
         let module = FXRolloverInterestModule::new(sample_records());
-        module.day_number.set(15);
+        module
+            .rollover_date
+            .set(NaiveDate::from_ymd_opt(2020, 1, 15));
         module.rollover_applied.set(true);
         module
             .rollover_totals
@@ -450,7 +514,7 @@ mod tests {
 
         module.reset();
 
-        assert_eq!(module.day_number.get(), 0);
+        assert_eq!(module.rollover_date.get(), None);
         assert!(!module.rollover_applied.get());
         assert!(module.rollover_totals.borrow().is_empty());
     }

--- a/crates/backtest/src/modules/fx_rollover.rs
+++ b/crates/backtest/src/modules/fx_rollover.rs
@@ -31,7 +31,10 @@ use nautilus_model::{
 use rust_decimal::prelude::ToPrimitive;
 use serde::Serialize;
 
-use super::{ExchangeContext, SimulationModule};
+use super::{
+    AccountAdjustmentError, AccountAdjustmentOutcome, ExchangeContext, SimulationModule,
+    SimulationModuleResult,
+};
 
 const LOCATION_CURRENCY_MAP: &[(&str, &str)] = &[
     ("AUS", "AUD"),
@@ -198,11 +201,19 @@ impl RolloverInterestCalculator {
 )]
 pub struct FXRolloverInterestModule {
     calculator: RolloverInterestCalculator,
-    rollover_time_ns: Cell<u64>,
     rollover_applied: Cell<bool>,
-    rollover_date: Cell<Option<NaiveDate>>,
+    rollover_day: RefCell<Option<RolloverDayState>>,
     rollover_totals: RefCell<AHashMap<Currency, f64>>,
-    warned_failures: RefCell<AHashSet<(InstrumentId, RolloverFailureKind)>>,
+}
+
+#[derive(Debug, Clone)]
+struct RolloverDayState {
+    date: NaiveDate,
+    scheduled_time_ns: u64,
+    warned_failures: AHashSet<(InstrumentId, RolloverFailureKind)>,
+    warned_adjustment_failures: AHashSet<(Currency, AccountAdjustmentFailureKind)>,
+    pending_adjustments: Option<Vec<Money>>,
+    attempt_time: Option<UnixNanos>,
 }
 
 enum RolloverCalculationOutcome {
@@ -218,6 +229,27 @@ enum RolloverFailureKind {
     Xrate,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum AccountAdjustmentFailureKind {
+    TotalOverflow,
+    FreeBalanceOverflow,
+    MissingBalance,
+    MissingAccount,
+    AccountStateGeneration,
+}
+
+impl From<&AccountAdjustmentError> for AccountAdjustmentFailureKind {
+    fn from(error: &AccountAdjustmentError) -> Self {
+        match error {
+            AccountAdjustmentError::TotalOverflow(_) => Self::TotalOverflow,
+            AccountAdjustmentError::FreeBalanceOverflow(_) => Self::FreeBalanceOverflow,
+            AccountAdjustmentError::MissingBalance(_) => Self::MissingBalance,
+            AccountAdjustmentError::MissingAccount(_) => Self::MissingAccount,
+            AccountAdjustmentError::AccountStateGeneration(_) => Self::AccountStateGeneration,
+        }
+    }
+}
+
 impl FXRolloverInterestModule {
     /// Creates a new FX rollover interest module.
     ///
@@ -229,12 +261,35 @@ impl FXRolloverInterestModule {
     pub fn new(records: Vec<InterestRateRecord>) -> anyhow::Result<Self> {
         Ok(Self {
             calculator: RolloverInterestCalculator::new(records)?,
-            rollover_time_ns: Cell::new(0),
             rollover_applied: Cell::new(false),
-            rollover_date: Cell::new(None),
+            rollover_day: RefCell::new(None),
             rollover_totals: RefCell::new(AHashMap::new()),
-            warned_failures: RefCell::new(AHashSet::new()),
         })
+    }
+
+    fn initialize_rollover_day(&self, date: NaiveDate) {
+        let rollover_eastern =
+            date.and_time(NaiveTime::from_hms_opt(17, 0, 0).expect("valid rollover time"));
+        let rollover_utc = Eastern
+            .from_local_datetime(&rollover_eastern)
+            .single()
+            .expect("unambiguous rollover time")
+            .naive_utc();
+        let scheduled_time_ns = rollover_utc
+            .and_utc()
+            .timestamp_nanos_opt()
+            .expect("rollover timestamp in range")
+            .cast_unsigned();
+
+        self.rollover_day.replace(Some(RolloverDayState {
+            date,
+            scheduled_time_ns,
+            warned_failures: AHashSet::new(),
+            warned_adjustment_failures: AHashSet::new(),
+            pending_adjustments: None,
+            attempt_time: None,
+        }));
+        self.rollover_applied.set(false);
     }
 
     /// Logs a calculation failure at warn level once per (instrument, kind)
@@ -248,11 +303,15 @@ impl FXRolloverInterestModule {
         kind: RolloverFailureKind,
         message: &str,
     ) {
-        if self
-            .warned_failures
+        let first_failure = self
+            .rollover_day
             .borrow_mut()
-            .insert((instrument_id, kind))
-        {
+            .as_mut()
+            .expect("rollover day initialized")
+            .warned_failures
+            .insert((instrument_id, kind));
+
+        if first_failure {
             log::warn!("{message}");
         } else {
             log::debug!("{message}");
@@ -331,11 +390,28 @@ impl FXRolloverInterestModule {
 
             let currency = if let Some(base) = ctx.base_currency {
                 // Rollover math is still f64; convert the Decimal rate at the boundary
-                let Some(xrate) = ctx
-                    .cache
-                    .get_xrate(ctx.venue, instrument.quote_currency(), base, PriceType::Mid)
-                    .and_then(|rate| rate.to_f64())
-                else {
+                let xrate_result = ctx.cache.try_get_xrate(
+                    ctx.venue,
+                    instrument.quote_currency(),
+                    base,
+                    PriceType::Mid,
+                );
+                let xrate = match xrate_result {
+                    Ok(Some(rate)) => rate.to_f64(),
+                    Ok(None) => None,
+                    Err(e) => {
+                        self.log_calculation_failure(
+                            instrument_id,
+                            RolloverFailureKind::Xrate,
+                            &format!(
+                                "Cannot calculate rollover for {instrument_id}: exchange rate from {} to {base}: {e}",
+                                instrument.quote_currency()
+                            ),
+                        );
+                        return RolloverCalculationOutcome::Retry;
+                    }
+                };
+                let Some(xrate) = xrate else {
                     self.log_calculation_failure(
                         instrument_id,
                         RolloverFailureKind::Xrate,
@@ -374,50 +450,159 @@ fn rollover_money(instrument_id: InstrumentId, value: f64, currency: Currency) -
 impl SimulationModule for FXRolloverInterestModule {
     fn pre_process(&self, _data: &Data) {}
 
-    fn process(&self, ts_now: UnixNanos, ctx: &ExchangeContext) -> Vec<Money> {
+    fn process(&self, ts_now: UnixNanos, ctx: &ExchangeContext) -> SimulationModuleResult {
         let utc_dt = nanos_to_utc_datetime(ts_now);
         let eastern_dt = Eastern.from_utc_datetime(&utc_dt);
-        let eastern_date = eastern_dt.date_naive();
+        let observed_date = eastern_dt.date_naive();
 
-        if self.rollover_date.get() != Some(eastern_date) {
-            self.rollover_date.set(Some(eastern_date));
-            self.rollover_applied.set(false);
-            self.warned_failures.borrow_mut().clear();
+        let initialize = {
+            let day = self.rollover_day.borrow();
+            day.as_ref()
+                .is_none_or(|day| self.rollover_applied.get() && day.date != observed_date)
+        };
 
-            let rollover_eastern = eastern_dt
-                .date_naive()
-                .and_time(NaiveTime::from_hms_opt(17, 0, 0).unwrap());
-            let rollover_utc = Eastern
-                .from_local_datetime(&rollover_eastern)
-                .single()
-                .unwrap()
-                .naive_utc();
-            let rollover_ns = rollover_utc
-                .and_utc()
-                .timestamp_nanos_opt()
-                .unwrap()
-                .cast_unsigned();
-            self.rollover_time_ns.set(rollover_ns);
+        if initialize {
+            self.initialize_rollover_day(observed_date);
         }
 
-        if !self.rollover_applied.get() && ts_now.as_u64() >= self.rollover_time_ns.get() {
-            let iso_weekday = eastern_dt.weekday().number_from_monday();
+        if self.rollover_applied.get() {
+            return SimulationModuleResult::NotReady;
+        }
 
-            if let RolloverCalculationOutcome::Completed(adjustments) =
-                self.calculate_rollover_interest(eastern_date, iso_weekday, ctx)
-            {
-                let mut totals = self.rollover_totals.borrow_mut();
-                for adjustment in &adjustments {
-                    let total = totals.entry(adjustment.currency).or_insert(0.0);
-                    *total += adjustment.as_f64();
-                }
-                self.rollover_applied.set(true);
-                self.warned_failures.borrow_mut().clear();
-                return adjustments;
+        {
+            let mut day = self.rollover_day.borrow_mut();
+            let day = day.as_mut().expect("rollover day initialized");
+            if let Some(adjustments) = &day.pending_adjustments {
+                let adjustments = adjustments.clone();
+                day.attempt_time = Some(ts_now);
+                return SimulationModuleResult::Completed(adjustments);
             }
         }
 
-        Vec::new()
+        let (date, scheduled_time_ns) = {
+            let day = self.rollover_day.borrow();
+            let day = day.as_ref().expect("rollover day initialized");
+            (day.date, day.scheduled_time_ns)
+        };
+
+        if ts_now.as_u64() < scheduled_time_ns {
+            return SimulationModuleResult::NotReady;
+        }
+
+        let iso_weekday = date.weekday().number_from_monday();
+        match self.calculate_rollover_interest(date, iso_weekday, ctx) {
+            RolloverCalculationOutcome::Completed(adjustments) => {
+                let mut day = self.rollover_day.borrow_mut();
+                let day = day.as_mut().expect("rollover day initialized");
+                day.pending_adjustments = Some(adjustments.clone());
+                day.attempt_time = Some(ts_now);
+                SimulationModuleResult::Completed(adjustments)
+            }
+            RolloverCalculationOutcome::Retry => SimulationModuleResult::NotReady,
+        }
+    }
+
+    fn acknowledge(&self, outcomes: &[AccountAdjustmentOutcome]) {
+        let (adjustments, attempt_time, date, scheduled_time_ns) = {
+            let mut day = self.rollover_day.borrow_mut();
+            let day = day.as_mut().expect("rollover day initialized");
+            let adjustment_count = day
+                .pending_adjustments
+                .as_ref()
+                .expect("no completed rollover batch to acknowledge")
+                .len();
+            assert_eq!(
+                outcomes.len(),
+                adjustment_count,
+                "rollover acknowledgement count must match adjustment count"
+            );
+            let adjustments = day
+                .pending_adjustments
+                .take()
+                .expect("no completed rollover batch to acknowledge");
+            (
+                adjustments,
+                day.attempt_time
+                    .take()
+                    .expect("rollover attempt time recorded"),
+                day.date,
+                day.scheduled_time_ns,
+            )
+        };
+
+        let mut failed = Vec::new();
+        {
+            let mut totals = self.rollover_totals.borrow_mut();
+
+            for (adjustment, outcome) in adjustments.into_iter().zip(outcomes) {
+                match outcome {
+                    AccountAdjustmentOutcome::Applied => {
+                        let total = totals.entry(adjustment.currency).or_insert(0.0);
+                        *total += adjustment.as_f64();
+                        self.rollover_day
+                            .borrow_mut()
+                            .as_mut()
+                            .expect("rollover day initialized")
+                            .warned_adjustment_failures
+                            .retain(|(currency, _)| *currency != adjustment.currency);
+                    }
+                    AccountAdjustmentOutcome::Failed(error) => {
+                        let kind = AccountAdjustmentFailureKind::from(error);
+                        let first_failure = self
+                            .rollover_day
+                            .borrow_mut()
+                            .as_mut()
+                            .expect("rollover day initialized")
+                            .warned_adjustment_failures
+                            .insert((adjustment.currency, kind));
+
+                        if first_failure {
+                            log::warn!(
+                                "Cannot apply rollover adjustment for {}: {error}",
+                                adjustment.currency
+                            );
+                        } else {
+                            log::debug!(
+                                "Cannot apply rollover adjustment for {}: {error}",
+                                adjustment.currency
+                            );
+                        }
+                        failed.push(adjustment);
+                    }
+                }
+            }
+        }
+
+        if failed.is_empty() {
+            self.rollover_applied.set(true);
+            self.rollover_day
+                .borrow_mut()
+                .as_mut()
+                .expect("rollover day initialized")
+                .warned_failures
+                .clear();
+            self.rollover_day
+                .borrow_mut()
+                .as_mut()
+                .expect("rollover day initialized")
+                .warned_adjustment_failures
+                .clear();
+
+            let attempt_eastern = Eastern.from_utc_datetime(&nanos_to_utc_datetime(attempt_time));
+
+            if attempt_eastern.date_naive() != date {
+                log::warn!(
+                    "Rollover for {date}, scheduled at {}, booked late at {attempt_time}",
+                    UnixNanos::from(scheduled_time_ns)
+                );
+            }
+        } else {
+            self.rollover_day
+                .borrow_mut()
+                .as_mut()
+                .expect("rollover day initialized")
+                .pending_adjustments = Some(failed);
+        }
     }
 
     fn log_diagnostics(&self) {
@@ -437,11 +622,9 @@ impl SimulationModule for FXRolloverInterestModule {
     }
 
     fn reset(&self) {
-        self.rollover_time_ns.set(0);
         self.rollover_applied.set(false);
-        self.rollover_date.set(None);
+        self.rollover_day.replace(None);
         self.rollover_totals.borrow_mut().clear();
-        self.warned_failures.borrow_mut().clear();
     }
 }
 
@@ -456,7 +639,9 @@ fn nanos_to_utc_datetime(ts: UnixNanos) -> NaiveDateTime {
 
 #[cfg(test)]
 mod tests {
-    use nautilus_model::identifiers::InstrumentId;
+    use indexmap::IndexMap;
+    use nautilus_common::cache::Cache;
+    use nautilus_model::identifiers::{InstrumentId, Venue};
     use rstest::rstest;
     use serde_json::json;
 
@@ -546,9 +731,7 @@ mod tests {
     #[rstest]
     fn test_module_reset() {
         let module = FXRolloverInterestModule::new(sample_records()).unwrap();
-        module
-            .rollover_date
-            .set(NaiveDate::from_ymd_opt(2020, 1, 15));
+        module.initialize_rollover_day(NaiveDate::from_ymd_opt(2020, 1, 15).unwrap());
         module.rollover_applied.set(true);
         module
             .rollover_totals
@@ -557,7 +740,7 @@ mod tests {
 
         module.reset();
 
-        assert_eq!(module.rollover_date.get(), None);
+        assert!(module.rollover_day.borrow().is_none());
         assert!(!module.rollover_applied.get());
         assert!(module.rollover_totals.borrow().is_empty());
     }
@@ -611,5 +794,145 @@ mod tests {
             rollover_money(InstrumentId::from("AUDUSD.SIM"), f64::MAX, Currency::USD());
 
         assert_eq!(adjustment, None);
+    }
+
+    #[rstest]
+    fn test_partial_acknowledgement_retries_only_failed_adjustments() {
+        let module = FXRolloverInterestModule::new(sample_records()).unwrap();
+        let date = NaiveDate::from_ymd_opt(2020, 1, 15).unwrap();
+        let attempt_time = UnixNanos::from(
+            date.and_hms_opt(22, 1, 0)
+                .unwrap()
+                .and_utc()
+                .timestamp_nanos_opt()
+                .unwrap()
+                .cast_unsigned(),
+        );
+        module.initialize_rollover_day(date);
+        {
+            let mut day = module.rollover_day.borrow_mut();
+            let day = day.as_mut().unwrap();
+            day.pending_adjustments =
+                Some(vec![Money::from("10.00 USD"), Money::from("20.00 AUD")]);
+            day.attempt_time = Some(attempt_time);
+        }
+
+        module.acknowledge(&[
+            AccountAdjustmentOutcome::Applied,
+            AccountAdjustmentOutcome::Failed(AccountAdjustmentError::MissingBalance(
+                Currency::AUD(),
+            )),
+        ]);
+
+        assert!(!module.rollover_applied.get());
+        assert_eq!(
+            module
+                .rollover_day
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .pending_adjustments,
+            Some(vec![Money::from("20.00 AUD")])
+        );
+        assert_eq!(
+            module.rollover_totals.borrow().get(&Currency::USD()),
+            Some(&10.0)
+        );
+        assert!(
+            !module
+                .rollover_totals
+                .borrow()
+                .contains_key(&Currency::AUD())
+        );
+        assert_eq!(
+            module
+                .rollover_day
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .warned_adjustment_failures
+                .len(),
+            1
+        );
+
+        let instruments = AHashMap::new();
+        let matching_engines = IndexMap::new();
+        let cache = Cache::default();
+        let ctx = ExchangeContext {
+            venue: Venue::new("SIM"),
+            base_currency: None,
+            instruments: &instruments,
+            matching_engines: &matching_engines,
+            cache: &cache,
+        };
+        assert_eq!(
+            module.process(attempt_time, &ctx),
+            SimulationModuleResult::Completed(vec![Money::from("20.00 AUD")])
+        );
+        module.acknowledge(&[AccountAdjustmentOutcome::Failed(
+            AccountAdjustmentError::MissingBalance(Currency::AUD()),
+        )]);
+        assert_eq!(
+            module
+                .rollover_day
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .warned_adjustment_failures
+                .len(),
+            1
+        );
+        assert_eq!(
+            module.process(attempt_time, &ctx),
+            SimulationModuleResult::Completed(vec![Money::from("20.00 AUD")])
+        );
+        module.acknowledge(&[AccountAdjustmentOutcome::Applied]);
+
+        assert!(module.rollover_applied.get());
+        assert_eq!(
+            module.rollover_totals.borrow().get(&Currency::USD()),
+            Some(&10.0)
+        );
+        assert_eq!(
+            module.rollover_totals.borrow().get(&Currency::AUD()),
+            Some(&20.0)
+        );
+        assert!(
+            module
+                .rollover_day
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .warned_adjustment_failures
+                .is_empty()
+        );
+    }
+
+    #[rstest]
+    fn test_acknowledgement_count_panic_preserves_pending_batch() {
+        let module = FXRolloverInterestModule::new(sample_records()).unwrap();
+        let date = NaiveDate::from_ymd_opt(2020, 1, 15).unwrap();
+        module.initialize_rollover_day(date);
+        {
+            let mut day = module.rollover_day.borrow_mut();
+            let day = day.as_mut().unwrap();
+            day.pending_adjustments = Some(vec![Money::from("10.00 USD")]);
+            day.attempt_time = Some(UnixNanos::from(1));
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            module.acknowledge(&[]);
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(
+            module
+                .rollover_day
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .pending_adjustments,
+            Some(vec![Money::from("10.00 USD")])
+        );
     }
 }

--- a/crates/backtest/src/modules/mod.rs
+++ b/crates/backtest/src/modules/mod.rs
@@ -17,6 +17,8 @@
 
 pub mod fx_rollover;
 
+use std::fmt::Display;
+
 use ahash::AHashMap;
 pub use fx_rollover::FXRolloverInterestModule;
 use indexmap::IndexMap;
@@ -57,9 +59,15 @@ impl SimulationModule for SimulationModuleAny {
         }
     }
 
-    fn process(&self, ts_now: UnixNanos, ctx: &ExchangeContext) -> Vec<Money> {
+    fn process(&self, ts_now: UnixNanos, ctx: &ExchangeContext) -> SimulationModuleResult {
         match self {
             Self::FXRolloverInterest(module) => module.process(ts_now, ctx),
+        }
+    }
+
+    fn acknowledge(&self, outcomes: &[AccountAdjustmentOutcome]) {
+        match self {
+            Self::FXRolloverInterest(module) => module.acknowledge(outcomes),
         }
     }
 
@@ -84,6 +92,73 @@ impl From<SimulationModuleAny> for Box<dyn SimulationModule> {
     }
 }
 
+/// Result of processing a simulation module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SimulationModuleResult {
+    /// The module does not yet have a complete batch of adjustments.
+    NotReady,
+    /// The module produced a complete batch, which may be empty.
+    Completed(Vec<Money>),
+}
+
+/// Failure applying an account adjustment produced by a simulation module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccountAdjustmentError {
+    /// The adjusted total balance would exceed [`Money`] bounds.
+    TotalOverflow(Currency),
+    /// The adjusted free balance would exceed [`Money`] bounds.
+    FreeBalanceOverflow(Currency),
+    /// The account has no balance for the adjustment currency.
+    MissingBalance(Currency),
+    /// The exchange has no account for the venue.
+    MissingAccount(Venue),
+    /// Generating the updated account state failed.
+    AccountStateGeneration(String),
+}
+
+impl Display for AccountAdjustmentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TotalOverflow(currency) => {
+                write!(
+                    f,
+                    "Cannot adjust account: {currency} total exceeds Money bounds"
+                )
+            }
+            Self::FreeBalanceOverflow(currency) => write!(
+                f,
+                "Cannot adjust account: {currency} free balance exceeds Money bounds"
+            ),
+            Self::MissingBalance(currency) => {
+                write!(
+                    f,
+                    "Cannot adjust account: no balance for currency {currency}"
+                )
+            }
+            Self::MissingAccount(venue) => {
+                write!(f, "Cannot adjust account: no account for venue {venue}")
+            }
+            Self::AccountStateGeneration(error) => {
+                write!(
+                    f,
+                    "Cannot adjust account: failed to generate account state: {error}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for AccountAdjustmentError {}
+
+/// Outcome of applying an account adjustment produced by a simulation module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccountAdjustmentOutcome {
+    /// The adjustment was applied successfully.
+    Applied,
+    /// The adjustment could not be applied.
+    Failed(AccountAdjustmentError),
+}
+
 /// Trait for custom simulation modules that extend backtesting functionality.
 ///
 /// Implementations can add specialized behavior such as rollover interest,
@@ -98,8 +173,20 @@ pub trait SimulationModule {
 
     /// Processes simulation logic at the given timestamp.
     ///
-    /// Returns account balance adjustments to be applied by the exchange.
-    fn process(&self, ts_now: UnixNanos, ctx: &ExchangeContext) -> Vec<Money>;
+    /// Returns a complete batch of account balance adjustments, or indicates
+    /// that the module is not ready.
+    fn process(&self, ts_now: UnixNanos, ctx: &ExchangeContext) -> SimulationModuleResult;
+
+    /// Acknowledges the ordered application outcomes for a completed batch.
+    ///
+    /// This is called exactly once for every [`SimulationModuleResult::Completed`],
+    /// including an empty batch.
+    ///
+    /// # Panics
+    ///
+    /// Implementations may panic if the outcome count does not match the
+    /// completed batch or if no completed batch is awaiting acknowledgement.
+    fn acknowledge(&self, outcomes: &[AccountAdjustmentOutcome]);
 
     /// Logs diagnostic information about the module's state.
     fn log_diagnostics(&self);

--- a/crates/backtest/tests/backtest_engine.rs
+++ b/crates/backtest/tests/backtest_engine.rs
@@ -24,7 +24,9 @@ use indexmap::IndexMap;
 use nautilus_backtest::{
     config::{BacktestEngineConfig, SimulatedVenueConfig},
     engine::BacktestEngine,
-    modules::{ExchangeContext, SimulationModule},
+    modules::{
+        AccountAdjustmentOutcome, ExchangeContext, SimulationModule, SimulationModuleResult,
+    },
 };
 use nautilus_common::{
     actor::{
@@ -4780,7 +4782,7 @@ struct CountingSimulationModule {
 impl SimulationModule for CountingSimulationModule {
     fn pre_process(&self, _data: &Data) {}
 
-    fn process(&self, ts_now: UnixNanos, _ctx: &ExchangeContext) -> Vec<Money> {
+    fn process(&self, ts_now: UnixNanos, _ctx: &ExchangeContext) -> SimulationModuleResult {
         let prev = self.tracker.last_ts.get();
         if prev == Some(ts_now) {
             self.tracker.duplicate_ts_seen.set(true);
@@ -4789,8 +4791,10 @@ impl SimulationModule for CountingSimulationModule {
         self.tracker
             .total_calls
             .set(self.tracker.total_calls.get() + 1);
-        Vec::new()
+        SimulationModuleResult::Completed(Vec::new())
     }
+
+    fn acknowledge(&self, _outcomes: &[AccountAdjustmentOutcome]) {}
 
     fn log_diagnostics(&self) {}
 

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -19,11 +19,17 @@ use std::{
     str::FromStr,
 };
 
+use ahash::AHashMap;
+use chrono::TimeZone;
+use chrono_tz::US::Eastern;
 use nautilus_backtest::{
     config::SimulatedVenueConfig,
     exchange::SimulatedExchange,
     execution_client::BacktestExecutionClient,
-    modules::{ExchangeContext, SimulationModule},
+    modules::{
+        ExchangeContext, FXRolloverInterestModule, SimulationModule,
+        fx_rollover::InterestRateRecord,
+    },
 };
 use nautilus_common::{
     cache::Cache,
@@ -43,7 +49,7 @@ use nautilus_execution::models::{
     latency::StaticLatencyModel,
 };
 use nautilus_model::{
-    accounts::{AccountAny, CashAccount, MarginAccount},
+    accounts::{Account, AccountAny, CashAccount, MarginAccount},
     data::{
         Bar, BarType, BookOrder, Data, FundingRateUpdate, InstrumentStatus, MarkPriceUpdate,
         OrderBookDelta, OrderBookDeltas, QuoteTick, TradeTick,
@@ -58,17 +64,19 @@ use nautilus_model::{
         order::spec::OrderPendingUpdateSpec,
     },
     identifiers::{
-        AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TradeId, TraderId,
-        Venue,
+        AccountId, ClientOrderId, InstrumentId, OrderListId, PositionId, StrategyId, Symbol,
+        TradeId, TraderId, Venue,
     },
     instruments::{
-        CryptoOption, CryptoPerpetual, Instrument, InstrumentAny, OptionContract,
-        stubs::{crypto_perpetual_ethusdt, xbtusd_bitmex},
+        CryptoOption, CryptoPerpetual, CurrencyPair, Instrument, InstrumentAny, OptionContract,
+        stubs::{audusd_sim, crypto_perpetual_ethusdt, gbpusd_sim, xbtusd_bitmex},
     },
     orders::{Order, OrderAny, OrderList, OrderTestBuilder, stubs::TestOrderEventStubs},
     position::Position,
     stubs::TestDefault,
-    types::{AccountBalance, Currency, Money, Price, Quantity, money::MONEY_RAW_MAX},
+    types::{
+        AccountBalance, Currency, MarginBalance, Money, Price, Quantity, money::MONEY_RAW_MAX,
+    },
 };
 use rstest::rstest;
 use rust_decimal::Decimal;
@@ -217,6 +225,160 @@ fn test_matching_engine_iteration_order_is_stable_across_rebuilds(
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);
     }
+}
+
+#[rstest]
+#[case(false)]
+#[case(true)]
+fn test_liquidation_closes_all_breached_currencies_in_one_pass(
+    audusd_sim: CurrencyPair,
+    #[case] reverse_balances: bool,
+) {
+    let usd = Currency::USD();
+    let jpy = Currency::JPY();
+    let audusd = InstrumentAny::CurrencyPair(audusd_sim.clone());
+    let mut usdjpy = audusd_sim;
+    usdjpy.id = InstrumentId::from("USD/JPY.SIM");
+    usdjpy.raw_symbol = Symbol::from("USD/JPY");
+    usdjpy.base_currency = usd;
+    usdjpy.quote_currency = jpy;
+    let usdjpy = InstrumentAny::CurrencyPair(usdjpy);
+    let mut balances = vec![
+        AccountBalance::new(Money::new(1.0, usd), Money::zero(usd), Money::new(1.0, usd)),
+        AccountBalance::new(Money::new(1.0, jpy), Money::zero(jpy), Money::new(1.0, jpy)),
+    ];
+
+    if reverse_balances {
+        balances.reverse();
+    }
+
+    let account = MarginAccount::new(
+        AccountState::new(
+            AccountId::from("SIM-001"),
+            AccountType::Margin,
+            balances.clone(),
+            vec![
+                MarginBalance::new(
+                    Money::new(10.0, usd),
+                    Money::new(10.0, usd),
+                    Some(audusd.id()),
+                ),
+                MarginBalance::new(
+                    Money::new(10.0, jpy),
+                    Money::new(10.0, jpy),
+                    Some(usdjpy.id()),
+                ),
+            ],
+            false,
+            UUID4::default(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            None,
+        ),
+        false,
+    );
+    let mut raw_cache = Cache::default();
+    raw_cache.add_account(AccountAny::Margin(account)).unwrap();
+    add_fx_position(
+        &mut raw_cache,
+        &audusd,
+        "T-LIQUIDATION-USD",
+        "100000",
+        "2.00000",
+    );
+    add_fx_position(
+        &mut raw_cache,
+        &usdjpy,
+        "T-LIQUIDATION-JPY",
+        "100000",
+        "200.00000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    let config = SimulatedVenueConfig::builder()
+        .venue(Venue::new("SIM"))
+        .oms_type(OmsType::Netting)
+        .account_type(AccountType::Margin)
+        .book_type(BookType::L1_MBP)
+        .starting_balances(
+            balances
+                .iter()
+                .map(|balance| balance.total)
+                .collect::<Vec<_>>(),
+        )
+        .default_leverage(Decimal::ONE)
+        .liquidation_enabled(true)
+        .fee_model(FeeModelAny::MakerTaker(MakerTakerFeeModel).into())
+        .build()
+        .unwrap();
+    let exchange = Rc::new(RefCell::new(
+        SimulatedExchange::new(config, cache.clone(), clock.clone()).unwrap(),
+    ));
+    let client = BacktestExecutionClient::new(
+        TraderId::test_default(),
+        AccountId::from("SIM-001"),
+        &exchange,
+        cache.clone(),
+        clock,
+        None,
+        None,
+    );
+    exchange.borrow_mut().register_client(Rc::new(client));
+    exchange
+        .borrow_mut()
+        .add_instrument(audusd.clone())
+        .unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(usdjpy.clone())
+        .unwrap();
+    add_fx_quote(&exchange, &cache, audusd.id(), "1.00000", "1.00010");
+    add_fx_quote(&exchange, &cache, usdjpy.id(), "100.00000", "100.00010");
+    let (handler, saving_handler) = get_typed_into_message_saving_handler::<OrderEventAny>(None);
+    msgbus::register_order_event_endpoint(MessagingSwitchboard::exec_engine_process(), handler);
+
+    {
+        let cache = cache.borrow();
+        let account = cache.account_for_venue_owned(&Venue::new("SIM")).unwrap();
+        let AccountAny::Margin(account) = account else {
+            panic!("expected margin account");
+        };
+        let currencies = account.currencies();
+        assert_eq!(currencies.len(), 2, "{currencies:?}");
+        assert_eq!(account.total_maintenance_margin(usd), Money::new(10.0, usd));
+        assert_eq!(account.total_maintenance_margin(jpy), Money::new(10.0, jpy));
+        assert_eq!(
+            cache
+                .positions_open(Some(&Venue::new("SIM")), None, None, None, None)
+                .len(),
+            2
+        );
+
+        for position in cache.positions_open(Some(&Venue::new("SIM")), None, None, None, None) {
+            assert!(cache.calculate_unrealized_pnl(&position).unwrap().as_f64() < 0.0);
+        }
+    }
+
+    exchange
+        .borrow_mut()
+        .process_liquidations(UnixNanos::from(3));
+
+    let mut liquidated = saving_handler
+        .get_messages()
+        .iter()
+        .filter_map(|event| match event {
+            OrderEventAny::Filled(fill)
+                if fill.client_order_id.as_str().starts_with("LIQUIDATION-") =>
+            {
+                Some(fill.instrument_id)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    liquidated.sort_unstable();
+    let mut expected = vec![audusd.id(), usdjpy.id()];
+    expected.sort_unstable();
+    assert_eq!(liquidated, expected);
 }
 
 #[rstest]
@@ -3127,6 +3289,244 @@ fn test_module_process_called_by_process_modules(crypto_perpetual_ethusdt: Crypt
     exchange.borrow_mut().process_modules(UnixNanos::from(100));
 
     assert_eq!(counts.process.get(), 1);
+}
+
+fn rollover_records() -> Vec<InterestRateRecord> {
+    ["2020-01", "2021-01"]
+        .into_iter()
+        .flat_map(|time| {
+            [
+                InterestRateRecord {
+                    location: "AUS".to_string(),
+                    time: time.to_string(),
+                    value: 0.75,
+                },
+                InterestRateRecord {
+                    location: "GBR".to_string(),
+                    time: time.to_string(),
+                    value: 0.50,
+                },
+                InterestRateRecord {
+                    location: "USA".to_string(),
+                    time: time.to_string(),
+                    value: 1.50,
+                },
+            ]
+        })
+        .collect()
+}
+
+fn rollover_timestamp(year: i32, month: u32, day: u32) -> UnixNanos {
+    let timestamp = Eastern
+        .with_ymd_and_hms(year, month, day, 17, 1, 0)
+        .single()
+        .unwrap()
+        .timestamp_nanos_opt()
+        .unwrap()
+        .cast_unsigned();
+    UnixNanos::from(timestamp)
+}
+
+fn add_fx_position(
+    cache: &mut Cache,
+    instrument: &InstrumentAny,
+    trade_id: &str,
+    quantity: &str,
+    price: &str,
+) {
+    cache.add_instrument(instrument.clone()).unwrap();
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(quantity))
+        .build();
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        instrument,
+        Some(TradeId::from(trade_id)),
+        Some(PositionId::from(format!("P-{trade_id}").as_str())),
+        Some(Price::from(price)),
+        Some(Quantity::from(quantity)),
+        None,
+        Some(Money::new(0.0, instrument.quote_currency())),
+        Some(UnixNanos::from(1)),
+        Some(AccountId::from("SIM-001")),
+    );
+    let position = Position::new(instrument, fill.into());
+    cache.add_position(&position, OmsType::Netting).unwrap();
+}
+
+fn process_rollover(
+    module: &FXRolloverInterestModule,
+    exchange: &Rc<RefCell<SimulatedExchange>>,
+    cache: &Rc<RefCell<Cache>>,
+    instruments: &AHashMap<InstrumentId, InstrumentAny>,
+    ts_now: UnixNanos,
+) -> Vec<Money> {
+    let exchange = exchange.borrow();
+    let cache = cache.borrow();
+    let ctx = ExchangeContext {
+        venue: Venue::new("SIM"),
+        base_currency: None,
+        instruments,
+        matching_engines: exchange.get_matching_engines(),
+        cache: &cache,
+    };
+    module.process(ts_now, &ctx)
+}
+
+fn add_fx_quote(
+    exchange: &Rc<RefCell<SimulatedExchange>>,
+    cache: &Rc<RefCell<Cache>>,
+    instrument_id: InstrumentId,
+    bid: &str,
+    ask: &str,
+) {
+    let quote = QuoteTick::new(
+        instrument_id,
+        Price::from(bid),
+        Price::from(ask),
+        Quantity::from("1000000"),
+        Quantity::from("1000000"),
+        UnixNanos::from(2),
+        UnixNanos::from(2),
+    );
+    cache.borrow_mut().add_quote(quote).unwrap();
+    exchange.borrow_mut().process_quote_tick(&quote);
+}
+
+#[rstest]
+fn test_fx_rollover_retries_after_quote_arrives(audusd_sim: CurrencyPair) {
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+    let mut raw_cache = Cache::default();
+    add_fx_position(
+        &mut raw_cache,
+        &instrument,
+        "T-ROLLOVER-RETRY",
+        "100000",
+        "1.00000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let exchange = get_exchange(
+        Venue::new("SIM"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    exchange
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    let instruments = AHashMap::from([(instrument.id(), instrument.clone())]);
+    let module = FXRolloverInterestModule::new(rollover_records());
+    let rollover = rollover_timestamp(2020, 1, 15);
+
+    assert!(process_rollover(&module, &exchange, &cache, &instruments, rollover).is_empty());
+
+    add_fx_quote(&exchange, &cache, instrument.id(), "0.99990", "1.00010");
+    assert_eq!(
+        process_rollover(&module, &exchange, &cache, &instruments, rollover + 1).len(),
+        1
+    );
+    assert!(process_rollover(&module, &exchange, &cache, &instruments, rollover + 2).is_empty());
+}
+
+#[rstest]
+fn test_fx_rollover_is_atomic_across_instruments(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+) {
+    let first = InstrumentAny::CurrencyPair(audusd_sim);
+    let second = InstrumentAny::CurrencyPair(gbpusd_sim);
+    let mut raw_cache = Cache::default();
+    add_fx_position(
+        &mut raw_cache,
+        &first,
+        "T-ROLLOVER-ATOMIC-1",
+        "100000",
+        "1.00000",
+    );
+    add_fx_position(
+        &mut raw_cache,
+        &second,
+        "T-ROLLOVER-ATOMIC-2",
+        "100000",
+        "1.20000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let exchange = get_exchange(
+        Venue::new("SIM"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    exchange.borrow_mut().add_instrument(first.clone()).unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(second.clone())
+        .unwrap();
+    let instruments = AHashMap::from([(first.id(), first.clone()), (second.id(), second.clone())]);
+    let module = FXRolloverInterestModule::new(rollover_records());
+    let rollover = rollover_timestamp(2020, 1, 15);
+
+    add_fx_quote(&exchange, &cache, first.id(), "0.99990", "1.00010");
+    assert!(process_rollover(&module, &exchange, &cache, &instruments, rollover).is_empty());
+
+    add_fx_quote(&exchange, &cache, second.id(), "1.19990", "1.20010");
+    assert_eq!(
+        process_rollover(&module, &exchange, &cache, &instruments, rollover + 1).len(),
+        2
+    );
+}
+
+#[rstest]
+fn test_fx_rollover_distinguishes_same_ordinal_across_years(audusd_sim: CurrencyPair) {
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+    let mut raw_cache = Cache::default();
+    add_fx_position(
+        &mut raw_cache,
+        &instrument,
+        "T-ROLLOVER-CROSS-YEAR",
+        "100000",
+        "1.00000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let exchange = get_exchange(
+        Venue::new("SIM"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    exchange
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    add_fx_quote(&exchange, &cache, instrument.id(), "0.99990", "1.00010");
+    let instruments = AHashMap::from([(instrument.id(), instrument)]);
+    let module = FXRolloverInterestModule::new(rollover_records());
+
+    assert_eq!(
+        process_rollover(
+            &module,
+            &exchange,
+            &cache,
+            &instruments,
+            rollover_timestamp(2020, 1, 15),
+        )
+        .len(),
+        1
+    );
+    assert_eq!(
+        process_rollover(
+            &module,
+            &exchange,
+            &cache,
+            &instruments,
+            rollover_timestamp(2021, 1, 15),
+        )
+        .len(),
+        1
+    );
 }
 
 #[rstest]

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -3223,6 +3223,7 @@ impl Log for CapturingLogger {
 static CAPTURING_LOGGER: CapturingLogger = CapturingLogger {
     messages: Mutex::new(Vec::new()),
 };
+static CAPTURING_LOGGER_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 struct AdjustmentSimulationModule {
     label: &'static str,
@@ -3401,6 +3402,70 @@ fn test_module_process_called_by_process_modules(crypto_perpetual_ethusdt: Crypt
     exchange.borrow_mut().process_modules(UnixNanos::from(100));
 
     assert_eq!(counts.process.get(), 1);
+}
+
+#[rstest]
+#[case(true, true)]
+#[case(false, false)]
+fn test_process_modules_skips_when_account_adjustments_are_unavailable(
+    #[case] frozen_account: bool,
+    #[case] register_client: bool,
+) {
+    let outcomes = Rc::new(RefCell::new(Vec::new()));
+    let sequence = Rc::new(RefCell::new(Vec::new()));
+    let modules: Vec<Box<dyn SimulationModule>> = vec![Box::new(AdjustmentSimulationModule {
+        label: "guarded",
+        adjustments: vec![Money::from("1 USD")],
+        outcomes: outcomes.clone(),
+        sequence: sequence.clone(),
+    })];
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    let config = SimulatedVenueConfig::builder()
+        .venue(Venue::new("SIM"))
+        .oms_type(OmsType::Netting)
+        .account_type(AccountType::Margin)
+        .book_type(BookType::L1_MBP)
+        .starting_balances(vec![Money::from("1000 USD")])
+        .default_leverage(Decimal::ONE)
+        .modules(modules)
+        .fee_model(FeeModelAny::MakerTaker(MakerTakerFeeModel).into())
+        .frozen_account(frozen_account)
+        .build()
+        .unwrap();
+    let exchange = Rc::new(RefCell::new(
+        SimulatedExchange::new(config, cache.clone(), clock.clone()).unwrap(),
+    ));
+
+    if register_client {
+        let execution_client = BacktestExecutionClient::new(
+            TraderId::test_default(),
+            AccountId::test_default(),
+            &exchange,
+            cache,
+            clock,
+            None,
+            Some(frozen_account),
+        );
+        exchange
+            .borrow_mut()
+            .register_client(Rc::new(execution_client));
+    }
+
+    let (handler, account_saver) = get_typed_message_saving_handler::<AccountState>(None);
+    msgbus::register_account_state_endpoint("Portfolio.update_account".into(), handler);
+
+    exchange.borrow_mut().process_modules(UnixNanos::from(100));
+
+    assert!(
+        sequence.borrow().is_empty(),
+        "module processing must be skipped"
+    );
+    assert!(
+        outcomes.borrow().is_empty(),
+        "module acknowledgement must be skipped"
+    );
+    assert!(account_saver.get_messages().is_empty());
 }
 
 #[rstest]
@@ -3610,7 +3675,7 @@ fn test_fx_rollover_retries_after_quote_arrives(audusd_sim: CurrencyPair) {
 }
 
 #[rstest]
-fn test_fx_rollover_retry_keeps_prior_economic_day(audusd_sim: CurrencyPair) {
+fn test_fx_rollover_catches_up_each_economic_day_in_order(audusd_sim: CurrencyPair) {
     let instrument = InstrumentAny::CurrencyPair(audusd_sim);
     let mut raw_cache = Cache::default();
     add_fx_position(
@@ -3659,7 +3724,7 @@ fn test_fx_rollover_retry_keeps_prior_economic_day(audusd_sim: CurrencyPair) {
         .is_empty()
     );
 
-    // The quote arrives on Thursday. The pending Wednesday remains first and
+    // The quote arrives on Friday. The pending Wednesday remains first and
     // uses January's rates plus the Wednesday triple multiplier.
     add_fx_quote(&exchange, &cache, instrument.id(), "0.99990", "1.00010");
     assert_eq!(
@@ -3668,7 +3733,7 @@ fn test_fx_rollover_retry_keeps_prior_economic_day(audusd_sim: CurrencyPair) {
             &exchange,
             &cache,
             &instruments,
-            rollover_timestamp(2024, 2, 1),
+            rollover_timestamp(2024, 2, 2),
         ),
         vec![Money::from("-8.22 USD")]
     );
@@ -3680,9 +3745,21 @@ fn test_fx_rollover_retry_keeps_prior_economic_day(audusd_sim: CurrencyPair) {
             &exchange,
             &cache,
             &instruments,
-            rollover_timestamp(2024, 2, 1) + 1,
+            rollover_timestamp(2024, 2, 2) + 1,
         ),
         vec![Money::from("10.96 USD")]
+    );
+
+    // Friday follows on the next invocation and uses the triple multiplier.
+    assert_eq!(
+        process_rollover(
+            &module,
+            &exchange,
+            &cache,
+            &instruments,
+            rollover_timestamp(2024, 2, 2) + 2,
+        ),
+        vec![Money::from("32.88 USD")]
     );
 }
 
@@ -3690,7 +3767,8 @@ fn test_fx_rollover_retry_keeps_prior_economic_day(audusd_sim: CurrencyPair) {
 fn test_missing_xrate_retries_emit_one_module_warning_and_no_cache_errors(
     audusd_sim: CurrencyPair,
 ) {
-    log::set_logger(&CAPTURING_LOGGER).unwrap();
+    let _guard = CAPTURING_LOGGER_TEST_LOCK.lock().unwrap();
+    let _ = log::set_logger(&CAPTURING_LOGGER);
     log::set_max_level(LevelFilter::Warn);
     CAPTURING_LOGGER.clear();
 
@@ -3763,6 +3841,201 @@ fn test_missing_xrate_retries_emit_one_module_warning_and_no_cache_errors(
             .iter()
             .all(|(_, message)| !message.contains("Failed to calculate xrate"))
     );
+}
+
+#[rstest]
+fn test_missing_rates_skip_instrument_and_do_not_stall_later_days(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+) {
+    let _guard = CAPTURING_LOGGER_TEST_LOCK.lock().unwrap();
+    let _ = log::set_logger(&CAPTURING_LOGGER);
+    log::set_max_level(LevelFilter::Warn);
+    CAPTURING_LOGGER.clear();
+
+    let supported = InstrumentAny::CurrencyPair(audusd_sim);
+    let missing_rates = InstrumentAny::CurrencyPair(gbpusd_sim);
+    let mut raw_cache = Cache::default();
+    add_fx_position(
+        &mut raw_cache,
+        &supported,
+        "T-ROLLOVER-SUPPORTED",
+        "100000",
+        "1.00000",
+    );
+    add_fx_position(
+        &mut raw_cache,
+        &missing_rates,
+        "T-ROLLOVER-MISSING-RATES",
+        "100000",
+        "1.20000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let exchange = get_exchange(
+        Venue::new("SIM"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    exchange
+        .borrow_mut()
+        .add_instrument(supported.clone())
+        .unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(missing_rates.clone())
+        .unwrap();
+    // Deliberately no quote for `missing_rates`: the permanently missing rate
+    // must skip the instrument before the transient no-price check can retry
+    // the whole day.
+    add_fx_quote(&exchange, &cache, supported.id(), "0.99990", "1.00010");
+    let instruments = AHashMap::from([
+        (supported.id(), supported.clone()),
+        (missing_rates.id(), missing_rates.clone()),
+    ]);
+    let records = rollover_records()
+        .into_iter()
+        .filter(|record| record.location != "GBR")
+        .collect();
+    let module = FXRolloverInterestModule::new(records).unwrap();
+    let first_day = rollover_timestamp(2020, 1, 15);
+
+    assert_eq!(
+        process_rollover(&module, &exchange, &cache, &instruments, first_day),
+        vec![Money::from("-6.16 USD")]
+    );
+
+    let only_missing = AHashMap::from([(missing_rates.id(), missing_rates)]);
+    let exchange_ref = exchange.borrow();
+    let cache_ref = cache.borrow();
+    let ctx = ExchangeContext {
+        venue: Venue::new("SIM"),
+        base_currency: None,
+        instruments: &only_missing,
+        matching_engines: exchange_ref.get_matching_engines(),
+        cache: &cache_ref,
+    };
+    assert_eq!(
+        module.process(rollover_timestamp(2020, 1, 16), &ctx),
+        SimulationModuleResult::Completed(Vec::new())
+    );
+    module.acknowledge(&[]);
+    assert_eq!(
+        module.process(rollover_timestamp(2020, 1, 17), &ctx),
+        SimulationModuleResult::Completed(Vec::new())
+    );
+
+    let messages = CAPTURING_LOGGER.messages();
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|(level, message)| {
+                *level == Level::Warn
+                    && message.contains("Skipping rollover for GBP/USD.SIM on 2020-01-15")
+            })
+            .count(),
+        1,
+        "captured messages: {messages:?}"
+    );
+}
+
+#[rstest]
+fn test_unrepresentable_money_warns_once_without_error_across_recalculation(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+) {
+    let _guard = CAPTURING_LOGGER_TEST_LOCK.lock().unwrap();
+    let _ = log::set_logger(&CAPTURING_LOGGER);
+    log::set_max_level(LevelFilter::Warn);
+    CAPTURING_LOGGER.clear();
+
+    let unrepresentable = InstrumentAny::CurrencyPair(audusd_sim);
+    let transient = InstrumentAny::CurrencyPair(gbpusd_sim);
+    let mut raw_cache = Cache::default();
+    add_fx_position(
+        &mut raw_cache,
+        &unrepresentable,
+        "T-ROLLOVER-MONEY",
+        "100000",
+        "1.00000",
+    );
+    add_fx_position(
+        &mut raw_cache,
+        &transient,
+        "T-ROLLOVER-MONEY-RETRY",
+        "100000",
+        "1.20000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let exchange = get_exchange(
+        Venue::new("SIM"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    exchange
+        .borrow_mut()
+        .add_instrument(unrepresentable.clone())
+        .unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(transient.clone())
+        .unwrap();
+    add_fx_quote(
+        &exchange,
+        &cache,
+        unrepresentable.id(),
+        "0.99990",
+        "1.00010",
+    );
+    let instruments = AHashMap::from([
+        (unrepresentable.id(), unrepresentable.clone()),
+        (transient.id(), transient.clone()),
+    ]);
+    let records = vec![
+        InterestRateRecord {
+            location: "AUS".to_string(),
+            time: "2020-01".to_string(),
+            value: f64::MAX,
+        },
+        InterestRateRecord {
+            location: "GBR".to_string(),
+            time: "2020-01".to_string(),
+            value: 0.5,
+        },
+        InterestRateRecord {
+            location: "USA".to_string(),
+            time: "2020-01".to_string(),
+            value: 1.5,
+        },
+    ];
+    let module = FXRolloverInterestModule::new(records).unwrap();
+    let rollover = rollover_timestamp(2020, 1, 15);
+
+    assert!(process_rollover(&module, &exchange, &cache, &instruments, rollover).is_empty());
+    add_fx_quote(&exchange, &cache, transient.id(), "1.19990", "1.20010");
+    assert_eq!(
+        process_rollover(&module, &exchange, &cache, &instruments, rollover + 1),
+        vec![Money::from("-9.86 USD")]
+    );
+
+    let messages = CAPTURING_LOGGER.messages();
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|(level, message)| {
+                *level == Level::Warn
+                    && message.contains("Skipping rollover for AUD/USD.SIM on 2020-01-15")
+            })
+            .count(),
+        1,
+        "captured messages: {messages:?}"
+    );
+    assert!(messages.iter().all(|(level, message)| {
+        *level != Level::Error
+            || !(message.contains("Skipping rollover for AUD/USD.SIM")
+                && message.contains("invalid adjustment"))
+    }));
 }
 
 #[rstest]

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -3725,7 +3725,7 @@ fn test_fx_rollover_catches_up_each_economic_day_in_order(audusd_sim: CurrencyPa
     );
 
     // The quote arrives on Friday. The pending Wednesday remains first and
-    // uses January's rates plus the Wednesday triple multiplier.
+    // the full due batch uses each booking date's rates and multiplier.
     add_fx_quote(&exchange, &cache, instrument.id(), "0.99990", "1.00010");
     assert_eq!(
         process_rollover(
@@ -3735,32 +3735,68 @@ fn test_fx_rollover_catches_up_each_economic_day_in_order(audusd_sim: CurrencyPa
             &instruments,
             rollover_timestamp(2024, 2, 2),
         ),
-        vec![Money::from("-8.22 USD")]
+        vec![
+            Money::from("-8.22 USD"),
+            Money::from("10.96 USD"),
+            Money::from("32.88 USD"),
+        ]
     );
 
-    // Once Wednesday is acknowledged, Thursday initializes and is immediately due.
-    assert_eq!(
+    // Acknowledgement advances the cursor to Friday, the stored batch end date.
+    assert!(
         process_rollover(
             &module,
             &exchange,
             &cache,
             &instruments,
             rollover_timestamp(2024, 2, 2) + 1,
-        ),
-        vec![Money::from("10.96 USD")]
+        )
+        .is_empty()
     );
+}
 
-    // Friday follows on the next invocation and uses the triple multiplier.
+#[rstest]
+fn test_fx_rollover_friday_to_monday_gap_books_monday_once(audusd_sim: CurrencyPair) {
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+    let mut raw_cache = Cache::default();
+    add_fx_position(
+        &mut raw_cache,
+        &instrument,
+        "T-ROLLOVER-WEEKEND",
+        "100000",
+        "1.00000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let exchange = get_exchange(
+        Venue::new("SIM"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    exchange
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    add_fx_quote(&exchange, &cache, instrument.id(), "0.99990", "1.00010");
+    let instruments = AHashMap::from([(instrument.id(), instrument)]);
+    let module = FXRolloverInterestModule::new(rollover_records()).unwrap();
+
     assert_eq!(
         process_rollover(
             &module,
             &exchange,
             &cache,
             &instruments,
-            rollover_timestamp(2024, 2, 2) + 2,
+            rollover_timestamp(2020, 1, 17),
         ),
-        vec![Money::from("32.88 USD")]
+        vec![Money::from("-6.16 USD")]
     );
+    let monday = rollover_timestamp(2020, 1, 20);
+    assert_eq!(
+        process_rollover(&module, &exchange, &cache, &instruments, monday),
+        vec![Money::from("-2.05 USD")]
+    );
+    assert!(process_rollover(&module, &exchange, &cache, &instruments, monday + 1).is_empty());
 }
 
 #[rstest]
@@ -4123,6 +4159,8 @@ fn test_fx_rollover_distinguishes_same_ordinal_across_years(audusd_sim: Currency
         .len(),
         1
     );
+    // The catch-up includes the remaining 12 January 2020 weekdays and the
+    // first 11 January 2021 weekdays. Dates without configured rates skip.
     assert_eq!(
         process_rollover(
             &module,
@@ -4132,7 +4170,7 @@ fn test_fx_rollover_distinguishes_same_ordinal_across_years(audusd_sim: Currency
             rollover_timestamp(2021, 1, 15),
         )
         .len(),
-        1
+        23
     );
 }
 

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -17,17 +17,20 @@ use std::{
     cell::{Cell, RefCell},
     rc::Rc,
     str::FromStr,
+    sync::Mutex,
 };
 
 use ahash::AHashMap;
 use chrono::TimeZone;
 use chrono_tz::US::Eastern;
+use log::{Level, LevelFilter, Log, Metadata, Record};
 use nautilus_backtest::{
     config::SimulatedVenueConfig,
     exchange::SimulatedExchange,
     execution_client::BacktestExecutionClient,
     modules::{
-        ExchangeContext, FXRolloverInterestModule, SimulationModule,
+        AccountAdjustmentError, AccountAdjustmentOutcome, ExchangeContext,
+        FXRolloverInterestModule, SimulationModule, SimulationModuleResult,
         fx_rollover::InterestRateRecord,
     },
 };
@@ -41,6 +44,7 @@ use nautilus_common::{
             TypedIntoMessageSavingHandler, get_any_saving_handler,
             get_typed_into_message_saving_handler, get_typed_message_saving_handler,
         },
+        typed_handler::TypedHandler,
     },
 };
 use nautilus_core::{UUID4, UnixNanos};
@@ -3184,6 +3188,69 @@ struct MockSimulationModule {
     counts: MockModuleCounts,
 }
 
+#[derive(Default)]
+struct CapturingLogger {
+    messages: Mutex<Vec<(Level, String)>>,
+}
+
+impl CapturingLogger {
+    fn clear(&self) {
+        self.messages.lock().unwrap().clear();
+    }
+
+    fn messages(&self) -> Vec<(Level, String)> {
+        self.messages.lock().unwrap().clone()
+    }
+}
+
+impl Log for CapturingLogger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.level() <= Level::Warn
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if self.enabled(record.metadata()) {
+            self.messages
+                .lock()
+                .unwrap()
+                .push((record.level(), record.args().to_string()));
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static CAPTURING_LOGGER: CapturingLogger = CapturingLogger {
+    messages: Mutex::new(Vec::new()),
+};
+
+struct AdjustmentSimulationModule {
+    label: &'static str,
+    adjustments: Vec<Money>,
+    outcomes: Rc<RefCell<Vec<AccountAdjustmentOutcome>>>,
+    sequence: Rc<RefCell<Vec<String>>>,
+}
+
+impl SimulationModule for AdjustmentSimulationModule {
+    fn pre_process(&self, _data: &Data) {}
+
+    fn process(&self, _ts_now: UnixNanos, _ctx: &ExchangeContext) -> SimulationModuleResult {
+        self.sequence
+            .borrow_mut()
+            .push(format!("process-{}", self.label));
+
+        SimulationModuleResult::Completed(self.adjustments.clone())
+    }
+
+    fn acknowledge(&self, outcomes: &[AccountAdjustmentOutcome]) {
+        self.outcomes.borrow_mut().extend_from_slice(outcomes);
+    }
+
+    fn log_diagnostics(&self) {}
+
+    fn reset(&self) {}
+}
+
 impl MockSimulationModule {
     fn new(counts: MockModuleCounts) -> Self {
         Self { counts }
@@ -3197,10 +3264,12 @@ impl SimulationModule for MockSimulationModule {
             .set(self.counts.pre_process.get() + 1);
     }
 
-    fn process(&self, _ts_now: UnixNanos, _ctx: &ExchangeContext) -> Vec<Money> {
+    fn process(&self, _ts_now: UnixNanos, _ctx: &ExchangeContext) -> SimulationModuleResult {
         self.counts.process.set(self.counts.process.get() + 1);
-        Vec::new()
+        SimulationModuleResult::Completed(Vec::new())
     }
+
+    fn acknowledge(&self, _outcomes: &[AccountAdjustmentOutcome]) {}
 
     fn log_diagnostics(&self) {
         self.counts
@@ -3217,14 +3286,19 @@ fn get_exchange_with_module(
     venue: Venue,
     counts: MockModuleCounts,
 ) -> Rc<RefCell<SimulatedExchange>> {
+    get_exchange_with_modules(venue, vec![Box::new(MockSimulationModule::new(counts))])
+}
+
+fn get_exchange_with_modules(
+    venue: Venue,
+    modules: Vec<Box<dyn SimulationModule>>,
+) -> Rc<RefCell<SimulatedExchange>> {
     let cache = Rc::new(RefCell::new(Cache::default()));
     let clock = Rc::new(RefCell::new(TestClock::new()));
 
     // Register msgbus handler so generate_account_state works during reset
     let (handler, _saving_handler) = get_typed_message_saving_handler::<AccountState>(None);
     msgbus::register_account_state_endpoint("Portfolio.update_account".into(), handler);
-
-    let modules: Vec<Box<dyn SimulationModule>> = vec![Box::new(MockSimulationModule::new(counts))];
 
     let config = SimulatedVenueConfig::builder()
         .venue(venue)
@@ -3329,6 +3403,65 @@ fn test_module_process_called_by_process_modules(crypto_perpetual_ethusdt: Crypt
     assert_eq!(counts.process.get(), 1);
 }
 
+#[rstest]
+fn test_process_modules_forwards_real_outcomes_after_shared_snapshot() {
+    let first_outcomes = Rc::new(RefCell::new(Vec::new()));
+    let second_outcomes = Rc::new(RefCell::new(Vec::new()));
+    let sequence = Rc::new(RefCell::new(Vec::new()));
+    let modules: Vec<Box<dyn SimulationModule>> = vec![
+        Box::new(AdjustmentSimulationModule {
+            label: "first",
+            adjustments: vec![Money::from("1 USD"), Money::from("1 AUD")],
+            outcomes: first_outcomes.clone(),
+            sequence: sequence.clone(),
+        }),
+        Box::new(AdjustmentSimulationModule {
+            label: "second",
+            adjustments: Vec::new(),
+            outcomes: second_outcomes.clone(),
+            sequence: sequence.clone(),
+        }),
+    ];
+    let exchange = get_exchange_with_modules(Venue::new("SIM"), modules);
+    let cache = exchange.borrow().cache().clone();
+    pre_populate_margin_account(&mut cache.borrow_mut(), "SIM-001");
+
+    // The saving handler registered by the fixture never applies account
+    // state back to the cache, so a balance probe cannot distinguish the
+    // processing orders. Record the account-state EMISSION instead: the
+    // successful USD adjustment emits exactly one AccountState, and under
+    // the shared-snapshot contract it must come after every module's
+    // process call, not between them.
+    let handler_sequence = sequence.clone();
+    msgbus::register_account_state_endpoint(
+        "Portfolio.update_account".into(),
+        TypedHandler::from(move |_: &AccountState| {
+            handler_sequence
+                .borrow_mut()
+                .push("account-state".to_string());
+        }),
+    );
+
+    exchange.borrow_mut().process_modules(UnixNanos::from(100));
+
+    assert_eq!(
+        *first_outcomes.borrow(),
+        vec![
+            AccountAdjustmentOutcome::Applied,
+            AccountAdjustmentOutcome::Failed(AccountAdjustmentError::MissingBalance(
+                Currency::AUD()
+            )),
+        ]
+    );
+    assert!(second_outcomes.borrow().is_empty());
+    assert_eq!(
+        *sequence.borrow(),
+        vec!["process-first", "process-second", "account-state"],
+        "all modules must process against the same pre-adjustment snapshot, \
+         with adjustments applied only after the read-only phase"
+    );
+}
+
 fn rollover_records() -> Vec<InterestRateRecord> {
     ["2020-01", "2021-01"]
         .into_iter()
@@ -3410,7 +3543,14 @@ fn process_rollover(
         matching_engines: exchange.get_matching_engines(),
         cache: &cache,
     };
-    module.process(ts_now, &ctx)
+
+    match module.process(ts_now, &ctx) {
+        SimulationModuleResult::NotReady => Vec::new(),
+        SimulationModuleResult::Completed(adjustments) => {
+            module.acknowledge(&vec![AccountAdjustmentOutcome::Applied; adjustments.len()]);
+            adjustments
+        }
+    }
 }
 
 fn add_fx_quote(
@@ -3467,6 +3607,162 @@ fn test_fx_rollover_retries_after_quote_arrives(audusd_sim: CurrencyPair) {
         1
     );
     assert!(process_rollover(&module, &exchange, &cache, &instruments, rollover + 2).is_empty());
+}
+
+#[rstest]
+fn test_fx_rollover_retry_keeps_prior_economic_day(audusd_sim: CurrencyPair) {
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+    let mut raw_cache = Cache::default();
+    add_fx_position(
+        &mut raw_cache,
+        &instrument,
+        "T-ROLLOVER-CROSS-DAY",
+        "100000",
+        "1.00000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let exchange = get_exchange(
+        Venue::new("SIM"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    exchange
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    let instruments = AHashMap::from([(instrument.id(), instrument.clone())]);
+    let records = [
+        ("AUS", "2024-01", 1.0),
+        ("USA", "2024-01", 2.0),
+        ("AUS", "2024-02", 5.0),
+        ("USA", "2024-02", 1.0),
+    ]
+    .into_iter()
+    .map(|(location, time, value)| InterestRateRecord {
+        location: location.to_string(),
+        time: time.to_string(),
+        value,
+    })
+    .collect();
+    let module = FXRolloverInterestModule::new(records).unwrap();
+
+    // Wednesday's rollover is not ready because the quote is absent.
+    assert!(
+        process_rollover(
+            &module,
+            &exchange,
+            &cache,
+            &instruments,
+            rollover_timestamp(2024, 1, 31),
+        )
+        .is_empty()
+    );
+
+    // The quote arrives on Thursday. The pending Wednesday remains first and
+    // uses January's rates plus the Wednesday triple multiplier.
+    add_fx_quote(&exchange, &cache, instrument.id(), "0.99990", "1.00010");
+    assert_eq!(
+        process_rollover(
+            &module,
+            &exchange,
+            &cache,
+            &instruments,
+            rollover_timestamp(2024, 2, 1),
+        ),
+        vec![Money::from("-8.22 USD")]
+    );
+
+    // Once Wednesday is acknowledged, Thursday initializes and is immediately due.
+    assert_eq!(
+        process_rollover(
+            &module,
+            &exchange,
+            &cache,
+            &instruments,
+            rollover_timestamp(2024, 2, 1) + 1,
+        ),
+        vec![Money::from("10.96 USD")]
+    );
+}
+
+#[rstest]
+fn test_missing_xrate_retries_emit_one_module_warning_and_no_cache_errors(
+    audusd_sim: CurrencyPair,
+) {
+    log::set_logger(&CAPTURING_LOGGER).unwrap();
+    log::set_max_level(LevelFilter::Warn);
+    CAPTURING_LOGGER.clear();
+
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+    let mut raw_cache = Cache::default();
+    add_fx_position(
+        &mut raw_cache,
+        &instrument,
+        "T-ROLLOVER-XRATE",
+        "100000",
+        "1.00000",
+    );
+    let cache = Rc::new(RefCell::new(raw_cache));
+    let exchange = get_exchange(
+        Venue::new("SIM"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    exchange
+        .borrow_mut()
+        .add_instrument(instrument.clone())
+        .unwrap();
+    let quote = QuoteTick::new(
+        instrument.id(),
+        Price::from("0.99990"),
+        Price::from("1.00010"),
+        Quantity::from("1000000"),
+        Quantity::from("1000000"),
+        UnixNanos::from(2),
+        UnixNanos::from(2),
+    );
+    exchange.borrow_mut().process_quote_tick(&quote);
+    let instruments = AHashMap::from([(instrument.id(), instrument)]);
+    let module = FXRolloverInterestModule::new(rollover_records()).unwrap();
+    let ts_now = rollover_timestamp(2020, 1, 15);
+
+    for _ in 0..2 {
+        let exchange = exchange.borrow();
+        let cache = cache.borrow();
+        let ctx = ExchangeContext {
+            venue: Venue::new("SIM"),
+            base_currency: Some(Currency::GBP()),
+            instruments: &instruments,
+            matching_engines: exchange.get_matching_engines(),
+            cache: &cache,
+        };
+        assert_eq!(
+            module.process(ts_now, &ctx),
+            SimulationModuleResult::NotReady
+        );
+    }
+
+    let messages = CAPTURING_LOGGER.messages();
+    assert_eq!(
+        messages
+            .iter()
+            .filter(|(level, message)| {
+                *level == Level::Warn
+                    && message.contains(
+                        "Cannot calculate rollover for AUD/USD.SIM: exchange rate from USD to GBP",
+                    )
+            })
+            .count(),
+        1,
+        "captured messages: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .all(|(_, message)| !message.contains("Failed to calculate xrate"))
+    );
 }
 
 #[rstest]

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -7575,27 +7575,43 @@ impl Cache {
         to_currency: Currency,
         price_type: PriceType,
     ) -> Option<Decimal> {
-        if from_currency == to_currency {
-            // When the source and target currencies are identical,
-            // no conversion is needed; return an exchange rate of one.
-            return Some(Decimal::ONE);
-        }
-
-        let (bid_quote, ask_quote) = self.build_quote_table(&venue);
-
-        match get_exchange_rate(
-            from_currency.code,
-            to_currency.code,
-            price_type,
-            bid_quote,
-            ask_quote,
-        ) {
+        match self.try_get_xrate(venue, from_currency, to_currency, price_type) {
             Ok(rate) => rate,
             Err(e) => {
                 log::error!("Failed to calculate xrate: {e}");
                 None
             }
         }
+    }
+
+    /// Tries to calculate the exchange rate without logging calculation errors.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the cached quotes cannot form a valid exchange
+    /// rate calculation.
+    pub fn try_get_xrate(
+        &self,
+        venue: Venue,
+        from_currency: Currency,
+        to_currency: Currency,
+        price_type: PriceType,
+    ) -> anyhow::Result<Option<Decimal>> {
+        if from_currency == to_currency {
+            // When the source and target currencies are identical,
+            // no conversion is needed; return an exchange rate of one.
+            return Ok(Some(Decimal::ONE));
+        }
+
+        let (bid_quote, ask_quote) = self.build_quote_table(&venue);
+
+        get_exchange_rate(
+            from_currency.code,
+            to_currency.code,
+            price_type,
+            bid_quote,
+            ask_quote,
+        )
     }
 
     fn build_quote_table(

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -3858,7 +3858,7 @@ impl Cache {
     /// Resets the cache.
     ///
     /// All stateful fields are reset to their initial value. Instruments,
-    /// currencies and synthetics are retained when `drop_instruments_on_reset`
+    /// currencies, and synthetics are retained when `drop_instruments_on_reset`
     /// is `false` so that repeated backtest runs can reuse the same dataset.
     pub fn reset(&mut self) {
         log::debug!("Resetting cache");

--- a/crates/common/src/python/cache.rs
+++ b/crates/common/src/python/cache.rs
@@ -1414,7 +1414,7 @@ impl Cache {
     /// Resets the cache.
     ///
     /// All stateful fields are reset to their initial value. Instruments,
-    /// currencies and synthetics are retained when `drop_instruments_on_reset`
+    /// currencies, and synthetics are retained when `drop_instruments_on_reset`
     /// is `false` so that repeated backtest runs can reuse the same dataset.
     #[pyo3(name = "reset")]
     fn py_reset(&mut self) {


### PR DESCRIPTION
## Liquidate every breached currency in one pass

`SimulatedExchange::process_liquidations` evaluated all account currencies but stopped at the first breach: a `break` ended the loop after triggering one currency's liquidation, and `last_liquidation_ns` suppresses another pass at the same timestamp, so a simultaneous breach in a second currency stayed open until some later tick re-triggered. Liquidation is Rust-only (introduced in #4077, which scoped each breach to instruments settling in that currency - a scope `liquidate_open_positions` already enforces), so removing the `break` lets each independently breached currency trigger without widening any single breach's scope.

## Make rollover application atomic and mark only on success

`FXRolloverInterestModule::process` set `rollover_applied` before calculating, and the calculation's `Vec<Money>` return conflated success, no-work, partial application, and failure: instruments could be silently skipped for a missing matching engine, market price, or rate record, and a missing base-currency exchange rate substituted `0.0` - an economic no-op booked as done. Any of these permanently skipped that day's rollover (the legacy Cython module marks the day only after applying, and raises on missing prices). The calculation now returns an explicit `Completed`/`Retry` outcome: every open FX instrument's book, rate, and required exchange rate are preflighted, adjustments are generated all-or-nothing, and `rollover_applied` and `rollover_totals` update only on `Completed` - so a `Retry` day is re-attempted on subsequent process calls until the inputs resolve. Failure warnings are deduplicated per (instrument, failure kind) within the day, with repeats at debug, since retrying re-runs the calculation each call. `rollover_totals` now sums the booked `Money` adjustments rather than pre-rounding floats, so diagnostics match what was actually applied.

## Key the rollover day by date, not day-of-year

The day-change check compared `eastern_dt.ordinal()` alone, so a sparse data jump landing on the same ordinal of another year - day N of year Y to day N of year Y+1 - was treated as the same day, keeping the stale `rollover_applied` and skipping that day entirely. The key is now the Eastern `NaiveDate`.

## Clear the inflight counter on reset

`SimulatedExchange::reset` cleared the message and inflight queues but not `inflight_counter`, so counter entries survived into the next run and post-reset commands at a previously-seen timestamp received gapped sequence numbers. The counter is now cleared alongside the queues, matching the Cython engine's reset.

## Testing

`test_liquidation_closes_all_breached_currencies_in_one_pass` runs a margin account with two collateral currencies and a losing position settled in each, drives one liquidation pass through the real breach math and matching-engine fill path, and asserts both positions close - parameterized over both balance insertion orders so it cannot pass by traversal order. `test_fx_rollover_retries_after_quote_arrives` pins the retry cycle (no price at rollover, no adjustment and the day stays retryable; a quote later the same Eastern day yields exactly one adjustment, with no duplicate after). `test_fx_rollover_is_atomic_across_instruments` holds two priced-later instruments and asserts neither is applied until both can be valued. `test_fx_rollover_distinguishes_same_ordinal_across_years` asserts two rollovers across a year boundary on the same ordinal. `test_reset_clears_inflight_counter` pins the reset. Every assertion was verified to fail against the unfixed code: the liquidation cases in both orders against the restored `break`, the retry test against a mark-before-calculation variant, the cross-year test against an ordinal-only key, and the reset test with the clear removed.
