### PR TITLE
Add a runtime log-level ceiling to the logging subsystem

### DIFF
--- a/crates/common/src/logging/logger.rs
+++ b/crates/common/src/logging/logger.rs
@@ -116,6 +116,9 @@ enum LoggerLifecycle {
 /// Process-global logger lifecycle serialization.
 static LOGGER_LIFECYCLE: Mutex<LoggerLifecycle> = Mutex::new(LoggerLifecycle::Uninitialized);
 
+/// Runtime ceiling stored before initialization or applied while the logger is running.
+static RUNTIME_LEVEL_OVERRIDE: Mutex<Option<LevelFilter>> = Mutex::new(None);
+
 #[cfg(all(test, not(all(feature = "simulation", madsim))))]
 struct InitPublishHook {
     reached: std::sync::mpsc::Sender<()>,
@@ -1051,7 +1054,10 @@ impl Logger {
             super::logging_set_bypass();
         }
 
-        let max_level = log::LevelFilter::Trace;
+        let max_level = RUNTIME_LEVEL_OVERRIDE
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .unwrap_or(LevelFilter::Trace);
         set_max_level(max_level);
 
         if print_config {
@@ -1317,6 +1323,22 @@ pub(crate) fn is_running() -> bool {
         .lock()
         .unwrap_or_else(PoisonError::into_inner)
         == LoggerLifecycle::Running
+}
+
+pub(crate) fn set_runtime_level(level: LevelFilter) {
+    let lifecycle = LOGGER_LIFECYCLE
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+
+    match *lifecycle {
+        LoggerLifecycle::Uninitialized => {
+            *RUNTIME_LEVEL_OVERRIDE
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = Some(level);
+        }
+        LoggerLifecycle::Running => set_max_level(level),
+        LoggerLifecycle::Terminated => {}
+    }
 }
 
 /// Flushes and syncs file logs to disk through the logging thread.
@@ -2075,10 +2097,152 @@ mod tests {
         use crate::{
             logging::{
                 LOGGING_BYPASSED, logging_clock_set_static_mode, logging_clock_set_static_time,
-                logging_is_initialized, logging_set_bypass, logging_sync_to_disk,
+                logging_is_initialized, logging_set_bypass, logging_set_level,
+                logging_sync_to_disk,
             },
             testing::wait_until,
         };
+
+        fn read_log_file(temp_dir: &tempfile::TempDir) -> String {
+            let log_path = std::fs::read_dir(temp_dir)
+                .expect("log directory must be readable")
+                .filter_map(Result::ok)
+                .find(|entry| entry.path().is_file())
+                .expect("logger must create a log file")
+                .path();
+            std::fs::read_to_string(log_path).expect("log file must be readable")
+        }
+
+        #[rstest]
+        fn test_runtime_level_rejects_off_without_applying_or_storing() {
+            let original_level = log::max_level();
+            let error = logging_set_level(LevelFilter::Off).expect_err("Off must be rejected");
+            assert!(error.to_string().contains("logging_shutdown"));
+            assert!(error.to_string().contains("shutdown-on-error"));
+            assert_eq!(log::max_level(), original_level);
+
+            let _guard = Logger::init_with_config(
+                TraderId::from("TRADER-OFF-REFUSAL"),
+                UUID4::new(),
+                LoggerConfig {
+                    stdout_level: LevelFilter::Off,
+                    ..Default::default()
+                },
+                FileWriterConfig::default(),
+            )
+            .expect("logger initialization must succeed");
+            assert_eq!(log::max_level(), LevelFilter::Trace);
+        }
+
+        #[rstest]
+        fn test_runtime_level_trace_matches_static_max_level() {
+            let result = logging_set_level(LevelFilter::Trace);
+
+            if STATIC_MAX_LEVEL >= LevelFilter::Trace {
+                assert!(result.is_ok());
+            } else {
+                let error = result.expect_err("compiled-out Trace must be rejected");
+                assert!(error.to_string().contains("release_max_level_debug"));
+            }
+        }
+
+        #[rstest]
+        fn test_runtime_level_raises_and_lowers_ceiling() {
+            let temp_dir = tempdir().expect("temporary directory must be created");
+            let config = LoggerConfig {
+                stdout_level: LevelFilter::Off,
+                fileout_level: LevelFilter::Debug,
+                ..Default::default()
+            };
+            let file_config = FileWriterConfig {
+                directory: Some(temp_dir.path().to_str().unwrap().to_string()),
+                ..Default::default()
+            };
+            let _guard = Logger::init_with_config(
+                TraderId::from("TRADER-RUNTIME"),
+                UUID4::new(),
+                config,
+                file_config,
+            )
+            .expect("logger initialization must succeed");
+
+            logging_set_level(LevelFilter::Info).expect("Info must be accepted");
+            log::info!(component = "RuntimeLevel"; "runtime initial info marker");
+            log::debug!(component = "RuntimeLevel"; "runtime initial debug marker");
+
+            logging_set_level(LevelFilter::Debug).expect("Debug must be accepted");
+            log::debug!(component = "RuntimeLevel"; "runtime raised debug marker");
+
+            logging_set_level(LevelFilter::Warn).expect("Warn must be accepted");
+            log::info!(component = "RuntimeLevel"; "runtime lowered info marker");
+            log::warn!(component = "RuntimeLevel"; "runtime lowered warn marker");
+
+            logging_sync_to_disk().expect("logging sync must succeed");
+            let contents = read_log_file(&temp_dir);
+            assert!(contents.contains("runtime initial info marker"));
+            assert!(!contents.contains("runtime initial debug marker"));
+            assert!(contents.contains("runtime raised debug marker"));
+            assert!(!contents.contains("runtime lowered info marker"));
+            assert!(contents.contains("runtime lowered warn marker"));
+        }
+
+        #[rstest]
+        fn test_runtime_level_set_before_init_is_honored() {
+            logging_set_level(LevelFilter::Warn).expect("Warn must be accepted before init");
+
+            let temp_dir = tempdir().expect("temporary directory must be created");
+            let config = LoggerConfig {
+                stdout_level: LevelFilter::Off,
+                fileout_level: LevelFilter::Debug,
+                ..Default::default()
+            };
+            let file_config = FileWriterConfig {
+                directory: Some(temp_dir.path().to_str().unwrap().to_string()),
+                ..Default::default()
+            };
+            let _guard = Logger::init_with_config(
+                TraderId::from("TRADER-PREINIT"),
+                UUID4::new(),
+                config,
+                file_config,
+            )
+            .expect("logger initialization must succeed");
+
+            log::info!(component = "RuntimeLevel"; "pre-init info marker");
+            log::warn!(component = "RuntimeLevel"; "pre-init warn marker");
+            logging_sync_to_disk().expect("logging sync must succeed");
+
+            let contents = read_log_file(&temp_dir);
+            assert!(!contents.contains("pre-init info marker"));
+            assert!(contents.contains("pre-init warn marker"));
+        }
+
+        #[rstest]
+        fn test_runtime_level_composes_with_component_filter() {
+            let temp_dir = tempdir().expect("temporary directory must be created");
+            let config =
+                LoggerConfig::from_spec("stdout=Off;fileout=Debug;CappedComponent=Info").unwrap();
+            let file_config = FileWriterConfig {
+                directory: Some(temp_dir.path().to_str().unwrap().to_string()),
+                ..Default::default()
+            };
+            let _guard = Logger::init_with_config(
+                TraderId::from("TRADER-COMPOSITION"),
+                UUID4::new(),
+                config,
+                file_config,
+            )
+            .expect("logger initialization must succeed");
+
+            logging_set_level(LevelFilter::Debug).expect("Debug must be accepted");
+            log::debug!(component = "CappedComponent"; "component-capped debug marker");
+            log::debug!(component = "UnfilteredComponent"; "unfiltered debug marker");
+            logging_sync_to_disk().expect("logging sync must succeed");
+
+            let contents = read_log_file(&temp_dir);
+            assert!(!contents.contains("component-capped debug marker"));
+            assert!(contents.contains("unfiltered debug marker"));
+        }
 
         #[rstest]
         fn test_shutdown_on_error_records_once_then_rearms() {
@@ -2849,7 +3013,9 @@ mod tests {
         };
 
         use super::*;
-        use crate::logging::{logging_is_initialized, logging_shutdown, logging_sync_to_disk};
+        use crate::logging::{
+            logging_is_initialized, logging_set_level, logging_shutdown, logging_sync_to_disk,
+        };
 
         const LIFECYCLE_CHILD_ENV: &str = "NAUTILUS_LOGGER_LIFECYCLE_CHILD";
 
@@ -3046,6 +3212,34 @@ mod tests {
                 error.to_string(),
                 "Logging has been shut down and cannot be re-initialized"
             );
+        }
+
+        #[rstest]
+        fn test_runtime_level_after_shutdown_is_noop() {
+            const MARKER: &str = "runtime-level-after-shutdown";
+            if !in_lifecycle_child(MARKER) {
+                run_lifecycle_child("test_runtime_level_after_shutdown_is_noop", MARKER);
+                return;
+            }
+
+            let _guard = Logger::init_with_config(
+                TraderId::from("TRADER-TERMINAL-LEVEL"),
+                UUID4::new(),
+                LoggerConfig {
+                    stdout_level: LevelFilter::Off,
+                    ..Default::default()
+                },
+                FileWriterConfig::default(),
+            )
+            .expect("logger initialization must succeed");
+            logging_shutdown();
+            assert_eq!(log::max_level(), LevelFilter::Off);
+
+            logging_set_level(LevelFilter::Debug)
+                .expect("valid post-shutdown level must be a no-op");
+            assert_eq!(log::max_level(), LevelFilter::Off);
+            assert!(logging_set_level(LevelFilter::Off).is_err());
+            assert_eq!(log::max_level(), LevelFilter::Off);
         }
     }
 

--- a/crates/common/src/logging/mod.rs
+++ b/crates/common/src/logging/mod.rs
@@ -121,6 +121,46 @@ pub fn logging_set_bypass() {
     LOGGING_BYPASSED.store(true, Ordering::Relaxed);
 }
 
+/// Sets the process-global runtime logging ceiling.
+///
+/// The runtime ceiling composes with the statically compiled maximum, configured sink levels,
+/// and component/module filters. Calling this before initialization stores the ceiling for the
+/// logger to apply during initialization. Calling it after terminal shutdown is a no-op.
+///
+/// Records already admitted to the logging channel may drain at the previous level.
+///
+/// # Errors
+///
+/// Returns an error for [`LevelFilter::Off`], which belongs to [`logging_shutdown`], or for
+/// [`LevelFilter::Trace`] when Trace logging was compiled out.
+pub fn logging_set_level(level: LevelFilter) -> anyhow::Result<()> {
+    validate_runtime_level(level, log::STATIC_MAX_LEVEL)?;
+    crate::logging::logger::set_runtime_level(level);
+    Ok(())
+}
+
+fn validate_runtime_level(
+    requested: LevelFilter,
+    static_max_level: LevelFilter,
+) -> anyhow::Result<()> {
+    if requested == LevelFilter::Off {
+        anyhow::bail!(
+            "Runtime log level Off is not supported; use logging_shutdown instead. Disabling the \
+             log macro fast path would prevent Logger::log, and therefore shutdown-on-error \
+             detection, from seeing error records"
+        );
+    }
+
+    if requested == LevelFilter::Trace && static_max_level < LevelFilter::Trace {
+        anyhow::bail!(
+            "Runtime log level Trace is unavailable because release_max_level_debug compiled \
+             Trace out (STATIC_MAX_LEVEL={static_max_level})"
+        );
+    }
+
+    Ok(())
+}
+
 /// Shuts down the logging subsystem.
 pub fn logging_shutdown() {
     // Perform a graceful shutdown: prevent new logs, signal Close, drain, and join.
@@ -415,6 +455,14 @@ mod tests {
     fn test_logging_set_bypass() {
         logging_set_bypass();
         assert!(LOGGING_BYPASSED.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    fn test_validate_runtime_level_rejects_unavailable_trace() {
+        let error = validate_runtime_level(LevelFilter::Trace, LevelFilter::Debug)
+            .expect_err("Trace must be rejected when compiled out");
+        assert!(error.to_string().contains("release_max_level_debug"));
+        assert!(validate_runtime_level(LevelFilter::Trace, LevelFilter::Trace).is_ok());
     }
 
     #[rstest]


### PR DESCRIPTION
## A runtime log-level ceiling beside the existing global controls

There is no way to change logging verbosity after initialization: `Logger.config` is an initialization snapshot, the logger installs via `set_boxed_logger` with no handle kept, the writers bake `stdout_level`/`fileout_level` at construction, and initialization unconditionally calls `set_max_level(Trace)`. A consumer wanting runtime verbosity control (for example gating a live run's log volume per session) can only call `log::set_max_level` directly - which works today because the `log` macros consult the global maximum before `Logger::enabled`, but rides on the unenforced assumption that Nautilus never re-sets the maximum mid-run; if that ever changed, the external caller's setting would be silently clobbered.

`logging_set_level(LevelFilter) -> anyhow::Result<()>` now sits beside `logging_set_bypass` and owns that fast path as a process-global runtime ceiling. It composes with, and never rewrites, the existing configuration: effective admission remains bounded by `log::STATIC_MAX_LEVEL`, the configured per-sink thresholds, and the component/module filters, so a runtime `Debug` cannot make a file configured at `Info` emit debug records, cannot create a file writer that initialization declined, and cannot bypass a component cap. No control event or per-record atomic is added - the `log` macros already read the global maximum per record; records admitted before a change may drain at the previous level.

Called before initialization, the validated level is stored and applied by initialization in place of the unconditional `Trace` (the store and the initialization read are both serialized under the logger lifecycle lock, so a concurrent setter cannot be clobbered by publication). Called while running, it applies immediately. After terminal shutdown, valid levels are accepted as no-ops and `log::max_level` stays `Off`. When never called, initialization behavior is unchanged.

## Two levels are refused rather than accepted-and-documented

`Off` returns an error directing the caller to `logging_shutdown`: the shutdown-on-error mechanism lives inside `Logger::log`, so suppressing all records at the macro fast path would also blind error detection - a setter that accepted `Off` would report success while disabling a safety mechanism.

`Trace` returns an error naming `release_max_level_debug` whenever `log::STATIC_MAX_LEVEL < Trace`. The workspace enables that `log` feature, which pins the static maximum to `Debug` in builds without debug assertions - and feature unification imposes it on every downstream consumer's `log` as well - so trace macro sites are compiled out and a runtime `Trace` could never surface a line. Accepting it silently would produce a setter that reports success and does nothing; where the static maximum permits `Trace` (debug-assertion builds), it is accepted normally. Validation precedes lifecycle dispatch, so both refusals hold before initialization and after shutdown too.

## Testing

Seven new tests. Under `serial_tests` (process-isolated by the nextest convention): a raise/lower sequence against file output with unique markers and `logging_sync_to_disk` (runtime `Info` admits Info and rejects Debug, a raise to `Debug` admits a new debug marker, a lower to `Warn` rejects a new info marker); a pre-initialization store honored by initialization (`Warn` set before init, info marker absent after); filter composition (runtime `Debug` does not override a component capped at `Info` while an unfiltered debug marker appears); the `Off` refusal with the documented error text and no state change; and a `Trace` test branching on the real `STATIC_MAX_LEVEL`. The pure validator is additionally tested with an injected static ceiling - `(Trace, Debug)` rejects naming `release_max_level_debug`, `(Trace, Trace)` accepts - because the test profile enables debug assertions, making the real static maximum `Trace` in-tree; the injected-ceiling test is what covers the release-build refusal branch. The post-shutdown no-op runs in the existing lifecycle child-process harness, since shutdown permanently terminates the process-global logger. The pre-initialization and raise/lower assertions were verified to fail against the unfixed behavior: with initialization's unconditional `set_max_level(Trace)` restored, the pre-init test fails at its suppressed-marker assertion.
