### PR TITLE
Fix Databento MBO snapshot sequence handling

### DIFF
--- a/crates/adapters/databento/src/decode/market_data.rs
+++ b/crates/adapters/databento/src/decode/market_data.rs
@@ -194,12 +194,20 @@ pub fn decode_mbo_msg(
     let ts_event = msg.ts_recv.into();
     let ts_init = ts_init.unwrap_or(ts_event);
 
+    // A replayed snapshot can carry source packet sequences in non-monotonic order,
+    // so it must not advance the book's incremental high-water mark.
+    let sequence = if msg.flags.is_snapshot() {
+        0
+    } else {
+        msg.sequence
+    };
+
     let delta = OrderBookDelta::new(
         instrument_id,
         action,
         order,
         msg.flags.raw(),
-        msg.sequence.into(),
+        sequence.into(),
         ts_event,
         ts_init,
     );

--- a/crates/adapters/databento/src/decode/tests.rs
+++ b/crates/adapters/databento/src/decode/tests.rs
@@ -610,6 +610,23 @@ fn mbo_msg_with_action(action: c_char, flags: dbn::FlagSet) -> dbn::MboMsg {
 }
 
 #[rstest]
+#[case::incremental(dbn::FlagSet::empty(), 1_000_000)]
+#[case::snapshot(dbn::FlagSet::empty().set_snapshot(), 0)]
+fn test_decode_mbo_msg_snapshot_does_not_advance_sequence(
+    #[case] flags: dbn::FlagSet,
+    #[case] expected_sequence: u64,
+) {
+    let msg = mbo_msg_with_action('A' as c_char, flags);
+    let instrument_id = InstrumentId::from("ESM4.GLBX");
+    let (delta, trade) = decode_mbo_msg(&msg, instrument_id, 2, Some(0.into()), false).unwrap();
+    let delta = delta.unwrap();
+
+    assert!(trade.is_none());
+    assert_eq!(delta.flags, flags.raw());
+    assert_eq!(delta.sequence, expected_sequence);
+}
+
+#[rstest]
 #[case('F' as c_char, true)] // Fill: attribution only - book impact arrives as explicit C/M
 #[case('F' as c_char, false)]
 #[case('N' as c_char, true)] // None: status record, no book impact


### PR DESCRIPTION
### Summary

- Set decoded Databento MBO snapshot sequences to zero so replay snapshots do not advance the order book incremental sequence high-water mark.
- Preserve source packet sequences for incremental MBO records.
- Cover both snapshot and incremental decoding with exact sequence assertions.

### Testing

- `cargo fmt --all --check`
- `CARGO_BUILD_JOBS=16 cargo test -p nautilus-databento test_decode_mbo_msg_snapshot_does_not_advance_sequence -- --nocapture`
- `CARGO_BUILD_JOBS=16 cargo test -p nautilus-databento --lib` (301 passed)
- Commit-time pre-commit hooks passed, including Cargo fmt, Clippy, docs, and repository convention checks.