### PR TITLE
Emit quote ticks from delayed IB market data

### DIFF
--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -1845,7 +1845,11 @@ fn update_quote_from_price_tick(
     ts_init: UnixNanos,
 ) -> Option<QuoteTick> {
     match price.tick_type {
-        TickType::Bid => cache.update_bid_price(
+        // Delayed variants carry identical semantics to their real-time counterparts.
+        // TWS emits them whenever the account has no real-time subscription for the
+        // instrument (error 10167) or `MarketDataType::Delayed`/`DelayedFrozen` is
+        // configured, so ignoring them drops every quote on a delayed feed.
+        TickType::Bid | TickType::DelayedBid => cache.update_bid_price(
             instrument_id,
             price.price,
             price_precision,
@@ -1853,7 +1857,7 @@ fn update_quote_from_price_tick(
             ts_event,
             ts_init,
         ),
-        TickType::Ask => cache.update_ask_price(
+        TickType::Ask | TickType::DelayedAsk => cache.update_ask_price(
             instrument_id,
             price.price,
             price_precision,
@@ -1861,7 +1865,7 @@ fn update_quote_from_price_tick(
             ts_event,
             ts_init,
         ),
-        TickType::Last => None,
+        TickType::Last | TickType::DelayedLast => None,
         _ => None,
     }
 }
@@ -1878,7 +1882,7 @@ fn update_quote_from_size_tick(
     ignore_size_updates: bool,
 ) -> Option<QuoteTick> {
     match size.tick_type {
-        TickType::BidSize => cache.update_bid_size_with_filter(
+        TickType::BidSize | TickType::DelayedBidSize => cache.update_bid_size_with_filter(
             instrument_id,
             size.size,
             price_precision,
@@ -1887,7 +1891,7 @@ fn update_quote_from_size_tick(
             ts_init,
             ignore_size_updates,
         ),
-        TickType::AskSize => cache.update_ask_size_with_filter(
+        TickType::AskSize | TickType::DelayedAskSize => cache.update_ask_size_with_filter(
             instrument_id,
             size.size,
             price_precision,
@@ -1911,7 +1915,7 @@ fn update_quote_from_price_size_tick(
     ts_init: UnixNanos,
 ) -> Option<QuoteTick> {
     let quote = match price_size.price_tick_type {
-        TickType::Bid => cache.update_bid_price(
+        TickType::Bid | TickType::DelayedBid => cache.update_bid_price(
             instrument_id,
             price_size.price,
             price_precision,
@@ -1919,7 +1923,7 @@ fn update_quote_from_price_size_tick(
             ts_event,
             ts_init,
         ),
-        TickType::Ask => cache.update_ask_price(
+        TickType::Ask | TickType::DelayedAsk => cache.update_ask_price(
             instrument_id,
             price_size.price,
             price_precision,
@@ -1927,7 +1931,7 @@ fn update_quote_from_price_size_tick(
             ts_event,
             ts_init,
         ),
-        TickType::Last => None,
+        TickType::Last | TickType::DelayedLast => None,
         _ => None,
     };
 
@@ -1936,7 +1940,7 @@ fn update_quote_from_price_size_tick(
     }
 
     match price_size.price_tick_type {
-        TickType::Bid => cache.update_bid_size(
+        TickType::Bid | TickType::DelayedBid => cache.update_bid_size(
             instrument_id,
             price_size.size,
             price_precision,
@@ -1944,7 +1948,7 @@ fn update_quote_from_price_size_tick(
             ts_event,
             ts_init,
         ),
-        TickType::Ask => cache.update_ask_size(
+        TickType::Ask | TickType::DelayedAsk => cache.update_ask_size(
             instrument_id,
             price_size.size,
             price_precision,
@@ -2578,6 +2582,116 @@ mod tests {
             }
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_process_quote_tick_result_emits_quote_from_delayed_price_ticks() {
+        // Regression: a delayed feed (no real-time subscription, or
+        // `MarketDataType::Delayed`) reports bid/ask as `DelayedBid`/`DelayedAsk`.
+        // These were previously ignored, so no quote was ever emitted.
+        let instrument_id = instrument_id();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+        let clock = get_atomic_clock_realtime();
+        let quote_cache = Arc::new(tokio::sync::Mutex::new(QuoteCache::new()));
+
+        let bid_action = process_quote_tick_result(
+            Ok::<_, &'static str>(TickTypes::Price(TickPrice {
+                tick_type: TickType::DelayedBid,
+                price: 312.44,
+                attributes: TickAttribute::default(),
+            })),
+            instrument_id,
+            2,
+            0,
+            &sender,
+            &quote_cache,
+            clock,
+            false,
+        )
+        .await
+        .unwrap();
+        let ask_action = process_quote_tick_result(
+            Ok::<_, &'static str>(TickTypes::Price(TickPrice {
+                tick_type: TickType::DelayedAsk,
+                price: 312.45,
+                attributes: TickAttribute::default(),
+            })),
+            instrument_id,
+            2,
+            0,
+            &sender,
+            &quote_cache,
+            clock,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(bid_action, StreamAction::Continue));
+        assert!(matches!(ask_action, StreamAction::Continue));
+
+        match receiver.recv().await.unwrap() {
+            DataEvent::Data(Data::Quote(quote)) => {
+                assert_eq!(quote.bid_price.as_f64(), 312.44);
+                assert_eq!(quote.ask_price.as_f64(), 312.45);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_quote_tick_result_emits_quote_from_delayed_size_ticks() {
+        // Delayed sizes arrive as `DelayedBidSize`/`DelayedAskSize`.
+        let instrument_id = instrument_id();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+        let clock = get_atomic_clock_realtime();
+        let quote_cache = Arc::new(tokio::sync::Mutex::new(QuoteCache::new()));
+
+        for tick in [
+            TickTypes::Price(TickPrice {
+                tick_type: TickType::DelayedBid,
+                price: 10.0,
+                attributes: TickAttribute::default(),
+            }),
+            TickTypes::Price(TickPrice {
+                tick_type: TickType::DelayedAsk,
+                price: 11.0,
+                attributes: TickAttribute::default(),
+            }),
+            TickTypes::Size(TickSize {
+                tick_type: TickType::DelayedBidSize,
+                size: 3.0,
+            }),
+            TickTypes::Size(TickSize {
+                tick_type: TickType::DelayedAskSize,
+                size: 4.0,
+            }),
+        ] {
+            process_quote_tick_result(
+                Ok::<_, &'static str>(tick),
+                instrument_id,
+                2,
+                0,
+                &sender,
+                &quote_cache,
+                clock,
+                false,
+            )
+            .await
+            .unwrap();
+        }
+
+        let mut last_quote = None;
+        while let Ok(event) = receiver.try_recv() {
+            if let DataEvent::Data(Data::Quote(quote)) = event {
+                last_quote = Some(quote);
+            }
+        }
+        let quote = last_quote.expect("expected at least one quote from delayed ticks");
+        assert_eq!(quote.bid_price.as_f64(), 10.0);
+        assert_eq!(quote.ask_price.as_f64(), 11.0);
+        assert_eq!(quote.bid_size.as_f64(), 3.0);
+        assert_eq!(quote.ask_size.as_f64(), 4.0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #4679.

### Problem

`subscribe_quote_ticks` emits no `QuoteTick` at all when the Interactive Brokers feed is delayed, even though TWS is streaming complete bid/ask data. This hits any account without a real-time subscription for the instrument (TWS error 10167) and any configuration using `MarketDataType::Delayed` / `DelayedFrozen`.

Quote assembly matched only the real-time tick types, so the delayed variants fell through `_ => None`:

```rust
TickType::Bid => cache.update_bid_price(...),
TickType::Ask => cache.update_ask_price(...),
TickType::Last => None,
_ => None,          // DelayedBid (66) / DelayedAsk (67) land here
```

The failure is silent — the subscription succeeds and ticks arrive, but no quote is ever produced, which reads as a connectivity or entitlement problem rather than a mapping gap.

### Change

Add the delayed variants to the matching arms in the three quote-assembly functions in `data/core_streams.rs`:

| Function | Added |
|---|---|
| `update_quote_from_price_tick` | `DelayedBid`, `DelayedAsk`, `DelayedLast` |
| `update_quote_from_size_tick` | `DelayedBidSize`, `DelayedAskSize` |
| `update_quote_from_price_size_tick` | `DelayedBid`, `DelayedAsk`, `DelayedLast` |

Delayed ticks carry identical semantics to their real-time counterparts, so they route to the same `QuoteCache` updates. `DelayedLast` is mapped alongside `Last` (both `None`) so the arms stay symmetrical and a future change to `Last` handling does not silently skip the delayed case.

No behaviour changes for real-time feeds — this only adds previously unmatched variants.

### Tests

Two regression tests in the existing `core_streams` test module:

- `test_process_quote_tick_result_emits_quote_from_delayed_price_ticks` — `DelayedBid` + `DelayedAsk` produce a quote
- `test_process_quote_tick_result_emits_quote_from_delayed_size_ticks` — delayed prices and sizes produce a fully populated quote

```
cargo test -p nautilus-interactive-brokers --lib
test result: ok. 380 passed; 0 failed
```

### Live verification

Verified end to end against an IBKR paper account with no market data subscription, US session open. Before the fix the account produced no quotes; applying the equivalent mapping to the released v1 Python adapter (1.231.0) and re-running an otherwise unchanged connectivity script gave quotes immediately:

```
quote received AAPL.NASDAQ bid=311.75 ask=311.76
quote received SPY.ARCA    bid=771.48 ask=771.50
```

Raw `ibapi` on the same connection confirmed TWS was always sending the data:

```
66:DELAYED_BID=312.44   67:DELAYED_ASK=312.45
69:DELAYED_BID_SIZE     70:DELAYED_ASK_SIZE
```

### Note

The same bug exists in the v1 Python adapter (`client/market_data.py`, `_try_create_quote_tick_from_market_data`, which reads only tick types 0/1/2/3). Happy to open a companion PR against `develop_v1` if that branch is still taking fixes.