### PR TITLE
Add post-start data-client registration to LiveNode

### DIFF
--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -460,6 +460,87 @@ impl DataEngine {
         log::debug!("Registered client {client_id}");
     }
 
+    /// Validates that a client and all of its routing can be registered atomically.
+    ///
+    /// A primary venue keeps [`Self::register_client`]'s overwrite semantics and never
+    /// conflicts; explicit venue routes conflict when routed to a different client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the client ID, default routing, or any explicit venue routing
+    /// conflicts with an existing registration.
+    pub fn validate_client_registration(
+        &self,
+        client_id: ClientId,
+        primary_venue: Option<Venue>,
+        default: bool,
+        venue_routes: &[Venue],
+    ) -> anyhow::Result<()> {
+        if self.clients.contains_key(&client_id) {
+            anyhow::bail!("Data client {client_id} is already registered");
+        }
+
+        if default && self.default_client_id.is_some_and(|id| id != client_id) {
+            anyhow::bail!("default client already registered");
+        }
+
+        for venue in venue_routes {
+            if primary_venue == Some(*venue) {
+                continue;
+            }
+
+            if let Some(existing_client_id) = self.routing_map.get(venue)
+                && *existing_client_id != client_id
+            {
+                anyhow::bail!(
+                    "Venue {venue} already routed to {existing_client_id}, cannot re-route to {client_id}"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Registers a client and all routing after validating that the complete operation can
+    /// succeed without mutating the engine.
+    ///
+    /// A primary venue keeps [`Self::register_client`]'s overwrite semantics; explicit venue
+    /// routes conflict when routed to a different client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the client ID, default routing, or any explicit venue routing
+    /// conflicts with an existing registration.
+    pub fn register_client_checked(
+        &mut self,
+        client: DataClientAdapter,
+        primary_venue: Option<Venue>,
+        default: bool,
+        venue_routes: &[Venue],
+    ) -> anyhow::Result<()> {
+        let client_id = client.client_id();
+        self.validate_client_registration(client_id, primary_venue, default, venue_routes)?;
+
+        if let Some(venue) = primary_venue {
+            self.routing_map.insert(venue, client_id);
+            log::debug!("Set client {client_id} routing for {venue}");
+        }
+
+        for venue in venue_routes {
+            self.routing_map.insert(*venue, client_id);
+            log::debug!("Set client {client_id} routing for {venue}");
+        }
+
+        if default || (client.venue.is_none() && self.default_client_id.is_none()) {
+            self.default_client_id = Some(client_id);
+            log::debug!("Registered client {client_id} for default routing");
+        }
+
+        self.clients.insert(client_id, client);
+        log::debug!("Registered client {client_id}");
+        Ok(())
+    }
+
     /// Deregisters the client for the `client_id`.
     ///
     /// # Panics

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -634,6 +634,74 @@ fn test_register_and_deregister_client(
 }
 
 #[rstest]
+fn test_register_client_checked_preserves_primary_venue_overwrite(
+    data_engine: Rc<RefCell<DataEngine>>,
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+) {
+    let mut data_engine = data_engine.borrow_mut();
+
+    let venue = Venue::test_default();
+    let client_id1 = ClientId::new("C1");
+    let data_client1 = DataClientAdapter::new(
+        client_id1,
+        Some(venue),
+        true,
+        true,
+        Box::new(MockDataClient::new(
+            clock.clone(),
+            cache.clone(),
+            client_id1,
+            Some(venue),
+        )),
+    );
+    data_engine
+        .register_client_checked(data_client1, Some(venue), false, &[])
+        .unwrap();
+
+    // A second primary registration for the same venue keeps register_client's
+    // overwrite semantics: the later client takes the route.
+    let client_id2 = ClientId::new("C2");
+    let data_client2 = DataClientAdapter::new(
+        client_id2,
+        Some(venue),
+        true,
+        true,
+        Box::new(MockDataClient::new(
+            clock.clone(),
+            cache.clone(),
+            client_id2,
+            Some(venue),
+        )),
+    );
+    data_engine
+        .register_client_checked(data_client2, Some(venue), false, &[])
+        .unwrap();
+    assert_eq!(
+        data_engine
+            .get_client(None, Some(&venue))
+            .unwrap()
+            .client_id(),
+        client_id2
+    );
+
+    // An explicit route to a venue owned by a different client still conflicts.
+    let client_id3 = ClientId::new("C3");
+    let data_client3 = DataClientAdapter::new(
+        client_id3,
+        None,
+        true,
+        true,
+        Box::new(MockDataClient::new(clock, cache, client_id3, Some(venue))),
+    );
+    let error = data_engine
+        .register_client_checked(data_client3, None, false, &[venue])
+        .unwrap_err();
+    assert!(error.to_string().contains("already routed"));
+    assert!(!data_engine.registered_clients().contains(&client_id3));
+}
+
+#[rstest]
 fn test_register_default_client(
     data_engine: Rc<RefCell<DataEngine>>,
     clock: Rc<RefCell<TestClock>>,

--- a/crates/live/src/node/builder.rs
+++ b/crates/live/src/node/builder.rs
@@ -561,6 +561,7 @@ impl LiveNodeBuilder {
         );
 
         self.config.validate_runtime_support()?;
+        let data_client_names = self.data_client_factories.keys().cloned().collect();
 
         if self.config.event_store.is_some() && self.event_store_factory.is_none() {
             anyhow::bail!(
@@ -629,23 +630,19 @@ impl LiveNodeBuilder {
 
                 let routing = self.data_client_routing.remove(&name).unwrap_or_default();
 
-                {
-                    let mut data_engine = kernel.data_engine.borrow_mut();
-                    data_engine.register_client(adapter, venue);
-
-                    if routing.default {
-                        data_engine.set_default_client(client_id)?;
-                    }
-
-                    if let Some(venues) = &routing.venues {
-                        for venue_str in venues {
-                            data_engine.register_venue_routing(
-                                client_id,
-                                Venue::new(venue_str.as_str()),
-                            )?;
-                        }
-                    }
-                }
+                let venue_routes = routing
+                    .venues
+                    .as_deref()
+                    .unwrap_or_default()
+                    .iter()
+                    .map(Venue::new)
+                    .collect::<Vec<_>>();
+                kernel.data_engine.borrow_mut().register_client_checked(
+                    adapter,
+                    venue,
+                    routing.default,
+                    &venue_routes,
+                )?;
 
                 log::info!("Registered DataClient-{client_id}");
             } else {
@@ -721,6 +718,7 @@ impl LiveNodeBuilder {
             exec_manager,
             exec_clients,
             self.cache_database_factory,
+            data_client_names,
             self.external_msgbus_ingress,
         );
         node.load_configured_plugins()?;

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -77,7 +77,10 @@
 //! maintenance below 100ms (defaults are seconds to minutes). Cadence drifts
 //! by at most one body duration per fire.
 
-use std::{collections::HashSet, fmt::Debug, future::Future, pin::Pin, time::Duration};
+use std::{
+    cell::Cell, collections::HashSet, fmt::Debug, future::Future, pin::Pin, task::Poll,
+    time::Duration,
+};
 
 use anyhow::Context;
 use indexmap::IndexSet;
@@ -183,6 +186,7 @@ impl LiveNode {
     ///
     /// This is an internal constructor used by `LiveNodeBuilder`.
     #[must_use]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new_from_builder(
         kernel: NautilusKernel,
         runner: AsyncRunner,
@@ -332,6 +336,16 @@ impl LiveNode {
             anyhow::bail!("Data client '{name}' is already registered");
         }
 
+        let venue_routes = routing
+            .venues
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|value| {
+                Venue::new_checked(value)
+                    .map_err(|e| anyhow::anyhow!("Invalid data client venue route '{value}': {e}"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
         let client = factory.create(
             &name,
             config.as_ref(),
@@ -340,29 +354,35 @@ impl LiveNode {
         )?;
         let client_id = client.client_id();
         let primary_venue = client.venue();
-        let venue_routes = routing
-            .venues
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .map(Venue::new)
-            .collect::<Vec<_>>();
         let adapter = DataClientAdapter::new(client_id, primary_venue, true, true, client);
+        let mut guard = LateDataClientGuard::new(adapter);
 
-        self.kernel
+        let validation_result = self
+            .kernel
             .data_engine
             .try_borrow_mut()
             .map_err(|e| {
                 anyhow::anyhow!("Cannot borrow data engine to validate client {client_id}: {e}")
-            })?
-            .validate_client_registration(
-                client_id,
-                primary_venue,
-                routing.default,
-                &venue_routes,
-            )?;
+            })
+            .and_then(|data_engine| {
+                data_engine.validate_client_registration(
+                    client_id,
+                    primary_venue,
+                    routing.default,
+                    &venue_routes,
+                )
+            });
 
-        let mut guard = LateDataClientGuard::new(adapter);
+        if let Err(e) = validation_result {
+            return Err(cleanup_late_data_client(
+                guard,
+                self.config.timeout_disconnection,
+                client_id,
+                e,
+            )
+            .await);
+        }
+
         if let Err(e) = guard.adapter_mut().start() {
             return Err(cleanup_late_data_client(
                 guard,
@@ -373,15 +393,86 @@ impl LiveNode {
             .await);
         }
 
+        if let Some(runner) = self.runner.as_mut() {
+            runner.bind_senders();
+        }
         let connection_deadline = dst::time::Instant::now() + self.config.timeout_connection;
-        let remaining = connection_deadline.saturating_duration_since(dst::time::Instant::now());
-        let connect_result = dst::time::timeout(remaining, guard.adapter_mut().connect()).await;
-        let connect_result = match connect_result {
-            Ok(result) => result,
-            Err(_) => Err(anyhow::anyhow!("connection timeout")),
+        let registration_result = {
+            let phase = Cell::new(RegistrationPhase::Connection);
+            let registration = async {
+                guard.adapter_mut().connect().await?;
+                phase.set(RegistrationPhase::Readiness);
+                std::future::poll_fn(|_| {
+                    if guard.adapter_mut().is_connected() {
+                        Poll::Ready(())
+                    } else {
+                        Poll::Pending
+                    }
+                })
+                .await;
+                anyhow::Ok(())
+            };
+            tokio::pin!(registration);
+            let interval = Duration::from_millis(100);
+            let mut first_poll = true;
+            let result = loop {
+                if self.handle.should_stop() || self.kernel.is_shutdown_requested() {
+                    break Err(anyhow::anyhow!(
+                        "Shutdown requested during data client registration"
+                    ));
+                }
+
+                let now = dst::time::Instant::now();
+                let outcome = if !first_poll && now >= connection_deadline {
+                    RegistrationOutcome::TimedOut(phase.get())
+                } else {
+                    let tick = (now + interval).min(connection_deadline);
+
+                    if let Some(runner) = self.runner.as_mut() {
+                        tokio::select! {
+                            biased;
+                            result = &mut registration => RegistrationOutcome::Complete(result),
+                            () = dst::time::sleep_until(tick) => RegistrationOutcome::Tick,
+                            event = runner.recv() => match event {
+                                Some(event) => RegistrationOutcome::Event(Box::new(event)),
+                                None => RegistrationOutcome::RunnerClosed,
+                            },
+                        }
+                    } else {
+                        tokio::select! {
+                            biased;
+                            result = &mut registration => RegistrationOutcome::Complete(result),
+                            () = dst::time::sleep_until(tick) => RegistrationOutcome::Tick,
+                        }
+                    }
+                };
+                first_poll = false;
+
+                match outcome {
+                    RegistrationOutcome::Complete(result) => break result,
+                    RegistrationOutcome::RunnerClosed => {
+                        break Err(anyhow::anyhow!(
+                            "Runner closed during data client registration"
+                        ));
+                    }
+                    RegistrationOutcome::TimedOut(RegistrationPhase::Connection) => {
+                        break Err(anyhow::anyhow!("connection timeout"));
+                    }
+                    RegistrationOutcome::TimedOut(RegistrationPhase::Readiness) => {
+                        break Err(anyhow::anyhow!(
+                            "Data client {client_id} readiness timed out"
+                        ));
+                    }
+                    RegistrationOutcome::Tick => {}
+                    RegistrationOutcome::Event(event) => self.process_runner_event(*event),
+                }
+            };
+            // The staged future and its borrow of `guard` end with this block, which
+            // is what lets the cleanup and commit paths below take the guard.
+            result
         };
 
-        if let Err(e) = connect_result {
+        if let Err(e) = registration_result {
             return Err(cleanup_late_data_client(
                 guard,
                 self.config.timeout_disconnection,
@@ -389,21 +480,6 @@ impl LiveNode {
                 e.context(format!("Failed to connect data client {client_id}")),
             )
             .await);
-        }
-
-        while !guard.adapter_mut().is_connected() {
-            let now = dst::time::Instant::now();
-            if now >= connection_deadline {
-                let error = anyhow::anyhow!("Data client {client_id} readiness timed out");
-                return Err(cleanup_late_data_client(
-                    guard,
-                    self.config.timeout_disconnection,
-                    client_id,
-                    error,
-                )
-                .await);
-            }
-            dst::time::sleep(Duration::from_millis(100).min(connection_deadline - now)).await;
         }
 
         // One borrow spans revalidation and commit: no await separates them, so the
@@ -2964,17 +3040,23 @@ impl LateDataClientGuard {
     async fn cleanup(mut self, timeout: Duration) -> anyhow::Result<()> {
         // Empty when the commit consumed the adapter before erroring; the engine
         // then owns whatever state remains and there is nothing left to clean.
-        let Some(mut adapter) = self.adapter.take() else {
+        if self.adapter.is_none() {
             return Ok(());
-        };
+        }
 
         let mut errors = Vec::new();
 
-        match dst::time::timeout(timeout, adapter.disconnect()).await {
+        // The adapter stays in `self` across the disconnect await so that dropping
+        // this future mid-disconnect still runs stop/dispose through `Drop`; it is
+        // taken only once the synchronous half below has run, which is what keeps
+        // that half from running twice.
+        match dst::time::timeout(timeout, self.adapter_mut().disconnect()).await {
             Ok(Ok(())) => {}
             Ok(Err(e)) => errors.push(format!("disconnect failed: {e}")),
             Err(_) => errors.push("disconnect timed out".to_string()),
         }
+
+        let mut adapter = self.take();
 
         if let Err(e) = adapter.stop() {
             errors.push(format!("stop failed: {e}"));
@@ -3006,6 +3088,20 @@ impl Drop for LateDataClientGuard {
     }
 }
 
+#[derive(Clone, Copy)]
+enum RegistrationPhase {
+    Connection,
+    Readiness,
+}
+
+enum RegistrationOutcome {
+    Complete(anyhow::Result<()>),
+    RunnerClosed,
+    TimedOut(RegistrationPhase),
+    Tick,
+    Event(Box<PendingRunnerEvent>),
+}
+
 async fn cleanup_late_data_client(
     guard: LateDataClientGuard,
     timeout: Duration,
@@ -3014,9 +3110,9 @@ async fn cleanup_late_data_client(
 ) -> anyhow::Error {
     match guard.cleanup(timeout).await {
         Ok(()) => error,
-        Err(cleanup_error) => {
-            anyhow::anyhow!("{error}; failed to clean up data client {client_id}: {cleanup_error}")
-        }
+        Err(cleanup_error) => error.context(format!(
+            "Failed to clean up data client {client_id}: {cleanup_error}"
+        )),
     }
 }
 

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -87,6 +87,7 @@ use nautilus_common::{
     clients::ExecutionClient,
     component::Component,
     enums::{Environment, LogColor},
+    factories::{ClientConfig, DataClientFactory},
     live::dst,
     log_info,
     messages::{
@@ -102,10 +103,11 @@ use nautilus_core::{
     UUID4,
     datetime::{NANOSECONDS_IN_MILLISECOND, mins_to_secs, secs_to_nanos_unchecked},
 };
+use nautilus_data::client::DataClientAdapter;
 use nautilus_execution::engine::ExecutionEngine;
 use nautilus_model::{
     events::OrderEventAny,
-    identifiers::{ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId},
+    identifiers::{ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId, Venue},
     orders::Order,
     reports::{OrderStatusReport, PositionStatusReport},
 };
@@ -141,7 +143,7 @@ mod state;
 
 use builder::ExternalMessageBusIngress;
 pub use builder::LiveNodeBuilder;
-use config::{LiveNodeConfig, PluginConfig, validate_live_environment};
+use config::{LiveNodeConfig, PluginConfig, RoutingConfig, validate_live_environment};
 pub use metrics::{RunnerChannelMetricsSnapshot, RunnerMetricsDelta, RunnerMetricsSnapshot};
 use metrics::{RunnerChannelQueueDepths, RunnerMetrics};
 use queue::{QueueMonitor, QueueStateTransition};
@@ -169,6 +171,7 @@ pub struct LiveNode {
     exec_manager: ExecutionManager,
     exec_clients: Vec<LiveExecutionClient>,
     cache_database_factory: Option<Box<dyn CacheDatabaseFactory>>,
+    data_client_names: HashSet<String>,
     external_msgbus: Option<ExternalMessageBusIngress>,
     shutdown_deadline: Option<dst::time::Instant>,
     #[cfg(feature = "plugin")]
@@ -187,6 +190,7 @@ impl LiveNode {
         exec_manager: ExecutionManager,
         exec_clients: Vec<LiveExecutionClient>,
         cache_database_factory: Option<Box<dyn CacheDatabaseFactory>>,
+        data_client_names: HashSet<String>,
         external_msgbus: Option<ExternalMessageBusIngress>,
     ) -> Self {
         Self {
@@ -197,6 +201,7 @@ impl LiveNode {
             exec_manager,
             exec_clients,
             cache_database_factory,
+            data_client_names,
             external_msgbus,
             shutdown_deadline: None,
             #[cfg(feature = "plugin")]
@@ -270,6 +275,7 @@ impl LiveNode {
             exec_manager,
             exec_clients: Vec::new(),
             cache_database_factory: None,
+            data_client_names: HashSet::new(),
             external_msgbus: None,
             shutdown_deadline: None,
             #[cfg(feature = "plugin")]
@@ -280,6 +286,165 @@ impl LiveNode {
         log::info!("LiveNode built successfully with kernel config");
 
         Ok(node)
+    }
+
+    /// Adds, starts, and connects a data client to a running node.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the node is not running, event-store replay is active, the name or
+    /// routing conflicts with an existing client, or the client cannot start or connect.
+    pub async fn add_data_client(
+        &mut self,
+        name: Option<String>,
+        factory: Box<dyn DataClientFactory>,
+        config: Box<dyn ClientConfig>,
+    ) -> anyhow::Result<ClientId> {
+        self.add_data_client_with_routing(name, factory, config, RoutingConfig::default())
+            .await
+    }
+
+    /// Adds, starts, and connects a data client with explicit routing to a running node.
+    ///
+    /// Registration is committed only after the client is connected and ready.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the node is not running, event-store replay is active, the name or
+    /// routing conflicts with an existing client, or the client cannot start or connect.
+    pub async fn add_data_client_with_routing(
+        &mut self,
+        name: Option<String>,
+        factory: Box<dyn DataClientFactory>,
+        config: Box<dyn ClientConfig>,
+        routing: RoutingConfig,
+    ) -> anyhow::Result<ClientId> {
+        if !self.state().is_running() {
+            anyhow::bail!("LiveNode is not running");
+        }
+
+        if self.kernel.is_event_store_replay() {
+            anyhow::bail!("Cannot add a data client during event-store replay");
+        }
+
+        let name = name.unwrap_or_else(|| factory.name().to_string());
+        if self.data_client_names.contains(&name) {
+            anyhow::bail!("Data client '{name}' is already registered");
+        }
+
+        let client = factory.create(
+            &name,
+            config.as_ref(),
+            self.kernel.cache().into(),
+            self.kernel.clock(),
+        )?;
+        let client_id = client.client_id();
+        let primary_venue = client.venue();
+        let venue_routes = routing
+            .venues
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(Venue::new)
+            .collect::<Vec<_>>();
+        let adapter = DataClientAdapter::new(client_id, primary_venue, true, true, client);
+
+        self.kernel
+            .data_engine
+            .try_borrow_mut()
+            .map_err(|e| {
+                anyhow::anyhow!("Cannot borrow data engine to validate client {client_id}: {e}")
+            })?
+            .validate_client_registration(
+                client_id,
+                primary_venue,
+                routing.default,
+                &venue_routes,
+            )?;
+
+        let mut guard = LateDataClientGuard::new(adapter);
+        if let Err(e) = guard.adapter_mut().start() {
+            return Err(cleanup_late_data_client(
+                guard,
+                self.config.timeout_disconnection,
+                client_id,
+                e.context(format!("Failed to start data client {client_id}")),
+            )
+            .await);
+        }
+
+        let connection_deadline = dst::time::Instant::now() + self.config.timeout_connection;
+        let remaining = connection_deadline.saturating_duration_since(dst::time::Instant::now());
+        let connect_result = dst::time::timeout(remaining, guard.adapter_mut().connect()).await;
+        let connect_result = match connect_result {
+            Ok(result) => result,
+            Err(_) => Err(anyhow::anyhow!("connection timeout")),
+        };
+
+        if let Err(e) = connect_result {
+            return Err(cleanup_late_data_client(
+                guard,
+                self.config.timeout_disconnection,
+                client_id,
+                e.context(format!("Failed to connect data client {client_id}")),
+            )
+            .await);
+        }
+
+        while !guard.adapter_mut().is_connected() {
+            let now = dst::time::Instant::now();
+            if now >= connection_deadline {
+                let error = anyhow::anyhow!("Data client {client_id} readiness timed out");
+                return Err(cleanup_late_data_client(
+                    guard,
+                    self.config.timeout_disconnection,
+                    client_id,
+                    error,
+                )
+                .await);
+            }
+            dst::time::sleep(Duration::from_millis(100).min(connection_deadline - now)).await;
+        }
+
+        // One borrow spans revalidation and commit: no await separates them, so the
+        // validated state cannot change before the adapter is consumed.
+        let commit_result = self
+            .kernel
+            .data_engine
+            .try_borrow_mut()
+            .map_err(|e| {
+                anyhow::anyhow!("Cannot borrow data engine to register client {client_id}: {e}")
+            })
+            .and_then(|mut data_engine| {
+                data_engine.validate_client_registration(
+                    client_id,
+                    primary_venue,
+                    routing.default,
+                    &venue_routes,
+                )?;
+                data_engine.register_client_checked(
+                    guard.take(),
+                    primary_venue,
+                    routing.default,
+                    &venue_routes,
+                )
+            });
+
+        if let Err(e) = commit_result {
+            return Err(cleanup_late_data_client(
+                guard,
+                self.config.timeout_disconnection,
+                client_id,
+                e,
+            )
+            .await);
+        }
+        self.data_client_names.insert(name);
+
+        if let Some(runner) = self.runner.as_mut() {
+            runner.flush_pending_data();
+        }
+        Ok(client_id)
     }
 
     /// Loads and registers plug-ins declared on the node config.
@@ -2770,6 +2935,88 @@ impl LiveNode {
         drop(targeted_order_report_task.take());
         drop(position_report_task.take());
         self.cleanup_cancelled_report_tasks(&planned_client_order_ids);
+    }
+}
+
+struct LateDataClientGuard {
+    adapter: Option<DataClientAdapter>,
+}
+
+impl LateDataClientGuard {
+    fn new(adapter: DataClientAdapter) -> Self {
+        Self {
+            adapter: Some(adapter),
+        }
+    }
+
+    fn adapter_mut(&mut self) -> &mut DataClientAdapter {
+        self.adapter
+            .as_mut()
+            .expect("late data client guard should contain an adapter")
+    }
+
+    fn take(&mut self) -> DataClientAdapter {
+        self.adapter
+            .take()
+            .expect("late data client guard should contain an adapter")
+    }
+
+    async fn cleanup(mut self, timeout: Duration) -> anyhow::Result<()> {
+        // Empty when the commit consumed the adapter before erroring; the engine
+        // then owns whatever state remains and there is nothing left to clean.
+        let Some(mut adapter) = self.adapter.take() else {
+            return Ok(());
+        };
+
+        let mut errors = Vec::new();
+
+        match dst::time::timeout(timeout, adapter.disconnect()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => errors.push(format!("disconnect failed: {e}")),
+            Err(_) => errors.push("disconnect timed out".to_string()),
+        }
+
+        if let Err(e) = adapter.stop() {
+            errors.push(format!("stop failed: {e}"));
+        }
+
+        if let Err(e) = adapter.dispose() {
+            errors.push(format!("dispose failed: {e}"));
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(errors.join("; "))
+        }
+    }
+}
+
+impl Drop for LateDataClientGuard {
+    fn drop(&mut self) {
+        if let Some(adapter) = self.adapter.as_mut() {
+            if let Err(e) = adapter.stop() {
+                log::error!("Failed to stop uncommitted data client: {e}");
+            }
+
+            if let Err(e) = adapter.dispose() {
+                log::error!("Failed to dispose uncommitted data client: {e}");
+            }
+        }
+    }
+}
+
+async fn cleanup_late_data_client(
+    guard: LateDataClientGuard,
+    timeout: Duration,
+    client_id: ClientId,
+    error: anyhow::Error,
+) -> anyhow::Error {
+    match guard.cleanup(timeout).await {
+        Ok(()) => error,
+        Err(cleanup_error) => {
+            anyhow::anyhow!("{error}; failed to clean up data client {client_id}: {cleanup_error}")
+        }
     }
 }
 

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -374,23 +374,17 @@ impl LiveNode {
             });
 
         if let Err(e) = validation_result {
-            return Err(cleanup_late_data_client(
-                guard,
-                self.config.timeout_disconnection,
-                client_id,
-                e,
-            )
-            .await);
+            return Err(self.cleanup_late_data_client(guard, client_id, e).await);
         }
 
         if let Err(e) = guard.adapter_mut().start() {
-            return Err(cleanup_late_data_client(
-                guard,
-                self.config.timeout_disconnection,
-                client_id,
-                e.context(format!("Failed to start data client {client_id}")),
-            )
-            .await);
+            return Err(self
+                .cleanup_late_data_client(
+                    guard,
+                    client_id,
+                    e.context(format!("Failed to start data client {client_id}")),
+                )
+                .await);
         }
 
         if let Some(runner) = self.runner.as_mut() {
@@ -473,13 +467,13 @@ impl LiveNode {
         };
 
         if let Err(e) = registration_result {
-            return Err(cleanup_late_data_client(
-                guard,
-                self.config.timeout_disconnection,
-                client_id,
-                e.context(format!("Failed to connect data client {client_id}")),
-            )
-            .await);
+            return Err(self
+                .cleanup_late_data_client(
+                    guard,
+                    client_id,
+                    e.context(format!("Failed to connect data client {client_id}")),
+                )
+                .await);
         }
 
         // One borrow spans revalidation and commit: no await separates them, so the
@@ -507,13 +501,7 @@ impl LiveNode {
             });
 
         if let Err(e) = commit_result {
-            return Err(cleanup_late_data_client(
-                guard,
-                self.config.timeout_disconnection,
-                client_id,
-                e,
-            )
-            .await);
+            return Err(self.cleanup_late_data_client(guard, client_id, e).await);
         }
         self.data_client_names.insert(name);
 
@@ -3012,6 +3000,44 @@ impl LiveNode {
         drop(position_report_task.take());
         self.cleanup_cancelled_report_tasks(&planned_client_order_ids);
     }
+
+    async fn cleanup_late_data_client(
+        &mut self,
+        guard: LateDataClientGuard,
+        client_id: ClientId,
+        error: anyhow::Error,
+    ) -> anyhow::Error {
+        let cleanup = guard.cleanup(self.config.timeout_disconnection);
+        tokio::pin!(cleanup);
+
+        let result = loop {
+            let outcome = if let Some(runner) = self.runner.as_mut() {
+                tokio::select! {
+                    biased;
+                    result = &mut cleanup => CleanupOutcome::Complete(result),
+                    event = runner.recv() => match event {
+                        Some(event) => CleanupOutcome::Event(Box::new(event)),
+                        None => CleanupOutcome::RunnerClosed,
+                    },
+                }
+            } else {
+                break cleanup.await;
+            };
+
+            match outcome {
+                CleanupOutcome::Complete(result) => break result,
+                CleanupOutcome::Event(event) => self.process_runner_event(*event),
+                CleanupOutcome::RunnerClosed => break cleanup.await,
+            }
+        };
+
+        match result {
+            Ok(()) => error,
+            Err(cleanup_error) => error.context(format!(
+                "Failed to clean up data client {client_id}: {cleanup_error}"
+            )),
+        }
+    }
 }
 
 struct LateDataClientGuard {
@@ -3102,18 +3128,10 @@ enum RegistrationOutcome {
     Event(Box<PendingRunnerEvent>),
 }
 
-async fn cleanup_late_data_client(
-    guard: LateDataClientGuard,
-    timeout: Duration,
-    client_id: ClientId,
-    error: anyhow::Error,
-) -> anyhow::Error {
-    match guard.cleanup(timeout).await {
-        Ok(()) => error,
-        Err(cleanup_error) => error.context(format!(
-            "Failed to clean up data client {client_id}: {cleanup_error}"
-        )),
-    }
+enum CleanupOutcome {
+    Complete(anyhow::Result<()>),
+    RunnerClosed,
+    Event(Box<PendingRunnerEvent>),
 }
 
 fn record_runner_dispatch(

--- a/crates/live/tests/node.rs
+++ b/crates/live/tests/node.rs
@@ -329,6 +329,8 @@ mod serial_tests {
         disconnect_attempted: Arc<AtomicBool>,
         connect_entered: Arc<tokio::sync::Notify>,
         release_connect: Arc<tokio::sync::Notify>,
+        disconnect_entered: Arc<tokio::sync::Notify>,
+        release_disconnect: Arc<tokio::sync::Notify>,
     }
 
     #[derive(Clone, Copy, Debug)]
@@ -336,6 +338,7 @@ mod serial_tests {
         Connects,
         ConnectFailsCleanup,
         ConnectFailsDisconnectPending,
+        ConnectFailsDisconnectGated,
         ConnectGated,
         ConnectPending,
         ReadinessGated,
@@ -695,6 +698,9 @@ mod serial_tests {
                 LifecycleClientBehavior::ConnectFailsDisconnectPending => {
                     anyhow::bail!("simulated data client connect failure before pending disconnect")
                 }
+                LifecycleClientBehavior::ConnectFailsDisconnectGated => {
+                    anyhow::bail!("simulated data client connect failure before gated disconnect")
+                }
                 LifecycleClientBehavior::ConnectGated => {
                     self.state.connect_entered.notify_one();
                     self.state.release_connect.notified().await;
@@ -729,6 +735,15 @@ mod serial_tests {
 
             if matches!(self.behavior, LifecycleClientBehavior::ConnectFailsCleanup) {
                 anyhow::bail!("simulated late data client cleanup failure");
+            }
+
+            if matches!(
+                self.behavior,
+                LifecycleClientBehavior::ConnectFailsDisconnectGated
+            ) {
+                self.state.disconnect_entered.notify_one();
+                self.state.release_disconnect.notified().await;
+                return Ok(());
             }
 
             if matches!(
@@ -908,7 +923,8 @@ mod serial_tests {
 
             match self.behavior {
                 LifecycleClientBehavior::ConnectFailsCleanup
-                | LifecycleClientBehavior::ConnectFailsDisconnectPending => {
+                | LifecycleClientBehavior::ConnectFailsDisconnectPending
+                | LifecycleClientBehavior::ConnectFailsDisconnectGated => {
                     anyhow::bail!("simulated execution client connect failure")
                 }
                 LifecycleClientBehavior::ConnectGated | LifecycleClientBehavior::ReadinessGated => {
@@ -1676,6 +1692,120 @@ mod serial_tests {
             LifecycleClientBehavior::ReadinessGated,
         )
         .await;
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_services_runner_while_cleanup_is_blocked() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            // Both durations here are watchdogs, not part of the assertion: the
+            // barriers below sequence the test. They are set far apart so a
+            // loaded host cannot let cleanup expire before the producer runs.
+            timeout_disconnection: Duration::from_secs(30),
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("LateDataClientCleanupTrafficNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+
+        let instrument_id = crypto_perpetual_ethusdt().id();
+        let strategy_id = StrategyId::from("LATE-CLEANUP-001");
+        let account_id = AccountId::from("LATE-CLEANUP-001");
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .strategy_id(strategy_id)
+            .instrument_id(instrument_id)
+            .quantity(Quantity::from("1.0"))
+            .price(Price::from("100.0"))
+            .build();
+        let client_order_id = order.client_order_id();
+        let submitted = TestOrderEventStubs::submitted(&order, account_id);
+        node.kernel()
+            .cache
+            .borrow_mut()
+            .add_order(order, None, None, false)
+            .unwrap();
+
+        let exec_engine = node.kernel().exec_engine.clone();
+        let pre_event_count = exec_engine.borrow().event_count();
+        let pre_command_count = exec_engine.borrow().command_count();
+        let state = LifecycleClientState::default();
+        let producer_state = state.clone();
+        let registration_returned = Arc::new(AtomicBool::new(false));
+        let producer_registration_returned = registration_returned.clone();
+        let time_acknowledged = Arc::new(AtomicBool::new(false));
+        let producer_time_acknowledged = time_acknowledged.clone();
+
+        let registration = async {
+            let result = node
+                .add_data_client(
+                    Some("cleanup-traffic-gated".to_string()),
+                    Box::new(LifecycleDataClientFactory::new(
+                        state.clone(),
+                        LifecycleClientBehavior::ConnectFailsDisconnectGated,
+                    )),
+                    Box::new(LifecycleDataClientConfig),
+                )
+                .await;
+            registration_returned.store(true, Ordering::Relaxed);
+            (result, state)
+        };
+        let producer = async move {
+            producer_state.disconnect_entered.notified().await;
+            let time_ack = producer_time_acknowledged.clone();
+            get_time_event_sender().send(TimeEventMessage::new(
+                TimeEvent::new(
+                    "late-cleanup".into(),
+                    UUID4::new(),
+                    UnixNanos::default(),
+                    UnixNanos::default(),
+                ),
+                TimeEventCallback::from(move |_: TimeEvent| {
+                    time_ack.store(true, Ordering::Relaxed);
+                }),
+            ));
+            get_exec_event_sender()
+                .send(ExecutionEvent::Order(submitted))
+                .unwrap();
+            get_trading_cmd_sender().execute(TradingCommandMessage::new(
+                MessagingSwitchboard::exec_engine_execute(),
+                TradingCommand::QueryOrder(QueryOrder::new(
+                    TraderId::from("TESTER-001"),
+                    None,
+                    strategy_id,
+                    instrument_id,
+                    client_order_id,
+                    None,
+                    UUID4::new(),
+                    UnixNanos::default(),
+                    None,
+                    None,
+                )),
+            ));
+
+            wait_until_async(
+                || async {
+                    producer_time_acknowledged.load(Ordering::Relaxed)
+                        && exec_engine.borrow().event_count() > pre_event_count
+                        && exec_engine.borrow().command_count() > pre_command_count
+                },
+                Duration::from_secs(5),
+            )
+            .await;
+            assert!(!producer_registration_returned.load(Ordering::Relaxed));
+            producer_state.release_disconnect.notify_one();
+        };
+
+        let ((result, state), ()) = tokio::join!(registration, producer);
+        let error = result.expect_err("connect should fail");
+        assert!(error.to_string().contains("Failed to connect data client"));
+        assert!(state.stopped.load(Ordering::Relaxed));
+        assert!(state.disposed.load(Ordering::Relaxed));
+        node.stop().await.unwrap();
     }
 
     #[rstest]

--- a/crates/live/tests/node.rs
+++ b/crates/live/tests/node.rs
@@ -38,18 +38,25 @@ use nautilus_common::{
     component::Component,
     enums::Environment,
     factories::{ClientConfig, DataClientFactory, ExecutionClientFactory},
-    live::{dst, runner::get_data_event_sender},
+    live::{
+        dst,
+        runner::{get_data_event_sender, get_exec_event_sender},
+    },
     messages::{
-        DataEvent,
+        DataEvent, ExecutionEvent,
         execution::{
             CancelAllOrders, GenerateOrderStatusReport, GenerateOrderStatusReports,
-            GeneratePositionStatusReports, QueryOrder,
+            GeneratePositionStatusReports, QueryOrder, TradingCommand,
         },
         system::{QueueStateChanged, ShutdownSystem},
     },
     msgbus::{self, MessagingSwitchboard, ShareableMessageHandler, switchboard},
     nautilus_actor,
+    runner::{
+        TimeEventMessage, TradingCommandMessage, get_time_event_sender, get_trading_cmd_sender,
+    },
     testing::{wait_until, wait_until_async},
+    timer::{TimeEvent, TimeEventCallback},
 };
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_live::{
@@ -320,12 +327,18 @@ mod serial_tests {
         connected: Arc<AtomicBool>,
         connect_attempted: Arc<AtomicBool>,
         disconnect_attempted: Arc<AtomicBool>,
+        connect_entered: Arc<tokio::sync::Notify>,
+        release_connect: Arc<tokio::sync::Notify>,
     }
 
     #[derive(Clone, Copy, Debug)]
     enum LifecycleClientBehavior {
         Connects,
+        ConnectFailsCleanup,
+        ConnectFailsDisconnectPending,
+        ConnectGated,
         ConnectPending,
+        ReadinessGated,
         ReadinessPending,
         ConnectDelayedReadinessPending,
         DisconnectPending,
@@ -676,8 +689,24 @@ mod serial_tests {
             }
 
             match self.behavior {
+                LifecycleClientBehavior::ConnectFailsCleanup => {
+                    anyhow::bail!("simulated data client connect failure")
+                }
+                LifecycleClientBehavior::ConnectFailsDisconnectPending => {
+                    anyhow::bail!("simulated data client connect failure before pending disconnect")
+                }
+                LifecycleClientBehavior::ConnectGated => {
+                    self.state.connect_entered.notify_one();
+                    self.state.release_connect.notified().await;
+                    self.state.connected.store(true, Ordering::Relaxed);
+                    Ok(())
+                }
                 LifecycleClientBehavior::ConnectPending => {
                     std::future::pending::<anyhow::Result<()>>().await
+                }
+                LifecycleClientBehavior::ReadinessGated => {
+                    self.state.connect_entered.notify_one();
+                    Ok(())
                 }
                 LifecycleClientBehavior::ReadinessPending => Ok(()),
                 LifecycleClientBehavior::ConnectDelayedReadinessPending => {
@@ -698,7 +727,15 @@ mod serial_tests {
                 .disconnect_attempted
                 .store(true, Ordering::Relaxed);
 
-            if matches!(self.behavior, LifecycleClientBehavior::DisconnectPending) {
+            if matches!(self.behavior, LifecycleClientBehavior::ConnectFailsCleanup) {
+                anyhow::bail!("simulated late data client cleanup failure");
+            }
+
+            if matches!(
+                self.behavior,
+                LifecycleClientBehavior::DisconnectPending
+                    | LifecycleClientBehavior::ConnectFailsDisconnectPending
+            ) {
                 return std::future::pending::<anyhow::Result<()>>().await;
             }
 
@@ -870,6 +907,14 @@ mod serial_tests {
             self.state.connect_attempted.store(true, Ordering::Relaxed);
 
             match self.behavior {
+                LifecycleClientBehavior::ConnectFailsCleanup
+                | LifecycleClientBehavior::ConnectFailsDisconnectPending => {
+                    anyhow::bail!("simulated execution client connect failure")
+                }
+                LifecycleClientBehavior::ConnectGated | LifecycleClientBehavior::ReadinessGated => {
+                    self.state.connected.store(true, Ordering::Relaxed);
+                    Ok(())
+                }
                 LifecycleClientBehavior::ConnectPending => {
                     std::future::pending::<anyhow::Result<()>>().await
                 }
@@ -1502,6 +1547,137 @@ mod serial_tests {
         assert!(!state.connected.load(Ordering::Relaxed));
     }
 
+    async fn assert_late_data_client_registration_services_runner(
+        behavior: LifecycleClientBehavior,
+    ) {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::from_secs(2),
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("LateDataClientTrafficNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+
+        let instrument_id = crypto_perpetual_ethusdt().id();
+        let strategy_id = StrategyId::from("LATE-TRAFFIC-001");
+        let account_id = AccountId::from("LATE-TRAFFIC-001");
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .strategy_id(strategy_id)
+            .instrument_id(instrument_id)
+            .quantity(Quantity::from("1.0"))
+            .price(Price::from("100.0"))
+            .build();
+        let client_order_id = order.client_order_id();
+        let submitted = TestOrderEventStubs::submitted(&order, account_id);
+        node.kernel()
+            .cache
+            .borrow_mut()
+            .add_order(order, None, None, false)
+            .unwrap();
+
+        let exec_engine = node.kernel().exec_engine.clone();
+        let pre_event_count = exec_engine.borrow().event_count();
+        let pre_command_count = exec_engine.borrow().command_count();
+        let state = LifecycleClientState::default();
+        let producer_state = state.clone();
+        let registration_returned = Arc::new(AtomicBool::new(false));
+        let producer_registration_returned = registration_returned.clone();
+        let time_acknowledged = Arc::new(AtomicBool::new(false));
+        let producer_time_acknowledged = time_acknowledged.clone();
+
+        let registration = async {
+            let result = node
+                .add_data_client(
+                    Some("traffic-gated".to_string()),
+                    Box::new(LifecycleDataClientFactory::new(state, behavior)),
+                    Box::new(LifecycleDataClientConfig),
+                )
+                .await;
+            registration_returned.store(true, Ordering::Relaxed);
+            result
+        };
+        let producer = async move {
+            producer_state.connect_entered.notified().await;
+            let time_ack = producer_time_acknowledged.clone();
+            get_time_event_sender().send(TimeEventMessage::new(
+                TimeEvent::new(
+                    "late-registration".into(),
+                    UUID4::new(),
+                    UnixNanos::default(),
+                    UnixNanos::default(),
+                ),
+                TimeEventCallback::from(move |_: TimeEvent| {
+                    time_ack.store(true, Ordering::Relaxed);
+                }),
+            ));
+            get_exec_event_sender()
+                .send(ExecutionEvent::Order(submitted))
+                .unwrap();
+            get_trading_cmd_sender().execute(TradingCommandMessage::new(
+                MessagingSwitchboard::exec_engine_execute(),
+                TradingCommand::QueryOrder(QueryOrder::new(
+                    TraderId::from("TESTER-001"),
+                    None,
+                    strategy_id,
+                    instrument_id,
+                    client_order_id,
+                    None,
+                    UUID4::new(),
+                    UnixNanos::default(),
+                    None,
+                    None,
+                )),
+            ));
+
+            wait_until_async(
+                || async {
+                    producer_time_acknowledged.load(Ordering::Relaxed)
+                        && exec_engine.borrow().event_count() > pre_event_count
+                        && exec_engine.borrow().command_count() > pre_command_count
+                },
+                Duration::from_secs(1),
+            )
+            .await;
+            assert!(!producer_registration_returned.load(Ordering::Relaxed));
+
+            match behavior {
+                LifecycleClientBehavior::ConnectGated => {
+                    producer_state.release_connect.notify_one();
+                }
+                LifecycleClientBehavior::ReadinessGated => {
+                    producer_state.connected.store(true, Ordering::Relaxed);
+                }
+                _ => unreachable!("traffic test requires a gated behavior"),
+            }
+        };
+
+        let (registered, ()) = tokio::join!(registration, producer);
+        registered.unwrap();
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_services_runner_while_connect_is_blocked() {
+        assert_late_data_client_registration_services_runner(LifecycleClientBehavior::ConnectGated)
+            .await;
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_services_runner_during_readiness_wait() {
+        assert_late_data_client_registration_services_runner(
+            LifecycleClientBehavior::ReadinessGated,
+        )
+        .await;
+    }
+
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_add_data_client_rejects_build_time_name_collision_before_factory() {
@@ -1651,7 +1827,360 @@ mod serial_tests {
         assert!(late_state.factory_created.load(Ordering::Relaxed));
         assert!(!late_state.started.load(Ordering::Relaxed));
         assert!(!late_state.connect_attempted.load(Ordering::Relaxed));
+        assert!(late_state.stopped.load(Ordering::Relaxed));
+        assert!(late_state.disposed.load(Ordering::Relaxed));
         node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_duplicate_id_disposes_created_client() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let client_id = ClientId::from("DUPLICATE-LATE-ID");
+        let mut node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name("LateDataClientDuplicateIdNode")
+            .add_data_client(
+                Some("existing-id-owner".to_string()),
+                Box::new(
+                    LifecycleDataClientFactory::new(
+                        LifecycleClientState::default(),
+                        LifecycleClientBehavior::Connects,
+                    )
+                    .with_client(client_id, None),
+                ),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        node.start().await.unwrap();
+        let late_state = LifecycleClientState::default();
+
+        let error = node
+            .add_data_client(
+                Some("duplicate-id-contender".to_string()),
+                Box::new(
+                    LifecycleDataClientFactory::new(
+                        late_state.clone(),
+                        LifecycleClientBehavior::Connects,
+                    )
+                    .with_client(client_id, None),
+                ),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .await
+            .expect_err("duplicate client ID should be rejected");
+
+        assert!(error.to_string().contains("already registered"));
+        assert!(late_state.stopped.load(Ordering::Relaxed));
+        assert!(late_state.disposed.load(Ordering::Relaxed));
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_default_conflict_disposes_created_client() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name("LateDataClientDefaultConflictNode")
+            .add_data_client_with_routing(
+                Some("default-owner".to_string()),
+                Box::new(LifecycleDataClientFactory::new(
+                    LifecycleClientState::default(),
+                    LifecycleClientBehavior::Connects,
+                )),
+                Box::new(LifecycleDataClientConfig),
+                RoutingConfig {
+                    default: true,
+                    venues: None,
+                },
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        node.start().await.unwrap();
+        let late_state = LifecycleClientState::default();
+
+        let error = node
+            .add_data_client_with_routing(
+                Some("default-contender".to_string()),
+                Box::new(LifecycleDataClientFactory::new(
+                    late_state.clone(),
+                    LifecycleClientBehavior::Connects,
+                )),
+                Box::new(LifecycleDataClientConfig),
+                RoutingConfig {
+                    default: true,
+                    venues: None,
+                },
+            )
+            .await
+            .expect_err("second default client should be rejected");
+
+        assert!(!error.to_string().is_empty());
+        assert!(late_state.stopped.load(Ordering::Relaxed));
+        assert!(late_state.disposed.load(Ordering::Relaxed));
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(
+        clippy::await_holding_refcell_ref,
+        reason = "the held borrow is the condition under test"
+    )]
+    async fn test_add_data_client_held_engine_borrow_disposes_created_client() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("LateDataClientBorrowConflictNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+        let late_state = LifecycleClientState::default();
+        let data_engine = node.kernel().data_engine.clone();
+        let held_borrow = data_engine.borrow_mut();
+
+        let error = node
+            .add_data_client(
+                Some("borrow-contender".to_string()),
+                Box::new(LifecycleDataClientFactory::new(
+                    late_state.clone(),
+                    LifecycleClientBehavior::Connects,
+                )),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .await
+            .expect_err("held data engine borrow should reject registration");
+
+        assert!(error.to_string().contains("Cannot borrow data engine"));
+        assert!(late_state.stopped.load(Ordering::Relaxed));
+        assert!(late_state.disposed.load(Ordering::Relaxed));
+        drop(held_borrow);
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_rejects_malformed_route_before_factory() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            ..Default::default()
+        };
+        let mut node = LiveNode::build("MalformedLateRouteNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+        let state = LifecycleClientState::default();
+
+        let error = node
+            .add_data_client_with_routing(
+                Some("malformed-route".to_string()),
+                Box::new(LifecycleDataClientFactory::new(
+                    state.clone(),
+                    LifecycleClientBehavior::Connects,
+                )),
+                Box::new(LifecycleDataClientConfig),
+                RoutingConfig {
+                    default: false,
+                    venues: Some(vec![String::new()]),
+                },
+            )
+            .await
+            .expect_err("empty venue route should return an error");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid data client venue route ''")
+        );
+        assert!(!state.factory_created.load(Ordering::Relaxed));
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_cleanup_preserves_connect_error_source() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node = LiveNode::build("LateCleanupChainNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+        let state = LifecycleClientState::default();
+
+        let error = node
+            .add_data_client(
+                Some("failing-cleanup".to_string()),
+                Box::new(LifecycleDataClientFactory::new(
+                    state,
+                    LifecycleClientBehavior::ConnectFailsCleanup,
+                )),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .await
+            .expect_err("connect and cleanup should fail");
+
+        assert!(
+            error
+                .chain()
+                .any(|cause| cause.to_string() == "simulated data client connect failure")
+        );
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_cancelled_during_cleanup_still_disposes() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            // Longer than the drop deadline below, so the disconnect is still
+            // pending when the registration future is cancelled.
+            timeout_disconnection: Duration::from_secs(30),
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("LateCancelDuringCleanupNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+        let state = LifecycleClientState::default();
+
+        let registration = node.add_data_client(
+            Some("cancelled-cleanup".to_string()),
+            Box::new(LifecycleDataClientFactory::new(
+                state.clone(),
+                LifecycleClientBehavior::ConnectFailsDisconnectPending,
+            )),
+            Box::new(LifecycleDataClientConfig),
+        );
+        // Elapsing drops the registration future while cleanup awaits disconnect.
+        dst::time::timeout(Duration::from_millis(200), registration)
+            .await
+            .expect_err("registration should still be inside a pending disconnect");
+
+        assert!(state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(state.stopped.load(Ordering::Relaxed));
+        assert!(state.disposed.load(Ordering::Relaxed));
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_shutdown_interrupts_blocked_connect() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::from_secs(5),
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("LateConnectShutdownNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+        let handle = node.handle();
+        let state = LifecycleClientState::default();
+        let stop_state = state.clone();
+        let stop = async move {
+            wait_until_async(
+                || async { stop_state.connect_attempted.load(Ordering::Relaxed) },
+                Duration::from_secs(1),
+            )
+            .await;
+            handle.stop();
+        };
+        let register = node.add_data_client(
+            Some("blocked-connect".to_string()),
+            Box::new(LifecycleDataClientFactory::new(
+                state.clone(),
+                LifecycleClientBehavior::ConnectPending,
+            )),
+            Box::new(LifecycleDataClientConfig),
+        );
+        let (error, ()) = tokio::join!(register, stop);
+        let error = error.expect_err("shutdown should interrupt blocked connect");
+
+        assert!(format!("{error:#}").contains("Shutdown requested"));
+        assert!(state.stopped.load(Ordering::Relaxed));
+        assert!(state.disposed.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_shutdown_interrupts_readiness_wait() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::from_secs(5),
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("LateReadinessShutdownNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+        let handle = node.handle();
+        let state = LifecycleClientState::default();
+        let stop_state = state.clone();
+        let stop = async move {
+            wait_until_async(
+                || async { stop_state.connect_attempted.load(Ordering::Relaxed) },
+                Duration::from_secs(1),
+            )
+            .await;
+            handle.stop();
+        };
+        let register = node.add_data_client(
+            Some("readiness-pending".to_string()),
+            Box::new(LifecycleDataClientFactory::new(
+                state.clone(),
+                LifecycleClientBehavior::ReadinessPending,
+            )),
+            Box::new(LifecycleDataClientConfig),
+        );
+        let (error, ()) = tokio::join!(register, stop);
+        let error = error.expect_err("shutdown should interrupt readiness wait");
+
+        assert!(format!("{error:#}").contains("Shutdown requested"));
+        assert!(state.stopped.load(Ordering::Relaxed));
+        assert!(state.disposed.load(Ordering::Relaxed));
     }
 
     #[rstest]

--- a/crates/live/tests/node.rs
+++ b/crates/live/tests/node.rs
@@ -38,8 +38,9 @@ use nautilus_common::{
     component::Component,
     enums::Environment,
     factories::{ClientConfig, DataClientFactory, ExecutionClientFactory},
-    live::dst,
+    live::{dst, runner::get_data_event_sender},
     messages::{
+        DataEvent,
         execution::{
             CancelAllOrders, GenerateOrderStatusReport, GenerateOrderStatusReports,
             GeneratePositionStatusReports, QueryOrder,
@@ -53,7 +54,7 @@ use nautilus_common::{
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_live::{
     builder::LiveNodeBuilder,
-    config::{LiveExecEngineConfig, LiveNodeConfig},
+    config::{LiveExecEngineConfig, LiveNodeConfig, RoutingConfig},
     node::{LiveNode, LiveNodeHandle, NodeState},
 };
 use nautilus_model::{
@@ -312,6 +313,10 @@ mod serial_tests {
 
     #[derive(Clone, Debug, Default)]
     struct LifecycleClientState {
+        factory_created: Arc<AtomicBool>,
+        started: Arc<AtomicBool>,
+        stopped: Arc<AtomicBool>,
+        disposed: Arc<AtomicBool>,
         connected: Arc<AtomicBool>,
         connect_attempted: Arc<AtomicBool>,
         disconnect_attempted: Arc<AtomicBool>,
@@ -346,6 +351,10 @@ mod serial_tests {
     struct LifecycleDataClient {
         state: LifecycleClientState,
         behavior: LifecycleClientBehavior,
+        client_id: ClientId,
+        venue: Option<Venue>,
+        connect_instrument: Option<InstrumentAny>,
+        hostile_connect: bool,
     }
 
     struct LifecycleExecutionClient {
@@ -420,6 +429,10 @@ mod serial_tests {
     struct LifecycleDataClientFactory {
         state: LifecycleClientState,
         behavior: LifecycleClientBehavior,
+        client_id: ClientId,
+        venue: Option<Venue>,
+        connect_instrument: Option<InstrumentAny>,
+        hostile_connect: bool,
     }
 
     #[derive(Debug)]
@@ -442,7 +455,30 @@ mod serial_tests {
 
     impl LifecycleDataClientFactory {
         fn new(state: LifecycleClientState, behavior: LifecycleClientBehavior) -> Self {
-            Self { state, behavior }
+            Self {
+                state,
+                behavior,
+                client_id: ClientId::from("LIFECYCLE-DATA"),
+                venue: None,
+                connect_instrument: None,
+                hostile_connect: false,
+            }
+        }
+
+        fn with_client(mut self, client_id: ClientId, venue: Option<Venue>) -> Self {
+            self.client_id = client_id;
+            self.venue = venue;
+            self
+        }
+
+        fn with_connect_instrument(mut self, instrument: InstrumentAny) -> Self {
+            self.connect_instrument = Some(instrument);
+            self
+        }
+
+        fn with_hostile_connect(mut self) -> Self {
+            self.hostile_connect = true;
+            self
         }
     }
 
@@ -504,9 +540,14 @@ mod serial_tests {
             _cache: CacheView,
             _clock: Rc<RefCell<dyn Clock>>,
         ) -> anyhow::Result<Box<dyn DataClient>> {
+            self.state.factory_created.store(true, Ordering::Relaxed);
             Ok(Box::new(LifecycleDataClient {
                 state: self.state.clone(),
                 behavior: self.behavior,
+                client_id: self.client_id,
+                venue: self.venue,
+                connect_instrument: self.connect_instrument.clone(),
+                hostile_connect: self.hostile_connect,
             }))
         }
 
@@ -586,18 +627,20 @@ mod serial_tests {
     #[async_trait(?Send)]
     impl DataClient for LifecycleDataClient {
         fn client_id(&self) -> ClientId {
-            ClientId::from("LIFECYCLE-DATA")
+            self.client_id
         }
 
         fn venue(&self) -> Option<Venue> {
-            None
+            self.venue
         }
 
         fn start(&mut self) -> anyhow::Result<()> {
+            self.state.started.store(true, Ordering::Relaxed);
             Ok(())
         }
 
         fn stop(&mut self) -> anyhow::Result<()> {
+            self.state.stopped.store(true, Ordering::Relaxed);
             Ok(())
         }
 
@@ -606,6 +649,7 @@ mod serial_tests {
         }
 
         fn dispose(&mut self) -> anyhow::Result<()> {
+            self.state.disposed.store(true, Ordering::Relaxed);
             Ok(())
         }
 
@@ -619,6 +663,17 @@ mod serial_tests {
 
         async fn connect(&mut self) -> anyhow::Result<()> {
             self.state.connect_attempted.store(true, Ordering::Relaxed);
+
+            if self.hostile_connect {
+                let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+                msgbus::send_any(MessagingSwitchboard::data_engine_process(), &instrument);
+            }
+
+            if let Some(instrument) = self.connect_instrument.clone() {
+                get_data_event_sender()
+                    .send(DataEvent::Instrument(instrument))
+                    .map_err(|e| anyhow::anyhow!("failed to emit connect instrument: {e}"))?;
+            }
 
             match self.behavior {
                 LifecycleClientBehavior::ConnectPending => {
@@ -1377,6 +1432,264 @@ mod serial_tests {
         let node = LiveNode::build("TestNode".to_string(), Some(config)).unwrap();
 
         assert_eq!(node.state(), NodeState::Idle);
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_after_start_registers_connects_routes_and_flushes() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::from_millis(50),
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node = LiveNode::build("LateDataClientNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+
+        let state = LifecycleClientState::default();
+        let client_id = ClientId::from("LATE-DATA");
+        let venue = Venue::from("LATE-ROUTE");
+        let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        let instrument_id = instrument.id();
+        let factory =
+            LifecycleDataClientFactory::new(state.clone(), LifecycleClientBehavior::Connects)
+                .with_client(client_id, None)
+                .with_connect_instrument(instrument);
+        let routing = RoutingConfig {
+            venues: Some(vec![venue.to_string()]),
+            ..Default::default()
+        };
+
+        let registered_id = node
+            .add_data_client_with_routing(
+                Some("late-data".to_string()),
+                Box::new(factory),
+                Box::new(LifecycleDataClientConfig),
+                routing,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(registered_id, client_id);
+        assert!(state.factory_created.load(Ordering::Relaxed));
+        assert!(state.started.load(Ordering::Relaxed));
+        assert!(state.connect_attempted.load(Ordering::Relaxed));
+        assert!(state.connected.load(Ordering::Relaxed));
+        assert!(
+            node.kernel()
+                .cache
+                .borrow()
+                .instrument(&instrument_id)
+                .is_some()
+        );
+        assert_eq!(
+            node.kernel()
+                .data_engine
+                .borrow_mut()
+                .get_client(None, Some(&venue))
+                .map(|client| client.client_id()),
+            Some(client_id)
+        );
+
+        node.stop().await.unwrap();
+
+        assert!(state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(state.stopped.load(Ordering::Relaxed));
+        assert!(!state.connected.load(Ordering::Relaxed));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_rejects_build_time_name_collision_before_factory() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::from_millis(50),
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let build_state = LifecycleClientState::default();
+        let mut node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name("LateDataClientNameCollisionNode")
+            .add_data_client(
+                Some("existing-data".to_string()),
+                Box::new(LifecycleDataClientFactory::new(
+                    build_state,
+                    LifecycleClientBehavior::Connects,
+                )),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        node.start().await.unwrap();
+
+        let late_state = LifecycleClientState::default();
+        let error = node
+            .add_data_client(
+                Some("existing-data".to_string()),
+                Box::new(LifecycleDataClientFactory::new(
+                    late_state.clone(),
+                    LifecycleClientBehavior::Connects,
+                )),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .await
+            .expect_err("duplicate build-time name should be rejected");
+
+        assert_eq!(
+            error.to_string(),
+            "Data client 'existing-data' is already registered"
+        );
+        assert!(!late_state.factory_created.load(Ordering::Relaxed));
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_connect_timeout_does_not_register_client() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::ZERO,
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("LateDataClientTimeoutNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+
+        let state = LifecycleClientState::default();
+        let client_id = ClientId::from("LATE-PENDING");
+        let factory =
+            LifecycleDataClientFactory::new(state.clone(), LifecycleClientBehavior::ConnectPending)
+                .with_client(client_id, None);
+        let error = node
+            .add_data_client(
+                Some("late-pending".to_string()),
+                Box::new(factory),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .await
+            .expect_err("pending connect should time out");
+
+        assert!(format!("{error:#}").contains("connection timeout"));
+        assert!(state.connect_attempted.load(Ordering::Relaxed));
+        assert!(state.disconnect_attempted.load(Ordering::Relaxed));
+        assert!(state.stopped.load(Ordering::Relaxed));
+        assert!(state.disposed.load(Ordering::Relaxed));
+        assert!(
+            node.kernel()
+                .data_engine()
+                .get_clients()
+                .iter()
+                .all(|client| client.client_id() != client_id)
+        );
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_route_conflict_precedes_start_and_connect() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::from_millis(50),
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let venue = Venue::from("CONFLICT");
+        let build_state = LifecycleClientState::default();
+        let build_factory =
+            LifecycleDataClientFactory::new(build_state, LifecycleClientBehavior::Connects)
+                .with_client(ClientId::from("ROUTE-OWNER"), Some(venue));
+        let mut node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name("LateDataClientRouteConflictNode")
+            .add_data_client(
+                Some("route-owner".to_string()),
+                Box::new(build_factory),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        node.start().await.unwrap();
+
+        let late_state = LifecycleClientState::default();
+        let late_factory =
+            LifecycleDataClientFactory::new(late_state.clone(), LifecycleClientBehavior::Connects)
+                .with_client(ClientId::from("ROUTE-CONTENDER"), None);
+        let error = node
+            .add_data_client_with_routing(
+                Some("route-contender".to_string()),
+                Box::new(late_factory),
+                Box::new(LifecycleDataClientConfig),
+                RoutingConfig {
+                    default: false,
+                    venues: Some(vec![venue.to_string()]),
+                },
+            )
+            .await
+            .expect_err("explicit route to another client's venue should be rejected");
+
+        assert!(error.to_string().contains("already routed"));
+        assert!(late_state.factory_created.load(Ordering::Relaxed));
+        assert!(!late_state.started.load(Ordering::Relaxed));
+        assert!(!late_state.connect_attempted.load(Ordering::Relaxed));
+        node.stop().await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_add_data_client_connect_can_reenter_data_engine_endpoint() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_connection: Duration::from_millis(50),
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("LateDataClientHostileConnectNode".to_string(), Some(config)).unwrap();
+        node.start().await.unwrap();
+
+        let state = LifecycleClientState::default();
+        let client_id = ClientId::from("HOSTILE-CONNECT");
+        let factory =
+            LifecycleDataClientFactory::new(state.clone(), LifecycleClientBehavior::Connects)
+                .with_client(client_id, None)
+                .with_hostile_connect();
+
+        let registered_id = node
+            .add_data_client(
+                Some("hostile-connect".to_string()),
+                Box::new(factory),
+                Box::new(LifecycleDataClientConfig),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(registered_id, client_id);
+        assert!(state.connected.load(Ordering::Relaxed));
+        node.stop().await.unwrap();
     }
 
     #[rstest]


### PR DESCRIPTION
Data clients could only be registered on `LiveNodeBuilder` before `build()`; a running node had no path to bring up a new venue's data client and had to be rebuilt.

## Add post-start data-client registration to LiveNode

`LiveNode::add_data_client` / `add_data_client_with_routing` create the client from its factory, start and connect it under the node's `timeout_connection` with no engine borrow held across the awaits, and only then commit registration - a client that fails to start or connect leaves no engine registration, route, or name behind (a drop guard stops and disposes it, with best-effort disconnect under `timeout_disconnection`). Holding no borrow across `connect()` matters because a `DataClient::connect` may synchronously reach a message-bus endpoint whose `DataEngine` handler borrows the engine. Committed clients participate in normal shutdown, and name collisions are refused with the builder's error.

## Checked atomic registration in DataEngine

`register_client` panics on duplicate IDs, and venue routing could fail after insertion. `register_client_checked` validates the client ID, default selection, and every explicit route first, then commits infallibly; the builder now registers through it so build-time and post-start semantics cannot diverge. A primary venue keeps `register_client`'s overwrite semantics and explicit routes conflict only when routed to a different client, so existing builder configurations are unaffected.

## Testing

Current-thread lifecycle tests cover the happy path (factory/start/connect ordering, venue routing reachable via `get_client`, a connect-emitted instrument cached before the call returns, disconnect and stop on node shutdown), a name collision with a build-time client that never invokes the second factory, a pending connect that times out leaving nothing registered, a route conflict that fails before start or connect, and a hostile client whose `connect()` synchronously sends into a `DataEngine` endpoint - pinning that no engine borrow spans the connect. An engine regression pins the preserved primary-venue overwrite. Differentials verified: neutering the name preflight fails the collision test, and a borrow-across-await variant panics the hostile test with `RefCell already borrowed`.
