### PR TITLE
Add opt-in Polymarket live book resync

### DIFF
--- a/crates/adapters/polymarket/src/data/auto_load.rs
+++ b/crates/adapters/polymarket/src/data/auto_load.rs
@@ -110,6 +110,7 @@ impl PolymarketDataClient {
         let last_quotes = self.last_quotes.clone();
         let resolve_poll_watchlist = self.resolve_poll_watchlist.clone();
         let pending_snapshot_after_tick_change = self.pending_snapshot_after_tick_change.clone();
+        let live_book_resyncs = self.live_book_resyncs.clone();
 
         get_runtime().spawn(async move {
             // Coalesce concurrent misses into one Gamma call.
@@ -230,6 +231,7 @@ impl PolymarketDataClient {
                                 &active_trade_subs,
                                 &resolve_poll_watchlist,
                                 &pending_snapshot_after_tick_change,
+                                &live_book_resyncs,
                                 &pending,
                                 &ws_open_tokens,
                                 &ws_sub_mutex,

--- a/crates/adapters/polymarket/src/data/dispatch.rs
+++ b/crates/adapters/polymarket/src/data/dispatch.rs
@@ -42,7 +42,8 @@ use tokio_util::sync::CancellationToken;
 use ustr::Ustr;
 
 use super::{
-    NEW_MARKET_EMPTY_RECHECK_DELAY, NEW_MARKET_EMPTY_RECHECK_MAX_ATTEMPTS,
+    LiveBookResync, LiveBookResyncPhase, NEW_MARKET_EMPTY_RECHECK_DELAY,
+    NEW_MARKET_EMPTY_RECHECK_MAX_ATTEMPTS,
     instruments::{TokenMeta, cache_instrument_if_active},
 };
 use crate::{
@@ -95,6 +96,7 @@ pub(super) struct WsMessageContext {
     pub(super) resolve_poll_watchlist: Arc<AtomicMap<String, ResolveWatchEntry>>,
     pub(super) resolve_watch_apply_mutex: Arc<StdMutex<()>>,
     pub(super) pending_snapshot_after_tick_change: Arc<AtomicSet<InstrumentId>>,
+    pub(super) live_book_resyncs: Arc<DashMap<InstrumentId, LiveBookResync>>,
     pub(super) new_market_inflight_keys: Arc<DashMap<String, ()>>,
     pub(super) new_market_fetch_semaphore: Arc<tokio::sync::Semaphore>,
     pub(super) rtds_feed: PolymarketRtdsFeed,
@@ -191,23 +193,39 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                     ts_init,
                 ) {
                     Ok(deltas) => {
-                        let mut book = ctx
-                            .order_books
-                            .entry(instrument_id)
-                            .or_insert_with(|| OrderBook::new(instrument_id, BookType::L2_MBP));
+                        let buffered = if !ctx
+                            .pending_snapshot_after_tick_change
+                            .contains(&instrument_id)
+                            && let Some(mut resync) = ctx.live_book_resyncs.get_mut(&instrument_id)
+                            && resync.phase != LiveBookResyncPhase::Passthrough
+                        {
+                            resync.buffered_deltas.push(deltas.clone());
+                            true
+                        } else {
+                            false
+                        };
 
-                        match book.apply_deltas(&deltas) {
-                            Ok(()) => book_seeded = true,
-                            Err(e) => {
-                                log::error!(
-                                    "Failed to apply book snapshot for {instrument_id}: {e}"
-                                );
+                        if !buffered {
+                            let mut book = ctx
+                                .order_books
+                                .entry(instrument_id)
+                                .or_insert_with(|| OrderBook::new(instrument_id, BookType::L2_MBP));
+
+                            match book.apply_deltas(&deltas) {
+                                Ok(()) => {
+                                    book_seeded = true;
+                                    let data: NautilusData =
+                                        OrderBookDeltas_API::new(deltas).into();
+                                    if let Err(e) = ctx.data_sender.send(DataEvent::Data(data)) {
+                                        log::error!("Failed to emit book deltas: {e}");
+                                    }
+                                }
+                                Err(e) => {
+                                    log::error!(
+                                        "Failed to apply book snapshot for {instrument_id}: {e}"
+                                    );
+                                }
                             }
-                        }
-
-                        let data: NautilusData = OrderBookDeltas_API::new(deltas).into();
-                        if let Err(e) = ctx.data_sender.send(DataEvent::Data(data)) {
-                            log::error!("Failed to emit book deltas: {e}");
                         }
                     }
                     Err(e) => log::error!("Failed to parse book snapshot: {e}"),
@@ -332,15 +350,29 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                                 RecordFlag::F_LAST as u8;
 
                             let deltas = OrderBookDeltas::new(instrument_id, parsed);
-                            if let Some(mut book) = ctx.order_books.get_mut(&instrument_id)
-                                && let Err(e) = book.apply_deltas(&deltas)
+                            let buffered = if let Some(mut resync) =
+                                ctx.live_book_resyncs.get_mut(&instrument_id)
+                                && resync.phase != LiveBookResyncPhase::Passthrough
                             {
-                                log::error!("Failed to apply book deltas for {instrument_id}: {e}");
-                            }
+                                resync.buffered_deltas.push(deltas.clone());
+                                true
+                            } else {
+                                false
+                            };
 
-                            let data: NautilusData = OrderBookDeltas_API::new(deltas).into();
-                            if let Err(e) = ctx.data_sender.send(DataEvent::Data(data)) {
-                                log::error!("Failed to emit book deltas: {e}");
+                            if !buffered {
+                                if let Some(mut book) = ctx.order_books.get_mut(&instrument_id)
+                                    && let Err(e) = book.apply_deltas(&deltas)
+                                {
+                                    log::error!(
+                                        "Failed to apply book deltas for {instrument_id}: {e}"
+                                    );
+                                }
+
+                                let data: NautilusData = OrderBookDeltas_API::new(deltas).into();
+                                if let Err(e) = ctx.data_sender.send(DataEvent::Data(data)) {
+                                    log::error!("Failed to emit book deltas: {e}");
+                                }
                             }
                         }
                     }
@@ -492,6 +524,10 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
             // Book epoch transition; see module docs.
             let instrument_id = meta.instrument_id;
             ctx.order_books.remove(&instrument_id);
+            if let Some(mut resync) = ctx.live_book_resyncs.get_mut(&instrument_id) {
+                resync.buffered_deltas.clear();
+                resync.phase = LiveBookResyncPhase::Passthrough;
+            }
 
             if ctx.active_delta_subs.contains(&instrument_id) {
                 ctx.pending_snapshot_after_tick_change.insert(instrument_id);
@@ -774,7 +810,7 @@ mod tests {
     };
     use nautilus_core::{Params, UUID4, UnixNanos, time::get_atomic_clock_realtime};
     use nautilus_model::{
-        data::{CustomData as ModelCustomData, DataType},
+        data::{CustomData as ModelCustomData, DataType, OrderBookDelta},
         enums::{InstrumentCloseType, OrderSide, PositionSide},
         events::{PositionEvent, PositionOpened},
         identifiers::{
@@ -978,6 +1014,7 @@ mod tests {
             resolve_poll_watchlist: Arc::new(AtomicMap::new()),
             resolve_watch_apply_mutex: Arc::new(StdMutex::new(())),
             pending_snapshot_after_tick_change: Arc::new(AtomicSet::new()),
+            live_book_resyncs: Arc::new(DashMap::new()),
             new_market_inflight_keys: Arc::new(DashMap::new()),
             new_market_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(
                 default_config.new_market_fetch_max_concurrency,
@@ -1115,6 +1152,7 @@ mod tests {
             resolve_poll_watchlist: client.resolve_poll_watchlist.clone(),
             resolve_watch_apply_mutex: client.resolve_watch_apply_mutex.clone(),
             pending_snapshot_after_tick_change: client.pending_snapshot_after_tick_change.clone(),
+            live_book_resyncs: client.live_book_resyncs.clone(),
             new_market_inflight_keys: client.new_market_inflight_keys.clone(),
             new_market_fetch_semaphore: client.new_market_fetch_semaphore.clone(),
             rtds_feed: client.rtds_feed.clone(),
@@ -3600,6 +3638,129 @@ mod tests {
     }
 
     #[rstest]
+    fn live_book_resync_buffers_price_change_without_mutating_or_emitting() {
+        let asset_id_str = "0xTOKEN_RESYNC";
+        let market = "0xMARKET";
+        let (ctx, mut data_rx) = make_ws_ctx();
+        let instrument_id = seed_instrument(
+            &ctx,
+            asset_id_str,
+            Price::from("0.01"),
+            Quantity::from("0.01"),
+        )
+        .id();
+        ctx.active_delta_subs.insert(instrument_id);
+        ctx.order_books.insert(
+            instrument_id,
+            OrderBook::new(instrument_id, BookType::L2_MBP),
+        );
+        ctx.live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: UUID4::new(),
+                pending_responses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                buffered_deltas: Vec::new(),
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
+
+        handle_market_message(make_price_change(market, asset_id_str, "0.50", "20"), &ctx);
+
+        assert!(data_rx.try_recv().is_err());
+        let book = ctx.order_books.get(&instrument_id).expect("book entry");
+        assert_eq!(book.best_bid_price(), None);
+        drop(book);
+        let resync = ctx
+            .live_book_resyncs
+            .get(&instrument_id)
+            .expect("resync state");
+        assert_eq!(resync.buffered_deltas.len(), 1);
+    }
+
+    #[rstest]
+    fn live_book_resync_buffers_ws_snapshot_without_mutating_or_emitting() {
+        let asset_id_str = "0xTOKEN_RESYNC_SNAPSHOT";
+        let market = "0xMARKET";
+        let (ctx, mut data_rx) = make_ws_ctx();
+        let instrument_id = seed_instrument(
+            &ctx,
+            asset_id_str,
+            Price::from("0.01"),
+            Quantity::from("0.01"),
+        )
+        .id();
+        ctx.active_delta_subs.insert(instrument_id);
+        ctx.live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: UUID4::new(),
+                pending_responses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                buffered_deltas: Vec::new(),
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
+
+        handle_market_message(make_snapshot(market, asset_id_str, &[("0.42", "10")]), &ctx);
+
+        assert!(data_rx.try_recv().is_err());
+        assert!(!ctx.order_books.contains_key(&instrument_id));
+        let resync = ctx
+            .live_book_resyncs
+            .get(&instrument_id)
+            .expect("resync state");
+        assert_eq!(resync.phase, LiveBookResyncPhase::Buffering);
+        assert_eq!(resync.buffered_deltas.len(), 1);
+    }
+
+    #[rstest]
+    fn tick_size_change_cancels_live_book_resync_buffer_before_epoch_gate() {
+        let asset_id_str = "0xTOKEN_RESYNC_TICK";
+        let market = "0xMARKET";
+        let (ctx, _data_rx) = make_ws_ctx();
+        let instrument_id = seed_instrument(
+            &ctx,
+            asset_id_str,
+            Price::from("0.001"),
+            Quantity::from("0.01"),
+        )
+        .id();
+        ctx.active_delta_subs.insert(instrument_id);
+        ctx.live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: UUID4::new(),
+                pending_responses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                buffered_deltas: vec![OrderBookDeltas::new(
+                    instrument_id,
+                    vec![OrderBookDelta::clear(
+                        instrument_id,
+                        0,
+                        UnixNanos::from(1),
+                        UnixNanos::from(1),
+                    )],
+                )],
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
+
+        handle_market_message(
+            make_tick_change(market, asset_id_str, "0.001", "0.01"),
+            &ctx,
+        );
+
+        let resync = ctx
+            .live_book_resyncs
+            .get(&instrument_id)
+            .expect("resync state");
+        assert_eq!(resync.phase, LiveBookResyncPhase::Passthrough);
+        assert!(resync.buffered_deltas.is_empty());
+        assert!(
+            ctx.pending_snapshot_after_tick_change
+                .contains(&instrument_id)
+        );
+    }
+
+    #[rstest]
     fn price_change_batches_interleaved_changes_by_instrument() {
         let asset_a = "0xTOKEN-A";
         let asset_b = "0xTOKEN-B";
@@ -3957,6 +4118,23 @@ mod tests {
         let instrument_id = inst.id();
         ctx.active_delta_subs.insert(instrument_id);
         ctx.pending_snapshot_after_tick_change.insert(instrument_id);
+        ctx.live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: UUID4::new(),
+                pending_responses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                buffered_deltas: vec![OrderBookDeltas::new(
+                    instrument_id,
+                    vec![OrderBookDelta::clear(
+                        instrument_id,
+                        0,
+                        UnixNanos::from(1),
+                        UnixNanos::from(1),
+                    )],
+                )],
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
 
         let empty = MarketWsMessage::Book(PolymarketBookSnapshot {
             market: Ustr::from(market),
@@ -3977,5 +4155,53 @@ mod tests {
             !events.iter().any(|e| matches!(e, DataEvent::Data(_))),
             "empty snapshot must not emit Data events: {events:?}",
         );
+        let resync = ctx
+            .live_book_resyncs
+            .get(&instrument_id)
+            .expect("live resync remains active");
+        assert_eq!(resync.phase, LiveBookResyncPhase::Buffering);
+        assert_eq!(resync.buffered_deltas.len(), 1);
+    }
+
+    #[rstest]
+    fn tick_gate_snapshot_seeds_book_while_live_resync_remains_buffering() {
+        let asset_id_str = "0xTOKEN_RESYNC_TICK_SNAPSHOT";
+        let market = "0xMARKET";
+        let (ctx, mut data_rx) = make_ws_ctx();
+        let instrument_id = seed_instrument(
+            &ctx,
+            asset_id_str,
+            Price::from("0.01"),
+            Quantity::from("0.01"),
+        )
+        .id();
+        ctx.active_delta_subs.insert(instrument_id);
+        ctx.pending_snapshot_after_tick_change.insert(instrument_id);
+        ctx.live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: UUID4::new(),
+                pending_responses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                buffered_deltas: Vec::new(),
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
+
+        handle_market_message(make_snapshot(market, asset_id_str, &[("0.42", "10")]), &ctx);
+
+        assert!(data_rx.try_recv().is_ok());
+        assert!(
+            !ctx.pending_snapshot_after_tick_change
+                .contains(&instrument_id)
+        );
+        let book = ctx.order_books.get(&instrument_id).expect("book entry");
+        assert_eq!(book.best_ask_price(), Some(Price::from("0.42")));
+        drop(book);
+        let resync = ctx
+            .live_book_resyncs
+            .get(&instrument_id)
+            .expect("resync state");
+        assert_eq!(resync.phase, LiveBookResyncPhase::Buffering);
+        assert!(resync.buffered_deltas.is_empty());
     }
 }

--- a/crates/adapters/polymarket/src/data/lifecycle.rs
+++ b/crates/adapters/polymarket/src/data/lifecycle.rs
@@ -89,6 +89,7 @@ impl PolymarketDataClient {
             resolve_poll_watchlist: self.resolve_poll_watchlist.clone(),
             resolve_watch_apply_mutex: self.resolve_watch_apply_mutex.clone(),
             pending_snapshot_after_tick_change: self.pending_snapshot_after_tick_change.clone(),
+            live_book_resyncs: self.live_book_resyncs.clone(),
             new_market_inflight_keys: self.new_market_inflight_keys.clone(),
             new_market_fetch_semaphore: self.new_market_fetch_semaphore.clone(),
             rtds_feed: self.rtds_feed.clone(),
@@ -142,6 +143,7 @@ impl PolymarketDataClient {
         let active_delta_subs = self.active_delta_subs.clone();
         let active_trade_subs = self.active_trade_subs.clone();
         let pending_snapshot_after_tick_change = self.pending_snapshot_after_tick_change.clone();
+        let live_book_resyncs = self.live_book_resyncs.clone();
         let pending_auto_loads = self.pending_auto_loads.clone();
         let ws_open_tokens = self.ws_open_tokens.clone();
         let ws_sub_mutex = self.ws_sub_mutex.clone();
@@ -163,6 +165,7 @@ impl PolymarketDataClient {
             resolve_poll_watchlist: self.resolve_poll_watchlist.clone(),
             resolve_watch_apply_mutex: self.resolve_watch_apply_mutex.clone(),
             pending_snapshot_after_tick_change: self.pending_snapshot_after_tick_change.clone(),
+            live_book_resyncs: self.live_book_resyncs.clone(),
             new_market_inflight_keys: self.new_market_inflight_keys.clone(),
             new_market_fetch_semaphore: self.new_market_fetch_semaphore.clone(),
             rtds_feed: self.rtds_feed.clone(),
@@ -202,6 +205,7 @@ impl PolymarketDataClient {
                             &active_trade_subs,
                             &watchlist,
                             &pending_snapshot_after_tick_change,
+                            &live_book_resyncs,
                             &pending_auto_loads,
                             &ws_open_tokens,
                             &ws_sub_mutex,
@@ -324,6 +328,8 @@ impl PolymarketDataClient {
         self.active_delta_subs = std::sync::Arc::new(AtomicSet::new());
         self.active_trade_subs = std::sync::Arc::new(AtomicSet::new());
         self.pending_snapshot_after_tick_change = std::sync::Arc::new(AtomicSet::new());
+        self.live_book_resyncs.clear();
+        self.live_book_resyncs = std::sync::Arc::new(DashMap::new());
         self.new_market_inflight_keys = std::sync::Arc::new(DashMap::new());
         self.ws_open_tokens = std::sync::Arc::new(AtomicSet::new());
         self.rtds_feed = crate::rtds::PolymarketRtdsFeed::new_with_proxy(
@@ -427,7 +433,7 @@ mod tests {
         live::runner::{replace_data_event_sender, replace_exec_event_sender},
         messages::{
             DataEvent, ExecutionEvent,
-            data::{SubscribeCustomData, UnsubscribeCustomData},
+            data::{SubscribeCustomData, UnsubscribeBookDeltas, UnsubscribeCustomData},
         },
         testing::wait_until_async,
     };
@@ -450,7 +456,10 @@ mod tests {
     use serde_json::Value;
     use ustr::Ustr;
 
-    use super::{super::NEW_MARKET_FETCH_MAX_CONCURRENCY_CAP, *};
+    use super::{
+        super::{LiveBookResync, LiveBookResyncPhase, NEW_MARKET_FETCH_MAX_CONCURRENCY_CAP},
+        *,
+    };
     use crate::{
         common::consts::{POLYMARKET_CLIENT_ID, POLYMARKET_VENUE, WS_DEFAULT_SUBSCRIPTIONS},
         config::PolymarketDataClientConfig,
@@ -620,6 +629,15 @@ mod tests {
         client
             .pending_snapshot_after_tick_change
             .insert(instrument_id);
+        client.live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: UUID4::new(),
+                pending_responses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                buffered_deltas: Vec::new(),
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
         client
             .pending_auto_loads
             .lock()
@@ -659,6 +677,16 @@ mod tests {
         client
             .pending_snapshot_after_tick_change
             .insert(instrument_id);
+        client.live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: UUID4::new(),
+                pending_responses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                buffered_deltas: Vec::new(),
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
+        let old_live_book_resyncs = client.live_book_resyncs.clone();
         client
             .pending_auto_loads
             .lock()
@@ -679,6 +707,12 @@ mod tests {
         assert!(client.ws_open_tokens.is_empty());
         assert!(client.new_market_inflight_keys.is_empty());
         assert!(client.pending_snapshot_after_tick_change.is_empty());
+        assert!(client.live_book_resyncs.is_empty());
+        assert!(old_live_book_resyncs.is_empty());
+        assert!(!Arc::ptr_eq(
+            &old_live_book_resyncs,
+            &client.live_book_resyncs
+        ));
         assert!(
             client
                 .pending_auto_loads
@@ -687,6 +721,37 @@ mod tests {
                 .is_empty()
         );
         assert!(!client.auto_load_scheduled.load(Ordering::Acquire));
+    }
+
+    #[rstest]
+    fn unsubscribe_book_deltas_clears_live_resync_state() {
+        let mut client = make_client_for_reset_test();
+        let instrument_id = InstrumentId::from("0xCOND-0xTOKEN.POLYMARKET");
+        client.active_delta_subs.insert(instrument_id);
+        client.live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: UUID4::new(),
+                pending_responses: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                buffered_deltas: Vec::new(),
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
+
+        client
+            .unsubscribe_book_deltas(&UnsubscribeBookDeltas::new(
+                instrument_id,
+                Some(*POLYMARKET_CLIENT_ID),
+                None,
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("unsubscribe book deltas");
+
+        assert!(!client.active_delta_subs.contains(&instrument_id));
+        assert!(!client.live_book_resyncs.contains_key(&instrument_id));
     }
 
     #[rstest]
@@ -1089,6 +1154,7 @@ mod tests {
             &client.active_trade_subs,
             &client.resolve_poll_watchlist,
             &client.pending_snapshot_after_tick_change,
+            &client.live_book_resyncs,
             &client.pending_auto_loads,
             &client.ws_open_tokens,
             &client.ws_sub_mutex,
@@ -1323,6 +1389,7 @@ mod tests {
                 &client.active_trade_subs,
                 &client.resolve_poll_watchlist,
                 &client.pending_snapshot_after_tick_change,
+                &client.live_book_resyncs,
                 &client.pending_auto_loads,
                 &client.ws_open_tokens,
                 &client.ws_sub_mutex,

--- a/crates/adapters/polymarket/src/data/mod.rs
+++ b/crates/adapters/polymarket/src/data/mod.rs
@@ -50,11 +50,11 @@ use nautilus_common::{
     msgbus::TypedHandler,
 };
 use nautilus_core::{
-    AtomicMap, AtomicSet,
+    AtomicMap, AtomicSet, Params, UUID4,
     time::{AtomicTime, get_atomic_clock_realtime},
 };
 use nautilus_model::{
-    data::QuoteTick,
+    data::{OrderBookDeltas, QuoteTick},
     enums::BookType,
     events::PositionEvent,
     identifiers::{ClientId, InstrumentId, Venue},
@@ -92,6 +92,7 @@ use crate::{
 const NEW_MARKET_FETCH_MAX_CONCURRENCY_CAP: usize = 64;
 pub(super) const NEW_MARKET_EMPTY_RECHECK_MAX_ATTEMPTS: usize = 1;
 pub(super) const NEW_MARKET_EMPTY_RECHECK_DELAY: Duration = Duration::from_millis(500);
+pub(super) const LIVE_BOOK_RESYNC_PARAM: &str = "resync_live_book";
 
 fn clamp_new_market_fetch_max_concurrency(value: usize) -> usize {
     value.clamp(1, NEW_MARKET_FETCH_MAX_CONCURRENCY_CAP)
@@ -127,6 +128,7 @@ pub struct PolymarketDataClient {
     resolve_poll_watchlist: Arc<AtomicMap<String, ResolveWatchEntry>>,
     resolve_watch_apply_mutex: Arc<StdMutex<()>>,
     pending_snapshot_after_tick_change: Arc<AtomicSet<InstrumentId>>,
+    live_book_resyncs: Arc<DashMap<InstrumentId, LiveBookResync>>,
     new_market_inflight_keys: Arc<DashMap<String, ()>>,
     new_market_fetch_semaphore: Arc<tokio::sync::Semaphore>,
     ws_open_tokens: Arc<AtomicSet<Ustr>>,
@@ -214,6 +216,7 @@ impl PolymarketDataClient {
             resolve_poll_watchlist: Arc::new(AtomicMap::new()),
             resolve_watch_apply_mutex: Arc::new(StdMutex::new(())),
             pending_snapshot_after_tick_change: Arc::new(AtomicSet::new()),
+            live_book_resyncs: Arc::new(DashMap::new()),
             new_market_inflight_keys: Arc::new(DashMap::new()),
             new_market_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(
                 fetch_max_concurrency,
@@ -572,6 +575,7 @@ impl DataClient for PolymarketDataClient {
         self.active_delta_subs.remove(&instrument_id);
         self.pending_snapshot_after_tick_change
             .remove(&instrument_id);
+        self.live_book_resyncs.remove(&instrument_id);
         self.drop_pending_if_unwanted(instrument_id);
         self.drop_local_book_state_if_unwanted(instrument_id);
         self.sync_ws_subscription(instrument_id);
@@ -622,4 +626,26 @@ impl DataClient for PolymarketDataClient {
 
         Ok(())
     }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct PendingBookSnapshotResponse {
+    request_id: UUID4,
+    client_id: ClientId,
+    params: Option<Params>,
+}
+
+#[derive(Debug)]
+pub(super) struct LiveBookResync {
+    generation: UUID4,
+    pending_responses: Arc<StdMutex<Vec<PendingBookSnapshotResponse>>>,
+    buffered_deltas: Vec<OrderBookDeltas>,
+    phase: LiveBookResyncPhase,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum LiveBookResyncPhase {
+    Buffering,
+    Completing,
+    Passthrough,
 }

--- a/crates/adapters/polymarket/src/data/requests.rs
+++ b/crates/adapters/polymarket/src/data/requests.rs
@@ -13,9 +13,10 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 
 use anyhow::Context;
+use dashmap::{DashMap, mapref::entry::Entry};
 use nautilus_common::{
     live::get_runtime,
     messages::{
@@ -27,10 +28,16 @@ use nautilus_common::{
         },
     },
 };
-use nautilus_core::datetime::datetime_to_unix_nanos;
-use nautilus_model::{data::CustomData, instruments::Instrument};
+use nautilus_core::{UUID4, UnixNanos, datetime::datetime_to_unix_nanos};
+use nautilus_model::{
+    data::{CustomData, Data as NautilusData, OrderBookDeltas, OrderBookDeltas_API},
+    identifiers::InstrumentId,
+    instruments::Instrument,
+    orderbook::OrderBook,
+};
 
 use super::{
+    LIVE_BOOK_RESYNC_PARAM, LiveBookResync, LiveBookResyncPhase, PendingBookSnapshotResponse,
     PolymarketDataClient, dispatch::WsMessageContext, instruments::cache_instrument_if_active,
 };
 use crate::{
@@ -43,6 +50,95 @@ use crate::{
         pause_resolve_watch_entries, request_params_has_explicit_condition_selector,
     },
 };
+
+fn replay_buffered_book_deltas(
+    order_books: &DashMap<InstrumentId, OrderBook>,
+    sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
+    instrument_id: InstrumentId,
+    buffered_deltas: impl IntoIterator<Item = OrderBookDeltas>,
+    after: Option<UnixNanos>,
+) {
+    for deltas in buffered_deltas {
+        if after.is_some_and(|snapshot_ts| deltas.ts_event <= snapshot_ts) {
+            continue;
+        }
+
+        if let Some(mut live_book) = order_books.get_mut(&instrument_id)
+            && let Err(e) = live_book.apply_deltas(&deltas)
+        {
+            log::error!("Failed to replay buffered book deltas for {instrument_id}: {e}");
+            continue;
+        }
+
+        let data: NautilusData = OrderBookDeltas_API::new(deltas).into();
+        if let Err(e) = sender.send(DataEvent::Data(data)) {
+            log::error!("Failed to emit buffered book deltas: {e}");
+        }
+    }
+}
+
+fn close_live_book_resync_admission(
+    live_book_resyncs: &DashMap<InstrumentId, LiveBookResync>,
+    instrument_id: InstrumentId,
+    generation: UUID4,
+) -> Option<Vec<PendingBookSnapshotResponse>> {
+    let mut resync = live_book_resyncs.get_mut(&instrument_id)?;
+    if resync.generation != generation || resync.phase != LiveBookResyncPhase::Buffering {
+        return None;
+    }
+
+    resync.phase = LiveBookResyncPhase::Completing;
+    let responses = std::mem::take(
+        &mut *resync
+            .pending_responses
+            .lock()
+            .expect("live book resync response mutex poisoned"),
+    );
+    Some(responses)
+}
+
+fn join_or_start_live_book_resync(
+    live_book_resyncs: &DashMap<InstrumentId, LiveBookResync>,
+    instrument_id: InstrumentId,
+    generation: UUID4,
+    pending_response: PendingBookSnapshotResponse,
+    pending_responses: Arc<StdMutex<Vec<PendingBookSnapshotResponse>>>,
+) -> bool {
+    match live_book_resyncs.entry(instrument_id) {
+        Entry::Occupied(mut entry) => {
+            if entry.get().phase == LiveBookResyncPhase::Buffering {
+                entry
+                    .get_mut()
+                    .pending_responses
+                    .lock()
+                    .expect("live book resync response mutex poisoned")
+                    .push(pending_response);
+                return true;
+            }
+
+            let buffered_deltas = if entry.get().phase == LiveBookResyncPhase::Completing {
+                std::mem::take(&mut entry.get_mut().buffered_deltas)
+            } else {
+                Vec::new()
+            };
+            entry.insert(LiveBookResync {
+                generation,
+                pending_responses,
+                buffered_deltas,
+                phase: LiveBookResyncPhase::Buffering,
+            });
+        }
+        Entry::Vacant(entry) => {
+            entry.insert(LiveBookResync {
+                generation,
+                pending_responses,
+                buffered_deltas: Vec::new(),
+                phase: LiveBookResyncPhase::Buffering,
+            });
+        }
+    }
+    false
+}
 
 pub(super) fn request_data(client: &PolymarketDataClient, request: RequestCustomData) {
     if request.data_type.type_name() != RESOLVE_REQUEST_TYPE_NAME {
@@ -88,6 +184,7 @@ pub(super) fn request_data(client: &PolymarketDataClient, request: RequestCustom
         resolve_poll_watchlist: client.resolve_poll_watchlist.clone(),
         resolve_watch_apply_mutex: client.resolve_watch_apply_mutex.clone(),
         pending_snapshot_after_tick_change: client.pending_snapshot_after_tick_change.clone(),
+        live_book_resyncs: client.live_book_resyncs.clone(),
         new_market_inflight_keys: client.new_market_inflight_keys.clone(),
         new_market_fetch_semaphore: client.new_market_fetch_semaphore.clone(),
         rtds_feed: client.rtds_feed.clone(),
@@ -349,6 +446,33 @@ pub(super) fn request_book_snapshot(
     let request_id = request.request_id;
     let params = request.params;
     let clock = client.clock;
+    let pending_response = PendingBookSnapshotResponse {
+        request_id,
+        client_id,
+        params: params.clone(),
+    };
+    let pending_responses = Arc::new(StdMutex::new(vec![pending_response.clone()]));
+    let resync_live_book = params
+        .as_ref()
+        .and_then(|params| params.get_bool(LIVE_BOOK_RESYNC_PARAM))
+        .unwrap_or(false);
+
+    if resync_live_book
+        && join_or_start_live_book_resync(
+            &client.live_book_resyncs,
+            instrument_id,
+            request_id,
+            pending_response,
+            pending_responses.clone(),
+        )
+    {
+        return Ok(());
+    }
+
+    let live_book_resyncs = client.live_book_resyncs.clone();
+    let order_books = client.order_books.clone();
+    let active_delta_subs = client.active_delta_subs.clone();
+    let pending_snapshot_after_tick_change = client.pending_snapshot_after_tick_change.clone();
 
     get_runtime().spawn(async move {
         match clob_client
@@ -357,22 +481,109 @@ pub(super) fn request_book_snapshot(
             .context("failed to request book snapshot from Polymarket")
         {
             Ok(book) => {
-                let response = DataResponse::Book(BookResponse::new(
-                    request_id,
-                    client_id,
-                    instrument_id,
-                    book,
-                    None,
-                    None,
-                    clock.get_time_ns(),
-                    params,
-                ));
+                let pending_responses = if resync_live_book {
+                    close_live_book_resync_admission(&live_book_resyncs, instrument_id, request_id)
+                        .unwrap_or_else(|| {
+                            std::mem::take(
+                                &mut *pending_responses
+                                    .lock()
+                                    .expect("pending response mutex poisoned"),
+                            )
+                        })
+                } else {
+                    std::mem::take(
+                        &mut *pending_responses
+                            .lock()
+                            .expect("pending response mutex poisoned"),
+                    )
+                };
+                for pending in pending_responses {
+                    let response = DataResponse::Book(BookResponse::new(
+                        pending.request_id,
+                        pending.client_id,
+                        instrument_id,
+                        book.clone(),
+                        None,
+                        None,
+                        clock.get_time_ns(),
+                        pending.params,
+                    ));
 
-                if let Err(e) = sender.send(DataEvent::Response(response)) {
-                    log::error!("Failed to send book snapshot response: {e}");
+                    if let Err(e) = sender.send(DataEvent::Response(response)) {
+                        log::error!("Failed to send book snapshot response: {e}");
+                    }
                 }
+
+                if resync_live_book
+                    && let Some(mut resync) = live_book_resyncs.get_mut(&instrument_id)
+                    && resync.generation == request_id
+                {
+                    if resync.phase == LiveBookResyncPhase::Completing
+                        && active_delta_subs.contains(&instrument_id)
+                        && !pending_snapshot_after_tick_change.contains(&instrument_id)
+                    {
+                        let snapshot_ts = book.ts_last;
+                        let snapshot_deltas = book.to_deltas(snapshot_ts, clock.get_time_ns());
+                        order_books.insert(instrument_id, book);
+
+                        let data: NautilusData = OrderBookDeltas_API::new(snapshot_deltas).into();
+                        if let Err(e) = sender.send(DataEvent::Data(data)) {
+                            log::error!("Failed to emit live book resync snapshot: {e}");
+                        }
+
+                        replay_buffered_book_deltas(
+                            &order_books,
+                            &sender,
+                            instrument_id,
+                            resync.buffered_deltas.drain(..),
+                            Some(snapshot_ts),
+                        );
+                    }
+
+                    resync.buffered_deltas.clear();
+                    resync.phase = LiveBookResyncPhase::Passthrough;
+                }
+
+                let _ = live_book_resyncs.remove_if(&instrument_id, |_, resync| {
+                    resync.generation == request_id
+                        && resync.phase == LiveBookResyncPhase::Passthrough
+                });
             }
-            Err(e) => log::error!("Book snapshot request failed: {e:?}"),
+            Err(e) => {
+                if resync_live_book {
+                    let _ = close_live_book_resync_admission(
+                        &live_book_resyncs,
+                        instrument_id,
+                        request_id,
+                    );
+                }
+                if resync_live_book
+                    && let Some(mut resync) = live_book_resyncs.get_mut(&instrument_id)
+                    && resync.generation == request_id
+                {
+                    if resync.phase == LiveBookResyncPhase::Completing
+                        && active_delta_subs.contains(&instrument_id)
+                        && !pending_snapshot_after_tick_change.contains(&instrument_id)
+                    {
+                        replay_buffered_book_deltas(
+                            &order_books,
+                            &sender,
+                            instrument_id,
+                            resync.buffered_deltas.drain(..),
+                            None,
+                        );
+                    }
+
+                    resync.buffered_deltas.clear();
+                    resync.phase = LiveBookResyncPhase::Passthrough;
+                }
+
+                let _ = live_book_resyncs.remove_if(&instrument_id, |_, resync| {
+                    resync.generation == request_id
+                        && resync.phase == LiveBookResyncPhase::Passthrough
+                });
+                log::error!("Book snapshot request failed: {e:?}");
+            }
         }
     });
 
@@ -454,4 +665,207 @@ pub(super) fn request_trades(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use dashmap::DashMap;
+    use nautilus_common::messages::DataEvent;
+    use nautilus_core::{UUID4, UnixNanos};
+    use nautilus_model::{
+        data::{BookOrder, Data as NautilusData, OrderBookDelta, OrderBookDeltas},
+        enums::{BookAction, BookType, OrderSide, RecordFlag},
+        identifiers::{ClientId, InstrumentId},
+        orderbook::OrderBook,
+        types::{Price, Quantity},
+    };
+
+    use super::{
+        LiveBookResync, LiveBookResyncPhase, PendingBookSnapshotResponse,
+        close_live_book_resync_admission, join_or_start_live_book_resync,
+        replay_buffered_book_deltas,
+    };
+
+    #[test]
+    fn live_resync_completion_atomically_closes_response_admission() {
+        let instrument_id = InstrumentId::from("TEST.POLYMARKET");
+        let generation = UUID4::new();
+        let pending_responses = Arc::new(Mutex::new(vec![PendingBookSnapshotResponse {
+            request_id: generation,
+            client_id: ClientId::from("POLYMARKET"),
+            params: None,
+        }]));
+        let live_book_resyncs = DashMap::new();
+        live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation,
+                pending_responses: pending_responses.clone(),
+                buffered_deltas: Vec::new(),
+                phase: LiveBookResyncPhase::Buffering,
+            },
+        );
+
+        let drained =
+            close_live_book_resync_admission(&live_book_resyncs, instrument_id, generation)
+                .expect("matching generation should close admission");
+
+        assert_eq!(drained.len(), 1);
+        assert!(pending_responses.lock().expect("response mutex").is_empty());
+        assert_eq!(
+            live_book_resyncs
+                .get(&instrument_id)
+                .expect("live resync")
+                .phase,
+            LiveBookResyncPhase::Completing,
+        );
+    }
+
+    #[test]
+    fn replacement_generation_inherits_completing_buffer() {
+        let instrument_id = InstrumentId::from("TEST.POLYMARKET");
+        let old_generation = UUID4::new();
+        let live_book_resyncs = DashMap::new();
+        live_book_resyncs.insert(
+            instrument_id,
+            LiveBookResync {
+                generation: old_generation,
+                pending_responses: Arc::new(Mutex::new(Vec::new())),
+                buffered_deltas: vec![add_bid(instrument_id, "0.41", 90)],
+                phase: LiveBookResyncPhase::Completing,
+            },
+        );
+        let new_generation = UUID4::new();
+        let pending_response = PendingBookSnapshotResponse {
+            request_id: new_generation,
+            client_id: ClientId::from("POLYMARKET"),
+            params: None,
+        };
+
+        let joined = join_or_start_live_book_resync(
+            &live_book_resyncs,
+            instrument_id,
+            new_generation,
+            pending_response,
+            Arc::new(Mutex::new(Vec::new())),
+        );
+
+        let resync = live_book_resyncs
+            .get(&instrument_id)
+            .expect("replacement live resync");
+        assert!(!joined);
+        assert_eq!(resync.generation, new_generation);
+        assert_eq!(resync.phase, LiveBookResyncPhase::Buffering);
+        assert_eq!(resync.buffered_deltas.len(), 1);
+    }
+
+    fn add_bid(instrument_id: InstrumentId, price: &str, ts_event: u64) -> OrderBookDeltas {
+        OrderBookDeltas::new(
+            instrument_id,
+            vec![OrderBookDelta::new(
+                instrument_id,
+                BookAction::Add,
+                BookOrder::new(
+                    OrderSide::Buy,
+                    Price::from(price),
+                    Quantity::from("10"),
+                    ts_event,
+                ),
+                RecordFlag::F_LAST as u8,
+                ts_event,
+                UnixNanos::from(ts_event),
+                UnixNanos::from(ts_event),
+            )],
+        )
+    }
+
+    fn add_ask(instrument_id: InstrumentId, price: &str, ts_event: u64) -> OrderBookDeltas {
+        OrderBookDeltas::new(
+            instrument_id,
+            vec![OrderBookDelta::new(
+                instrument_id,
+                BookAction::Add,
+                BookOrder::new(
+                    OrderSide::Sell,
+                    Price::from(price),
+                    Quantity::from("10"),
+                    ts_event,
+                ),
+                RecordFlag::F_LAST as u8,
+                ts_event,
+                UnixNanos::from(ts_event),
+                UnixNanos::from(ts_event),
+            )],
+        )
+    }
+
+    #[test]
+    fn live_resync_replays_only_deltas_newer_than_snapshot() {
+        let instrument_id = InstrumentId::from("TEST.POLYMARKET");
+        let order_books = dashmap::DashMap::new();
+        order_books.insert(
+            instrument_id,
+            OrderBook::new(instrument_id, BookType::L2_MBP),
+        );
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+
+        replay_buffered_book_deltas(
+            &order_books,
+            &sender,
+            instrument_id,
+            [
+                add_bid(instrument_id, "0.41", 90),
+                add_bid(instrument_id, "0.42", 110),
+            ],
+            Some(UnixNanos::from(100)),
+        );
+
+        let book = order_books.get(&instrument_id).expect("book entry");
+        let adapter_bid = book.best_bid_price();
+        assert_eq!(adapter_bid, Some(Price::from("0.42")));
+        drop(book);
+        let emitted = match receiver.try_recv() {
+            Ok(DataEvent::Data(NautilusData::Deltas(deltas))) => deltas,
+            other => panic!("expected emitted book deltas, found {other:?}"),
+        };
+        let mut cache_book = OrderBook::new(instrument_id, BookType::L2_MBP);
+        cache_book
+            .apply_deltas(&emitted)
+            .expect("apply emitted deltas");
+        assert_eq!(cache_book.best_bid_price(), adapter_bid);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn failed_live_resync_replays_every_buffered_delta() {
+        let instrument_id = InstrumentId::from("TEST.POLYMARKET");
+        let order_books = dashmap::DashMap::new();
+        let mut old_book = OrderBook::new(instrument_id, BookType::L2_MBP);
+        old_book
+            .apply_deltas(&add_ask(instrument_id, "0.60", 80))
+            .expect("seed old book");
+        order_books.insert(instrument_id, old_book);
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+
+        replay_buffered_book_deltas(
+            &order_books,
+            &sender,
+            instrument_id,
+            [
+                add_bid(instrument_id, "0.41", 90),
+                add_bid(instrument_id, "0.42", 110),
+            ],
+            None,
+        );
+
+        let book = order_books.get(&instrument_id).expect("book entry");
+        assert_eq!(book.best_bid_price(), Some(Price::from("0.42")));
+        assert_eq!(book.best_ask_price(), Some(Price::from("0.60")));
+        drop(book);
+        assert!(receiver.try_recv().is_ok());
+        assert!(receiver.try_recv().is_ok());
+        assert!(receiver.try_recv().is_err());
+    }
 }

--- a/crates/adapters/polymarket/src/data/runtime.rs
+++ b/crates/adapters/polymarket/src/data/runtime.rs
@@ -29,6 +29,7 @@ use nautilus_model::{
 use ustr::Ustr;
 
 use super::{
+    LiveBookResync,
     instruments::TokenMeta,
     subscriptions::{resolve_token_id_from, sync_ws_subscription_async},
 };
@@ -88,6 +89,7 @@ fn has_live_runtime_state(
     active_delta_subs: &Arc<AtomicSet<InstrumentId>>,
     active_trade_subs: &Arc<AtomicSet<InstrumentId>>,
     pending_snapshot_after_tick_change: &Arc<AtomicSet<InstrumentId>>,
+    live_book_resyncs: &Arc<DashMap<InstrumentId, LiveBookResync>>,
     pending_auto_loads: &Arc<StdMutex<AHashSet<InstrumentId>>>,
     ws_open_tokens: &Arc<AtomicSet<Ustr>>,
 ) -> bool {
@@ -95,6 +97,7 @@ fn has_live_runtime_state(
         || active_delta_subs.contains(&instrument_id)
         || active_trade_subs.contains(&instrument_id)
         || pending_snapshot_after_tick_change.contains(&instrument_id)
+        || live_book_resyncs.contains_key(&instrument_id)
         || order_books.contains_key(&instrument_id)
         || last_quotes.contains_key(&instrument_id)
     {
@@ -131,6 +134,7 @@ pub(crate) async fn retire_local_instrument_state(
     active_trade_subs: &Arc<AtomicSet<InstrumentId>>,
     resolve_poll_watchlist: &Arc<AtomicMap<String, ResolveWatchEntry>>,
     pending_snapshot_after_tick_change: &Arc<AtomicSet<InstrumentId>>,
+    live_book_resyncs: &Arc<DashMap<InstrumentId, LiveBookResync>>,
     pending_auto_loads: &Arc<StdMutex<AHashSet<InstrumentId>>>,
     ws_open_tokens: &Arc<AtomicSet<Ustr>>,
     ws_sub_mutex: &Arc<tokio::sync::Mutex<()>>,
@@ -157,6 +161,7 @@ pub(crate) async fn retire_local_instrument_state(
     }
 
     pending_snapshot_after_tick_change.remove(&instrument_id);
+    live_book_resyncs.remove(&instrument_id);
     {
         let mut pending = pending_auto_loads
             .lock()
@@ -192,6 +197,7 @@ pub(crate) async fn retire_expired_local_instruments(
     active_trade_subs: &Arc<AtomicSet<InstrumentId>>,
     resolve_poll_watchlist: &Arc<AtomicMap<String, ResolveWatchEntry>>,
     pending_snapshot_after_tick_change: &Arc<AtomicSet<InstrumentId>>,
+    live_book_resyncs: &Arc<DashMap<InstrumentId, LiveBookResync>>,
     pending_auto_loads: &Arc<StdMutex<AHashSet<InstrumentId>>>,
     ws_open_tokens: &Arc<AtomicSet<Ustr>>,
     ws_sub_mutex: &Arc<tokio::sync::Mutex<()>>,
@@ -223,6 +229,7 @@ pub(crate) async fn retire_expired_local_instruments(
                 active_delta_subs,
                 active_trade_subs,
                 pending_snapshot_after_tick_change,
+                live_book_resyncs,
                 pending_auto_loads,
                 ws_open_tokens,
             )
@@ -245,6 +252,7 @@ pub(crate) async fn retire_expired_local_instruments(
             active_trade_subs,
             resolve_poll_watchlist,
             pending_snapshot_after_tick_change,
+            live_book_resyncs,
             pending_auto_loads,
             ws_open_tokens,
             ws_sub_mutex,
@@ -370,6 +378,7 @@ mod tests {
         let active_trade_subs = Arc::new(AtomicSet::new());
         let resolve_poll_watchlist = Arc::new(AtomicMap::new());
         let pending_snapshot_after_tick_change = Arc::new(AtomicSet::new());
+        let live_book_resyncs = Arc::new(DashMap::new());
         let pending_auto_loads = Arc::new(StdMutex::new(AHashSet::new()));
         let ws_open_tokens = Arc::new(AtomicSet::new());
         let ws_sub_mutex = Arc::new(tokio::sync::Mutex::new(()));
@@ -409,6 +418,7 @@ mod tests {
             &active_trade_subs,
             &resolve_poll_watchlist,
             &pending_snapshot_after_tick_change,
+            &live_book_resyncs,
             &pending_auto_loads,
             &ws_open_tokens,
             &ws_sub_mutex,
@@ -440,6 +450,7 @@ mod tests {
             &active_trade_subs,
             &resolve_poll_watchlist,
             &pending_snapshot_after_tick_change,
+            &live_book_resyncs,
             &pending_auto_loads,
             &ws_open_tokens,
             &ws_sub_mutex,

--- a/crates/adapters/polymarket/src/http/clob.rs
+++ b/crates/adapters/polymarket/src/http/clob.rs
@@ -17,7 +17,9 @@
 
 use std::{collections::HashMap, result::Result as StdResult, str::from_utf8, sync::Arc};
 
+use anyhow::Context;
 use nautilus_core::{
+    UnixNanos,
     consts::NAUTILUS_USER_AGENT,
     time::{AtomicTime, get_atomic_clock_realtime},
 };
@@ -708,14 +710,22 @@ impl PolymarketClobPublicClient {
             .get_book(token_id)
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
+        let ts_event = UnixNanos::from_millis(
+            resp.timestamp
+                .parse::<u64>()
+                .context("invalid Polymarket book snapshot timestamp")?,
+        );
 
         let mut book = OrderBook::new(instrument_id, BookType::L2_MBP);
+        if resp.bids.is_empty() && resp.asks.is_empty() {
+            book.clear(0, ts_event);
+        }
 
         for (i, level) in resp.bids.iter().enumerate() {
             let price = parse_price(&level.price, price_precision)?;
             let size = parse_quantity(&level.size, size_precision)?;
             let order = BookOrder::new(OrderSide::Buy, price, size, i as u64);
-            book.add(order, 0, i as u64, Default::default());
+            book.add(order, 0, i as u64, ts_event);
         }
 
         let bids_len = resp.bids.len();
@@ -723,7 +733,7 @@ impl PolymarketClobPublicClient {
             let price = parse_price(&level.price, price_precision)?;
             let size = parse_quantity(&level.size, size_precision)?;
             let order = BookOrder::new(OrderSide::Sell, price, size, (bids_len + i) as u64);
-            book.add(order, 0, (bids_len + i) as u64, Default::default());
+            book.add(order, 0, (bids_len + i) as u64, ts_event);
         }
 
         log::debug!(
@@ -797,6 +807,7 @@ mod tests {
     #[rstest]
     fn test_build_order_book_from_clob_response() {
         let resp = ClobBookResponse {
+            timestamp: "1700000000000".to_string(),
             bids: vec![
                 ClobBookLevel {
                     price: "0.48".to_string(),
@@ -838,6 +849,7 @@ mod tests {
     #[rstest]
     fn test_build_order_book_empty_response() {
         let resp = ClobBookResponse {
+            timestamp: "1700000000000".to_string(),
             bids: vec![],
             asks: vec![],
         };

--- a/crates/adapters/polymarket/src/http/models.rs
+++ b/crates/adapters/polymarket/src/http/models.rs
@@ -351,9 +351,10 @@ pub struct ClobBookLevel {
 
 /// Response from the CLOB `GET /book` endpoint.
 ///
-/// Extra fields (`market`, `asset_id`, `hash`, `timestamp`) are silently ignored.
+/// Extra fields (`market`, `asset_id`, `hash`) are silently ignored.
 #[derive(Clone, Debug, Deserialize)]
 pub struct ClobBookResponse {
+    pub timestamp: String,
     pub bids: Vec<ClobBookLevel>,
     pub asks: Vec<ClobBookLevel>,
 }

--- a/crates/adapters/polymarket/test_data/clob_book_response_empty_ask.json
+++ b/crates/adapters/polymarket/test_data/clob_book_response_empty_ask.json
@@ -1,0 +1,15 @@
+{
+  "market": "0x9d839bf0aa31324b9848f5b89841b779238a7c07dee2f7fca675d934e8ab5bf2",
+  "asset_id": "72610532355343625199299853218161700546393390326785971247545541945337255643692",
+  "timestamp": "1785734468581",
+  "hash": "d7df883ae546b09533a4f485bfae0810da1af04e",
+  "bids": [
+    {"price": "0.001", "size": "667.12"},
+    {"price": "0.002", "size": "6.99"}
+  ],
+  "asks": [],
+  "min_order_size": "5",
+  "tick_size": "0.001",
+  "neg_risk": true,
+  "last_trade_price": ""
+}

--- a/crates/adapters/polymarket/test_data/clob_book_response_empty_ask.source.md
+++ b/crates/adapters/polymarket/test_data/clob_book_response_empty_ask.source.md
@@ -1,0 +1,8 @@
+# Source
+
+Captured from the public Polymarket CLOB endpoint on 2026-08-03T05:27:48Z:
+
+`https://clob.polymarket.com/book?token_id=72610532355343625199299853218161700546393390326785971247545541945337255643692`
+
+The response fields are retained as captured and reformatted as JSON to cover a current,
+reachable book with an empty ask side.

--- a/crates/adapters/polymarket/tests/data_client.rs
+++ b/crates/adapters/polymarket/tests/data_client.rs
@@ -24,7 +24,7 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU16, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -35,6 +35,7 @@ use axum::{
         State,
         ws::{Message, WebSocket, WebSocketUpgrade},
     },
+    http::StatusCode,
     response::{Json, Response},
     routing::get,
 };
@@ -47,14 +48,20 @@ use nautilus_common::{
         DataEvent, DataResponse,
         data::{
             RequestBookSnapshot, RequestInstrument, RequestInstruments, RequestTrades,
-            SubscribeBookDepth10, SubscribeInstrument, SubscribeInstrumentClose,
-            SubscribeInstrumentStatus, SubscribeQuotes, UnsubscribeInstrument,
+            SubscribeBookDeltas, SubscribeBookDepth10, SubscribeInstrument,
+            SubscribeInstrumentClose, SubscribeInstrumentStatus, SubscribeQuotes,
+            UnsubscribeInstrument,
         },
     },
     testing::wait_until_async,
 };
-use nautilus_core::{UUID4, UnixNanos};
-use nautilus_model::{enums::BookType, identifiers::InstrumentId, instruments::InstrumentAny};
+use nautilus_core::{Params, UUID4, UnixNanos};
+use nautilus_model::{
+    data::Data as NautilusData,
+    enums::{BookType, RecordFlag},
+    identifiers::InstrumentId,
+    instruments::InstrumentAny,
+};
 use nautilus_network::{retry::RetryConfig, websocket::TransportBackend};
 use nautilus_polymarket::{
     common::consts::{POLYMARKET_CLIENT_ID, POLYMARKET_VENUE, WS_DEFAULT_SUBSCRIPTIONS},
@@ -119,6 +126,9 @@ struct TestServerState {
     gamma_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     gamma_request_count: Arc<AtomicUsize>,
     book_response: Arc<tokio::sync::Mutex<Option<Value>>>,
+    book_request_count: Arc<AtomicUsize>,
+    book_response_delay_ms: Arc<AtomicUsize>,
+    book_status_code: Arc<AtomicU16>,
     trades_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     market_payloads: Arc<tokio::sync::Mutex<Vec<Value>>>,
 }
@@ -139,14 +149,21 @@ async fn handle_gamma_markets_keyset(State(state): State<TestServerState>) -> Js
     Json(serde_json::json!({"markets": markets}))
 }
 
-async fn handle_book(State(state): State<TestServerState>) -> Json<Value> {
+async fn handle_book(State(state): State<TestServerState>) -> (StatusCode, Json<Value>) {
+    state.book_request_count.fetch_add(1, Ordering::Relaxed);
+    let delay_ms = state.book_response_delay_ms.load(Ordering::Relaxed);
+    if delay_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(delay_ms as u64)).await;
+    }
     let body = state
         .book_response
         .lock()
         .await
         .clone()
         .unwrap_or_else(|| load_json("clob_book_response.json"));
-    Json(body)
+    let status = StatusCode::from_u16(state.book_status_code.load(Ordering::Relaxed))
+        .unwrap_or(StatusCode::OK);
+    (status, Json(body))
 }
 
 async fn handle_trades(State(state): State<TestServerState>) -> Json<Value> {
@@ -698,6 +715,322 @@ async fn test_request_book_snapshot_returns_book_response() {
         book_response_count, 1,
         "request_book_snapshot must send a DataResponse::Book; events were: {events:?}",
     );
+    assert!(
+        events
+            .iter()
+            .all(|event| !matches!(event, DataEvent::Data(NautilusData::Deltas(_)))),
+        "a standard historical request must not mutate the live book; events were: {events:?}",
+    );
+}
+
+fn live_resync_params() -> Params {
+    let mut params = Params::new();
+    params.insert("resync_live_book".to_string(), serde_json::json!(true));
+    params
+}
+
+async fn create_live_book_client(
+    state: &TestServerState,
+) -> (
+    PolymarketDataClient,
+    tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
+    InstrumentId,
+) {
+    *state.gamma_response.lock().await = Some(serde_json::json!([gamma_market_request_fixture()]));
+    let addr = start_mock_server(state.clone()).await;
+    let (mut client, mut rx) = create_test_data_client(addr);
+    let instrument_id = yes_instrument_id();
+
+    let request_id = UUID4::new();
+    client
+        .request_instrument(RequestInstrument::new(
+            instrument_id,
+            None,
+            None,
+            None,
+            request_id,
+            UnixNanos::default(),
+            None,
+        ))
+        .expect("prime cache");
+    let _ = collect_data_events_until_response(&mut rx, request_id, Duration::from_secs(5)).await;
+    client
+        .subscribe_book_deltas(SubscribeBookDeltas::new(
+            instrument_id,
+            BookType::L2_MBP,
+            Some(*POLYMARKET_CLIENT_ID),
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            true,
+            None,
+            None,
+        ))
+        .expect("subscribe book deltas");
+
+    (client, rx, instrument_id)
+}
+
+async fn collect_live_resync_events(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
+    request_id: UUID4,
+) -> Vec<DataEvent> {
+    let mut events = Vec::new();
+    let mut received_response = false;
+    let mut received_snapshot = false;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !received_response || !received_snapshot {
+            let event = rx.recv().await.expect("data event channel closed");
+            received_response |= matches!(
+                &event,
+                DataEvent::Response(response) if response.correlation_id() == &request_id
+            );
+            received_snapshot |= matches!(
+                &event,
+                DataEvent::Data(NautilusData::Deltas(deltas))
+                    if deltas.deltas.iter().all(|delta| RecordFlag::F_SNAPSHOT.matches(delta.flags))
+            );
+            events.push(event);
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for live resync {request_id}"));
+    events
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_book_snapshot_live_resync_emits_snapshot_and_response() {
+    let state = TestServerState::default();
+    let (client, mut rx, instrument_id) = create_live_book_client(&state).await;
+
+    let snapshot_request_id = UUID4::new();
+    client
+        .request_book_snapshot(RequestBookSnapshot::new(
+            instrument_id,
+            None,
+            Some(*POLYMARKET_CLIENT_ID),
+            snapshot_request_id,
+            UnixNanos::default(),
+            Some(live_resync_params()),
+        ))
+        .expect("request live book resync");
+
+    let events = collect_live_resync_events(&mut rx, snapshot_request_id).await;
+    let snapshots = events
+        .iter()
+        .filter_map(|event| match event {
+            DataEvent::Data(NautilusData::Deltas(deltas)) => Some(deltas),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(snapshots.len(), 1, "events were: {events:?}");
+    assert!(
+        snapshots[0]
+            .deltas
+            .iter()
+            .all(|delta| RecordFlag::F_SNAPSHOT.matches(delta.flags)),
+    );
+    let response_position = events
+        .iter()
+        .position(|event| matches!(event, DataEvent::Response(DataResponse::Book(_))))
+        .expect("historical response");
+    let snapshot_position = events
+        .iter()
+        .position(|event| matches!(event, DataEvent::Data(NautilusData::Deltas(_))))
+        .expect("live snapshot");
+    assert!(
+        response_position < snapshot_position,
+        "events were: {events:?}"
+    );
+    assert_eq!(state.book_request_count.load(Ordering::Relaxed), 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_book_snapshot_live_resync_emits_empty_ask_snapshot() {
+    let state = TestServerState::default();
+    *state.book_response.lock().await = Some(load_json("clob_book_response_empty_ask.json"));
+    let (client, mut rx, instrument_id) = create_live_book_client(&state).await;
+
+    let request_id = UUID4::new();
+    client
+        .request_book_snapshot(RequestBookSnapshot::new(
+            instrument_id,
+            None,
+            Some(*POLYMARKET_CLIENT_ID),
+            request_id,
+            UnixNanos::default(),
+            Some(live_resync_params()),
+        ))
+        .expect("request one-sided live book resync");
+
+    let events = collect_live_resync_events(&mut rx, request_id).await;
+    let snapshot = events.iter().find_map(|event| match event {
+        DataEvent::Data(NautilusData::Deltas(deltas)) => Some(deltas),
+        _ => None,
+    });
+    let response = events.iter().find_map(|event| match event {
+        DataEvent::Response(DataResponse::Book(response)) => Some(response),
+        _ => None,
+    });
+
+    let snapshot = snapshot.expect("one-sided snapshot event");
+    assert_eq!(snapshot.deltas.len(), 2);
+    assert!(
+        snapshot
+            .deltas
+            .iter()
+            .all(|delta| RecordFlag::F_SNAPSHOT.matches(delta.flags))
+    );
+    let response = response.expect("empty historical response");
+    assert!(response.data.best_bid_price().is_some());
+    assert!(response.data.best_ask_price().is_none());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_failed_live_resync_does_not_leave_request_coalescing_stuck() {
+    let state = TestServerState::default();
+    *state.book_response.lock().await = Some(serde_json::json!({
+        "timestamp": "invalid",
+        "bids": [],
+        "asks": [],
+    }));
+    let (client, mut rx, instrument_id) = create_live_book_client(&state).await;
+
+    client
+        .request_book_snapshot(RequestBookSnapshot::new(
+            instrument_id,
+            None,
+            Some(*POLYMARKET_CLIENT_ID),
+            UUID4::new(),
+            UnixNanos::default(),
+            Some(live_resync_params()),
+        ))
+        .expect("request failing live book resync");
+    wait_until_async(
+        || {
+            let state = state.clone();
+            async move { state.book_request_count.load(Ordering::Relaxed) == 1 }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    *state.book_response.lock().await = None;
+    let retry_request_id = UUID4::new();
+    client
+        .request_book_snapshot(RequestBookSnapshot::new(
+            instrument_id,
+            None,
+            Some(*POLYMARKET_CLIENT_ID),
+            retry_request_id,
+            UnixNanos::default(),
+            Some(live_resync_params()),
+        ))
+        .expect("retry live book resync");
+
+    let events = collect_live_resync_events(&mut rx, retry_request_id).await;
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, DataEvent::Data(NautilusData::Deltas(_))))
+    );
+    assert_eq!(state.book_request_count.load(Ordering::Relaxed), 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_failure_live_resync_allows_retry() {
+    let state = TestServerState::default();
+    state.book_status_code.store(
+        StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+        Ordering::Relaxed,
+    );
+    let (client, mut rx, instrument_id) = create_live_book_client(&state).await;
+
+    client
+        .request_book_snapshot(RequestBookSnapshot::new(
+            instrument_id,
+            None,
+            Some(*POLYMARKET_CLIENT_ID),
+            UUID4::new(),
+            UnixNanos::default(),
+            Some(live_resync_params()),
+        ))
+        .expect("request failing live book resync");
+    wait_until_async(
+        || {
+            let state = state.clone();
+            async move { state.book_request_count.load(Ordering::Relaxed) == 1 }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    state
+        .book_status_code
+        .store(StatusCode::OK.as_u16(), Ordering::Relaxed);
+    let retry_request_id = UUID4::new();
+    client
+        .request_book_snapshot(RequestBookSnapshot::new(
+            instrument_id,
+            None,
+            Some(*POLYMARKET_CLIENT_ID),
+            retry_request_id,
+            UnixNanos::default(),
+            Some(live_resync_params()),
+        ))
+        .expect("retry live book resync");
+
+    let events = collect_live_resync_events(&mut rx, retry_request_id).await;
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, DataEvent::Data(NautilusData::Deltas(_))))
+    );
+    assert_eq!(state.book_request_count.load(Ordering::Relaxed), 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_book_snapshot_live_resync_coalesces_concurrent_requests() {
+    let state = TestServerState::default();
+    state.book_response_delay_ms.store(100, Ordering::Relaxed);
+    let (client, mut rx, instrument_id) = create_live_book_client(&state).await;
+
+    let first_request_id = UUID4::new();
+    let second_request_id = UUID4::new();
+    for request_id in [first_request_id, second_request_id] {
+        client
+            .request_book_snapshot(RequestBookSnapshot::new(
+                instrument_id,
+                None,
+                Some(*POLYMARKET_CLIENT_ID),
+                request_id,
+                UnixNanos::default(),
+                Some(live_resync_params()),
+            ))
+            .expect("request live book resync");
+    }
+
+    let events =
+        collect_data_events_until_response(&mut rx, second_request_id, Duration::from_secs(5))
+            .await;
+    let response_ids = events
+        .iter()
+        .filter_map(|event| match event {
+            DataEvent::Response(DataResponse::Book(response)) => Some(response.correlation_id),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(response_ids.contains(&first_request_id));
+    assert!(response_ids.contains(&second_request_id));
+    assert_eq!(state.book_request_count.load(Ordering::Relaxed), 1);
 }
 
 #[rstest]


### PR DESCRIPTION
Closes #4635.

Adds an opt-in resync_live_book request parameter to Polymarket book snapshot requests. Standard requests retain historical-only behavior. Live resync requests buffer per-instrument WebSocket deltas, replace the adapter book from REST, publish an F_SNAPSHOT delta batch, and replay newer deltas in order.

Failure keeps the old book and replays all buffered deltas. Concurrent requests coalesce per instrument, with generation-safe response admission and buffer handoff. Tick-size epoch recovery remains authoritative.

Validation:
- cargo test -p nautilus-polymarket --lib --quiet: 816 passed
- cargo test -p nautilus-polymarket --test data_client --quiet: 16 passed
- cargo clippy -p nautilus-polymarket --all-targets -- -D warnings
- release wheel short public-data probe: historical response followed by matching F_SNAPSHOT and continuous ordinary deltas
- release wheel 60-minute public-data sandbox: 1,361 live callbacks, 0 failures, 0 Cache-count regressions, 0 ts_event regressions, normal exit 0