### PR TITLE
Average bet position price by stake on increase

### DIFF
--- a/crates/model/src/data/bet.rs
+++ b/crates/model/src/data/bet.rs
@@ -275,9 +275,27 @@ impl BetPosition {
     }
 
     /// Increases the position with the provided bet.
+    ///
+    /// A same-side increase sets the price to the stake-weighted mean of the decimal odds.
     pub fn position_increase(&mut self, bet: &Bet) {
         if self.side().is_none() {
             self.price = bet.price;
+        } else {
+            let abs_self_exposure = self.exposure.abs();
+            let abs_bet_exposure = bet.exposure().abs();
+            // The mean is only meaningful for a same-side bet with well-formed odds:
+            // `add_bet` routes the opposite side to `position_decrease`, but this
+            // method is public, and `Bet` enforces neither a positive price nor a
+            // positive stake. These conditions also guarantee a positive denominator
+            // below. Anything else keeps the price it had.
+            if self.side() == Some(bet.side)
+                && self.price > Decimal::ZERO
+                && bet.price > Decimal::ZERO
+                && bet.stake > Decimal::ZERO
+            {
+                let total_stake = abs_self_exposure / self.price + bet.stake;
+                self.price = (abs_self_exposure + abs_bet_exposure) / total_stake;
+            }
         }
         self.exposure += bet.exposure();
     }
@@ -654,6 +672,75 @@ mod tests {
     }
 
     #[rstest]
+    fn test_position_increase_cancelling_stakes_preserves_price() {
+        let mut position = BetPosition::default();
+        position.add_bet(Bet::new(dec!(2.0), dec!(100.0), BetSide::Back));
+        // `Bet` does not enforce a positive stake, and a cancelling one drives the
+        // aggregate stake to zero.
+        position.add_bet(Bet::new(dec!(2.0), dec!(-100.0), BetSide::Back));
+
+        assert_eq!(position.price, dec!(2.0));
+        assert_eq!(position.exposure, dec!(0.0));
+    }
+
+    #[rstest]
+    fn test_position_increase_negative_stake_preserves_price() {
+        let mut position = BetPosition::default();
+        position.add_bet(Bet::new(dec!(2.0), dec!(100.0), BetSide::Back));
+        // Leaves a positive aggregate stake, so only the stake sign rejects it.
+        position.add_bet(Bet::new(dec!(3.0), dec!(-50.0), BetSide::Back));
+
+        assert_eq!(position.price, dec!(2.0));
+        assert_eq!(position.exposure, dec!(50.0));
+    }
+
+    #[rstest]
+    fn test_position_increase_opposite_side_preserves_price() {
+        let mut position = BetPosition::default();
+        position.add_bet(Bet::new(dec!(2.0), dec!(100.0), BetSide::Back));
+        // `add_bet` would route this to `position_decrease`; the public method is
+        // callable directly and must not average across sides.
+        position.position_increase(&Bet::new(dec!(3.0), dec!(50.0), BetSide::Lay));
+
+        assert_eq!(position.price, dec!(2.0));
+    }
+
+    #[rstest]
+    #[case(dec!(0.0))]
+    #[case(dec!(-3.0))]
+    fn test_position_increase_non_positive_price_preserves_price(#[case] price: Decimal) {
+        let mut position = BetPosition::default();
+        position.add_bet(Bet::new(dec!(2.0), dec!(100.0), BetSide::Back));
+        // Both stakes are positive, so only the incoming price rejects it.
+        position.add_bet(Bet::new(price, dec!(50.0), BetSide::Back));
+
+        assert_eq!(position.price, dec!(2.0));
+    }
+
+    #[rstest]
+    fn test_position_increase_back_averages_price_and_conserves_pnl() {
+        let mut position = BetPosition::default();
+        let bet1 = Bet::new(dec!(2.0), dec!(100.0), BetSide::Back);
+        let bet2 = Bet::new(dec!(4.0), dec!(50.0), BetSide::Back);
+        let settlement_price = dec!(3.0);
+        let constituent_pnl = calc_bets_pnl(&[
+            bet1.clone(),
+            bet1.hedging_bet(settlement_price),
+            bet2.clone(),
+            bet2.hedging_bet(settlement_price),
+        ]);
+
+        position.add_bet(bet1);
+        position.add_bet(bet2);
+
+        assert_eq!(position.price, dec!(400.0) / dec!(150.0));
+        assert_eq!(
+            position.total_pnl(settlement_price).round_dp(8),
+            constituent_pnl.round_dp(8)
+        );
+    }
+
+    #[rstest]
     fn test_position_increase_lay() {
         let mut position = BetPosition::default();
         let bet1 = Bet::new(dec!(2.0), dec!(100.0), BetSide::Lay);
@@ -662,6 +749,29 @@ mod tests {
         position.add_bet(bet2);
         // exposure = -200 + (-100) = -300
         assert_eq!(position.exposure, dec!(-300.0));
+    }
+
+    #[rstest]
+    fn test_position_increase_lay_averages_price_and_conserves_pnl() {
+        let mut position = BetPosition::default();
+        let bet1 = Bet::new(dec!(2.0), dec!(100.0), BetSide::Lay);
+        let bet2 = Bet::new(dec!(4.0), dec!(50.0), BetSide::Lay);
+        let settlement_price = dec!(3.0);
+        let constituent_pnl = calc_bets_pnl(&[
+            bet1.clone(),
+            bet1.hedging_bet(settlement_price),
+            bet2.clone(),
+            bet2.hedging_bet(settlement_price),
+        ]);
+
+        position.add_bet(bet1);
+        position.add_bet(bet2);
+
+        assert_eq!(position.price, dec!(400.0) / dec!(150.0));
+        assert_eq!(
+            position.total_pnl(settlement_price).round_dp(8),
+            constituent_pnl.round_dp(8)
+        );
     }
 
     #[rstest]

--- a/crates/model/src/data/bet.rs
+++ b/crates/model/src/data/bet.rs
@@ -708,13 +708,30 @@ mod tests {
     #[rstest]
     #[case(dec!(0.0))]
     #[case(dec!(-3.0))]
-    fn test_position_increase_non_positive_price_preserves_price(#[case] price: Decimal) {
+    fn test_position_increase_non_positive_incoming_price_preserves_price(#[case] price: Decimal) {
         let mut position = BetPosition::default();
         position.add_bet(Bet::new(dec!(2.0), dec!(100.0), BetSide::Back));
         // Both stakes are positive, so only the incoming price rejects it.
         position.add_bet(Bet::new(price, dec!(50.0), BetSide::Back));
 
         assert_eq!(position.price, dec!(2.0));
+    }
+
+    #[rstest]
+    fn test_position_increase_non_positive_current_price_preserves_price() {
+        let mut position = BetPosition::default();
+        // `Bet` enforces no positive price, so an opening bet can leave a nonempty
+        // position whose current price is negative.
+        position.add_bet(Bet::new(dec!(-3.0), dec!(100.0), BetSide::Lay));
+        assert_eq!(position.side(), Some(BetSide::Back));
+
+        // Same side, positive incoming price and stake, so only the current price
+        // rejects it: the aggregate stake would be 300 / -3 + 100, and averaging
+        // would divide by zero.
+        position.add_bet(Bet::new(dec!(2.0), dec!(100.0), BetSide::Back));
+
+        assert_eq!(position.price, dec!(-3.0));
+        assert_eq!(position.exposure, dec!(500.0));
     }
 
     #[rstest]


### PR DESCRIPTION
`BetPosition` reports a cost basis it never paid once a position is increased at more than one price.

## The position keeps its first price

`BetPosition::position_increase` assigns `self.price` only when the position is empty, so a same-side increase at a different price accumulates exposure while the price stays at the first bet's odds. Every reader of that field then works from the wrong basis: `as_bet` reconstructs the aggregate stake as `exposure / price`, and `flattening_bet`, `unrealized_pnl`, `total_pnl` and `position_decrease` all derive from it.

The result is that profit and loss stops conserving. Backing 100 at 2.0 and then 50 at 4.0 gives an aggregate that should pay 250 on a win, matching the two bets taken separately. Holding the price at 2.0 makes `as_bet` report a stake of 200 and a payoff of 200, losing 50 from the accounting.

## Averaging the odds by stake

The conserving aggregate is the stake-weighted arithmetic mean of the decimal odds. Writing `A` for the absolute exposure and `S` for the total stake, the constituents of a BACK position pay `A - S` on a win while the aggregate pays `A - A/P`; those agree only when `P = A/S`. LAY gives the same result with both signs flipped, and the losing outcome agrees as well. Applied incrementally against the existing state, `P_new = (A + a) / (A/P + s)` for an incoming bet of stake `s` and exposure `a`.

Averaging applies to a same-side bet with a positive current price, incoming price, and stake. `add_bet` routes an opposite side to `position_decrease` and real odds are positive, but `position_increase` is public and `Bet` validates neither field, so anything outside that keeps the price it had rather than mixing signed and absolute quantities or dividing by a cancelled stake. Those conditions also make the denominator positive. An empty position still adopts the incoming price directly, and `position_decrease` is unchanged - its three branches consume the corrected price as they always did.

## Testing

`test_position_increase_back_averages_price_and_conserves_pnl` and its LAY counterpart build the 100 at 2.0 plus 50 at 4.0 position, assert the averaged price, and assert `total_pnl` at a settlement price equals `calc_bets_pnl` over each constituent bet paired with its own hedge - stating the conservation property rather than a precomputed number.

Four more cover the guard, one per condition: an opposite-side bet through the public method, a cancelling stake, a negative stake that still leaves a positive aggregate stake, and a zero or negative incoming price. Each asserts the price is left alone.

The new assertions were checked against the unfixed implementation. Removing the averaging fails the price assertion at 2.0 against 400/150, and fails the conservation assertion at -66.67 against -16.67. Removing the stake condition misprices the position to 7.0 against 2.0, and removing the cancellation condition panics in `rust_decimal` with a division by zero.
