### PR TITLE
Fix CMO indicator value exceeding range bounds

### DIFF
--- a/crates/indicators/src/average/vidya.rs
+++ b/crates/indicators/src/average/vidya.rs
@@ -211,7 +211,7 @@ mod tests {
         indicator_vidya_10.update_raw(1.00020);
         indicator_vidya_10.update_raw(1.00010);
         indicator_vidya_10.update_raw(1.00000);
-        assert_eq!(indicator_vidya_10.value, 0.046_813_474_863_949_87);
+        assert_eq!(indicator_vidya_10.value, 0.046_813_474_863_949_864);
     }
 
     #[rstest]

--- a/crates/indicators/src/momentum/cmo.rs
+++ b/crates/indicators/src/momentum/cmo.rs
@@ -300,13 +300,13 @@ mod tests {
         assert!(cmo.value <= 100.0 && cmo.value >= -100.0);
     }
 
-    #[test]
+    #[rstest]
     fn test_cmo_value_stays_within_bounds() {
-        use crate::average::vidya::VariableIndexDynamicAverage;
+        use crate::{average::vidya::VariableIndexDynamicAverage, MovingAverage};
 
         let mut cmo = ChandeMomentumOscillator::new(14, None);
         let mut vidya = VariableIndexDynamicAverage::new(14, None, None);
-        for price in std::iter::repeat(100.0).take(21).chain(std::iter::repeat(50.0).take(20)) {
+        for price in std::iter::repeat_n(100.0, 21).chain(std::iter::repeat_n(50.0, 20)) {
             cmo.update_raw(price);
             vidya.update_raw(price);
         }

--- a/crates/indicators/src/momentum/cmo.rs
+++ b/crates/indicators/src/momentum/cmo.rs
@@ -137,7 +137,7 @@ impl ChandeMomentumOscillator {
                 self.value = 0.0;
             } else {
                 self.value =
-                    100.0 * (self.average_gain.value() - self.average_loss.value()) / divisor;
+                    100.0 * ((self.average_gain.value() - self.average_loss.value()) / divisor);
             }
         }
         self.previous_close = close;
@@ -298,5 +298,19 @@ mod tests {
         }
         assert!(cmo.initialized);
         assert!(cmo.value <= 100.0 && cmo.value >= -100.0);
+    }
+
+    #[test]
+    fn test_cmo_value_stays_within_bounds() {
+        use crate::average::vidya::VariableIndexDynamicAverage;
+
+        let mut cmo = ChandeMomentumOscillator::new(14, None);
+        let mut vidya = VariableIndexDynamicAverage::new(14, None, None);
+        for price in std::iter::repeat(100.0).take(21).chain(std::iter::repeat(50.0).take(20)) {
+            cmo.update_raw(price);
+            vidya.update_raw(price);
+        }
+        assert!((-100.0..=100.0).contains(&cmo.value));
+        assert!((0.0..=1.0).contains(&vidya.cmo_pct));
     }
 }


### PR DESCRIPTION
Fixes #4654.

## Problem
When `average_gain` decays to exactly zero, `ChandeMomentumOscillator` lands one ULP outside of the `[-100, 100]` bound (`-100.00000000000001`). `VIDYA` uses this value as a smoothing weight and expects it to be at most 1, resulting in weights above 1 which inverted the sign of the complement `1 - alpha * cmo_pct`.
This was caused by multiplying by `100.0` before dividing by `divisor`.

## Solution
Changed the CMO calculation order to `100.0 * ((average_gain - average_loss) / divisor)`. This ensures that when `average_gain` is 0, `(0 - L) / L` is exactly `-1.0` before being scaled to `-100.0`.
Updated one regression test constant in `vidya` to reflect the 1-ULP change and added the reproducer to `cmo.rs` tests.