### PR TITLE
Add LiveNode coordinated external-order-claim lifecycle API

### DIFF
--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -346,6 +346,18 @@ impl ExecutionEngine {
         self.external_order_claims.get(instrument_id).copied()
     }
 
+    /// Returns the instruments with external order claims owned by `strategy_id`.
+    #[must_use]
+    pub fn get_external_order_claims_for_strategy(
+        &self,
+        strategy_id: StrategyId,
+    ) -> HashSet<InstrumentId> {
+        self.external_order_claims
+            .iter()
+            .filter_map(|(instrument_id, owner)| (*owner == strategy_id).then_some(*instrument_id))
+            .collect()
+    }
+
     /// Registers a new execution client.
     ///
     /// # Errors
@@ -602,6 +614,41 @@ impl ExecutionEngine {
         }
 
         Ok(())
+    }
+
+    /// Commits external order claims for `strategy_id` without validation.
+    ///
+    /// The caller must have preflighted every instrument against
+    /// [`Self::get_external_order_claim`]: an existing claim is overwritten
+    /// without error. Coordinated live-node callers should use
+    /// `LiveNode::register_external_order_claims`, which preflights both the
+    /// execution engine and the reconciliation manager before committing;
+    /// ordinary callers should use
+    /// [`Self::register_external_order_claims`] instead.
+    pub fn commit_external_order_claims(
+        &mut self,
+        strategy_id: StrategyId,
+        instrument_ids: &HashSet<InstrumentId>,
+    ) {
+        self.external_order_claims.extend(
+            instrument_ids
+                .iter()
+                .map(|instrument_id| (*instrument_id, strategy_id)),
+        );
+
+        if !instrument_ids.is_empty() {
+            log::info!("Registered external order claims for {strategy_id}: {instrument_ids:?}");
+        }
+    }
+
+    /// Deregisters all external order claims owned by `strategy_id`.
+    ///
+    /// Coordinated live-node callers should use
+    /// `LiveNode::deregister_external_order_claims` so the execution engine and
+    /// reconciliation manager remain consistent.
+    pub fn deregister_external_order_claims(&mut self, strategy_id: StrategyId) {
+        self.external_order_claims
+            .retain(|_, owner| *owner != strategy_id);
     }
 
     /// # Errors

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -18,7 +18,10 @@
 //! This module provides the execution manager for reconciling execution state between
 //! the local cache and connected venues, as well as purging old state during live trading.
 
-use std::{cell::RefCell, fmt::Debug, rc::Rc, str::FromStr, sync::LazyLock, time::Duration};
+use std::{
+    cell::RefCell, collections::HashSet, fmt::Debug, rc::Rc, str::FromStr, sync::LazyLock,
+    time::Duration,
+};
 
 use indexmap::{IndexMap, IndexSet};
 use nautilus_common::{
@@ -2087,6 +2090,18 @@ impl ExecutionManager {
         self.external_order_claims.get(instrument_id).copied()
     }
 
+    /// Returns the instruments with external order claims owned by `strategy_id`.
+    #[must_use]
+    pub(crate) fn get_external_order_claims_for_strategy(
+        &self,
+        strategy_id: StrategyId,
+    ) -> HashSet<InstrumentId> {
+        self.external_order_claims
+            .iter()
+            .filter_map(|(instrument_id, owner)| (*owner == strategy_id).then_some(*instrument_id))
+            .collect()
+    }
+
     /// Claims external orders for a specific strategy and instrument.
     ///
     /// # Errors
@@ -2104,6 +2119,28 @@ impl ExecutionManager {
         self.external_order_claims
             .insert(instrument_id, strategy_id);
         Ok(())
+    }
+
+    pub(crate) fn register_external_order_claims(
+        &mut self,
+        strategy_id: StrategyId,
+        instrument_ids: &HashSet<InstrumentId>,
+    ) {
+        self.external_order_claims.extend(
+            instrument_ids
+                .iter()
+                .map(|instrument_id| (*instrument_id, strategy_id)),
+        );
+    }
+
+    /// Deregisters all external order claims owned by `strategy_id`.
+    ///
+    /// Coordinated live-node callers should use
+    /// `LiveNode::deregister_external_order_claims` so the reconciliation
+    /// manager and execution engine remain consistent.
+    pub(crate) fn deregister_external_order_claims(&mut self, strategy_id: StrategyId) {
+        self.external_order_claims
+            .retain(|_, owner| *owner != strategy_id);
     }
 
     /// Records position activity for reconciliation tracking, scoped per (instrument, account).

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -18,10 +18,9 @@
 //! This module provides the execution manager for reconciling execution state between
 //! the local cache and connected venues, as well as purging old state during live trading.
 
-use std::{
-    cell::RefCell, collections::HashSet, fmt::Debug, rc::Rc, str::FromStr, sync::LazyLock,
-    time::Duration,
-};
+#[cfg(feature = "node")]
+use std::collections::HashSet;
+use std::{cell::RefCell, fmt::Debug, rc::Rc, str::FromStr, sync::LazyLock, time::Duration};
 
 use indexmap::{IndexMap, IndexSet};
 use nautilus_common::{
@@ -2092,6 +2091,7 @@ impl ExecutionManager {
 
     /// Returns the instruments with external order claims owned by `strategy_id`.
     #[must_use]
+    #[cfg(feature = "node")]
     pub(crate) fn get_external_order_claims_for_strategy(
         &self,
         strategy_id: StrategyId,
@@ -2121,6 +2121,7 @@ impl ExecutionManager {
         Ok(())
     }
 
+    #[cfg(feature = "node")]
     pub(crate) fn register_external_order_claims(
         &mut self,
         strategy_id: StrategyId,
@@ -2138,6 +2139,7 @@ impl ExecutionManager {
     /// Coordinated live-node callers should use
     /// `LiveNode::deregister_external_order_claims` so the reconciliation
     /// manager and execution engine remain consistent.
+    #[cfg(feature = "node")]
     pub(crate) fn deregister_external_order_claims(&mut self, strategy_id: StrategyId) {
         self.external_order_claims
             .retain(|_, owner| *owner != strategy_id);

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -101,6 +101,7 @@ use nautilus_core::{
     UUID4,
     datetime::{NANOSECONDS_IN_MILLISECOND, mins_to_secs, secs_to_nanos_unchecked},
 };
+use nautilus_execution::engine::ExecutionEngine;
 use nautilus_model::{
     events::OrderEventAny,
     identifiers::{ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId},
@@ -2303,6 +2304,9 @@ impl LiveNode {
     /// Returns an error if:
     /// - The node is currently running.
     /// - A strategy with the same ID is already registered.
+    /// - The strategy configures external order claims and the request repeats an
+    ///   instrument, either tier already contains a requested claim, or the
+    ///   execution engine is already borrowed.
     pub fn add_strategy<T>(&mut self, mut strategy: T) -> anyhow::Result<()>
     where
         T: Strategy + StrategyNative + DataActorNative + Component + Debug + 'static,
@@ -2320,30 +2324,88 @@ impl LiveNode {
             .borrow()
             .prepare_strategy_for_registration(&mut strategy)?;
         let oms_type = StrategyNative::strategy_core(&strategy).config.oms_type;
-        if let Some(claims) = strategy
-            .external_order_claims()
-            .filter(|claims| !claims.is_empty())
-        {
-            self.register_external_order_claims(strategy_id, &claims)?;
-        }
+        let claims = strategy.external_order_claims().unwrap_or_default();
+
+        // The engine borrow is only needed for claims or an OMS override; a
+        // strategy requiring neither must not fail on an unavailable borrow.
+        let mut exec_engine = if claims.is_empty() && oms_type.is_none() {
+            None
+        } else {
+            Some(
+                self.kernel
+                    .exec_engine
+                    .try_borrow_mut()
+                    .map_err(|e| anyhow::anyhow!("Cannot register external order claims: {e}"))?,
+            )
+        };
+        let instrument_ids = match &exec_engine {
+            Some(exec_engine) => Self::preflight_external_order_claims(
+                &self.exec_manager,
+                exec_engine,
+                strategy_id,
+                &claims,
+            )?,
+            None => HashSet::new(),
+        };
 
         self.kernel.trader.borrow_mut().add_strategy(strategy)?;
 
-        if let Some(oms_type) = oms_type {
-            self.kernel
-                .exec_engine
-                .borrow_mut()
-                .register_oms_type(strategy_id, oms_type);
+        // No fallible operation may follow the trader addition: the commits
+        // below are infallible against the preflighted request.
+        if let Some(exec_engine) = &mut exec_engine {
+            exec_engine.commit_external_order_claims(strategy_id, &instrument_ids);
+            self.exec_manager
+                .register_external_order_claims(strategy_id, &instrument_ids);
+
+            if let Some(oms_type) = oms_type {
+                exec_engine.register_oms_type(strategy_id, oms_type);
+            }
         }
 
         Ok(())
     }
 
-    pub(crate) fn register_external_order_claims(
+    /// Registers external order claims on both live execution tiers.
+    ///
+    /// The operation is synchronous and atomic across the reconciliation manager and execution
+    /// engine. It can be called while the node is idle, between [`poll`](Self::poll) calls after
+    /// manual [`start`](Self::start), or after the node stops. It cannot be called while
+    /// [`run`](Self::run) owns the node.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error without changing either tier if the execution engine is already borrowed,
+    /// the request repeats an instrument, or either tier already contains any requested claim.
+    pub fn register_external_order_claims(
         &mut self,
         strategy_id: StrategyId,
         claims: &[InstrumentId],
     ) -> anyhow::Result<()> {
+        let mut exec_engine = self
+            .kernel
+            .exec_engine
+            .try_borrow_mut()
+            .map_err(|e| anyhow::anyhow!("Cannot register external order claims: {e}"))?;
+        let instrument_ids = Self::preflight_external_order_claims(
+            &self.exec_manager,
+            &exec_engine,
+            strategy_id,
+            claims,
+        )?;
+
+        exec_engine.commit_external_order_claims(strategy_id, &instrument_ids);
+        self.exec_manager
+            .register_external_order_claims(strategy_id, &instrument_ids);
+
+        Ok(())
+    }
+
+    fn preflight_external_order_claims(
+        exec_manager: &ExecutionManager,
+        exec_engine: &ExecutionEngine,
+        strategy_id: StrategyId,
+        claims: &[InstrumentId],
+    ) -> anyhow::Result<HashSet<InstrumentId>> {
         let mut instrument_ids = HashSet::new();
 
         for instrument_id in claims {
@@ -2354,33 +2416,59 @@ impl LiveNode {
             }
         }
 
-        {
-            let exec_engine = self.kernel.exec_engine.borrow();
+        for instrument_id in &instrument_ids {
+            if let Some(existing) = exec_manager.get_external_order_claim(instrument_id) {
+                anyhow::bail!(
+                    "External order claim for {instrument_id} already exists for {existing}"
+                );
+            }
 
-            for instrument_id in &instrument_ids {
-                if let Some(existing) = self.exec_manager.get_external_order_claim(instrument_id) {
-                    anyhow::bail!(
-                        "External order claim for {instrument_id} already exists for {existing}"
-                    );
-                }
-
-                if let Some(existing) = exec_engine.get_external_order_claim(instrument_id) {
-                    anyhow::bail!(
-                        "External order claim for {instrument_id} already exists for {existing}"
-                    );
-                }
+            if let Some(existing) = exec_engine.get_external_order_claim(instrument_id) {
+                anyhow::bail!(
+                    "External order claim for {instrument_id} already exists for {existing}"
+                );
             }
         }
 
-        for instrument_id in &instrument_ids {
-            self.exec_manager
-                .claim_external_orders(*instrument_id, strategy_id)?;
+        Ok(instrument_ids)
+    }
+
+    /// Deregisters all external order claims owned by `strategy_id` from both execution tiers.
+    ///
+    /// Remove the strategy through the trader or controller first, then call this method before
+    /// registering a successor. The operation is synchronous and can be called while the node is
+    /// idle, between [`poll`](Self::poll) calls after manual [`start`](Self::start), or after the
+    /// node stops. It cannot be called while [`run`](Self::run) owns the node.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error without changing either tier if the execution engine is already borrowed
+    /// or the two tiers do not contain identical claim sets for the strategy.
+    pub fn deregister_external_order_claims(
+        &mut self,
+        strategy_id: StrategyId,
+    ) -> anyhow::Result<()> {
+        let mut exec_engine = self
+            .kernel
+            .exec_engine
+            .try_borrow_mut()
+            .map_err(|e| anyhow::anyhow!("Cannot deregister external order claims: {e}"))?;
+        let manager_instruments = self
+            .exec_manager
+            .get_external_order_claims_for_strategy(strategy_id);
+        let engine_instruments = exec_engine.get_external_order_claims_for_strategy(strategy_id);
+
+        if manager_instruments != engine_instruments {
+            anyhow::bail!(
+                "External order claims for {strategy_id} differ between the execution manager and engine"
+            );
         }
 
-        self.kernel
-            .exec_engine
-            .borrow_mut()
-            .register_external_order_claims(strategy_id, &instrument_ids)
+        exec_engine.deregister_external_order_claims(strategy_id);
+        self.exec_manager
+            .deregister_external_order_claims(strategy_id);
+
+        Ok(())
     }
 
     /// Adds an execution algorithm to the trader.
@@ -4025,6 +4113,233 @@ mod tests {
     }
 
     #[rstest]
+    fn test_register_external_order_claims_after_build_reaches_both_tiers() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .build()
+            .unwrap();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+
+        node.register_external_order_claims(strategy_id, &[instrument_id])
+            .unwrap();
+
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_register_external_order_claims_while_running_reaches_both_tiers() {
+        let mut node = live_node_with_replay_store(false);
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+
+        node.start().await.unwrap();
+        assert_eq!(node.state(), NodeState::Running);
+
+        node.register_external_order_claims(strategy_id, &[instrument_id])
+            .unwrap();
+
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+    }
+
+    #[rstest]
+    fn test_register_external_order_claims_conflicting_batch_leaves_new_claims_absent() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .build()
+            .unwrap();
+        let existing_instrument = InstrumentId::from("AUDUSD.SIM");
+        let new_instruments = [
+            InstrumentId::from("EURUSD.SIM"),
+            InstrumentId::from("GBPUSD.SIM"),
+        ];
+        let existing_strategy_id = StrategyId::from("CLAIMS-001");
+        let new_strategy_id = StrategyId::from("CLAIMS-002");
+        node.register_external_order_claims(existing_strategy_id, &[existing_instrument])
+            .unwrap();
+
+        let result = node.register_external_order_claims(
+            new_strategy_id,
+            &[new_instruments[0], existing_instrument, new_instruments[1]],
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            node.exec_manager
+                .get_external_order_claim(&existing_instrument),
+            Some(existing_strategy_id)
+        );
+
+        for instrument_id in new_instruments {
+            assert_eq!(
+                node.exec_manager.get_external_order_claim(&instrument_id),
+                None
+            );
+            assert_eq!(
+                node.kernel
+                    .exec_engine
+                    .borrow()
+                    .get_external_order_claim(&instrument_id),
+                None
+            );
+        }
+    }
+
+    #[rstest]
+    fn test_register_external_order_claims_one_tier_conflict_changes_neither_tier() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .build()
+            .unwrap();
+        let conflicting_instrument = InstrumentId::from("AUDUSD.SIM");
+        let new_instrument = InstrumentId::from("EURUSD.SIM");
+        let existing_strategy_id = StrategyId::from("CLAIMS-001");
+        let new_strategy_id = StrategyId::from("CLAIMS-002");
+        node.exec_manager
+            .claim_external_orders(conflicting_instrument, existing_strategy_id)
+            .unwrap();
+
+        let result = node.register_external_order_claims(
+            new_strategy_id,
+            &[new_instrument, conflicting_instrument],
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            node.exec_manager
+                .get_external_order_claim(&conflicting_instrument),
+            Some(existing_strategy_id)
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&conflicting_instrument),
+            None
+        );
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&new_instrument),
+            None
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&new_instrument),
+            None
+        );
+    }
+
+    #[rstest]
+    fn test_deregister_external_order_claims_allows_successor_to_claim() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .build()
+            .unwrap();
+        let instruments = [
+            InstrumentId::from("AUDUSD.SIM"),
+            InstrumentId::from("EURUSD.SIM"),
+        ];
+        let first_strategy_id = StrategyId::from("CLAIMS-001");
+        let successor_strategy_id = StrategyId::from("CLAIMS-002");
+        node.register_external_order_claims(first_strategy_id, &instruments)
+            .unwrap();
+
+        node.deregister_external_order_claims(first_strategy_id)
+            .unwrap();
+        node.register_external_order_claims(successor_strategy_id, &instruments)
+            .unwrap();
+
+        for instrument_id in instruments {
+            assert_eq!(
+                node.exec_manager.get_external_order_claim(&instrument_id),
+                Some(successor_strategy_id)
+            );
+            assert_eq!(
+                node.kernel
+                    .exec_engine
+                    .borrow()
+                    .get_external_order_claim(&instrument_id),
+                Some(successor_strategy_id)
+            );
+        }
+    }
+
+    #[rstest]
+    fn test_deregister_external_order_claims_divergence_changes_neither_tier() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .build()
+            .unwrap();
+        let manager_instrument = InstrumentId::from("AUDUSD.SIM");
+        let engine_instrument = InstrumentId::from("EURUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+        node.exec_manager
+            .claim_external_orders(manager_instrument, strategy_id)
+            .unwrap();
+        node.kernel
+            .exec_engine
+            .borrow_mut()
+            .register_external_order_claims(strategy_id, &HashSet::from([engine_instrument]))
+            .unwrap();
+
+        let result = node.deregister_external_order_claims(strategy_id);
+
+        assert!(result.is_err());
+        assert_eq!(
+            node.exec_manager
+                .get_external_order_claim(&manager_instrument),
+            Some(strategy_id)
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&engine_instrument),
+            Some(strategy_id)
+        );
+    }
+
+    #[rstest]
+    fn test_deregister_external_order_claims_without_claims_is_idempotent() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .build()
+            .unwrap();
+        let strategy_id = StrategyId::from("CLAIMS-001");
+
+        node.deregister_external_order_claims(strategy_id).unwrap();
+        node.deregister_external_order_claims(strategy_id).unwrap();
+    }
+
+    #[rstest]
     fn test_add_strategy_rejects_duplicate_external_order_claim_without_overwriting() {
         let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
             .unwrap()
@@ -4105,6 +4420,72 @@ mod tests {
             let exec_engine = node.kernel().exec_engine.borrow();
             assert_eq!(exec_engine.get_external_order_claim(&instrument_id), None);
         }
+    }
+
+    #[rstest]
+    fn test_add_strategy_failure_does_not_register_external_order_claims() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .with_delay_post_stop_secs(0)
+            .with_timeout_connection(1)
+            .build()
+            .unwrap();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+        let mut strategy = TestStrategy::new(StrategyConfig {
+            strategy_id: Some(strategy_id),
+            external_order_claims: Some(vec![instrument_id]),
+            ..Default::default()
+        });
+
+        strategy
+            .core
+            .register(
+                node.trader_id(),
+                node.kernel.clock(),
+                node.kernel.cache.clone(),
+                node.kernel.portfolio.clone(),
+            )
+            .unwrap();
+
+        let result = node.add_strategy(strategy);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("already registered with trader")
+        );
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&instrument_id),
+            None
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&instrument_id),
+            None
+        );
+    }
+
+    #[rstest]
+    fn test_add_strategy_without_claims_does_not_require_engine_borrow() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .build()
+            .unwrap();
+        let exec_engine = node.kernel.exec_engine.clone();
+        let _engine_borrow = exec_engine.borrow_mut();
+
+        node.add_strategy(TestStrategy::new(StrategyConfig {
+            strategy_id: Some(StrategyId::from("NOCLAIMS-001")),
+            ..Default::default()
+        }))
+        .unwrap();
     }
 
     #[rstest]

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -2304,9 +2304,11 @@ impl LiveNode {
     /// Returns an error if:
     /// - The node is currently running.
     /// - A strategy with the same ID is already registered.
-    /// - The strategy configures external order claims and the request repeats an
-    ///   instrument, either tier already contains a requested claim, or the
-    ///   execution engine is already borrowed.
+    /// - The strategy configures one or more external order claims and the request repeats
+    ///   an instrument, or either tier already contains a requested claim.
+    /// - The strategy configures one or more external order claims or an OMS type override,
+    ///   and the execution engine is already borrowed. A strategy configuring neither does
+    ///   not take the borrow and cannot fail this way.
     pub fn add_strategy<T>(&mut self, mut strategy: T) -> anyhow::Result<()>
     where
         T: Strategy + StrategyNative + DataActorNative + Component + Debug + 'static,
@@ -2331,12 +2333,9 @@ impl LiveNode {
         let mut exec_engine = if claims.is_empty() && oms_type.is_none() {
             None
         } else {
-            Some(
-                self.kernel
-                    .exec_engine
-                    .try_borrow_mut()
-                    .map_err(|e| anyhow::anyhow!("Cannot register external order claims: {e}"))?,
-            )
+            Some(self.kernel.exec_engine.try_borrow_mut().map_err(|e| {
+                anyhow::anyhow!("Cannot register external order claims or OMS type: {e}")
+            })?)
         };
         let instrument_ids = match &exec_engine {
             Some(exec_engine) => Self::preflight_external_order_claims(
@@ -4255,6 +4254,59 @@ mod tests {
     }
 
     #[rstest]
+    fn test_register_external_order_claims_engine_only_conflict_changes_neither_tier() {
+        let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .with_reconciliation(false)
+            .build()
+            .unwrap();
+        let conflicting_instrument = InstrumentId::from("AUDUSD.SIM");
+        let new_instrument = InstrumentId::from("EURUSD.SIM");
+        let existing_strategy_id = StrategyId::from("CLAIMS-001");
+        let new_strategy_id = StrategyId::from("CLAIMS-002");
+
+        // Seed the conflict on the engine tier only, mirroring the manager-only case.
+        node.kernel
+            .exec_engine
+            .borrow_mut()
+            .register_external_order_claims(
+                existing_strategy_id,
+                &HashSet::from([conflicting_instrument]),
+            )
+            .unwrap();
+
+        let result = node.register_external_order_claims(
+            new_strategy_id,
+            &[new_instrument, conflicting_instrument],
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&conflicting_instrument),
+            Some(existing_strategy_id)
+        );
+        assert_eq!(
+            node.exec_manager
+                .get_external_order_claim(&conflicting_instrument),
+            None
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&new_instrument),
+            None
+        );
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&new_instrument),
+            None
+        );
+    }
+
+    #[rstest]
     fn test_deregister_external_order_claims_allows_successor_to_claim() {
         let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
             .unwrap()
@@ -4472,7 +4524,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_add_strategy_without_claims_does_not_require_engine_borrow() {
+    fn test_add_strategy_without_claims_or_oms_type_does_not_require_engine_borrow() {
         let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
             .unwrap()
             .with_reconciliation(false)

--- a/crates/live/src/python/node.rs
+++ b/crates/live/src/python/node.rs
@@ -452,6 +452,9 @@ impl LiveNode {
     /// Returns an error if:
     /// - The node is currently running.
     /// - A strategy with the same ID is already registered.
+    /// - The strategy configures external order claims and the request repeats an
+    ///   instrument, either tier already contains a requested claim, or the
+    ///   execution engine is already borrowed.
     #[allow(
         unsafe_code,
         reason = "Required for Python strategy component registration"

--- a/crates/live/src/python/node.rs
+++ b/crates/live/src/python/node.rs
@@ -452,9 +452,11 @@ impl LiveNode {
     /// Returns an error if:
     /// - The node is currently running.
     /// - A strategy with the same ID is already registered.
-    /// - The strategy configures external order claims and the request repeats an
-    ///   instrument, either tier already contains a requested claim, or the
-    ///   execution engine is already borrowed.
+    /// - The strategy configures one or more external order claims and the request repeats
+    ///   an instrument, or either tier already contains a requested claim.
+    /// - The strategy configures one or more external order claims or an OMS type override,
+    ///   and the execution engine is already borrowed. A strategy configuring neither does
+    ///   not take the borrow and cannot fail this way.
     #[allow(
         unsafe_code,
         reason = "Required for Python strategy component registration"


### PR DESCRIPTION
## Post-build claim registration reaching both tiers

External order claims live in two maps: the live reconciliation manager's (`ExecutionManager::external_order_claims`, consulted when reconciliation attributes venue-originated activity) and the execution engine's (consulted when materializing venue-originated status and fills). The only operation that registered claims with both was `LiveNode::add_strategy`, which requires `NodeState::Idle`; the coordinating `register_external_order_claims` was `pub(crate)`. A strategy added to a running node through `Controller`/`Trader::add_strategy` therefore could not populate the manager tier at all - the engine's `register_external_order_claims` is public, but `Controller` holds only the `Trader` and cannot reach the node-owned manager - so external orders on that strategy's instruments were attributed to `EXTERNAL` by reconciliation regardless of the engine-tier claim. `LiveNode::register_external_order_claims` is now public with no node-state restriction: it acquires the engine's `RefCell` with `try_borrow_mut` before any mutation, rejects in-request duplicates, preflights every instrument against both maps, and only then commits the whole batch to both tiers through infallible inserts. Every error path leaves both maps unchanged.

## Owner-scoped claim removal

Both maps were insert-only: the manager's `claim_external_orders` rejects an existing claim and nothing ever removed one, so a stopped-and-removed strategy's claims lingered on both tiers - a successor strategy on the same instrument was refused the claim and ran unclaimed, while stale claims kept routing external activity to the removed strategy ID. `LiveNode::deregister_external_order_claims` removes all claims owned by a `StrategyId` from both tiers: it collects the owner's instrument set from each map under the held engine borrow, errors without mutation if the sets diverge, and otherwise removes the full set from both. Removal is keyed by strategy rather than instrument so a caller cannot omit one configured instrument or remove another strategy's claim; removal with no claims present is an idempotent success. `Trader::remove_strategy` does not (and structurally cannot) touch the node-owned manager, so the documented sequence is: remove the strategy through the trader or controller, deregister its claims through the node, then register the successor's.

## No claims committed for a strategy the trader rejected

`LiveNode::add_strategy` registered claims before `Trader::add_strategy`, so a trader-side failure (for example a duplicate registration) left orphaned claims on both tiers with no strategy behind them. The path is now a preflight-and-commit split: claims are validated against both tiers first, the trader addition runs, and only on its success are the claims and the OMS override committed - through a new infallible `ExecutionEngine::commit_external_order_claims` whose contract requires the preflight, so no fallible operation follows the trader call. The engine borrow is taken only when the strategy actually configures claims or an OMS override, so adding a plain strategy no longer requires the engine `RefCell` to be available.

Both new methods are synchronous with no await points and are usable while the node is idle, between `poll` calls after a manual `start`, or after stopping; they cannot be called while `run(&mut self)` owns the node. The only Python-side change is a regenerated wrapper docstring; no signatures or stubs changed.

A deliberate follow-up, not part of this change: routing runtime strategy lifecycle through a node-owned command queue with responses. That would make claim cleanup automatic on strategy removal (covering the `Controller` path this PR cannot reach), and allow claim mutation while `run` owns the node.

## Testing

Eight new `rstest` cases in `crates/live/src/node/mod.rs` pin: registration after `build()` reaches both tiers; registration on a running node (after manual `start`) reaches both tiers; a batch containing one conflicting instrument leaves every new instrument absent from both tiers; a conflict present in only one tier changes neither; owner-scoped removal clears both tiers and a successor strategy can then claim the released instruments; divergent owner sets fail removal without mutation; removal with no claims is idempotent; and a forced `Trader::add_strategy` failure after successful claim preflight leaves neither tier populated. A ninth test holds an engine `borrow_mut` across a claimless `add_strategy` to pin that no borrow is required. The assertions were verified to fail against the unfixed implementation where expressible: the trader-failure case fails against the old commit-before-add ordering (the manager retained the claim), a preflight-bypass mutation fails the one-tier-conflict test, and a neutered divergence check fails the divergence test.
