### PR TITLE
Support BinaryView custom data decoding

### DIFF
--- a/crates/persistence/macros/src/custom.rs
+++ b/crates/persistence/macros/src/custom.rs
@@ -207,6 +207,11 @@ fn use_string_extract(ty: &Type, json: bool) -> bool {
     }
 }
 
+/// Returns true if the field uses binary extraction (`Binary` or `BinaryView`).
+fn use_binary_extract(ty: &Type) -> bool {
+    type_for_macro(ty).is_some_and(|(outer, inner)| outer == "Vec" && inner == "u8")
+}
+
 /// Arrow `DataType` and array type for encoding/decoding. Emits token streams that reference
 /// `arrow::datatypes::DataType` and arrow array types.
 fn arrow_type_for_rust_type(
@@ -1075,6 +1080,14 @@ fn gen_decode_batch_impl(ctx: &ExpansionContext<'_>) -> TokenStream {
             if use_string_extract(ty, f.options.serde) {
                 quote! {
                     let #col_name = nautilus_serialization::arrow::extract_column_string(
+                        record_batch.columns(),
+                        #fn_str,
+                        #idx,
+                    )?;
+                }
+            } else if use_binary_extract(ty) {
+                quote! {
+                    let #col_name = nautilus_serialization::arrow::extract_column_binary(
                         record_batch.columns(),
                         #fn_str,
                         #idx,

--- a/crates/persistence/src/test_data.rs
+++ b/crates/persistence/src/test_data.rs
@@ -49,6 +49,14 @@ pub struct RustTestCustomData {
     pub ts_init: UnixNanos,
 }
 
+/// Rust custom data type that exercises raw byte field support.
+#[custom_data]
+pub struct RustTestBytesCustomData {
+    pub value: Vec<u8>,
+    pub ts_event: UnixNanos,
+    pub ts_init: UnixNanos,
+}
+
 /// YieldCurveData-equivalent custom data type using the macro with `Vec<f64>` fields.
 ///
 /// Tests `Vec<f64>` / `ListFloat64` support. Exposed to Python for roundtrip tests.

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -42,8 +42,8 @@ use nautilus_persistence::{
         session::{DataBackendSession, QueryResult},
     },
     test_data::{
-        MacroYieldCurveData, RustTestCustomData, RustTestHashMapCustomData,
-        RustTestParamsCustomData, RustTestPriceMapCustomData,
+        MacroYieldCurveData, RustTestBytesCustomData, RustTestCustomData,
+        RustTestHashMapCustomData, RustTestParamsCustomData, RustTestPriceMapCustomData,
     },
 };
 use nautilus_serialization::{arrow::ArrowSchemaProvider, ensure_custom_data_registered};
@@ -65,6 +65,7 @@ fn ensure_test_custom_data_registered() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
         ensure_custom_data_registered::<MacroYieldCurveData>();
+        ensure_custom_data_registered::<RustTestBytesCustomData>();
         ensure_custom_data_registered::<RustTestCustomData>();
         ensure_custom_data_registered::<RustTestHashMapCustomData>();
         ensure_custom_data_registered::<RustTestParamsCustomData>();
@@ -3603,6 +3604,66 @@ fn test_rust_custom_data_roundtrip() {
         } else {
             panic!("Expected Data::Custom variant");
         }
+    }
+}
+
+#[rstest]
+fn test_rust_custom_data_binary_roundtrip() {
+    ensure_test_custom_data_registered();
+    let (_temp_dir, mut catalog) = create_temp_catalog();
+
+    let instrument_id = InstrumentId::from("RUST.TEST");
+    let data_type = DataType::new(
+        "RustTestBytesCustomData",
+        None,
+        Some(instrument_id.to_string()),
+    );
+    let original_data = [
+        RustTestBytesCustomData {
+            value: Vec::new(),
+            ts_event: UnixNanos::from(1),
+            ts_init: UnixNanos::from(1),
+        },
+        RustTestBytesCustomData {
+            value: vec![0x00, 0x7F, 0xFF],
+            ts_event: UnixNanos::from(2),
+            ts_init: UnixNanos::from(2),
+        },
+    ];
+    let custom_data = original_data
+        .iter()
+        .cloned()
+        .map(|item| CustomData::new(Arc::new(item), data_type.clone()))
+        .collect();
+
+    catalog
+        .write_custom_data_batch(custom_data, None, None, Some(false))
+        .unwrap();
+
+    let identifiers = [instrument_id.to_string()];
+    let loaded = catalog
+        .query_custom_data_dynamic(
+            "RustTestBytesCustomData",
+            Some(&identifiers),
+            None,
+            None,
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+
+    assert_eq!(loaded.len(), original_data.len());
+    for (expected, actual) in original_data.iter().zip(&loaded) {
+        let Data::Custom(custom) = actual else {
+            panic!("Expected custom data, was {actual:?}");
+        };
+        let actual = custom
+            .data
+            .as_any()
+            .downcast_ref::<RustTestBytesCustomData>()
+            .expect("Expected RustTestBytesCustomData");
+        assert_eq!(actual, expected);
     }
 }
 

--- a/crates/serialization/src/arrow/mod.rs
+++ b/crates/serialization/src/arrow/mod.rs
@@ -44,7 +44,10 @@ use std::{
 };
 
 use arrow::{
-    array::{Array, ArrayRef, FixedSizeBinaryArray, StringArray, StringViewArray},
+    array::{
+        Array, ArrayRef, BinaryArray, BinaryViewArray, FixedSizeBinaryArray, StringArray,
+        StringViewArray,
+    },
     datatypes::{DataType, Schema},
     error::ArrowError,
     ipc::writer::StreamWriter,
@@ -435,6 +438,57 @@ impl StringColumnRef<'_> {
         match self {
             Self::Utf8(arr) => arr.value(i),
             Self::Utf8View(arr) => arr.value(i),
+        }
+    }
+}
+
+/// Extracts a binary column, accepting both Binary (`BinaryArray`) and BinaryView
+/// (`BinaryViewArray`).
+/// DataFusion may return BinaryView when reading Parquet, so this handles both formats.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - `column_index` is out of range: `EncodingError::MissingColumn`.
+/// - The column type is neither Binary nor BinaryView: `EncodingError::InvalidColumnType`.
+pub fn extract_column_binary<'a>(
+    cols: &'a [ArrayRef],
+    column_key: &'static str,
+    column_index: usize,
+) -> Result<BinaryColumnRef<'a>, EncodingError> {
+    let column_values = cols
+        .get(column_index)
+        .ok_or(EncodingError::MissingColumn(column_key, column_index))?;
+    let dt = column_values.data_type();
+    if let Some(arr) = column_values.as_any().downcast_ref::<BinaryArray>() {
+        Ok(BinaryColumnRef::Binary(arr))
+    } else if let Some(arr) = column_values.as_any().downcast_ref::<BinaryViewArray>() {
+        Ok(BinaryColumnRef::BinaryView(arr))
+    } else {
+        Err(EncodingError::InvalidColumnType(
+            column_key,
+            column_index,
+            DataType::Binary,
+            dt.clone(),
+        ))
+    }
+}
+
+/// Reference to a binary column, either Binary or BinaryView.
+#[derive(Debug)]
+pub enum BinaryColumnRef<'a> {
+    Binary(&'a BinaryArray),
+    BinaryView(&'a BinaryViewArray),
+}
+
+impl BinaryColumnRef<'_> {
+    /// Returns the bytes at row `i`.
+    #[inline]
+    #[must_use]
+    pub fn value(&self, i: usize) -> &[u8] {
+        match self {
+            Self::Binary(arr) => arr.value(i),
+            Self::BinaryView(arr) => arr.value(i),
         }
     }
 }


### PR DESCRIPTION
Hi @cjdsellers 

Writing custom data containing a `Vec<u8>` field with `ParquetDataCatalog::write_custom_data_batch` succeeds, but querying it with `query_custom_data_dynamic` fails with `InvalidColumnType`. DataFusion 54.1 [enables `schema_force_view_types` by default](https://github.com/apache/datafusion/blob/54.1.0/datafusion/common/src/config.rs#L820-L822), converting Parquet `Binary` columns to `BinaryView`, while the generated custom-data decoder accepts only `BinaryArray`.

This change accepts both `BinaryArray` and `BinaryViewArray` when decoding `Vec<u8>` fields, mirroring the existing `Utf8`/`Utf8View` handling. 

A focused catalog round-trip test covers the write and query path.

Closes #4671 