### PR TITLE
Fix Polymarket maker fill ownership and count dropped trades

### DIFF
--- a/crates/adapters/polymarket/src/common/models.rs
+++ b/crates/adapters/polymarket/src/common/models.rs
@@ -63,6 +63,22 @@ pub struct PolymarketMakerOrder {
     pub side: Option<PolymarketOrderSide>,
 }
 
+impl PolymarketMakerOrder {
+    /// Returns whether this maker order belongs to the account identified by
+    /// `user_address` and `api_key`.
+    ///
+    /// The address comparison ignores ASCII case: hex letter case carries no
+    /// account identity (EIP-55 checksumming encodes only a display checksum),
+    /// and the two sides routinely disagree: recorded venue payloads carry
+    /// checksummed maker addresses while configured funder addresses are
+    /// commonly lowercase, or vice versa. The API-key comparison stays exact
+    /// because keys are opaque credentials.
+    #[must_use]
+    pub fn is_owned_by(&self, user_address: &str, api_key: &str) -> bool {
+        self.maker_address.eq_ignore_ascii_case(user_address) || self.owner == api_key
+    }
+}
+
 /// Human-readable label for a Polymarket instrument.
 #[derive(Debug, Clone)]
 pub struct PolymarketLabel {
@@ -154,6 +170,54 @@ mod tests {
         let json = serde_json::to_string(&order).unwrap();
         let order2: PolymarketMakerOrder = serde_json::from_str(&json).unwrap();
         assert_eq!(order, order2);
+    }
+
+    #[rstest]
+    fn test_maker_order_ownership_ignores_address_case() {
+        let mut order: PolymarketMakerOrder =
+            serde_json::from_str(sample_maker_order_json()).unwrap();
+        let lowercase_address = order.maker_address.clone();
+        // All-uppercase hex stands in for the mixed-case checksummed form the
+        // venue sends; any case difference exercises the same comparison.
+        let uppercase_variant_address = lowercase_address
+            .to_ascii_uppercase()
+            .replacen("0X", "0x", 1);
+        assert_ne!(uppercase_variant_address, lowercase_address);
+
+        // Production direction: venue payloads carry checksummed maker
+        // addresses while configured funder addresses are commonly lowercase.
+        order.maker_address = uppercase_variant_address.clone();
+        assert!(order.is_owned_by(&lowercase_address, "no-such-key"));
+
+        // Reverse direction: lowercase payload, mixed-case configuration.
+        order.maker_address = lowercase_address;
+        assert!(order.is_owned_by(&uppercase_variant_address, "no-such-key"));
+    }
+
+    #[rstest]
+    fn test_maker_order_ownership_matches_exact_api_key() {
+        let order: PolymarketMakerOrder = serde_json::from_str(sample_maker_order_json()).unwrap();
+        let owner = order.owner.clone();
+
+        assert!(order.is_owned_by("0xother", &owner));
+    }
+
+    #[rstest]
+    fn test_maker_order_ownership_requires_exact_api_key() {
+        let mut order: PolymarketMakerOrder =
+            serde_json::from_str(sample_maker_order_json()).unwrap();
+        order.owner = "abcdefab-0000-0000-0000-000000000002".to_string();
+        let case_variant_key = order.owner.to_ascii_uppercase();
+        assert_ne!(case_variant_key, order.owner);
+
+        assert!(!order.is_owned_by("0xother", &case_variant_key));
+    }
+
+    #[rstest]
+    fn test_maker_order_ownership_rejects_foreign_identity() {
+        let order: PolymarketMakerOrder = serde_json::from_str(sample_maker_order_json()).unwrap();
+
+        assert!(!order.is_owned_by("0xother", "no-such-key"));
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/execution/reconciliation.rs
+++ b/crates/adapters/polymarket/src/execution/reconciliation.rs
@@ -57,6 +57,16 @@ pub(crate) struct FillContext<'a> {
     pub clock: &'static AtomicTime,
 }
 
+/// Counts of confirmed trade evidence dropped while building fill reports.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct FillBuildDiscards {
+    /// Fill entries dropped because their instrument is not loaded.
+    pub unmapped_instruments: usize,
+    /// Confirmed maker trades dropped because no maker order in the match is
+    /// owned by the account.
+    pub unowned_maker_trades: usize,
+}
+
 /// Converts trade reports into fill reports: single implementation of maker/taker
 /// parsing used by both `generate_fill_reports()` and `generate_mass_status()`.
 pub(crate) fn build_fill_reports_from_trades(
@@ -65,9 +75,9 @@ pub(crate) fn build_fill_reports_from_trades(
     instruments: &AtomicMap<Ustr, InstrumentAny>,
     instrument_filter: Option<InstrumentId>,
     ts_init: UnixNanos,
-) -> (Vec<FillReport>, usize) {
+) -> (Vec<FillReport>, FillBuildDiscards) {
     let mut reports = Vec::new();
-    let mut filtered = 0usize;
+    let mut discards = FillBuildDiscards::default();
 
     for trade in trades {
         if trade.status != PolymarketTradeStatus::Confirmed {
@@ -77,8 +87,21 @@ pub(crate) fn build_fill_reports_from_trades(
         let is_maker = trade.trader_side == PolymarketLiquiditySide::Maker;
 
         if is_maker {
+            if !trade
+                .maker_orders
+                .iter()
+                .any(|mo| mo.is_owned_by(ctx.user_address, ctx.api_key))
+            {
+                discards.unowned_maker_trades += 1;
+                log::debug!(
+                    "Confirmed maker trade {} holds no maker order owned by the account",
+                    trade.id,
+                );
+                continue;
+            }
+
             for mo in &trade.maker_orders {
-                if mo.maker_address != ctx.user_address && mo.owner != ctx.api_key {
+                if !mo.is_owned_by(ctx.user_address, ctx.api_key) {
                     continue;
                 }
                 let token_id = Ustr::from(mo.asset_id.as_str());
@@ -86,7 +109,7 @@ pub(crate) fn build_fill_reports_from_trades(
                 let (instrument_id, price_prec, size_prec) = match instrument {
                     Some(i) => (i.id(), i.price_precision(), i.size_precision()),
                     None => {
-                        filtered += 1;
+                        discards.unmapped_instruments += 1;
                         continue;
                     }
                 };
@@ -129,7 +152,7 @@ pub(crate) fn build_fill_reports_from_trades(
                         instrument_fee_exponent(&i),
                     ),
                     None => {
-                        filtered += 1;
+                        discards.unmapped_instruments += 1;
                         continue;
                     }
                 };
@@ -156,7 +179,7 @@ pub(crate) fn build_fill_reports_from_trades(
         }
     }
 
-    (reports, filtered)
+    (reports, discards)
 }
 
 /// Converts open orders into order status reports.
@@ -301,8 +324,16 @@ pub(crate) async fn generate_mass_status(
         .await
         .context("failed to fetch trades for mass status")?;
 
-    let (mut fill_reports, fills_filtered) =
+    let (mut fill_reports, fill_discards) =
         build_fill_reports_from_trades(&trades, ctx, instruments, None, ts_init);
+
+    if fill_discards.unowned_maker_trades > 0 {
+        log::error!(
+            "Mass status is missing {} confirmed maker trade(s) holding no maker order owned by \
+             the account; executed quantity may be understated",
+            fill_discards.unowned_maker_trades,
+        );
+    }
 
     // Snap dust drift on REST fills the same way the WS path does.
     // Commission stays as venue-reported.
@@ -342,11 +373,13 @@ pub(crate) async fn generate_mass_status(
         );
     } else {
         log::debug!(
-            "Generated mass status: {} orders ({} filtered), {} fills ({} filtered), {} positions",
+            "Generated mass status: {} orders ({} filtered), {} fills ({} instrument-filtered, \
+             {} unowned maker trades), {} positions",
             order_reports.len(),
             orders_filtered,
             fill_reports.len(),
-            fills_filtered,
+            fill_discards.unmapped_instruments,
+            fill_discards.unowned_maker_trades,
             position_reports.len(),
         );
     }

--- a/crates/adapters/polymarket/src/execution/responses.rs
+++ b/crates/adapters/polymarket/src/execution/responses.rs
@@ -1073,6 +1073,91 @@ mod tests {
     }
 
     #[rstest]
+    fn test_confirmed_maker_trade_owned_by_case_variant_address_generates_fill_report() {
+        let instrument = test_instrument();
+        let mut trade: crate::http::models::PolymarketTradeReport = load("http_trade_report.json");
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+
+        // Recorded venue payloads carry EIP-55 checksummed (mixed-case) maker
+        // addresses while configured funder addresses are commonly lowercase.
+        // Mirror that direction: give the payload side a case variant (all-
+        // uppercase hex stands in for the checksummed form), keep the
+        // configured side lowercase. Any case variant of the same address
+        // must still establish ownership.
+        let configured_address = trade.maker_orders[0].maker_address.clone();
+        let uppercase_variant_address = configured_address
+            .to_ascii_uppercase()
+            .replacen("0X", "0x", 1);
+        assert_ne!(uppercase_variant_address, configured_address);
+        trade.maker_orders[0].maker_address = uppercase_variant_address;
+        let foreign_api_key = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+        assert_ne!(trade.maker_orders[0].owner, foreign_api_key);
+
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = crate::execution::reconciliation::FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: &configured_address,
+            api_key: foreign_api_key,
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let (reports, discards) = crate::execution::reconciliation::build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert_eq!(
+            reports.len(),
+            1,
+            "the account's own confirmed maker fill must be reported",
+        );
+        assert_eq!(
+            discards.unowned_maker_trades, 0,
+            "entry-level skips of foreign entries in an owned trade are not trade drops",
+        );
+        assert_eq!(discards.unmapped_instruments, 0);
+    }
+
+    #[rstest]
+    fn test_confirmed_maker_trade_without_owned_order_is_counted() {
+        let instrument = test_instrument();
+        let mut trade: crate::http::models::PolymarketTradeReport = load("http_trade_report.json");
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        // Neither the address nor the API key matches any maker order, so the
+        // whole confirmed trade is dropped; the drop must be observable.
+        let ctx = crate::execution::reconciliation::FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x000000000000000000000000000000000000dead",
+            api_key: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let (reports, discards) = crate::execution::reconciliation::build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(
+            discards.unowned_maker_trades, 1,
+            "a confirmed maker trade dropped whole must be counted, not silent",
+        );
+        assert_eq!(discards.unmapped_instruments, 0);
+    }
+
+    #[rstest]
     fn test_unknown_submit_tracks_expected_id_for_ws_order_recovery() {
         let ws_order: PolymarketUserOrder = load("ws_user_order_placement.json");
         let instrument = test_instrument();

--- a/crates/adapters/polymarket/src/websocket/dispatch.rs
+++ b/crates/adapters/polymarket/src/websocket/dispatch.rs
@@ -568,7 +568,7 @@ fn dispatch_maker_fills(
 }
 
 fn is_user_maker_order(order: &PolymarketMakerOrder, ctx: &WsDispatchContext<'_>) -> bool {
-    order.maker_address == ctx.user_address || order.owner == ctx.user_api_key
+    order.is_owned_by(ctx.user_address, ctx.user_api_key)
 }
 
 fn dispatch_taker_fill(


### PR DESCRIPTION
## Summary

Maker-order ownership was decided by case-sensitive string equality on the maker address. Venue payloads carry EIP-55 checksummed (mixed-case) addresses while configured funder addresses are commonly lowercase, so an account's own confirmed maker fills failed the ownership test and the whole trade vanished from the generated mass status with no fill report, no counter, and no log line, silently understating executed quantity.

- Add `PolymarketMakerOrder::is_owned_by`: the address compare ignores ASCII case (hex letter case carries no account identity) while the API-key compare stays exact; both prior inline spellings (REST reconciliation and WS dispatch) now delegate to it
- Count confirmed maker trades dropped for holding no owned maker order in a typed `FillBuildDiscards`, and raise one error per mass-status pass when the count is nonzero; polled report paths are unaffected
- Reproduction tests fail at the parent commit and pass here; a config-side-normalization mutant is killed by the direction-pinned tests

## Known open, deliberately not bundled

The Python adapter has the identical defect: `nautilus_trader/adapters/polymarket/schemas/trade.py:79` and `schemas/user.py:226` compare `order.maker_address == maker_address or order.owner == api_key`, and callers `execution.py:851` (REST trade reports) and `execution.py:2335` (WS user trade) iterate the returned list, so an empty result is a silent no-op. This PR fixes the Rust adapter only to keep the change small and reviewable; the Python instance needs its own reproduction and fix.

## Testing

- `cargo nextest run -p nautilus-polymarket`: 1232 passed, 0 skipped
- `cargo clippy -p nautilus-polymarket --all-targets -- -D warnings`: clean
- `make pre-commit` (all files) run locally before the single push
