### PR TITLE
Fix Interactive Brokers continuous futures historical bar requests

### DIFF
--- a/crates/adapters/interactive_brokers/src/data/convert.rs
+++ b/crates/adapters/interactive_brokers/src/data/convert.rs
@@ -363,6 +363,44 @@ pub fn calculate_duration_segments(
     results
 }
 
+/// Adapt duration segments for an IB historical bars request.
+///
+/// For continuous futures the end date is dropped and only the first segment is
+/// kept (IB rejects an explicit end date with error 10339), logging a warning
+/// when the requested range cannot be honored.
+pub fn bar_request_segments(
+    segments: Vec<(Timestamp, IBDuration)>,
+    is_continuous_future: bool,
+) -> Vec<(Option<Timestamp>, IBDuration)> {
+    if is_continuous_future {
+        // Treat end dates within the last second as "now" so requests whose
+        // end defaults to the current time do not trigger a spurious warning.
+        let now = Timestamp::now();
+        let end_in_past = segments
+            .first()
+            .is_some_and(|(end, _)| *end < now - jiff::SignedDuration::from_secs(1));
+
+        if end_in_past || segments.len() > 1 {
+            tracing::warn!(
+                "Continuous futures cannot use an explicit end_date_time (IB error 10339); \
+                 the request is anchored to the current time using only the first duration \
+                 segment, so the returned bars may not cover the full requested range"
+            );
+        }
+
+        segments
+            .into_iter()
+            .take(1)
+            .map(|(_, d)| (None, d))
+            .collect()
+    } else {
+        segments
+            .into_iter()
+            .map(|(end, d)| (Some(end), d))
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use nautilus_model::{
@@ -746,5 +784,37 @@ mod tests {
         // Check first segment is ~1Y
         let dur1 = &segments[0].1;
         assert!(dur1.to_string().contains("1 Y") || dur1.to_string().contains("1Y"));
+    }
+
+    #[rstest]
+    fn test_bar_request_segments_attaches_end_dates_when_not_continuous() {
+        let end = "2025-01-01T00:00:00Z".parse::<Timestamp>().unwrap();
+        let earlier = "2024-06-01T00:00:00Z".parse::<Timestamp>().unwrap();
+        let segments = vec![(end, IBDuration::years(1)), (earlier, IBDuration::days(30))];
+
+        let result = bar_request_segments(segments, false);
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0, Some(end));
+        assert_eq!(result[1].0, Some(earlier));
+    }
+
+    #[rstest]
+    fn test_bar_request_segments_drops_end_date_and_keeps_only_first_for_continuous() {
+        let end = "2025-01-01T00:00:00Z".parse::<Timestamp>().unwrap();
+        let earlier = "2024-06-01T00:00:00Z".parse::<Timestamp>().unwrap();
+        let segments = vec![(end, IBDuration::years(1)), (earlier, IBDuration::days(30))];
+
+        let result = bar_request_segments(segments, true);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, None);
+        assert_eq!(result[0].1, IBDuration::years(1));
+    }
+
+    #[rstest]
+    fn test_bar_request_segments_empty_input_yields_nothing_for_continuous() {
+        let result = bar_request_segments(vec![], true);
+        assert!(result.is_empty());
     }
 }

--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -70,9 +70,10 @@ use self::streams::{
 use super::{
     cache::{OptionGreeksCache, QuoteCache},
     convert::{
-        apply_bar_price_magnifier, apply_price_magnifier, bar_type_to_ib_bar_size,
-        calculate_duration, calculate_duration_segments, ib_bar_to_nautilus_bar,
-        jiff_to_ib_datetime, price_type_to_ib_realtime_what_to_show_for_security,
+        apply_bar_price_magnifier, apply_price_magnifier, bar_request_segments,
+        bar_type_to_ib_bar_size, calculate_duration, calculate_duration_segments,
+        ib_bar_to_nautilus_bar, jiff_to_ib_datetime,
+        price_type_to_ib_realtime_what_to_show_for_security,
         price_type_to_ib_what_to_show_for_security,
     },
 };
@@ -2217,7 +2218,9 @@ impl DataClient for InteractiveBrokersDataClient {
         let ib_what_to_show =
             price_type_to_ib_what_to_show_for_security(cmd.bar_type.spec().price_type, is_crypto);
 
-        // Calculate segments to break down the request if needed
+        // Calculate segments to break down the request if needed.
+        // Omit the end date for continuous futures (IB error 10339).
+        let is_continuous_future = contract.security_type == SecurityType::ContinuousFuture;
         let segments = if let (Some(start), Some(end)) = (cmd.start, cmd.end) {
             calculate_duration_segments(start, end)
         } else {
@@ -2225,6 +2228,7 @@ impl DataClient for InteractiveBrokersDataClient {
             let duration = calculate_duration(cmd.start, cmd.end).unwrap_or_else(|_| 1i32.days());
             vec![(end_date, duration)]
         };
+        let segments = bar_request_segments(segments, is_continuous_future);
 
         let bar_type = cmd.bar_type;
         let data_sender = self.data_sender.clone();
@@ -2245,17 +2249,17 @@ impl DataClient for InteractiveBrokersDataClient {
             let mut all_bars = Vec::new();
 
             for (seg_end, seg_duration) in segments {
-                let end_ib = jiff_to_ib_datetime(&seg_end);
-
-                match client_clone
+                let mut request = client_clone
                     .historical_data(&contract, ib_bar_size)
-                    .ending(end_ib)
                     .duration(seg_duration)
                     .what_to_show(ib_what_to_show)
-                    .trading_hours(trading_hours)
-                    .fetch()
-                    .await
-                {
+                    .trading_hours(trading_hours);
+
+                if let Some(end) = seg_end {
+                    request = request.ending(jiff_to_ib_datetime(&end));
+                }
+
+                match request.fetch().await {
                     Ok(historical_data) => {
                         // Convert IB bars to Nautilus bars
                         for ib_bar in &historical_data.bars {

--- a/crates/adapters/interactive_brokers/src/historical/client.rs
+++ b/crates/adapters/interactive_brokers/src/historical/client.rs
@@ -20,7 +20,7 @@ use std::{fmt::Debug, str::FromStr, sync::Arc};
 use anyhow::Context;
 use ibapi::{
     client::Client,
-    contracts::Contract,
+    contracts::{Contract, SecurityType},
     market_data::{IgnoreSize, TradingHours, historical},
     prelude::{StreamExt, SubscriptionItemStreamExt},
 };
@@ -41,9 +41,9 @@ use crate::{
     },
     config::InteractiveBrokersDataClientConfig,
     data::convert::{
-        apply_bar_price_magnifier, apply_price_magnifier, bar_type_to_ib_bar_size,
-        ib_bar_to_nautilus_bar, ib_timestamp_to_unix_nanos, jiff_to_ib_datetime,
-        price_type_to_ib_what_to_show_for_security,
+        apply_bar_price_magnifier, apply_price_magnifier, bar_request_segments,
+        bar_type_to_ib_bar_size, ib_bar_to_nautilus_bar, ib_timestamp_to_unix_nanos,
+        jiff_to_ib_datetime, price_type_to_ib_what_to_show_for_security,
     },
     providers::instruments::InteractiveBrokersInstrumentProvider,
 };
@@ -196,6 +196,15 @@ impl HistoricalInteractiveBrokersClient {
     }
 
     /// Request historical bars.
+    ///
+    /// # Continuous futures
+    ///
+    /// Continuous futures (`CONTFUT`) reject an explicit end date/time with IB
+    /// error 10339. For these contracts the end date is dropped and only the
+    /// first duration segment is requested, anchored to the current time, so
+    /// the returned bars may fall outside `[start_date_time, end_date_time]`.
+    /// A warning is logged when the requested end date/time is in the past or
+    /// the range spans more than one duration segment.
     ///
     /// # Arguments
     ///
@@ -366,26 +375,34 @@ impl HistoricalInteractiveBrokersClient {
                 let ib_what_to_show =
                     price_type_to_ib_what_to_show_for_security(bar_spec.price_type, is_crypto);
 
-                // Calculate duration segments
-                let segments =
-                    self.calculate_duration_segments(start_date_time, end_date_time, duration);
+                // Omit the end date for continuous futures (IB error 10339).
+                let is_continuous_future = contract.security_type == SecurityType::ContinuousFuture;
+                let segments = bar_request_segments(
+                    self.calculate_duration_segments(start_date_time, end_date_time, duration),
+                    is_continuous_future,
+                );
 
                 for (segment_end, segment_duration) in segments {
                     tracing::debug!(
-                        "Requesting historical bars ending on {} with duration {}",
+                        "Requesting historical bars ending on {:?} with duration {}",
                         segment_end,
                         segment_duration
                     );
 
+                    let mut request = self
+                        .ib_client
+                        .historical_data(&contract, ib_bar_size)
+                        .duration(segment_duration)
+                        .what_to_show(ib_what_to_show)
+                        .trading_hours(trading_hours);
+
+                    if let Some(end) = segment_end {
+                        request = request.ending(jiff_to_ib_datetime(&end));
+                    }
+
                     let historical_data = tokio::time::timeout(
                         std::time::Duration::from_secs(timeout),
-                        self.ib_client
-                            .historical_data(&contract, ib_bar_size)
-                            .ending(jiff_to_ib_datetime(&segment_end))
-                            .duration(segment_duration)
-                            .what_to_show(ib_what_to_show)
-                            .trading_hours(trading_hours)
-                            .fetch(),
+                        request.fetch(),
                     )
                     .await
                     .context(format!(

--- a/crates/adapters/interactive_brokers/src/python/historical.rs
+++ b/crates/adapters/interactive_brokers/src/python/historical.rs
@@ -52,6 +52,15 @@ impl HistoricalInteractiveBrokersClient {
 
     /// Request historical bars.
     ///
+    /// # Continuous futures
+    ///
+    /// Continuous futures (`CONTFUT`) reject an explicit end date/time with IB
+    /// error 10339. For these contracts the end date is dropped and only the
+    /// first duration segment is requested, anchored to the current time, so
+    /// the returned bars may fall outside `[start_date_time, end_date_time]`.
+    /// A warning is logged when the requested end date/time is in the past or
+    /// the range spans more than one duration segment.
+    ///
     /// # Arguments
     ///
     /// * `bar_specifications` - List of bar specifications (e.g., ["1-HOUR-LAST"])


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

> External contributions must not modify files under `.github/workflows` or `.github/actions`;
> workflow changes are maintainer‑only.

<!-- PR title: use a capitalized, imperative subject naming the affected surface, for example
     "Fix Bybit post-only rejection flag". Do NOT use Conventional Commits (`feat:`, `fix:`) syntax.
     A squash merge turns this title into the commit subject. -->

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and followed the established practices
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Continuous futures (CONTFUT) historical bar downloads failed with IB error `10339` ("Setting end date/time for continuous future security type is not allowed") because the bars request always sent an end date/time. The request now omits the end date for continuous futures (matching the legacy v1 client, which blanked `endDateTime` for CONTFUT) and uses only the first duration segment, since without an end date the request cannot page backward. Behavior for every other security type is unchanged.

## Related issues/PRs

None.

## Type of change

<!-- Select all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A — non-breaking. Continuous futures previously errored and now return bars; all other security types follow the original segmented request path unchanged.

## Documentation

No documentation changes.

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

**Ensure new or changed logic is covered by tests.** Check at least one:

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

Added unit tests in `crates/adapters/interactive_brokers/src/historical/client.rs` (`historical::client::tests`) for the extracted `bar_request_segments` helper: non-continuous segments retain their end dates in order; continuous futures drop the end date and keep only the first (largest) duration segment; empty input yields nothing.
