### PR TITLE
Add Polymarket instrument provider series_ids scoping

### DIFF
--- a/crates/adapters/polymarket/src/config.rs
+++ b/crates/adapters/polymarket/src/config.rs
@@ -190,6 +190,8 @@ pub struct PolymarketInstrumentProviderConfig {
     pub market_slugs: Option<Vec<String>>,
     /// Optional Rust-backed Up/Down event slug builder.
     pub event_slug_builder: Option<PolymarketUpDownEventSlugConfig>,
+    /// Optional Gamma series IDs whose active events resolve to markets during bootstrap.
+    pub series_ids: Option<Vec<u64>>,
     /// Whether provider warnings should be logged.
     #[builder(default = true)]
     pub log_warnings: bool,
@@ -208,6 +210,7 @@ nautilus_core::impl_pyo3_config_getters!(PolymarketInstrumentProviderConfig {
     event_slugs: Option<Vec<String>>,
     market_slugs: Option<Vec<String>>,
     event_slug_builder: Option<PolymarketUpDownEventSlugConfig>,
+    series_ids: Option<Vec<u64>>,
     log_warnings: bool,
     use_gamma_markets: bool,
 });
@@ -226,10 +229,26 @@ impl PolymarketInstrumentProviderConfig {
 
     #[must_use]
     pub fn should_load_all(&self) -> bool {
-        self.load_all
-            || self.event_slug_builder.is_some()
+        self.load_all || self.has_explicit_scope()
+    }
+
+    /// Returns whether any explicit bootstrap scope (slug, builder, or series) is configured.
+    #[must_use]
+    pub fn has_explicit_scope(&self) -> bool {
+        self.event_slug_builder.is_some()
             || self.event_slugs.as_ref().is_some_and(|s| !s.is_empty())
             || self.market_slugs.as_ref().is_some_and(|s| !s.is_empty())
+            || self.has_series_ids()
+    }
+
+    #[must_use]
+    pub fn has_series_ids(&self) -> bool {
+        self.series_ids.as_ref().is_some_and(|ids| !ids.is_empty())
+    }
+
+    #[must_use]
+    pub fn has_nonempty_filters(&self) -> bool {
+        self.filters.as_ref().is_some_and(|map| !map.is_empty())
     }
 
     #[must_use]
@@ -676,6 +695,28 @@ mod tests {
             err.to_string()
                 .contains("event_slug_builder.interval_mins must be positive")
         );
+    }
+
+    #[rstest]
+    fn provider_config_series_ids_trigger_load_all() {
+        let config = PolymarketInstrumentProviderConfig {
+            series_ids: Some(vec![10684]),
+            ..PolymarketInstrumentProviderConfig::default()
+        };
+
+        assert!(config.has_series_ids());
+        assert!(config.should_load_all());
+    }
+
+    #[rstest]
+    fn provider_config_empty_series_ids_do_not_trigger_load_all() {
+        let config = PolymarketInstrumentProviderConfig {
+            series_ids: Some(Vec::new()),
+            ..PolymarketInstrumentProviderConfig::default()
+        };
+
+        assert!(!config.has_series_ids());
+        assert!(!config.should_load_all());
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/providers.rs
+++ b/crates/adapters/polymarket/src/providers.rs
@@ -215,46 +215,67 @@ impl PolymarketInstrumentProvider {
         Ok(())
     }
 
+    /// Loads instruments for the given Gamma series IDs additively into the store.
+    ///
+    /// Resolves each series to its active, unresolved events and loads their
+    /// markets. Unlike [`Self::load_all`], this does **not** clear existing
+    /// instruments or mark the store as initialized.
+    pub async fn load_by_series_ids(&mut self, series_ids: Vec<u64>) -> anyhow::Result<()> {
+        let instruments = self
+            .http_client
+            .request_instruments_by_event_params(series_events_params(series_ids))
+            .await?;
+        self.add_instruments(instruments);
+        Ok(())
+    }
+
     /// Initializes the provider using its configured bootstrap scope.
     pub async fn initialize(&mut self, reload: bool) -> anyhow::Result<()> {
         if self.store.is_initialized() && !reload {
             return Ok(());
         }
 
-        if self.config.should_load_all() {
-            self.load_scoped_all().await?;
-            self.store.set_initialized();
+        let should_load_all = self.config.should_load_all();
+        let has_load_ids = self.config.has_load_ids();
+
+        if !should_load_all && !has_load_ids {
+            if self.config.log_warnings {
+                log::warn!(
+                    "No Polymarket instrument bootstrap configured: set instrument_config.load_all, instrument_config.load_ids, instrument_config.event_slugs, instrument_config.market_slugs, instrument_config.event_slug_builder, or instrument_config.series_ids"
+                );
+            }
             return Ok(());
         }
 
-        if self.config.has_load_ids() {
-            let load_ids = self.config.load_ids.clone().unwrap_or_default();
-            let filters = self.config.filters.clone();
-            self.load_ids(&load_ids, filters.as_ref()).await?;
-            self.store.set_initialized();
-            return Ok(());
-        }
-
-        if self.config.log_warnings {
+        // Registered `InstrumentFilter`s take precedence over the Gamma filter map,
+        // so say when the map is being dropped rather than ignoring it silently.
+        if self.config.log_warnings
+            && !self.filters.is_empty()
+            && self.config.has_nonempty_filters()
+        {
             log::warn!(
-                "No Polymarket instrument bootstrap configured: set instrument_config.load_all, instrument_config.load_ids, instrument_config.event_slugs, instrument_config.market_slugs, or instrument_config.event_slug_builder"
+                "Registered instrument filters take precedence: instrument_config.filters is ignored for this bootstrap"
             );
         }
+
+        if should_load_all {
+            self.load_scoped_all().await?;
+        }
+
+        if has_load_ids {
+            // Deliberately not passed `config.filters`: `load_ids` names instruments
+            // explicitly, so intersecting it with the filter map would silently drop
+            // any ID that falls outside those filters. The scopes are additive, and
+            // an explicitly requested instrument is requested unconditionally.
+            let load_ids = self.config.load_ids.clone().unwrap_or_default();
+            self.load_ids(&load_ids, None).await?;
+        }
+
+        self.store.set_initialized();
         Ok(())
     }
 
     async fn load_scoped_all(&mut self) -> anyhow::Result<()> {
-        let has_explicit_slug_scope = self.config.event_slug_builder.is_some()
-            || self
-                .config
-                .event_slugs
-                .as_ref()
-                .is_some_and(|slugs| !slugs.is_empty())
-            || self
-                .config
-                .market_slugs
-                .as_ref()
-                .is_some_and(|slugs| !slugs.is_empty());
         let event_slugs = self.resolve_event_slugs()?;
         let market_slugs = self
             .config
@@ -264,6 +285,33 @@ impl PolymarketInstrumentProvider {
             .into_iter()
             .filter(|slug| !slug.trim().is_empty())
             .collect::<Vec<_>>();
+        let series_ids = self.config.series_ids.clone().unwrap_or_default();
+
+        // The clearing bulk load must run before the additive scoped loads.
+        // Explicit scoping never broadens into an unfiltered full-universe fetch,
+        // but every filter-driven query is bounded, so it composes with explicit
+        // scopes instead of being silently dropped. Registered `InstrumentFilter`s
+        // count here just as the Gamma filter map does, otherwise this path would
+        // drop them while `fetch_configured_instruments` keeps them, and the
+        // bootstrap and interval-refresh universes would diverge.
+        //
+        // This deliberately does not go through `load_all`, which marks the store
+        // initialized on completion. The additive scopes below are still
+        // outstanding at this point, and a failure in one of them would otherwise
+        // leave an initialized-but-incomplete store that makes a subsequent
+        // `initialize(false)` short-circuit and skip the missing scopes for good.
+        if !self.config.has_explicit_scope()
+            || self.config.has_nonempty_filters()
+            || !self.filters.is_empty()
+        {
+            let filters = self.config.filters.clone();
+            let instruments = self.fetch_bulk_instruments(filters.as_ref()).await?;
+            self.replace_instruments(instruments);
+        }
+
+        if !series_ids.is_empty() {
+            self.load_by_series_ids(series_ids).await?;
+        }
 
         if !event_slugs.is_empty() {
             self.load_by_event_slugs(event_slugs).await?;
@@ -273,12 +321,7 @@ impl PolymarketInstrumentProvider {
             self.load_by_slugs(market_slugs).await?;
         }
 
-        if has_explicit_slug_scope {
-            return Ok(());
-        }
-
-        let filters = self.config.filters.clone();
-        self.load_all(filters.as_ref()).await
+        Ok(())
     }
 
     fn resolve_event_slugs(&self) -> anyhow::Result<Vec<String>> {
@@ -300,6 +343,38 @@ impl PolymarketInstrumentProvider {
     /// each filter's methods that return `Some`.
     async fn load_filtered(&self) -> anyhow::Result<Vec<InstrumentAny>> {
         fetch_instruments(&self.http_client, &self.filters).await
+    }
+
+    /// Fetches the bulk instrument universe without mutating provider state.
+    ///
+    /// Registered [`InstrumentFilter`]s take precedence; otherwise a non-empty
+    /// Gamma filter map bounds the query, and an absent or empty map falls back
+    /// to the full universe.
+    async fn fetch_bulk_instruments(
+        &self,
+        filters: Option<&HashMap<String, String>>,
+    ) -> anyhow::Result<Vec<InstrumentAny>> {
+        if !self.filters.is_empty() {
+            return self.load_filtered().await;
+        }
+
+        match filters {
+            Some(map) if !map.is_empty() => {
+                let params = build_gamma_params_from_hashmap(map)?;
+                self.http_client.request_instruments_by_params(params).await
+            }
+            _ => self.http_client.request_instruments().await,
+        }
+    }
+
+    /// Replaces the store contents, leaving the initialized flag untouched.
+    ///
+    /// Callers that complete a full bootstrap are responsible for marking the
+    /// store initialized once every scope has succeeded.
+    fn replace_instruments(&mut self, instruments: Vec<InstrumentAny>) {
+        self.store.clear();
+        self.token_index.clear();
+        self.add_instruments(instruments);
     }
 }
 
@@ -375,15 +450,7 @@ pub async fn fetch_configured_instruments(
     let mut instruments = Vec::new();
 
     if config.should_load_all() {
-        let has_explicit_slug_scope = config.event_slug_builder.is_some()
-            || config
-                .event_slugs
-                .as_ref()
-                .is_some_and(|slugs| !slugs.is_empty())
-            || config
-                .market_slugs
-                .as_ref()
-                .is_some_and(|slugs| !slugs.is_empty());
+        let has_explicit_scope = config.has_explicit_scope();
         let event_slugs = if let Some(builder) = config.event_slug_builder.as_ref() {
             builder.build_event_slugs()?
         } else {
@@ -404,6 +471,30 @@ pub async fn fetch_configured_instruments(
             .filter(|slug| !slug.trim().is_empty())
             .collect::<Vec<_>>();
 
+        let series_ids = config.series_ids.clone().unwrap_or_default();
+
+        // Explicit scoping never broadens into an unfiltered full-universe
+        // fetch, but every filter-driven query is bounded, so it composes with
+        // explicit series and slug scopes instead of being silently dropped.
+        // This mirrors `load_scoped_all`, which the interval refresh and
+        // `request_instruments` paths must stay consistent with.
+        if !filters.is_empty() {
+            instruments.extend(fetch_instruments(http_client, filters).await?);
+        } else if let Some(map) = config.filters.as_ref().filter(|map| !map.is_empty()) {
+            let params = build_gamma_params_from_hashmap(map)?;
+            instruments.extend(http_client.request_instruments_by_params(params).await?);
+        } else if !has_explicit_scope {
+            instruments.extend(http_client.request_instruments().await?);
+        }
+
+        if !series_ids.is_empty() {
+            instruments.extend(
+                http_client
+                    .request_instruments_by_event_params(series_events_params(series_ids))
+                    .await?,
+            );
+        }
+
         if !event_slugs.is_empty() {
             instruments.extend(
                 http_client
@@ -419,31 +510,13 @@ pub async fn fetch_configured_instruments(
                     .await?,
             );
         }
+    }
 
-        if has_explicit_slug_scope {
-            // Explicit slug scoping should never broaden into a full-universe fetch.
-        } else if filters.is_empty() {
-            if let Some(map) = config.filters.as_ref() {
-                if map.is_empty() {
-                    instruments.extend(http_client.request_instruments().await?);
-                } else {
-                    let params = build_gamma_params_from_hashmap(map)?;
-                    instruments.extend(http_client.request_instruments_by_params(params).await?);
-                }
-            } else {
-                instruments.extend(http_client.request_instruments().await?);
-            }
-        } else {
-            instruments.extend(fetch_instruments(http_client, filters).await?);
-        }
-    } else if config.has_load_ids() {
-        let base_params = config
-            .filters
-            .as_ref()
-            .map(build_gamma_params_from_hashmap)
-            .transpose()?
-            .unwrap_or_default();
-
+    if config.has_load_ids() {
+        // Queried by condition ID alone. Merging `config.filters` in here would
+        // intersect an explicit scope with a filter scope, so an ID outside those
+        // filters would never load despite being named directly. Mirrors the
+        // `load_ids` call in `initialize`.
         let condition_ids = config
             .load_ids
             .clone()
@@ -457,16 +530,32 @@ pub async fn fetch_configured_instruments(
         for chunk in condition_ids.chunks(GAMMA_CONDITION_IDS_BATCH_SIZE) {
             let params = GetGammaMarketsParams {
                 condition_ids: Some(chunk.to_vec()),
-                ..base_params.clone()
+                ..Default::default()
             };
             instruments.extend(http_client.request_instruments_by_params(params).await?);
         }
     }
 
+    // Deduplicated but NOT filtered by `accept` here. `fetch_instruments` already
+    // applies acceptance to the results of filter-driven queries, which is the only
+    // place it belongs: applying it again across the whole collection would let a
+    // registered filter reject series, slug, and ID instruments that the provider's
+    // `load_scoped_all` adds unconditionally, so a refresh would silently drop
+    // instruments the bootstrap had loaded.
     let mut seen = AHashSet::new();
     instruments.retain(|inst| seen.insert(inst.id()));
-    instruments.retain(|inst| filters.iter().all(|f| f.accept(inst)));
     Ok(instruments)
+}
+
+/// Builds the Gamma events query that resolves series IDs to their active,
+/// unresolved events.
+fn series_events_params(series_ids: Vec<u64>) -> GetGammaEventsParams {
+    GetGammaEventsParams {
+        series_id: Some(series_ids),
+        active: Some(true),
+        closed: Some(false),
+        ..Default::default()
+    }
 }
 
 /// Extracts the condition ID from an instrument symbol.
@@ -936,27 +1025,8 @@ impl InstrumentProvider for PolymarketInstrumentProvider {
     }
 
     async fn load_all(&mut self, filters: Option<&HashMap<String, String>>) -> anyhow::Result<()> {
-        let instruments = if self.filters.is_empty() {
-            // If HashMap filters are provided, convert to Gamma params
-            if let Some(map) = filters {
-                if map.is_empty() {
-                    self.http_client.request_instruments().await?
-                } else {
-                    let params = build_gamma_params_from_hashmap(map)?;
-                    self.http_client
-                        .request_instruments_by_params(params)
-                        .await?
-                }
-            } else {
-                self.http_client.request_instruments().await?
-            }
-        } else {
-            self.load_filtered().await?
-        };
-
-        self.store.clear();
-        self.token_index.clear();
-        self.add_instruments(instruments);
+        let instruments = self.fetch_bulk_instruments(filters).await?;
+        self.replace_instruments(instruments);
         self.store.set_initialized();
 
         Ok(())
@@ -1034,8 +1104,12 @@ impl InstrumentProvider for PolymarketInstrumentProvider {
             }
         }
 
-        // Fallback: full load_all if not initialized
-        if !self.store.is_initialized() {
+        // Fallback: full load_all if not initialized. A provider with an explicit
+        // scope is excluded: `load_all` would broaden it into the full-universe
+        // fetch that scoping exists to avoid, and would also clear the partially
+        // loaded store and mark it initialized, making a later `initialize(false)`
+        // skip the scopes it still owes after a failed bootstrap.
+        if !self.store.is_initialized() && !self.config.has_explicit_scope() {
             self.load_all(filters).await?;
         }
 

--- a/crates/adapters/polymarket/src/python/config.rs
+++ b/crates/adapters/polymarket/src/python/config.rs
@@ -79,7 +79,7 @@ impl PolymarketInstrumentProviderConfig {
     /// This mirrors the Python adapter's `instrument_config` layering so scoped
     /// market bootstrap can migrate naturally to the Rust/pyO3 live path.
     #[new]
-    #[pyo3(signature = (load_all=None, load_ids=None, filters=None, event_slugs=None, market_slugs=None, event_slug_builder=None, log_warnings=None, use_gamma_markets=None))]
+    #[pyo3(signature = (load_all=None, load_ids=None, filters=None, event_slugs=None, market_slugs=None, event_slug_builder=None, log_warnings=None, use_gamma_markets=None, series_ids=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
         load_all: Option<bool>,
@@ -90,6 +90,7 @@ impl PolymarketInstrumentProviderConfig {
         event_slug_builder: Option<PolymarketUpDownEventSlugConfig>,
         log_warnings: Option<bool>,
         use_gamma_markets: Option<bool>,
+        series_ids: Option<Vec<u64>>,
     ) -> PyResult<Self> {
         let default = Self::default();
         let config = Self {
@@ -99,6 +100,7 @@ impl PolymarketInstrumentProviderConfig {
             event_slugs,
             market_slugs,
             event_slug_builder,
+            series_ids,
             log_warnings: log_warnings.unwrap_or(default.log_warnings),
             use_gamma_markets: use_gamma_markets.unwrap_or(default.use_gamma_markets),
         };

--- a/crates/adapters/polymarket/src/python/mod.rs
+++ b/crates/adapters/polymarket/src/python/mod.rs
@@ -218,6 +218,9 @@ fn extract_provider_config_from_pyobject(
     let event_slug_builder = getattr_optional(obj, "event_slug_builder")?
         .map(|value| extract_event_slug_builder(&value))
         .transpose()?;
+    let series_ids = getattr_optional(obj, "series_ids")?
+        .map(|value| value.extract::<Vec<u64>>())
+        .transpose()?;
     let log_warnings = getattr_optional(obj, "log_warnings")?
         .map(|value| value.extract::<bool>())
         .transpose()?
@@ -234,6 +237,7 @@ fn extract_provider_config_from_pyobject(
         event_slugs,
         market_slugs,
         event_slug_builder,
+        series_ids,
         log_warnings,
         use_gamma_markets,
     };

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -45,8 +45,8 @@ use nautilus_polymarket::{
     },
     config::{PolymarketInstrumentProviderConfig, PolymarketUpDownEventSlugConfig},
     filters::{
-        EventParamsFilter, EventSlugFilter, GammaQueryFilter, MarketSlugFilter, SearchFilter,
-        TagFilter,
+        EventParamsFilter, EventSlugFilter, GammaQueryFilter, InstrumentFilter, MarketSlugFilter,
+        PredicateFilter, SearchFilter, TagFilter,
     },
     http::{
         clob::{HeartbeatResponse, PolymarketClobHttpClient},
@@ -97,6 +97,7 @@ struct TestServerState {
     gamma_force_error: Arc<std::sync::atomic::AtomicBool>,
     gamma_event_slug_responses: Arc<tokio::sync::Mutex<AHashMap<String, Value>>>,
     gamma_events_response: Arc<tokio::sync::Mutex<Option<Value>>>,
+    gamma_events_force_error: Arc<std::sync::atomic::AtomicBool>,
     gamma_events_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     gamma_events_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     gamma_events_query_pair_log: QueryPairLog,
@@ -132,6 +133,7 @@ impl Default for TestServerState {
             gamma_force_error: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             gamma_event_slug_responses: Arc::new(tokio::sync::Mutex::new(AHashMap::new())),
             gamma_events_response: Arc::new(tokio::sync::Mutex::new(None)),
+            gamma_events_force_error: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             gamma_events_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             gamma_events_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             gamma_events_query_pair_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
@@ -509,6 +511,13 @@ async fn handle_gamma_events(
         .await
         .push(query_pairs(&uri));
 
+    if state
+        .gamma_events_force_error
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
     if let Some(slug) = params.get("slug") {
         let slug_map = state.gamma_event_slug_responses.lock().await;
         if let Some(v) = slug_map.get(slug) {
@@ -536,6 +545,13 @@ async fn handle_gamma_events_keyset(
         .lock()
         .await
         .push(query_pairs(&uri));
+
+    if state
+        .gamma_events_force_error
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
 
     if let Some(page) = state.gamma_events_pages.lock().await.pop_front() {
         return Json(page).into_response();
@@ -1767,6 +1783,95 @@ async fn test_provider_initialize_uses_instrument_config_event_slugs() {
 
 #[rstest]
 #[tokio::test]
+async fn test_provider_initialize_uses_instrument_config_series_ids() {
+    let state = TestServerState::default();
+
+    let market1 = gamma_market_with_slug(
+        "series-market-1",
+        "0xcondition_series1",
+        ["62000000000000000001", "62000000000000000002"],
+    );
+    let market2 = gamma_market_with_slug(
+        "series-market-2",
+        "0xcondition_series2",
+        ["62000000000000000003", "62000000000000000004"],
+    );
+    let event = gamma_event_with_markets("series-event", &[market1, market2]);
+    *state.gamma_events_response.lock().await = Some(json!([event]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![10684, 10192]),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+    let mut provider = PolymarketInstrumentProvider::new(http_client, Some(config));
+
+    provider.initialize(false).await.unwrap();
+
+    // 2 markets × 2 outcomes = 4 instruments
+    assert_eq!(provider.store().count(), 4);
+    assert!(provider.store().is_initialized());
+
+    let log = state.gamma_events_query_pair_log.lock().await;
+    let mut actual = log[0].clone();
+    actual.sort();
+    let expected = vec![
+        ("active".to_string(), "true".to_string()),
+        ("closed".to_string(), "false".to_string()),
+        ("limit".to_string(), "500".to_string()),
+        ("series_id".to_string(), "10192".to_string()),
+        ("series_id".to_string(), "10684".to_string()),
+    ];
+    assert_eq!(actual, expected);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_provider_initialize_composes_series_ids_with_filters() {
+    let state = TestServerState::default();
+
+    let filtered_market = gamma_market_with_slug(
+        "tag-market",
+        "0xcondition_tag",
+        ["63000000000000000001", "63000000000000000002"],
+    );
+    *state.gamma_response.lock().await = Some(json!([filtered_market]));
+
+    let series_market = gamma_market_with_slug(
+        "series-market",
+        "0xcondition_series",
+        ["63000000000000000003", "63000000000000000004"],
+    );
+    let event = gamma_event_with_markets("series-event", &[series_market]);
+    *state.gamma_events_response.lock().await = Some(json!([event]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![11312]),
+        filters: Some(HashMap::from([("tag_id".to_string(), "84".to_string())])),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+    let mut provider = PolymarketInstrumentProvider::new(http_client, Some(config));
+
+    provider.initialize(false).await.unwrap();
+
+    // The tag-filtered market and the series market both load: 2 markets × 2 outcomes.
+    assert_eq!(provider.store().count(), 4);
+    assert!(provider.store().is_initialized());
+
+    let markets_queries = state.gamma_markets_query_log.lock().await;
+    assert!(
+        markets_queries
+            .iter()
+            .any(|params| params.get("tag_id").is_some_and(|value| value == "84")),
+        "tag_id filter should still be queried alongside series scope"
+    );
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_fetch_configured_instruments_uses_rust_event_slug_builder_result() {
     let event_slug_builder = PolymarketUpDownEventSlugConfig {
         assets: vec!["btc".to_string()],
@@ -1809,6 +1914,424 @@ async fn test_fetch_configured_instruments_uses_rust_event_slug_builder_result()
             .id()
             .to_string()
             .contains("0xcondition_builder_evt")
+    }));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_provider_initialize_composes_series_ids_with_registered_filters() {
+    let state = TestServerState::default();
+
+    // Served for the registered `TagFilter`; the series markets arrive via `/events`.
+    let filtered_market = gamma_market_with_slug(
+        "registered-tag-market",
+        "0xcondition_registered_tag",
+        ["66000000000000000001", "66000000000000000002"],
+    );
+    *state.gamma_response.lock().await = Some(json!([filtered_market]));
+
+    let series_market = gamma_market_with_slug(
+        "registered-series-market",
+        "0xcondition_registered_series",
+        ["66000000000000000003", "66000000000000000004"],
+    );
+    let event = gamma_event_with_markets("registered-series-event", &[series_market]);
+    *state.gamma_events_response.lock().await = Some(json!([event]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![11312]),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+    let mut provider = PolymarketInstrumentProvider::with_filter(
+        http_client,
+        Some(config),
+        Arc::new(TagFilter::from_tag_id(84)),
+    );
+
+    provider.initialize(false).await.unwrap();
+
+    // Bootstrap must match what the interval refresh would return: both scopes,
+    // 2 markets x 2 outcomes.
+    assert_eq!(provider.store().count(), 4);
+    assert!(provider.store().is_initialized());
+
+    let markets_queries = state.gamma_markets_query_log.lock().await;
+    assert!(
+        markets_queries
+            .iter()
+            .any(|params| params.get("tag_id").is_some_and(|value| value == "84")),
+        "registered filter should still be queried alongside the series scope"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_provider_load_does_not_mark_partial_scoped_store_initialized() {
+    let state = TestServerState::default();
+
+    let filtered_market = gamma_market_with_slug(
+        "clobber-tag-market",
+        "0xcondition_clobber_tag",
+        ["67000000000000000001", "67000000000000000002"],
+    );
+    *state.gamma_response.lock().await = Some(json!([filtered_market]));
+
+    // The bulk filtered load succeeds, then the additive series scope fails, which
+    // is exactly the partially-loaded, still-uninitialized state.
+    state
+        .gamma_events_force_error
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![11312]),
+        filters: Some(HashMap::from([("tag_id".to_string(), "84".to_string())])),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+    let mut provider = PolymarketInstrumentProvider::new(http_client, Some(config));
+
+    provider
+        .initialize(false)
+        .await
+        .expect_err("series failure should surface");
+    assert!(!provider.store().is_initialized());
+
+    // An auto-load miss must not fall back to a full-universe load on a scoped
+    // provider: that would mark the store initialized and make the retrying
+    // `initialize(false)` skip the series scope it still owes.
+    let unknown = InstrumentId::from("0xcondition_absent-67000000000000000009.POLYMARKET");
+    provider
+        .load(&unknown, None)
+        .await
+        .expect_err("unknown instrument should not resolve");
+
+    assert!(
+        !provider.store().is_initialized(),
+        "scoped provider must stay uninitialized so the failed scope is retried"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_provider_initialize_retries_scopes_after_series_failure() {
+    let state = TestServerState::default();
+
+    let filtered_market = gamma_market_with_slug(
+        "retry-tag-market",
+        "0xcondition_retry_tag",
+        ["65000000000000000001", "65000000000000000002"],
+    );
+    *state.gamma_response.lock().await = Some(json!([filtered_market]));
+
+    // The bulk filtered load succeeds, then the additive series scope fails.
+    state
+        .gamma_events_force_error
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![11312]),
+        filters: Some(HashMap::from([("tag_id".to_string(), "84".to_string())])),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+    let mut provider = PolymarketInstrumentProvider::new(http_client, Some(config));
+
+    provider
+        .initialize(false)
+        .await
+        .expect_err("series failure should surface");
+
+    // A partially loaded store must not look initialized, otherwise the retry
+    // below short-circuits and the series scope never loads.
+    assert!(!provider.store().is_initialized());
+
+    let series_market = gamma_market_with_slug(
+        "retry-series-market",
+        "0xcondition_retry_series",
+        ["65000000000000000003", "65000000000000000004"],
+    );
+    let event = gamma_event_with_markets("retry-series-event", &[series_market]);
+    *state.gamma_events_response.lock().await = Some(json!([event]));
+    state
+        .gamma_events_force_error
+        .store(false, std::sync::atomic::Ordering::Relaxed);
+
+    provider
+        .initialize(false)
+        .await
+        .expect("retry should complete every scope");
+
+    // Both scopes now present: 2 markets × 2 outcomes.
+    assert_eq!(provider.store().count(), 4);
+    assert!(provider.store().is_initialized());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_fetch_configured_instruments_uses_series_ids() {
+    let state = TestServerState::default();
+
+    let market = gamma_market_with_slug(
+        "fetch-series-market",
+        "0xcondition_fetch_series",
+        ["64000000000000000001", "64000000000000000002"],
+    );
+    let event = gamma_event_with_markets("fetch-series-event", &[market]);
+    *state.gamma_events_response.lock().await = Some(json!([event]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![10684, 10192]),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+
+    let instruments =
+        nautilus_polymarket::providers::fetch_configured_instruments(&http_client, &config, &[])
+            .await
+            .expect("series scope should fetch instruments");
+
+    assert_eq!(instruments.len(), 2);
+    assert!(instruments.iter().all(|instrument| {
+        instrument
+            .id()
+            .to_string()
+            .contains("0xcondition_fetch_series")
+    }));
+
+    let log = state.gamma_events_query_pair_log.lock().await;
+    let mut actual = log[0].clone();
+    actual.sort();
+    let expected = vec![
+        ("active".to_string(), "true".to_string()),
+        ("closed".to_string(), "false".to_string()),
+        ("limit".to_string(), "500".to_string()),
+        ("series_id".to_string(), "10192".to_string()),
+        ("series_id".to_string(), "10684".to_string()),
+    ];
+    assert_eq!(actual, expected);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_fetch_configured_instruments_composes_filters_with_series_scope() {
+    let state = TestServerState::default();
+
+    // Served for the `TagFilter` query; the series markets arrive via `/events`.
+    let filtered_market = gamma_market_with_slug(
+        "fetch-tag-market",
+        "0xcondition_fetch_tag",
+        ["64100000000000000001", "64100000000000000002"],
+    );
+    *state.gamma_response.lock().await = Some(json!([filtered_market]));
+
+    let series_market = gamma_market_with_slug(
+        "fetch-series-market",
+        "0xcondition_fetch_series",
+        ["64100000000000000003", "64100000000000000004"],
+    );
+    let event = gamma_event_with_markets("fetch-series-event", &[series_market]);
+    *state.gamma_events_response.lock().await = Some(json!([event]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![11312]),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+    let filters: Vec<Arc<dyn InstrumentFilter>> = vec![Arc::new(TagFilter::from_tag_id(84))];
+
+    let instruments = nautilus_polymarket::providers::fetch_configured_instruments(
+        &http_client,
+        &config,
+        &filters,
+    )
+    .await
+    .expect("filters should compose with the series scope");
+
+    // Both scopes load: the tag-filtered market and the series market, 2 outcomes each.
+    assert_eq!(instruments.len(), 4);
+    assert!(
+        instruments.iter().any(|instrument| instrument
+            .id()
+            .to_string()
+            .contains("0xcondition_fetch_tag")),
+        "filter-selected market should not be dropped by the series scope"
+    );
+    assert!(instruments.iter().any(|instrument| {
+        instrument
+            .id()
+            .to_string()
+            .contains("0xcondition_fetch_series")
+    }));
+
+    let markets_queries = state.gamma_markets_query_log.lock().await;
+    assert!(
+        markets_queries
+            .iter()
+            .any(|params| params.get("tag_id").is_some_and(|value| value == "84")),
+        "tag_id filter should still be queried alongside the series scope"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_fetch_configured_instruments_composes_load_ids_with_series_scope() {
+    let state = TestServerState::default();
+
+    // No bulk scope is configured, so `/markets` only serves the condition ID lookup.
+    let load_id_market = gamma_market_with_slug(
+        "fetch-ids-market",
+        "0xcondition_fetch_ids",
+        ["64200000000000000001", "64200000000000000002"],
+    );
+    *state.gamma_response.lock().await = Some(json!([load_id_market]));
+
+    let series_market = gamma_market_with_slug(
+        "fetch-series-market",
+        "0xcondition_fetch_series",
+        ["64200000000000000003", "64200000000000000004"],
+    );
+    let event = gamma_event_with_markets("fetch-series-event", &[series_market]);
+    *state.gamma_events_response.lock().await = Some(json!([event]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![11312]),
+        load_ids: Some(vec![InstrumentId::from(
+            "0xcondition_fetch_ids-64200000000000000001.POLYMARKET",
+        )]),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+
+    let instruments =
+        nautilus_polymarket::providers::fetch_configured_instruments(&http_client, &config, &[])
+            .await
+            .expect("load_ids should compose with the series scope");
+
+    assert_eq!(instruments.len(), 4);
+    assert!(
+        instruments.iter().any(|instrument| instrument
+            .id()
+            .to_string()
+            .contains("0xcondition_fetch_ids")),
+        "load_ids market should load alongside the series scope"
+    );
+    assert!(instruments.iter().any(|instrument| {
+        instrument
+            .id()
+            .to_string()
+            .contains("0xcondition_fetch_series")
+    }));
+
+    let markets_queries = state.gamma_markets_query_log.lock().await;
+    assert!(
+        markets_queries
+            .iter()
+            .any(|params| params.contains_key("condition_ids")),
+        "load_ids should issue a condition_ids lookup"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_fetch_configured_instruments_load_ids_are_not_intersected_with_filters() {
+    let state = TestServerState::default();
+
+    let load_id_market = gamma_market_with_slug(
+        "ids-outside-filter",
+        "0xcondition_outside_filter",
+        ["68000000000000000001", "68000000000000000002"],
+    );
+    *state.gamma_response.lock().await = Some(json!([load_id_market]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        filters: Some(HashMap::from([("tag_id".to_string(), "84".to_string())])),
+        load_ids: Some(vec![InstrumentId::from(
+            "0xcondition_outside_filter-68000000000000000001.POLYMARKET",
+        )]),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+
+    let instruments =
+        nautilus_polymarket::providers::fetch_configured_instruments(&http_client, &config, &[])
+            .await
+            .expect("load_ids should fetch instruments");
+
+    assert!(
+        instruments.iter().any(|instrument| instrument
+            .id()
+            .to_string()
+            .contains("0xcondition_outside_filter")),
+        "an explicitly named instrument must load even when it falls outside the filters"
+    );
+
+    // The discriminating assertion: the condition-ID lookup must carry no filter
+    // params. Intersecting the two scopes silently drops IDs outside the filters.
+    let markets_queries = state.gamma_markets_query_log.lock().await;
+    let id_query = markets_queries
+        .iter()
+        .find(|params| params.contains_key("condition_ids"))
+        .expect("a condition_ids query should have been issued");
+    assert!(
+        !id_query.contains_key("tag_id"),
+        "load_ids must be queried by condition ID alone: {id_query:?}"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_fetch_configured_instruments_keeps_series_rejected_by_registered_filter() {
+    let state = TestServerState::default();
+
+    let series_market = gamma_market_with_slug(
+        "reject-series-market",
+        "0xcondition_reject_series",
+        ["69000000000000000001", "69000000000000000002"],
+    );
+    let event = gamma_event_with_markets("reject-series-event", &[series_market]);
+    *state.gamma_events_response.lock().await = Some(json!([event]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let http_client = create_gamma_domain_client(&addr);
+    let config = PolymarketInstrumentProviderConfig {
+        series_ids: Some(vec![11312]),
+        ..PolymarketInstrumentProviderConfig::default()
+    };
+
+    // Rejects everything. `accept` belongs to results of filter-driven queries, so it
+    // must not reach instruments the series scope contributed -- otherwise a refresh
+    // would drop what the provider bootstrap loaded unconditionally.
+    let filters: Vec<Arc<dyn InstrumentFilter>> = vec![Arc::new(PredicateFilter::new(
+        "reject-all",
+        |_instrument| false,
+    ))];
+
+    let instruments = nautilus_polymarket::providers::fetch_configured_instruments(
+        &http_client,
+        &config,
+        &filters,
+    )
+    .await
+    .expect("series scope should fetch instruments");
+
+    assert_eq!(
+        instruments.len(),
+        2,
+        "series instruments must survive a registered filter that rejects them"
+    );
+    assert!(instruments.iter().all(|instrument| {
+        instrument
+            .id()
+            .to_string()
+            .contains("0xcondition_reject_series")
     }));
 }
 

--- a/docs/integrations/polymarket.md
+++ b/docs/integrations/polymarket.md
@@ -739,8 +739,19 @@ demand so that strategies can subscribe to markets that are not in the cache:
 
 The feature is enabled by default. Disable it by setting `auto_load_missing_instruments=False` on
 `PolymarketDataClientConfig`. To preload a known set of markets at startup instead, supply
-`load_ids`, `event_slugs`, `market_slugs`, or `event_slug_builder` on
+`load_ids`, `event_slugs`, `market_slugs`, `event_slug_builder`, or `series_ids` on
 `PolymarketInstrumentProviderConfig`.
+
+These scopes compose rather than override each other: filter-driven queries run alongside any
+explicit slug or series scope, and `load_ids` loads additively on top. Only the unfiltered
+full-universe fetch is suppressed once an explicit scope is present. The same composition applies
+to the periodic refresh driven by `update_instruments_interval_mins`, so a scope configured at
+startup keeps refreshing for the life of the client, and the bootstrap and refresh universes
+match.
+
+Filters come in two forms: the `filters` map on `PolymarketInstrumentProviderConfig`, and Rust
+`InstrumentFilter`s registered on the client. Registered filters take precedence: when both are
+present the `filters` map is ignored and the provider logs a warning.
 
 Newly-minted markets pass through a CLOB hydration window of several minutes during which Gamma
 reports `active=true` but `GET /markets/{cid}` returns either a 404 or a 200 with empty
@@ -1080,6 +1091,7 @@ Pass `PolymarketInstrumentProviderConfig` as `instrument_config` on the data cli
 | `event_slugs`        | `None`  | Resolve all markets for the listed events at bootstrap. |
 | `market_slugs`       | `None`  | Load the listed Gamma market slugs at bootstrap.        |
 | `event_slug_builder` | `None`  | Rust‑backed Up/Down event‑slug generator.               |
+| `series_ids`         | `None`  | Load markets for the listed Gamma series at bootstrap.  |
 | `log_warnings`       | `true`  | Emit provider warnings.                                 |
 | `use_gamma_markets`  | `false` | Reserved compatibility field with no additional effect. |
 
@@ -1153,9 +1165,30 @@ instrument_config = PolymarketInstrumentProviderConfig(
 )
 ```
 
-For custom event patterns, pass explicit `event_slugs`, pass direct `market_slugs`, or add a Rust
-filter or builder. The adapter rejects Python callable `event_slug_builder` values so adapter
-operations do not cross into Python during live trading.
+For custom event patterns, pass explicit `event_slugs`, pass direct `market_slugs`, scope by
+`series_ids`, or add a Rust filter or builder. The adapter rejects Python callable
+`event_slug_builder` values so adapter operations do not cross into Python during live trading.
+
+#### Series IDs
+
+A Gamma *series* groups a recurring market family, such as the 5-minute Up/Down crypto intervals or
+a daily weather market. Scoping by `series_ids` loads the markets of every active, unresolved event
+in those series, which avoids reconstructing slugs client-side as each interval rolls over:
+
+```python
+from nautilus_trader.adapters.polymarket import PolymarketInstrumentProviderConfig
+
+instrument_config = PolymarketInstrumentProviderConfig(
+    series_ids=[10684, 10192],
+)
+```
+
+The provider resolves each series through the Gamma events endpoint with `active=true` and
+`closed=false`, then loads the markets of the matching events. Because the query is re-evaluated on
+every refresh, pairing `series_ids` with `update_instruments_interval_mins` on the data client keeps
+a rolling family of markets current without any slug arithmetic.
+
+Find the series ID for a market family in the `series` field of its Gamma event payload.
 
 ## Python discovery and historical data
 

--- a/python/nautilus_trader/adapters/polymarket/__init__.pyi
+++ b/python/nautilus_trader/adapters/polymarket/__init__.pyi
@@ -182,6 +182,8 @@ class PolymarketInstrumentProviderConfig:
     @property
     def event_slug_builder(self) -> PolymarketUpDownEventSlugConfig | None: ...
     @property
+    def series_ids(self) -> list[int] | None: ...
+    @property
     def log_warnings(self) -> bool: ...
     @property
     def use_gamma_markets(self) -> bool: ...
@@ -195,6 +197,7 @@ class PolymarketInstrumentProviderConfig:
         event_slug_builder: PolymarketUpDownEventSlugConfig | None = None,
         log_warnings: bool | None = None,
         use_gamma_markets: bool | None = None,
+        series_ids: typing.Sequence[int] | None = None,
     ) -> None: ...
 
 @typing.final


### PR DESCRIPTION
Closes #4651

## Summary

Adds `series_ids: Option<Vec<u64>>` to `PolymarketInstrumentProviderConfig` (Rust + Python binding + stub). The provider resolves each series to its active, unresolved events via the existing Gamma events plumbing (`GetGammaEventsParams.series_id`, `request_instruments_by_event_params`) and loads their markets additively.

Recurring market families (e.g. `btc-up-or-down-5m` id 10684, `hong-kong-daily-weather` id 11312) can now be scoped by the venue's own authoritative series grouping instead of client-side slug arithmetic, and roll forward naturally with `update_instruments_interval_mins` — the existing `event_slug_builder` supports only a single builder with a scalar `interval_mins`, so multi-interval up/down universes were previously inexpressible in one provider.

Series-scoped events queries return a bounded set (the active periods of a family), so the bulk-Gamma pagination limits from #4086 are not in play.

## Behavior change: bootstrap scopes now compose

Previously any slug scope silently disabled the `filters` map (the `initialize()` early-return) and made `load_ids` unreachable — a config combining them validated but only loaded the slug component, with no warning. Now:

- A non-empty `filters` map fetches alongside explicit slug/series scopes; only the *unfiltered* full-universe fetch remains suppressed under explicit scoping (preserving the "explicit scoping never broadens into a full-universe fetch" invariant).
- `load_ids` loads additively with `load_all`/scoped bootstrap instead of being unreachable.

Scope predicates are hoisted onto the config (`has_explicit_scope`, `has_series_ids`, `has_nonempty_filters`) and shared by both bootstrap paths (`load_scoped_all`, `fetch_configured_instruments`), which previously each maintained their own copy.

## Example

```python
instrument_config = PolymarketInstrumentProviderConfig(
    series_ids=[10684, 10192, 11326, 11330],   # btc/bnb up-or-down 5m/15m
    filters={"tag_id": "84", "active": "true", "closed": "false"},
)
```

## Testing

- `cargo test -p nautilus-polymarket`: 1,230 tests pass, including new integration tests asserting the series query shape (`series_id`/`active`/`closed` params, single batched request) and the filters+series composition, plus config unit tests for `should_load_all`/`has_series_ids`.
- `cargo clippy -p nautilus-polymarket --all-targets`: clean.
- `cargo +nightly fmt`: applied.
- Verified against the live Gamma API that `GET /events?series_id=...&active=true&closed=false` returns the expected events and that up/down and daily-weather events embed these series ids.