### PR TITLE
Retain backtest data past the window end and bound the no-data horizon

### DIFF
--- a/crates/backtest/src/data_iterator.rs
+++ b/crates/backtest/src/data_iterator.rs
@@ -183,6 +183,18 @@ impl BacktestDataIterator {
         self.rebuild_heap();
     }
 
+    /// Returns the next backtest data element without advancing the stream cursor.
+    pub(crate) fn peek(&self) -> Option<&Data> {
+        if let Some(p) = self.single_priority {
+            let data = self.streams.get(&p)?;
+            let idx = *self.indices.get(&p)?;
+            return data.get(idx);
+        }
+
+        let entry = self.heap.peek()?;
+        self.streams.get(&entry.priority)?.get(entry.index)
+    }
+
     /// Returns the next backtest data element across all streams in replay order.
     pub(crate) fn next_item(&mut self) -> Option<Data> {
         // Fast path for single stream
@@ -341,6 +353,17 @@ mod tests {
     }
 
     #[rstest]
+    fn test_peek_does_not_consume_single_stream_item() {
+        let mut it = BacktestDataIterator::new();
+        it.add_data("s", vec![quote("A.B", 1), quote("A.B", 2)], true);
+
+        assert_eq!(it.peek().unwrap().ts_init(), UnixNanos::from(1));
+        assert_eq!(it.peek().unwrap().ts_init(), UnixNanos::from(1));
+        assert_eq!(it.next().unwrap().ts_init(), UnixNanos::from(1));
+        assert_eq!(it.peek().unwrap().ts_init(), UnixNanos::from(2));
+    }
+
+    #[rstest]
     fn test_single_stream_sorts_unsorted_input() {
         let mut it = BacktestDataIterator::new();
         it.add_data(
@@ -359,6 +382,19 @@ mod tests {
         it.add_data("s2", vec![quote("C.D", 2), quote("C.D", 3)], false);
 
         assert_eq!(collect_ts(&mut it), vec![1, 2, 3, 4]);
+    }
+
+    #[rstest]
+    fn test_peek_does_not_consume_multi_stream_heap_item() {
+        let mut it = BacktestDataIterator::new();
+        it.add_data("s1", vec![quote("A.B", 1), quote("A.B", 4)], true);
+        it.add_data("s2", vec![quote("C.D", 2), quote("C.D", 3)], true);
+
+        assert_eq!(it.peek().unwrap().ts_init(), UnixNanos::from(1));
+        assert_eq!(it.peek().unwrap().ts_init(), UnixNanos::from(1));
+        assert_eq!(it.next().unwrap().ts_init(), UnixNanos::from(1));
+        assert_eq!(it.peek().unwrap().ts_init(), UnixNanos::from(2));
+        assert_eq!(collect_ts(&mut it), vec![2, 3, 4]);
     }
 
     #[rstest]

--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -729,10 +729,7 @@ impl BacktestEngine {
 
         // Determine time boundaries
         let start_ns = start.unwrap_or_else(|| self.ts_first.unwrap_or_default());
-        let end_ns = end.unwrap_or_else(|| {
-            self.ts_last_data
-                .unwrap_or(UnixNanos::from(4_102_444_800_000_000_000u64))
-        });
+        let end_ns = end.unwrap_or_else(|| self.ts_last_data.unwrap_or(start_ns));
         anyhow::ensure!(start_ns <= end_ns, "start was > end");
         self.end_ns = end_ns;
         self.last_ns = start_ns;
@@ -795,16 +792,15 @@ impl BacktestEngine {
         self.log_run();
 
         // Skip data before start_ns
-        let mut data = self.data_iterator.next_item();
-        while let Some(ref d) = data {
+        while let Some(d) = self.data_iterator.peek() {
             if d.ts_init() >= start_ns {
                 break;
             }
-            data = self.data_iterator.next_item();
+            self.data_iterator.next_item();
         }
 
         // Initialize last_ns before first data point
-        if let Some(ref d) = data {
+        if let Some(d) = self.data_iterator.peek() {
             let ts = d.ts_init();
             self.last_ns = if ts.as_u64() > 0 {
                 UnixNanos::from(ts.as_u64() - 1)
@@ -826,7 +822,7 @@ impl BacktestEngine {
                 break;
             }
 
-            if data.is_none() {
+            let Some(d) = self.data_iterator.peek() else {
                 if streaming {
                     // In streaming mode, don't advance timers past the
                     // current batch. The next batch will provide more data
@@ -834,19 +830,19 @@ impl BacktestEngine {
                     break;
                 }
                 let done = self.process_next_timer(&clocks)?;
-                data = self.data_iterator.next_item();
-                if data.is_none() && done {
+                if self.data_iterator.peek().is_none() && done {
                     break;
                 }
                 continue;
-            }
+            };
 
-            let d = data.as_ref().unwrap();
             let ts_init = d.ts_init();
 
             if ts_init > end_ns {
                 break;
             }
+
+            let d = self.data_iterator.next_item().unwrap();
 
             if ts_init > self.last_ns {
                 self.last_ns = ts_init;
@@ -860,18 +856,20 @@ impl BacktestEngine {
                 break;
             }
 
-            self.route_data_to_exchange(d);
-            self.kernel.data_engine.borrow_mut().process_data(d.clone());
+            self.route_data_to_exchange(&d);
+            self.kernel.data_engine.borrow_mut().process_data(d);
 
             // Drain deferred commands, then process exchange queues
             self.drain_command_queues();
             self.settle_venues(ts_init);
 
             let prev_last_ns = self.last_ns;
-            data = self.data_iterator.next_item();
-
             // If timestamp changed (or exhausted), flush timers then run modules
-            if data.is_none() || data.as_ref().unwrap().ts_init() > prev_last_ns {
+            if self
+                .data_iterator
+                .peek()
+                .is_none_or(|next| next.ts_init() > prev_last_ns)
+            {
                 self.flush_accumulator_events(&clocks, prev_last_ns)?;
                 self.finalize_timestamp(&clocks, prev_last_ns)?;
             }

--- a/crates/backtest/tests/backtest_engine.rs
+++ b/crates/backtest/tests/backtest_engine.rs
@@ -206,6 +206,46 @@ impl DataActor for CustomDataRecorder {
     }
 }
 
+struct RecurringTimerShutdownActor {
+    core: DataActorCore,
+    fired: Rc<Cell<u32>>,
+}
+
+impl RecurringTimerShutdownActor {
+    fn new(fired: Rc<Cell<u32>>) -> Self {
+        let config = DataActorConfig {
+            actor_id: Some(ActorId::from("RECURRING-TIMER-SHUTDOWN")),
+            ..Default::default()
+        };
+        Self {
+            core: DataActorCore::new(config),
+            fired,
+        }
+    }
+}
+
+nautilus_actor!(RecurringTimerShutdownActor);
+
+impl Debug for RecurringTimerShutdownActor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(stringify!(RecurringTimerShutdownActor))
+            .finish()
+    }
+}
+
+impl DataActor for RecurringTimerShutdownActor {
+    fn on_start(&mut self) -> anyhow::Result<()> {
+        self.clock()
+            .set_timer_ns("recurring", 1_000_000_000, None, None, None, None, None)
+    }
+
+    fn on_time_event(&mut self, _event: &TimeEvent) -> anyhow::Result<()> {
+        self.fired.set(self.fired.get() + 1);
+        self.shutdown_system(Some("stop recurring timer test".to_string()));
+        Ok(())
+    }
+}
+
 struct EmptyExecAlgorithm {
     core: ExecutionAlgorithmCore,
 }
@@ -1253,6 +1293,21 @@ fn test_run_with_empty_data(crypto_perpetual_ethusdt: CryptoPerpetual) {
     let bt_result = engine.get_result();
     assert_eq!(bt_result.iterations, 0);
     assert_eq!(bt_result.total_orders, 0);
+}
+
+#[rstest]
+fn test_run_with_empty_data_does_not_advance_recurring_timer() {
+    let mut engine = BacktestEngine::new(BacktestEngineConfig::default()).unwrap();
+    let fired = Rc::new(Cell::new(0));
+    engine
+        .add_actor(RecurringTimerShutdownActor::new(Rc::clone(&fired)))
+        .unwrap();
+
+    let start = UnixNanos::from(10_000_000_000u64);
+    engine.run(Some(start), None, None, false).unwrap();
+
+    assert_eq!(fired.get(), 0);
+    assert_eq!(engine.kernel().clock.borrow().timestamp_ns(), start);
 }
 
 #[rstest]
@@ -3093,6 +3148,39 @@ fn test_streaming_mode_processes_data_in_batches(crypto_perpetual_ethusdt: Crypt
 
     let result2 = engine.get_result();
     assert_eq!(result2.iterations, 5); // Total across both batches
+}
+
+#[rstest]
+fn test_streaming_windows_retain_first_item_past_end() {
+    let mut engine = BacktestEngine::new(BacktestEngineConfig::default()).unwrap();
+    let first = stub_custom_data(1, 1, None, None);
+    let data_type = first.data_type.clone();
+    let received = Rc::new(RefCell::new(Vec::new()));
+    engine
+        .add_actor(CustomDataRecorder::new(data_type, Rc::clone(&received)))
+        .unwrap();
+    engine
+        .add_data(
+            vec![
+                Data::Custom(first),
+                Data::Custom(stub_custom_data(2, 2, None, None)),
+                Data::Custom(stub_custom_data(3, 3, None, None)),
+            ],
+            None,
+            true,
+            true,
+        )
+        .unwrap();
+
+    engine
+        .run(None, Some(UnixNanos::from(2)), None, true)
+        .unwrap();
+    assert_eq!(*received.borrow(), vec![1, 2]);
+
+    engine
+        .run(None, Some(UnixNanos::from(3)), None, true)
+        .unwrap();
+    assert_eq!(*received.borrow(), vec![1, 2, 3]);
 }
 
 #[rstest]


### PR DESCRIPTION
Two boundary defects in `BacktestEngine::run_impl`: one drops a data point at every streaming window, the other gives a data-less run a horizon in the year 2100.

## The first item past `end_ns` is consumed and discarded

The run loop pulled the next item at the bottom of the body and tested it against `end_ns` at the top of the following pass. By then the item had already left `BacktestDataIterator`, so breaking out of the loop discarded it. Streaming a backtest as consecutive windows therefore lost exactly one data point per boundary, silently.

`BacktestDataIterator` gains a non-consuming `peek`, covering both the single-stream index path and the multi-stream heap path, and the loop now inspects the next item before deciding to take it: an item beyond `end_ns` ends the run while staying in the iterator, so the next window delivers it. The lookahead that drives the timestamp-boundary flush is a peek for the same reason. Ordering is otherwise unchanged - the item is processed, the next timestamp inspected, then `flush_accumulator_events` and `finalize_timestamp` run against the current timestamp.

## A run with no data adopts a year-2100 horizon

With no explicit `end` and no data loaded, `end_ns` fell back to a hardcoded `4_102_444_800_000_000_000`, or 2100-01-01, so any registered timer advanced simulated time across seventy-odd years of nothing. The horizon now falls back to `start_ns`: without data or an explicit end there is no evidence simulated time should move past the requested start. An explicit `end` is still honoured with no data, since that is a deliberate timer-only run, and a run with data still uses the last data timestamp.

## Testing

`test_streaming_windows_retain_first_item_past_end` runs two consecutive windows over one iterator without clearing it between them, asserting all three timestamps arrive. Restoring the old consume-then-test order yields `[1, 2]` against `[1, 2, 3]`.

`test_run_with_empty_data_does_not_advance_recurring_timer` registers a recurring timer on an engine with no data and asserts it never fires and the clock does not advance. Under the old horizon the timer fires and requests shutdown, giving one event instead of none.

`test_peek_does_not_consume_single_stream_item` and `test_peek_does_not_consume_multi_stream_heap_item` cover both cursor implementations, since the fast path advances an index while the merge path pops a heap.
