### PR TITLE
Fix cdylib symbols on macOS to prevent pyarrow SIGSEGV

### DIFF
--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -13,6 +13,7 @@ documentation.workspace = true
 repository.workspace = true
 homepage.workspace = true
 publish = false # Never publish to crates.io
+build = "build.rs" # Hides the cdylib export table on macOS (see issue #4633)
 
 [lints]
 workspace = true

--- a/crates/pyo3/build.rs
+++ b/crates/pyo3/build.rs
@@ -1,0 +1,49 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Build script for the `nautilus-pyo3` extension module.
+//!
+//! On macOS the extension module statically links Arrow (and other C/C++ heavy dependencies).
+//! When `pyarrow` or `pandas` is imported first, dyld has already loaded another copy of those
+//! symbols, and the flat namespace lets the two runtimes interpose on each other which crashes
+//! the process with a SIGSEGV (see issue #4633).
+//!
+//! Restricting the export table of the `cdylib` to the module initializer removes every symbol
+//! that could collide, so each Arrow runtime keeps using its own statically linked copy.
+
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+
+    // The `ffi` feature deliberately exposes the C API for external consumers, so the export
+    // table must stay intact in that configuration.
+    if std::env::var_os("CARGO_FEATURE_FFI").is_some() {
+        return;
+    }
+
+    // Must match the `#[pymodule]` function name (`cython-compat` renames it to `nautilus_pyo3`),
+    // with the leading underscore Mach-O prepends to C symbols.
+    let init_symbol = if std::env::var_os("CARGO_FEATURE_CYTHON_COMPAT").is_some() {
+        "_PyInit_nautilus_pyo3"
+    } else {
+        "_PyInit__libnautilus"
+    };
+
+    // Passing `-exported_symbol` makes every other symbol in the image non-external.
+    println!("cargo::rustc-link-arg-cdylib=-Wl,-exported_symbol,{init_symbol}");
+}

--- a/tests/test_sigsegv.py
+++ b/tests/test_sigsegv.py
@@ -1,0 +1,7 @@
+import pandas
+import nautilus_trader
+from nautilus_trader.model import Currency
+
+if __name__ == '__main__':
+    c = Currency.from_str("USDC")
+    print("ok")


### PR DESCRIPTION
## Problem
Issue #4633 reports a SIGSEGV when pyarrow or pandas is imported before nautilus_trader on macOS arm64.
This is caused by symbol collisions between statically linked Arrow in `_libnautilus` and pyarrow's Arrow runtime. By default on macOS, rustc exports all symbols in a `cdylib` if not explicitly hidden, meaning `libarrow` symbols leak into the flat namespace and interpose with `pyarrow`.

## Solution
Added a build script `crates/pyo3/build.rs` to restrict the export table of the `cdylib` to only the module initializer (`_PyInit__libnautilus` or `_PyInit_nautilus_pyo3` depending on the cython-compat feature). This is done using `cargo::rustc-link-arg-cdylib=-Wl,-exported_symbol,...` on macOS.
This ensures statically linked Arrow symbols become non-external and can no longer collide with pyarrow/pandas' Arrow runtime.

## Verification
- Statically linked Arrow symbols are now properly hidden in the shared object.
- `import pyarrow; import pandas; import nautilus_trader` executes cleanly on macOS arm64 without segfaulting.