### PR TITLE
Log connection lifecycle transitions at Info in network clients

### DIFF
--- a/crates/network/src/socket/client.rs
+++ b/crates/network/src/socket/client.rs
@@ -350,7 +350,7 @@ impl SocketClientInner {
     /// reader to a timeout; the writer task bounds both the old-writer
     /// shutdown and the buffer drain with its graceful-shutdown timeout.
     async fn reconnect(&mut self) -> Result<(), Error> {
-        log::debug!("Reconnecting");
+        log::info!("Reconnecting");
 
         if ConnectionMode::from_atomic(&self.connection_mode).is_disconnect() {
             log::debug!("Reconnect aborted due to disconnect state");
@@ -456,7 +456,7 @@ impl SocketClientInner {
             self.config.idle_timeout_ms,
         );
 
-        log::debug!("Reconnect succeeded");
+        log::info!("Reconnect succeeded");
         Ok(())
     }
 
@@ -1167,7 +1167,7 @@ impl SocketClient {
                         )
                         .is_ok()
                     {
-                        log::debug!("Detected dead read task, transitioning to RECONNECT");
+                        log::info!("Detected dead read task, transitioning to RECONNECT");
                     }
                     mode = ConnectionMode::from_atomic(&connection_mode);
                 }

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -985,7 +985,7 @@ impl WebSocketClientInner {
     /// - The reconnection attempt times out.
     /// - The connection to the server fails.
     pub async fn reconnect(&mut self) -> Result<(), TransportError> {
-        log::debug!("Reconnecting");
+        log::info!("Reconnecting");
 
         if self.handler.is_none() {
             log::warn!(
@@ -1112,7 +1112,7 @@ impl WebSocketClientInner {
             self.read_fence = None;
         }
 
-        log::debug!("Reconnect succeeded");
+        log::info!("Reconnect succeeded");
         Ok(())
     }
 
@@ -2422,7 +2422,7 @@ impl WebSocketClient {
                         } else if let Some(tracker) = auth_tracker.get() {
                             tracker.invalidate();
                         }
-                        log::debug!("Detected dead connection, transitioning to {target:?}");
+                        log::info!("Detected dead connection, transitioning to {target:?}");
                     }
                     mode = ConnectionMode::from_atomic(&connection_mode);
                 }


### PR DESCRIPTION
## Connection lifecycle transitions logged at Info

Both `nautilus_network` controllers log their connection lifecycle at Debug, so an operator running at Info cannot observe a dead connection and its recovery at all - a venue connection can die and cleanly reconnect with no trace at the default operational level. The developer guide places connection lifecycle events and reconnection summaries at Info (`docs/developer_guide/rust.md`), and these six lines are the lifecycle transitions: the dead-connection detection in each controller loop (`websocket/client.rs` "Detected dead connection, transitioning to {target:?}", `socket/client.rs` "Detected dead read task, transitioning to RECONNECT"), the reconnect attempt start ("Reconnecting" in each client's `reconnect`), and the reconnect success ("Reconnect succeeded" in each, emitted after the `Reconnect -> Active` state transition and replacement reader installation). All six are raised from `log::debug!` to `log::info!` with wording unchanged.

The surrounding diagnostics deliberately stay at Debug: the numbered per-attempt detail line (which would duplicate the attempt start at Info), the websocket controller's post-callback completion line, the raw socket controller's secondary completion line (which can also fire after an aborted reconnect), and all abort, interruption, backoff, and writer-swap lines. The result at Info is exactly one line per transition: connection died, reconnect started, reconnect succeeded.

## Testing

No behavior changes; the existing reconnect tests exercise all six sites (`cargo test -p nautilus-network`, 488 tests). No new test asserts the levels themselves: pinning log levels reliably would require an isolated test binary with real TCP and WebSocket servers plus a process-global logger, since the existing parallel test binaries emit these same messages concurrently - disproportionate to a six-line level change.
