### PR TITLE
fix(adapters): deserialize Bybit smpGroup as string or integer (#4655)

### DIFF
--- a/crates/adapters/bybit/src/common/parse.rs
+++ b/crates/adapters/bybit/src/common/parse.rs
@@ -2943,3 +2943,25 @@ mod tests {
         assert_eq!(report.venue_position_id, None);
     }
 }
+
+pub mod i32_from_str_or_number {
+    use serde::{de, Deserialize, Deserializer};
+    use std::str::FromStr;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<i32, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StringOrInt {
+            String(String),
+            Int(i32),
+        }
+
+        match StringOrInt::deserialize(deserializer)? {
+            StringOrInt::String(s) => i32::from_str(&s).map_err(de::Error::custom),
+            StringOrInt::Int(i) => Ok(i),
+        }
+    }
+}

--- a/crates/adapters/bybit/src/http/models.rs
+++ b/crates/adapters/bybit/src/http/models.rs
@@ -852,7 +852,7 @@ pub struct BybitAccountInfo {
     pub dcp_status: bool,
     #[serde(default)]
     pub time_window: i32,
-    #[serde(default)]
+    #[serde(default, with = "crate::common::parse::i32_from_str_or_number")]
     pub smp_group: i32,
 }
 
@@ -910,6 +910,7 @@ pub struct BybitOrder {
     pub reduce_only: bool,
     pub close_on_trigger: bool,
     pub smp_type: BybitSmpType,
+    #[serde(default, with = "crate::common::parse::i32_from_str_or_number")]
     pub smp_group: i32,
     pub smp_order_id: Ustr,
     pub tpsl_mode: Option<BybitTpSlMode>,

--- a/crates/adapters/bybit/src/websocket/messages.rs
+++ b/crates/adapters/bybit/src/websocket/messages.rs
@@ -792,6 +792,7 @@ pub struct BybitWsAccountOrder {
     pub close_on_trigger: bool,
     pub place_type: Ustr,
     pub smp_type: BybitSmpType,
+    #[serde(default, with = "crate::common::parse::i32_from_str_or_number")]
     pub smp_group: i32,
     pub smp_order_id: Ustr,
     pub fee_currency: Ustr,


### PR DESCRIPTION
Fixes #4655.

## Problem
Bybit Testnet occasionally returns `smpGroup` as a string instead of an integer. Because Nautilus expects it to be an `i32`, this breaks order reconciliation, order reports parsing, and native cancel-all logic.

## Solution
Added a custom deserializer `i32_from_str_or_number` in the Bybit adapter's parse module to gracefully handle both `i32` and string-encoded integers, falling back to parsing the string using `from_str`.
Applied this to all occurrences of `smp_group` in `BybitOrder`, `BybitAccountInfo`, and `BybitWsAccountOrder`.