### PR TITLE
Keep ChandeMomentumOscillator inside its bounds

### DIFF
--- a/crates/indicators/src/average/vidya.rs
+++ b/crates/indicators/src/average/vidya.rs
@@ -211,7 +211,7 @@ mod tests {
         indicator_vidya_10.update_raw(1.00020);
         indicator_vidya_10.update_raw(1.00010);
         indicator_vidya_10.update_raw(1.00000);
-        assert_eq!(indicator_vidya_10.value, 0.046_813_474_863_949_87);
+        assert_eq!(indicator_vidya_10.value, 0.046_813_474_863_949_864);
     }
 
     #[rstest]

--- a/crates/indicators/src/momentum/cmo.rs
+++ b/crates/indicators/src/momentum/cmo.rs
@@ -136,8 +136,10 @@ impl ChandeMomentumOscillator {
             if divisor == 0.0 {
                 self.value = 0.0;
             } else {
+                // Divide before scaling, so a zero gain average gives exactly -100
+                // rather than a value just outside the oscillator's range.
                 self.value =
-                    100.0 * (self.average_gain.value() - self.average_loss.value()) / divisor;
+                    100.0 * ((self.average_gain.value() - self.average_loss.value()) / divisor);
             }
         }
         self.previous_close = close;
@@ -160,6 +162,23 @@ mod tests {
         assert_eq!(display_str, "ChandeMomentumOscillator(10)");
         assert_eq!(cmo_10.period, 10);
         assert!(!cmo_10.initialized);
+    }
+
+    #[rstest]
+    fn test_value_stays_within_bounds_when_gain_average_is_zero() {
+        // A drop followed by flat prices decays the gain average to exactly zero, so
+        // the oscillator sits on its lower bound. Scaling before dividing put it just
+        // outside, which `VariableIndexDynamicAverage` then read as a weight above one.
+        let mut cmo = ChandeMomentumOscillator::new(14, None);
+        for price in std::iter::repeat_n(100.0, 21).chain(std::iter::repeat_n(50.0, 20)) {
+            cmo.update_raw(price);
+            assert!(
+                (-100.0..=100.0).contains(&cmo.value),
+                "value {} outside [-100, 100]",
+                cmo.value
+            );
+        }
+        assert_eq!(cmo.value, -100.0);
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #4654.

Scaling before dividing meant that a zero gain average gave
-100.00000000000001 rather than -100. VariableIndexDynamicAverage divides
that by 100 and uses it as a smoothing weight, so it read 1.0000000000000002,
which the crate asserts against at vidya.rs:346.

Dividing first makes the degenerate case exact, and stochastics.rs already
writes the expression that way.

The reorder moves the pinned constant in vidya::tests::test_value_with_ten_inputs
by one ULP; updated with it.

Closes #4654.