### PR TITLE
Fix root-anchored README links that 404 on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ See the [Integrations](https://nautilustrader.io/docs/latest/integrations/) docu
 
 ## Roadmap
 
-The [Roadmap](/ROADMAP.md) outlines NautilusTrader's strategic direction.
+The [Roadmap](https://github.com/nautechsystems/nautilus_trader/blob/develop/ROADMAP.md) outlines NautilusTrader's strategic direction.
 Current priorities include completing the Rust-native core, improving documentation, and enhancing code ergonomics.
 
 The open-source project focuses on single-node backtesting and live trading for individual and small-team quantitative traders.
 UI dashboards, distributed orchestration, and built-in AI/ML tooling are out of scope to maintain focus on the core engine and ecosystem sustainability.
 
 New integration proposals should start with an RFC issue to discuss suitability before submitting a PR.
-See [Community-contributed integrations](/ROADMAP.md#community-contributed-integrations) for guidelines.
+See [Community-contributed integrations](https://github.com/nautechsystems/nautilus_trader/blob/develop/ROADMAP.md#community-contributed-integrations) for guidelines.
 
 ## Security
 
@@ -533,10 +533,10 @@ A `Makefile` is provided to automate most installation and build tasks for devel
 Indicators and strategies can be developed in Python, Cython, or Rust. For performance and
 latency-sensitive applications, we recommend Rust. Below are some examples:
 
-- [indicator](/examples/backtest/example_07_using_indicators/strategy.py) example written in Python.
-- [indicator](/python/nautilus_trader/indicators/) implementations exposed through PyO3.
-- [strategy](/examples/backtest/example_01_load_bars_from_custom_csv/strategy.py) example written in Python.
-- [backtest](/examples/backtest/) examples using a `BacktestEngine` directly.
+- [indicator](https://github.com/nautechsystems/nautilus_trader/blob/develop/examples/backtest/example_07_using_indicators/strategy.py) example written in Python.
+- [indicator](https://github.com/nautechsystems/nautilus_trader/tree/develop/python/nautilus_trader/indicators/) implementations exposed through PyO3.
+- [strategy](https://github.com/nautechsystems/nautilus_trader/blob/develop/examples/backtest/example_01_load_bars_from_custom_csv/strategy.py) example written in Python.
+- [backtest](https://github.com/nautechsystems/nautilus_trader/tree/develop/examples/backtest/) examples using a `BacktestEngine` directly.
 
 ## Docker
 
@@ -615,7 +615,7 @@ the project. If you have an idea for an enhancement or a bug fix, the first step
 on GitHub to discuss it with the team. This helps to ensure that your contribution will be
 well-aligned with the goals of the project and avoids duplication of effort.
 
-Before getting started, be sure to review the [open-source scope](/ROADMAP.md#open-source-scope) outlined in the project's roadmap to understand what's in and out of scope.
+Before getting started, be sure to review the [open-source scope](https://github.com/nautechsystems/nautilus_trader/blob/develop/ROADMAP.md#open-source-scope) outlined in the project's roadmap to understand what's in and out of scope.
 
 Once you're ready to start working on your contribution, make sure to follow the guidelines
 outlined in the [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) file. This includes signing a Contributor License Agreement (CLA)


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

> External contributions must not modify files under `.github/workflows` or `.github/actions`;
> workflow changes are maintainer‑only.

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and followed the established practices
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

PyPI renders the README as the project long description and resolves root-anchored
links such as `/ROADMAP.md` against the pypi.org origin, so all seven such links
404 on the project page while working on GitHub. This replaces the seven
root-anchored links with absolute GitHub URLs (`blob/develop/` for files,
`tree/develop/` for directories) so they resolve identically on both sites. The
plain relative links mentioned in passing in the issue are left unchanged to keep
this focused.

## Related issues/PRs

Resolves #4644

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

**Ensure new or changed logic is covered by tests.** Check at least one:

- [x] Affected code paths are already covered by the test suite

Documentation-only change with no code paths affected. Manually verified all
seven new URLs return HTTP 200.