### PR TITLE
Fix Indicator::reset leaving state behind in AMA and FuzzyCandlesticks

### DIFF
--- a/crates/indicators/src/average/ama.rs
+++ b/crates/indicators/src/average/ama.rs
@@ -101,10 +101,12 @@ impl Indicator for AdaptiveMovingAverage {
     }
 
     fn reset(&mut self) {
-        self.value = 0.0;
-        self.count = 0;
-        self.has_inputs = false;
-        self.initialized = false;
+        // Delegate rather than repeat the field list: the copy that used to
+        // live here had already fallen behind and left `prior_value` set.
+        // This resolves to the inherent `reset` because Rust prefers inherent
+        // methods; deleting that one would turn this into infinite recursion,
+        // which `trait_reset_clears_prior_value` below would catch.
+        Self::reset(self);
     }
 }
 
@@ -362,5 +364,26 @@ mod tests {
             let _ = AdaptiveMovingAverage::new(10, 20, 5, None);
         });
         assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn trait_reset_clears_prior_value() {
+        // `Indicator::reset` and the inherent `reset` are written out separately,
+        // so they can drift. Anything reached through `dyn Indicator` or a
+        // generic bound gets the trait one, and a `prior_value` left behind
+        // there feeds pre-reset data into the next update.
+        let mut ama = AdaptiveMovingAverage::new(10, 2, 30, None);
+        for i in 1..=12 {
+            ama.update_raw(f64::from(i));
+        }
+        assert!(ama.prior_value.is_some());
+
+        Indicator::reset(&mut ama);
+
+        assert_eq!(ama.prior_value, None);
+        assert_eq!(ama.value, 0.0);
+        assert_eq!(ama.count, 0);
+        assert!(!ama.has_inputs);
+        assert!(!ama.initialized);
     }
 }

--- a/crates/indicators/src/volatility/fuzzy.rs
+++ b/crates/indicators/src/volatility/fuzzy.rs
@@ -245,16 +245,12 @@ impl Indicator for FuzzyCandlesticks {
     }
 
     fn reset(&mut self) {
-        self.lengths.clear();
-        self.body_percents.clear();
-        self.upper_wick_percents.clear();
-        self.lower_wick_percents.clear();
-        self.last_open = 0.0;
-        self.last_high = 0.0;
-        self.last_close = 0.0;
-        self.last_low = 0.0;
-        self.has_inputs = false;
-        self.initialized = false;
+        // Delegate rather than repeat the field list: the copy that used to
+        // live here had already fallen behind and left `value` and `vector`
+        // holding the last candle's classification. This resolves to the
+        // inherent `reset`; deleting that one would turn this into infinite
+        // recursion, which `trait_reset_clears_value_and_vector` would catch.
+        Self::reset(self);
     }
 }
 
@@ -839,5 +835,33 @@ mod tests {
             fuzzy_candlesticks_3.value.upper_wick_size,
             CandleWickSize::Large
         );
+    }
+
+    #[rstest]
+    fn trait_reset_clears_value_and_vector() {
+        // Same drift as `ama`: the trait copy of `reset` was missing `value`
+        // and `vector`, so a reset through `dyn Indicator` left the previous
+        // candle's classification readable.
+        let mut fc = FuzzyCandlesticks::new(10, 0.5, 1.0, 2.0, 3.0);
+        for i in 0..12 {
+            let base = 100.0 + f64::from(i);
+            fc.update_raw(base, base + 10.0, base - 10.0, base + 5.0);
+        }
+        assert!(fc.initialized());
+        assert!(!fc.vector.is_empty());
+        assert_ne!(fc.value.direction, CandleDirection::None);
+
+        Indicator::reset(&mut fc);
+
+        assert!(fc.vector.is_empty());
+        // All five fields, not a sample of them: a partial check would pass
+        // while one stayed dirty.
+        assert_eq!(fc.value.direction, CandleDirection::None);
+        assert_eq!(fc.value.size, CandleSize::None);
+        assert_eq!(fc.value.body_size, CandleBodySize::None);
+        assert_eq!(fc.value.upper_wick_size, CandleWickSize::None);
+        assert_eq!(fc.value.lower_wick_size, CandleWickSize::None);
+        assert!(!fc.has_inputs);
+        assert!(!fc.initialized);
     }
 }


### PR DESCRIPTION
Closes #4665.

Exactly two indicators write reset twice, once as an inherent method and
once for the Indicator trait, and both had drifted apart. The inherent copy
is the complete one in each case.

AdaptiveMovingAverage's trait reset never cleared prior_value, so the first
update_raw after a reset smoothed against a price from before it.
FuzzyCandlesticks' trait reset never cleared value or vector, so the last
candle's classification stayed readable and the next vector kept the old
one's length.

Calling reset() on a concrete instance picks the inherent method and is
fine. Anything going through dyn Indicator or a generic Indicator bound
gets the trait method and the stale state, which is the path taken by
anything holding a boxed indicator.

Both trait impls now delegate to the inherent one. Rust prefers inherent
methods, so this resolves the way it reads; if the inherent method were
ever deleted it would become infinite recursion instead, and the two tests
added here would catch that.

Found by comparing, for all 37 indicators, the fields mutated in update_raw
against the fields cleared in reset. Only these two define reset twice, and
neither pair matched.