### PR TITLE
fix(persistence): correctly handle custom feather paths for parquet conversion (#4607)

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -3755,8 +3755,14 @@ impl ParquetDataCatalog {
                     continue;
                 };
 
+                let expected_prefix = if data_name.starts_with("custom/") {
+                    format!("data/{data_name}/")
+                } else {
+                    format!("{data_name}/")
+                };
+
                 if let Some(data_relative_path) =
-                    relative_path.strip_prefix(&format!("{data_name}/"))
+                    relative_path.strip_prefix(&expected_prefix)
                 {
                     if let Some(identifiers) = identifiers {
                         let identifier_path = data_relative_path
@@ -3948,8 +3954,12 @@ impl ParquetDataCatalog {
         }
 
         // Convert data class name to filename (e.g., "quotes" -> "quotes")
-        // The data_cls should already be in the correct format (snake_case)
-        let data_name = to_snake_case(data_cls);
+        // Custom data types must preserve their `custom/` prefix and exact casing for discovery
+        let data_name = if data_cls.starts_with("custom/") {
+            data_cls.to_string()
+        } else {
+            to_snake_case(data_cls)
+        };
 
         // List all feather files for this data class
         let feather_files =

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -5161,3 +5161,64 @@ fn test_instrument_roundtrip_with_unregistered_base_currency() {
     assert_eq!(decoded.base_currency.code.as_str(), unknown_code);
     assert_eq!(decoded.base_currency.currency_type, CurrencyType::Crypto);
 }
+
+#[test]
+fn test_convert_stream_to_data_custom_data_daily_roundtrip() {
+    ensure_test_custom_data_registered();
+
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+    let root_path = _temp_dir.path();
+
+    let instance_id = "2026-07-24";
+    let subdirectory = "live";
+
+    // Write three RustTestHashMapCustomData records for "ident_a"
+    // and three for "ident_b" through FeatherWriter.
+    let mut writer = nautilus_persistence::backend::writer::FeatherWriter::new(
+        root_path.to_str().unwrap(),
+        instance_id,
+        subdirectory,
+        None,
+    ).unwrap();
+
+    let dt = "2026-07-24T00:00:00Z".parse::<nautilus_core::dt::DateTime>().unwrap();
+
+    for ident in ["ident_a", "ident_b"] {
+        for i in 0..3 {
+            let data = nautilus_model::custom::CustomData::new(
+                "RustTestHashMapCustomData",
+                b"{}",
+                ident,
+                (dt.as_nanos() as u64) + i,
+            ).unwrap();
+            writer.write_custom_data(&data).unwrap();
+        }
+    }
+    
+    // Close writers
+    writer.close().unwrap();
+
+    catalog
+        .convert_stream_to_data(
+            instance_id,
+            "custom/RustTestHashMapCustomData",
+            Some(subdirectory),
+            None,
+            false,
+        )
+        .unwrap();
+
+    let queried = catalog
+        .query_custom_data_dynamic(
+            "RustTestHashMapCustomData",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(queried.len(), 6, "expected all 6 written records back");
+}


### PR DESCRIPTION
## Problem
Issue #4607 reports that `ParquetDataCatalog::convert_stream_to_data` silently finishes while failing to convert custom data into parquet files.
This is because:
1. `to_snake_case` incorrectly mutated the `custom/` prefix, breaking discovery for custom datatypes.
2. `list_feather_files` was searching beneath `{root}/live/{instance_id}/custom/{TypeName}/...` instead of `{root}/live/{instance_id}/data/custom/{TypeName}/...` where `FeatherWriter` actually places them.

## Solution
- Prevent `to_snake_case` from altering data class strings that begin with `custom/` (preserving exact casing for user types).
- Adjust the expected search path prefix within `list_feather_files` to look beneath `data/custom/...` for custom data.
- Added a full round-trip test `test_convert_stream_to_data_custom_data_daily_roundtrip` replicating the exact issue setup.

## Verification
- Added test successfully simulates writes via `FeatherWriter` followed by stream conversion and dynamically queries the expected data.