### PR TITLE
Distinguish aborted reconnects from completed reconnections

### DIFF
--- a/crates/network/src/mode.rs
+++ b/crates/network/src/mode.rs
@@ -49,6 +49,20 @@ impl ReadSessionFence {
     }
 }
 
+/// Result of a reconnection attempt that did not fail outright.
+///
+/// A reconnect can finish without reconnecting: a teardown may be requested while
+/// it is in flight, at which point it unwinds and leaves the mode terminal. That is
+/// normal control flow rather than an error, so it needs to be distinguishable from
+/// a completed reconnection by the caller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReconnectOutcome {
+    /// A replacement connection was established and the mode is now `Active`.
+    Reconnected,
+    /// The attempt unwound without reconnecting; the mode was left unchanged.
+    Aborted,
+}
+
 /// The lifecycle state of a socket client.
 ///
 /// Clients store the active, reconnecting, disconnecting, or closed state in an atomic flag so
@@ -127,6 +141,30 @@ impl ConnectionMode {
             .is_ok()
     }
 
+    /// Atomically completes a reconnection by transitioning `Reconnect` to `Active`.
+    ///
+    /// Returns [`ReconnectOutcome::Reconnected`] if this call performed the
+    /// transition, and [`ReconnectOutcome::Aborted`] if the mode had already moved
+    /// on - which a concurrent [`Self::request_disconnect`] or a terminal `Closed`
+    /// store can do while the reconnect is in flight. Aborting here is not an
+    /// error: it means a teardown won the race and the replacement connection must
+    /// not be adopted.
+    pub(crate) fn complete_reconnect(value: &AtomicU8) -> ReconnectOutcome {
+        if value
+            .compare_exchange(
+                Self::Reconnect.as_u8(),
+                Self::Active.as_u8(),
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            ReconnectOutcome::Reconnected
+        } else {
+            ReconnectOutcome::Aborted
+        }
+    }
+
     /// Converts a [`ConnectionMode`] to its `u8` representation.
     #[inline]
     #[must_use]
@@ -182,6 +220,41 @@ mod tests {
         let mode = AtomicU8::new(start.as_u8());
 
         assert_eq!(ConnectionMode::request_reconnect(&mode), expected_result);
+        assert_eq!(ConnectionMode::from_atomic(&mode), expected_mode);
+    }
+
+    // Only a mode still in `Reconnect` may be adopted as `Active`. A teardown that won
+    // the race - `Disconnect` or `Closed` - must report `Aborted` and leave the terminal
+    // mode intact, so the caller can tell a completed reconnection from an unwound one.
+    #[rstest]
+    #[case(
+        ConnectionMode::Reconnect,
+        ReconnectOutcome::Reconnected,
+        ConnectionMode::Active
+    )]
+    #[case(
+        ConnectionMode::Disconnect,
+        ReconnectOutcome::Aborted,
+        ConnectionMode::Disconnect
+    )]
+    #[case(
+        ConnectionMode::Closed,
+        ReconnectOutcome::Aborted,
+        ConnectionMode::Closed
+    )]
+    #[case(
+        ConnectionMode::Active,
+        ReconnectOutcome::Aborted,
+        ConnectionMode::Active
+    )]
+    fn complete_reconnect_transitions(
+        #[case] start: ConnectionMode,
+        #[case] expected_outcome: ReconnectOutcome,
+        #[case] expected_mode: ConnectionMode,
+    ) {
+        let mode = AtomicU8::new(start.as_u8());
+
+        assert_eq!(ConnectionMode::complete_reconnect(&mode), expected_outcome);
         assert_eq!(ConnectionMode::from_atomic(&mode), expected_mode);
     }
 

--- a/crates/network/src/socket/client.rs
+++ b/crates/network/src/socket/client.rs
@@ -62,7 +62,7 @@ use crate::{
     dst,
     error::{SendError, is_connection_drop_io_error},
     logging::{log_task_aborted, log_task_started, log_task_stopped},
-    mode::{ConnectionMode, ReadSessionFence},
+    mode::{ConnectionMode, ReadSessionFence, ReconnectOutcome},
     net::TcpStream,
     tls::{create_tls_config_from_certs_dir, tcp_tls},
 };
@@ -349,12 +349,12 @@ impl SocketClientInner {
     /// so buffered messages can never drain into a connection that lost its
     /// reader to a timeout; the writer task bounds both the old-writer
     /// shutdown and the buffer drain with its graceful-shutdown timeout.
-    async fn reconnect(&mut self) -> Result<(), Error> {
+    async fn reconnect(&mut self) -> Result<ReconnectOutcome, Error> {
         log::info!("Reconnecting");
 
         if ConnectionMode::from_atomic(&self.connection_mode).is_disconnect() {
             log::debug!("Reconnect aborted due to disconnect state");
-            return Ok(());
+            return Ok(ReconnectOutcome::Aborted);
         }
 
         // Bound only connection establishment; the swap below must run to completion
@@ -379,7 +379,7 @@ impl SocketClientInner {
 
         if ConnectionMode::from_atomic(&self.connection_mode).is_disconnect() {
             log::debug!("Reconnect aborted mid-flight (after connect)");
-            return Ok(());
+            return Ok(ReconnectOutcome::Aborted);
         }
         log::debug!("Connected");
 
@@ -419,7 +419,7 @@ impl SocketClientInner {
 
         if ConnectionMode::from_atomic(&self.connection_mode).is_disconnect() {
             log::debug!("Reconnect aborted mid-flight (after delay)");
-            return Ok(());
+            return Ok(ReconnectOutcome::Aborted);
         }
 
         self.read_fence.invalidate();
@@ -431,18 +431,9 @@ impl SocketClientInner {
 
         // Atomically transition from Reconnect to Active
         // This prevents race condition where disconnect could be requested between check and store
-        if self
-            .connection_mode
-            .compare_exchange(
-                ConnectionMode::Reconnect.as_u8(),
-                ConnectionMode::Active.as_u8(),
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            )
-            .is_err()
-        {
+        if ConnectionMode::complete_reconnect(&self.connection_mode) == ReconnectOutcome::Aborted {
             log::debug!("Reconnect aborted (state changed during reconnect)");
-            return Ok(());
+            return Ok(ReconnectOutcome::Aborted);
         }
 
         // Spawn new read task
@@ -457,7 +448,7 @@ impl SocketClientInner {
         );
 
         log::info!("Reconnect succeeded");
-        Ok(())
+        Ok(ReconnectOutcome::Reconnected)
     }
 
     /// Returns whether the read and write tasks are still running.
@@ -1253,12 +1244,15 @@ impl SocketClient {
                         None => {
                             log::debug!("Reconnect interrupted by disconnect");
                         }
-                        Some(Ok(())) => {
+                        Some(Ok(ReconnectOutcome::Reconnected)) => {
                             log::debug!("Reconnected successfully");
                             reconnected_at = Some(dst::time::Instant::now());
 
                             state_notify.notify_waiters();
 
+                            // The outcome records a completed reconnection; emit recovery
+                            // callbacks only while the replacement is still `Active`, not
+                            // after a teardown or another drop.
                             if ConnectionMode::from_atomic(&connection_mode).is_active() {
                                 if let Some(ref handler) = post_reconnection {
                                     handler();
@@ -1269,6 +1263,9 @@ impl SocketClient {
                                     "Skipping post_reconnection handlers due to disconnect state"
                                 );
                             }
+                        }
+                        Some(Ok(ReconnectOutcome::Aborted)) => {
+                            log::debug!("Reconnect aborted");
                         }
                         Some(Err(e)) => {
                             let duration = inner.backoff.next_duration();
@@ -1741,6 +1738,74 @@ mod rust_tests {
             Ok(Err(e)) => panic!("{name} failed: {e}"),
             Err(e) => panic!("{name} did not terminate within the test timeout: {e}"),
         }
+    }
+
+    fn reconnect_test_config(port: u16) -> SocketConfig {
+        SocketConfig {
+            url: format!("127.0.0.1:{port}"),
+            mode: Mode::Plain,
+            suffix: b"\r\n".to_vec(),
+            message_handler: None,
+            heartbeat: None,
+            reconnect_timeout_ms: Some(1_000),
+            reconnect_delay_initial_ms: None,
+            reconnect_backoff_factor: None,
+            reconnect_delay_max_ms: None,
+            reconnect_jitter_ms: None,
+            connection_max_retries: Some(1),
+            reconnect_max_attempts: None,
+            idle_timeout_ms: None,
+            certs_dir: None,
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_reconnect_outcome_is_aborted_before_dial() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let mut inner = SocketClientInner::connect_url(reconnect_test_config(port))
+            .await
+            .unwrap();
+        inner
+            .connection_mode
+            .store(ConnectionMode::Disconnect.as_u8(), Ordering::SeqCst);
+
+        let outcome = inner.reconnect().await.unwrap();
+
+        assert_eq!(outcome, ReconnectOutcome::Aborted);
+        server.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_reconnect_outcome_is_reconnected() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (_first, _) = listener.accept().await.unwrap();
+            let (_second, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let mut inner = SocketClientInner::connect_url(reconnect_test_config(port))
+            .await
+            .unwrap();
+        inner
+            .connection_mode
+            .store(ConnectionMode::Reconnect.as_u8(), Ordering::SeqCst);
+
+        let outcome = inner.reconnect().await.unwrap();
+
+        assert_eq!(outcome, ReconnectOutcome::Reconnected);
+        assert_eq!(
+            ConnectionMode::from_atomic(&inner.connection_mode),
+            ConnectionMode::Active
+        );
+        server.abort();
     }
 
     struct ScriptedReader {

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -103,7 +103,7 @@ use crate::{
     dst,
     error::{SendError, is_connection_drop_io_error},
     logging::{log_task_aborted, log_task_started, log_task_stopped},
-    mode::{ConnectionMode, ReadSessionFence},
+    mode::{ConnectionMode, ReadSessionFence, ReconnectOutcome},
     ratelimiter::{RateLimiter, clock::MonotonicClock, quota::Quota},
     transport::{BoxedWsTransport, Message, TransportError, tungstenite::TungsteniteTransport},
 };
@@ -985,6 +985,10 @@ impl WebSocketClientInner {
     /// - The reconnection attempt times out.
     /// - The connection to the server fails.
     pub async fn reconnect(&mut self) -> Result<(), TransportError> {
+        self.reconnect_with_outcome().await.map(|_| ())
+    }
+
+    async fn reconnect_with_outcome(&mut self) -> Result<ReconnectOutcome, TransportError> {
         log::info!("Reconnecting");
 
         if self.handler.is_none() {
@@ -999,12 +1003,16 @@ impl WebSocketClientInner {
                 self.auth_tracker.as_ref(),
                 "WebSocket stream mode cannot reconnect",
             );
-            return Ok(());
+            // Publish the terminal state only once its bookkeeping is complete; the
+            // controller used to notify after `reconnect` returned, so a waiter must
+            // not observe `Closed` before pending authentication has been failed.
+            self.state_notify.notify_waiters();
+            return Ok(ReconnectOutcome::Aborted);
         }
 
         if ConnectionMode::from_atomic(&self.connection_mode).is_disconnect() {
             log::debug!("Reconnect aborted due to disconnect state");
-            return Ok(());
+            return Ok(ReconnectOutcome::Aborted);
         }
 
         // Bound only connection establishment; the swap below must run to completion
@@ -1030,7 +1038,7 @@ impl WebSocketClientInner {
 
         if ConnectionMode::from_atomic(&self.connection_mode).is_disconnect() {
             log::debug!("Reconnect aborted mid-flight (after connect)");
-            return Ok(());
+            return Ok(ReconnectOutcome::Aborted);
         }
 
         // Use a oneshot channel to synchronize the writer swap before transitioning
@@ -1064,7 +1072,7 @@ impl WebSocketClientInner {
 
         if ConnectionMode::from_atomic(&self.connection_mode).is_disconnect() {
             log::debug!("Reconnect aborted mid-flight (after delay)");
-            return Ok(());
+            return Ok(ReconnectOutcome::Aborted);
         }
 
         if let Some(read_fence) = self.read_fence.take() {
@@ -1080,18 +1088,9 @@ impl WebSocketClientInner {
 
         // Atomically transition from Reconnect to Active
         // This prevents race condition where disconnect could be requested between check and store
-        if self
-            .connection_mode
-            .compare_exchange(
-                ConnectionMode::Reconnect.as_u8(),
-                ConnectionMode::Active.as_u8(),
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            )
-            .is_err()
-        {
+        if ConnectionMode::complete_reconnect(&self.connection_mode) == ReconnectOutcome::Aborted {
             log::debug!("Reconnect aborted (state changed during reconnect)");
-            return Ok(());
+            return Ok(ReconnectOutcome::Aborted);
         }
 
         if self.handler.is_some() {
@@ -1113,7 +1112,7 @@ impl WebSocketClientInner {
         }
 
         log::info!("Reconnect succeeded");
-        Ok(())
+        Ok(ReconnectOutcome::Reconnected)
     }
 
     /// Returns whether the client's transport tasks are still running.
@@ -2491,7 +2490,7 @@ impl WebSocketClient {
                     // Race reconnect against disconnect notification
                     let reconnect_result = tokio::select! {
                         biased;
-                        result = inner.reconnect() => Some(result),
+                        result = inner.reconnect_with_outcome() => Some(result),
                         () = async {
                             loop {
                                 // Enable before the check so a disconnect notify between iterations is not missed
@@ -2510,11 +2509,14 @@ impl WebSocketClient {
                         None => {
                             log::debug!("Reconnect interrupted by disconnect");
                         }
-                        Some(Ok(())) => {
+                        Some(Ok(ReconnectOutcome::Reconnected)) => {
                             reconnected_at = Some(dst::time::Instant::now());
 
                             state_notify.notify_waiters();
 
+                            // The outcome records a completed reconnection; emit recovery
+                            // callbacks only while the replacement is still `Active`, not
+                            // after a teardown or another drop.
                             if ConnectionMode::from_atomic(&connection_mode).is_active() {
                                 if let Some(ref handler) = inner.handler {
                                     let connection_epoch =
@@ -2539,6 +2541,9 @@ impl WebSocketClient {
                             } else {
                                 log::debug!("Skipping reconnect handlers due to disconnect state");
                             }
+                        }
+                        Some(Ok(ReconnectOutcome::Aborted)) => {
+                            log::debug!("Reconnect aborted");
                         }
                         Some(Err(e)) => {
                             let duration = inner.backoff.next_duration();
@@ -3257,7 +3262,7 @@ mod rust_tests {
     };
 
     use super::*;
-    use crate::websocket::types::channel_message_handler;
+    use crate::websocket::types::{channel_epoch_message_handler, channel_message_handler};
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -3309,6 +3314,123 @@ mod rust_tests {
             Ok(Err(e)) => panic!("{name} failed: {e}"),
             Err(e) => panic!("{name} did not terminate within the test timeout: {e}"),
         }
+    }
+
+    fn reconnect_test_config(port: u16) -> WebSocketConfig {
+        WebSocketConfig {
+            url: format!("ws://127.0.0.1:{port}"),
+            headers: vec![],
+            heartbeat: None,
+            heartbeat_msg: None,
+            reconnect_timeout_ms: Some(1_000),
+            reconnect_delay_initial_ms: None,
+            reconnect_delay_max_ms: None,
+            reconnect_backoff_factor: None,
+            reconnect_jitter_ms: None,
+            reconnect_max_attempts: None,
+            idle_timeout_ms: None,
+            backend: TransportBackend::Tungstenite,
+            proxy_url: None,
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_reconnect_outcome_is_aborted_before_dial() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _websocket = accept_async(stream).await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let (handler, _rx) = channel_message_handler();
+        let mut inner =
+            WebSocketClientInner::connect_url(reconnect_test_config(port), Some(handler), None)
+                .await
+                .unwrap();
+        inner
+            .connection_mode
+            .store(ConnectionMode::Disconnect.as_u8(), Ordering::SeqCst);
+
+        let outcome = inner.reconnect_with_outcome().await.unwrap();
+
+        assert_eq!(outcome, ReconnectOutcome::Aborted);
+        server.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_stream_reconnect_outcome_is_aborted_and_notifies_closed() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _websocket = accept_async(stream).await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let mut inner = WebSocketClientInner::connect_url(reconnect_test_config(port), None, None)
+            .await
+            .unwrap();
+        let state_notify = Arc::clone(&inner.state_notify);
+        let mut notified = std::pin::pin!(state_notify.notified());
+        notified.as_mut().enable();
+
+        let outcome = inner.reconnect_with_outcome().await.unwrap();
+
+        assert_eq!(outcome, ReconnectOutcome::Aborted);
+        assert_eq!(
+            ConnectionMode::from_atomic(&inner.connection_mode),
+            ConnectionMode::Closed
+        );
+        tokio::time::timeout(TEST_TIMEOUT, notified)
+            .await
+            .expect("stream close notification was not published");
+        server.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_reconnect_outcome_is_reconnected_with_handler() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _first = accept_async(stream).await.unwrap();
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut second = accept_async(stream).await.unwrap();
+            second
+                .send(WsMessage::Text("replacement".into()))
+                .await
+                .unwrap();
+            std::future::pending::<()>().await;
+        });
+        let (epoch_handler, mut epoch_rx) = channel_epoch_message_handler();
+        let mut inner = WebSocketClientInner::connect_url_with_handler(
+            reconnect_test_config(port),
+            Some(IncomingHandler::Epoch(epoch_handler)),
+            None,
+        )
+        .await
+        .unwrap();
+        inner
+            .connection_mode
+            .store(ConnectionMode::Reconnect.as_u8(), Ordering::SeqCst);
+
+        let outcome = inner.reconnect_with_outcome().await.unwrap();
+
+        assert_eq!(outcome, ReconnectOutcome::Reconnected);
+        assert_eq!(
+            ConnectionMode::from_atomic(&inner.connection_mode),
+            ConnectionMode::Active
+        );
+        let (epoch, message) = tokio::time::timeout(TEST_TIMEOUT, epoch_rx.recv())
+            .await
+            .expect("replacement epoch message was not delivered")
+            .expect("epoch handler channel closed");
+        assert_eq!(epoch, 1);
+        assert_eq!(message, WsMessage::Text("replacement".into()));
+        server.abort();
     }
 
     struct RecordingServer {


### PR DESCRIPTION
## Aborted reconnects are indistinguishable from completed ones

Both `nautilus_network` controllers drive reconnection through an `async fn reconnect()` returning `Result<(), _>`, and that type cannot express the third outcome the function actually has. Nine early returns unwind without reconnecting - the stream-mode refusal, three `is_disconnect()` checks in each client (before dialing, after `connect_with_server`, and after the graceful-shutdown delay), and the final `compare_exchange(Reconnect -> Active)` in each - and every one of them returns `Ok(())`, the same value a completed reconnection returns. The controller task consuming that result has no way to tell the two apart, so it runs its success bookkeeping either way and then re-derives the outcome by reading the connection-mode atomic a second time.

That re-read is not equivalent to knowing the outcome. It answers a different question - what the mode is now, not what the attempt did - and the two diverge in both directions: a reconnection that succeeded and whose replacement immediately died reads as not-active, while the mode being terminal does not distinguish an attempt that unwound from one that completed before the teardown landed.

This adds a `ReconnectOutcome` returned by both clients' `reconnect()`, with the final transition extracted to `ConnectionMode::complete_reconnect` in `mode.rs` alongside the existing `request_reconnect` and `request_disconnect`, which are its siblings - it performs the same compare-exchange both controllers previously open-coded and names the two results. `Err` keeps its present meaning of an attempt that failed and should warn and back off. The controllers now match on the outcome, and success bookkeeping runs only under `Reconnected`. `WebSocketClientInner::reconnect` is public and re-exported, so it keeps its `Result<(), _>` signature as a wrapper over the outcome-returning form rather than breaking that surface.

The `is_active()` check is deliberately retained around the recovery callbacks, because it was doing a second job unrelated to classification: suppressing venue-facing side effects once a teardown has been requested. Adapters register `post_reconnection` handlers that replay authentication and subscriptions, so firing them into a shutdown would put traffic on a connection being torn down. Classification now comes from the outcome; the guard now answers only whether the replacement is still usable.

## Raw socket controller logs success on an aborted reconnect

The raw socket controller emits `"Reconnected successfully"` as the first statement of its `Ok` arm, above and outside the `is_active()` guard, whereas the websocket controller emits its equivalent inside that guard. With every abort path returning the same `Ok(())`, the raw socket client therefore claims a successful reconnection every time one unwinds - including on the ordinary teardown path, where a disconnect races an in-flight reconnect. #4621 noted this line as one that "can also fire after an aborted reconnect" when it left the surrounding lifecycle lines at Debug; this is that case. The line is now reachable only under `ReconnectOutcome::Reconnected`.

Both controllers also record the reconnect timestamp that feeds the backoff stability ladder on every `Ok`, abort included. That bookkeeping has no observable consequence on the current code: every abort leaves the mode terminal, and both controller loops break on `is_disconnect()` and `is_closed()` before reaching the ladder, so the recorded instant is never consumed. It is corrected here because the contract makes it free to correct, not because a reachable defect was traced to it.

One ordering fix comes with it: the stream-mode refusal stored `Closed` and notified state waiters before failing pending authentication, so a waiter could observe the terminal mode before its bookkeeping completed. The notification now follows `fail_registered_auth`.

## Testing

`complete_reconnect_transitions` in `mode.rs` is a four-case table over the transition itself - `Reconnect` yields `Reconnected` and leaves the mode `Active`; `Disconnect`, `Closed` and `Active` each yield `Aborted` and leave the mode untouched. It needs no sockets and no clock, which is why the compare-exchange branch is pinned there rather than through a client: driving that branch through a real connection means racing a store against the reconnect path's internal delay, and a test that depends on winning a scheduling window is a flake waiting to happen on a loaded CI runner.

The per-client tests cover the remaining paths against real loopback servers, deterministically - each waits on a completion signal rather than a duration. `test_reconnect_outcome_is_aborted_before_dial` and `test_reconnect_outcome_is_reconnected` in the raw socket client; `test_reconnect_outcome_is_aborted_before_dial`, `test_stream_reconnect_outcome_is_aborted_and_notifies_closed` and `test_reconnect_outcome_is_reconnected_with_handlers` in the websocket client, the last asserting that a replacement connection's traffic reaches both the message and epoch handlers and that the mode is `Active`.

Two limitations are worth stating rather than leaving to be discovered. First, these tests pin the abort-versus-success contract at the `reconnect()` boundary; they are not a red-to-green differential, because the assertions name a type the previous code did not have, so they cannot be run against it. Second, the controller-loop consequences are not covered by an automated test - that an aborted attempt no longer records a reconnect timestamp, no longer notifies waiters, and no longer reaches the callback guard. Reaching those from a test needs either a controller injection seam or capture of a debug line through the process-global logger, and neither seemed proportionate to the defect; the existing turmoil reconnect tests continue to cover the success-path controller effects, including `RECONNECTED` delivery and `post_reconnection`.

`cargo test -p nautilus-network` passes, as does the crate under `--cfg madsim`.
