### PR TITLE
fix: CachePostgresAdapter discards passed config and ignores explicit connect kwargs (#4615)

### DIFF
--- a/nautilus_trader/cache/adapter.py
+++ b/nautilus_trader/cache/adapter.py
@@ -60,10 +60,23 @@ class CachePostgresAdapter(CacheDatabaseFacade):
         self,
         config: CacheConfig | None = None,
     ) -> None:
-        if config:
+        if config is None:
             config = CacheConfig()
         super().__init__(config)
-        self._backing: PostgresCacheDatabase = PostgresCacheDatabase.connect()
+        db_cfg = config.database
+        if db_cfg is not None and db_cfg.type == "postgres":
+            self._backing: PostgresCacheDatabase = PostgresCacheDatabase.connect(
+                host=db_cfg.host,
+                port=db_cfg.port,
+                username=db_cfg.username,
+                password=db_cfg.password,
+                database=getattr(db_cfg, "database", None),
+            )
+        else:
+            # Fall back to env-var-driven connect for callers who rely on
+            # POSTGRES_HOST / POSTGRES_PORT / POSTGRES_USERNAME /
+            # POSTGRES_PASSWORD / POSTGRES_DATABASE environment variables.
+            self._backing = PostgresCacheDatabase.connect()
 
     def dispose(self):
         self._backing.close()

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -27,9 +27,9 @@ from pathlib import Path
 
 import msgspec
 
+from nautilus_trader.cache.adapter import CachePostgresAdapter
 from nautilus_trader.cache.base import CacheFacade
 from nautilus_trader.cache.cache import Cache
-from nautilus_trader.cache.adapter import CachePostgresAdapter
 from nautilus_trader.cache.database import CacheDatabaseAdapter
 from nautilus_trader.common import Environment
 from nautilus_trader.common.actor import Actor

--- a/nautilus_trader/system/kernel.py
+++ b/nautilus_trader/system/kernel.py
@@ -29,6 +29,7 @@ import msgspec
 
 from nautilus_trader.cache.base import CacheFacade
 from nautilus_trader.cache.cache import Cache
+from nautilus_trader.cache.adapter import CachePostgresAdapter
 from nautilus_trader.cache.database import CacheDatabaseAdapter
 from nautilus_trader.common import Environment
 from nautilus_trader.common.actor import Actor
@@ -321,11 +322,14 @@ class NautilusKernel:
                 ),
                 config=config.cache,
             )
+        elif config.cache.database.type == "postgres":
+            cache_db = CachePostgresAdapter(config=config.cache)
         else:
             raise ValueError(
                 f"Unrecognized `config.cache.database.type`, was '{config.cache.database.type}'. "
-                "The only database type currently supported is 'redis', if you don't want a cache database backing "
-                "then you can pass `None` for the `cache.database` ('in-memory' is no longer valid)",
+                "Supported database types are 'redis' and 'postgres'. "
+                "If you don't want a cache database backing then pass `None` for `cache.database` "
+                "('in-memory' is no longer valid).",
             )
 
         ########################################################################


### PR DESCRIPTION

## Summary

`CachePostgresAdapter.__init__` contained two defects that together made any
explicitly passed `CacheConfig` completely unreachable at the connection layer.

### Defect 1 — Inverted None-guard (`adapter.py:63`)

The guard `if config:` is truthy precisely when a real `CacheConfig` is passed,
causing it to be immediately overwritten with a fresh `CacheConfig()` default.
The correct Python idiom is `if config is None:`. Any caller passing explicit
connection details via `CacheConfig(database=DatabaseConfig(type="postgres",
host=..., port=...))` had their config silently discarded before it reached
`super().__init__()`.

### Defect 2 — No-args connect (`adapter.py:66`)

`PostgresCacheDatabase.connect()` was always called with zero arguments, forcing
the Rust core to read `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_USERNAME` /
`POSTGRES_PASSWORD` / `POSTGRES_DATABASE` environment variables for every
connection. The pyo3 stub at `nautilus_pyo3.pyi:5121-5128` clearly exposes all
five parameters as optional keyword arguments, so the intended path was always
to forward them from the passed config. This meant explicit Python-side config
was unreachable even after fixing Defect 1, and callers were forced into
container-level env-var pollution where unqualified `POSTGRES_*` names can
collide with unrelated tooling (psql client, Alembic, other Postgres consumers).

### Companion fix — kernel.py routing gap

`NautilusKernel` had no `elif type == "postgres":` branch in its cache-db
routing block (`kernel.py:310-329`). Passing `CacheConfig(database=DatabaseConfig
(type="postgres", ...))` raised `ValueError` before `CachePostgresAdapter` was
even constructed, making the adapter entirely unreachable through the standard
kernel config surface. Added the missing branch so the kernel now correctly
instantiates `CachePostgresAdapter` and forwards the full `CacheConfig`.

### Behaviour after this fix

- `CachePostgresAdapter(config=my_cfg)` correctly forwards `host`, `port`,
  `username`, `password`, and `database` from `my_cfg.database` to
  `PostgresCacheDatabase.connect()`.
- Callers who pass no config (or a config with `database=None`) retain the
  existing env-var-driven fallback — no behaviour change for them.
- `NautilusKernel` with `CacheConfig(database=DatabaseConfig(type="postgres"))`
  now routes to `CachePostgresAdapter` instead of raising `ValueError`.
    
Closes #4615