### PR TITLE
Remove redundant Coinbase request test waits

### DIFF
--- a/crates/adapters/coinbase/tests/data_client.rs
+++ b/crates/adapters/coinbase/tests/data_client.rs
@@ -574,8 +574,6 @@ async fn test_data_client_request_instruments() {
     let mut client = CoinbaseDataClient::new(*COINBASE_CLIENT_ID, config).unwrap();
     client.connect().await.unwrap();
 
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
     while rx.try_recv().is_ok() {}
 
     let request = RequestInstruments::new(
@@ -613,8 +611,6 @@ async fn test_data_client_request_instrument() {
     let config = create_data_client_config(addr);
     let mut client = CoinbaseDataClient::new(*COINBASE_CLIENT_ID, config).unwrap();
     client.connect().await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     while rx.try_recv().is_ok() {}
 
@@ -654,8 +650,6 @@ async fn test_data_client_request_book_snapshot() {
     let config = create_data_client_config(addr);
     let mut client = CoinbaseDataClient::new(*COINBASE_CLIENT_ID, config).unwrap();
     client.connect().await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     while rx.try_recv().is_ok() {}
 
@@ -699,8 +693,6 @@ async fn test_data_client_request_book_snapshot_with_depth() {
     let config = create_data_client_config(addr);
     let mut client = CoinbaseDataClient::new(*COINBASE_CLIENT_ID, config).unwrap();
     client.connect().await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     while rx.try_recv().is_ok() {}
 
@@ -747,8 +739,6 @@ async fn test_data_client_request_bars() {
     let config = create_data_client_config(addr);
     let mut client = CoinbaseDataClient::new(*COINBASE_CLIENT_ID, config).unwrap();
     client.connect().await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     while rx.try_recv().is_ok() {}
 
@@ -799,8 +789,6 @@ async fn test_data_client_request_trades() {
     let config = create_data_client_config(addr);
     let mut client = CoinbaseDataClient::new(*COINBASE_CLIENT_ID, config).unwrap();
     client.connect().await.unwrap();
-
-    tokio::time::sleep(Duration::from_millis(500)).await;
 
     while rx.try_recv().is_ok() {}
 


### PR DESCRIPTION
## Summary

- remove six fixed 500 ms waits from Coinbase v2 data-client request tests
- rely on the completed `connect().await` contract before draining synchronously emitted bootstrap events
- retain waits that follow asynchronous requests or exercise polling/reconnect timing

This removes roughly 3 seconds of unconditional wall-clock delay from the module test suite without changing production behavior.

Closes #4636.

## Testing

- `rustfmt --check --edition 2024 crates/adapters/coinbase/tests/data_client.rs`
- `git diff --check`
- `cargo test -p nautilus-coinbase --test data_client` attempted, but the local Windows environment does not have the MSVC `link.exe` toolchain installed; GitHub CI should run the full target

## Scope

One v2 test module only: `crates/adapters/coinbase/tests/data_client.rs`.