### PR TITLE
Make dYdX fallback URL test deterministic

### DIFF
--- a/crates/adapters/dydx/src/grpc/client.rs
+++ b/crates/adapters/dydx/src/grpc/client.rs
@@ -547,11 +547,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_new_with_fallback_invalid_urls() {
-        // Test with invalid URLs that will fail to connect
-        let invalid_urls = vec!["invalid://bad-url", "http://0.0.0.0:1"];
+        // Use malformed URLs that fail deterministically during parsing
+        let invalid_urls = vec!["http://", "http://[::1"];
         let result = DydxGrpcClient::new_with_fallback(&invalid_urls).await;
 
-        // Should fail with either Config or Grpc error
-        assert!(result.is_err());
+        assert!(matches!(result, Err(DydxError::Config(_))));
     }
 }


### PR DESCRIPTION
## Summary

- Replace network-dependent invalid URL fixtures in the dYdX gRPC fallback test with malformed URIs rejected during parsing.
- Assert `DydxError::Config` so the test remains on the deterministic configuration-validation path.

## Motivation

The test previously used `invalid://bad-url` and `http://0.0.0.0:1`. Both values parse as URIs, and their connection results can depend on DNS, container networking, routing, or local listeners. In some environments the constructor therefore returns `Ok`, making the test nondeterministic.

The replacement URIs are rejected by `Channel::from_shared` during parsing, before any network connection is attempted.

## Impact

This is a test-only change. It does not modify production connection behavior, public APIs, dependencies, or any other adapter.

## Testing

- `make format`
- `make pre-commit`
- `git diff --check`
- Independent static review
- Full Rust test matrix delegated to GitHub Actions