### PR TITLE
Return no orders for an unknown instrument in the simulated exchange

### DIFF
--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -490,54 +490,57 @@ impl SimulatedExchange {
     }
 
     /// Returns all open orders, optionally filtered by instrument ID.
+    ///
+    /// An instrument ID with no matching engine returns no orders.
     #[must_use]
     pub fn get_open_orders(&self, instrument_id: Option<InstrumentId>) -> Vec<RestingOrder> {
-        instrument_id
-            .and_then(|id| {
-                self.matching_engines
-                    .get(&id)
-                    .map(OrderMatchingEngine::get_open_orders)
-            })
-            .unwrap_or_else(|| {
-                self.matching_engines
-                    .values()
-                    .flat_map(OrderMatchingEngine::get_open_orders)
-                    .collect()
-            })
+        match instrument_id {
+            Some(id) => self
+                .matching_engines
+                .get(&id)
+                .map_or_else(Vec::new, OrderMatchingEngine::get_open_orders),
+            None => self
+                .matching_engines
+                .values()
+                .flat_map(OrderMatchingEngine::get_open_orders)
+                .collect(),
+        }
     }
 
     /// Returns all open bid orders, optionally filtered by instrument ID.
+    ///
+    /// An instrument ID with no matching engine returns no orders.
     #[must_use]
     pub fn get_open_bid_orders(&self, instrument_id: Option<InstrumentId>) -> Vec<RestingOrder> {
-        instrument_id
-            .and_then(|id| {
-                self.matching_engines
-                    .get(&id)
-                    .map(OrderMatchingEngine::get_open_bid_orders)
-            })
-            .unwrap_or_else(|| {
-                self.matching_engines
-                    .values()
-                    .flat_map(OrderMatchingEngine::get_open_bid_orders)
-                    .collect()
-            })
+        match instrument_id {
+            Some(id) => self
+                .matching_engines
+                .get(&id)
+                .map_or_else(Vec::new, OrderMatchingEngine::get_open_bid_orders),
+            None => self
+                .matching_engines
+                .values()
+                .flat_map(OrderMatchingEngine::get_open_bid_orders)
+                .collect(),
+        }
     }
 
     /// Returns all open ask orders, optionally filtered by instrument ID.
+    ///
+    /// An instrument ID with no matching engine returns no orders.
     #[must_use]
     pub fn get_open_ask_orders(&self, instrument_id: Option<InstrumentId>) -> Vec<RestingOrder> {
-        instrument_id
-            .and_then(|id| {
-                self.matching_engines
-                    .get(&id)
-                    .map(OrderMatchingEngine::get_open_ask_orders)
-            })
-            .unwrap_or_else(|| {
-                self.matching_engines
-                    .values()
-                    .flat_map(OrderMatchingEngine::get_open_ask_orders)
-                    .collect()
-            })
+        match instrument_id {
+            Some(id) => self
+                .matching_engines
+                .get(&id)
+                .map_or_else(Vec::new, OrderMatchingEngine::get_open_ask_orders),
+            None => self
+                .matching_engines
+                .values()
+                .flat_map(OrderMatchingEngine::get_open_ask_orders)
+                .collect(),
+        }
     }
 
     /// Returns the account for this exchange, if an execution client is registered.

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -936,6 +936,124 @@ fn test_submit_order_list_routes_mixed_instrument_legs_to_own_matching_engine(
 }
 
 #[rstest]
+fn test_open_order_accessors_filter_by_instrument_id(crypto_perpetual_ethusdt: CryptoPerpetual) {
+    let _saving_handler = register_order_event_saving_handler();
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let exchange = get_exchange(
+        Venue::new("BINANCE"),
+        AccountType::Margin,
+        BookType::L1_MBP,
+        Some(cache.clone()),
+    );
+    let eth_instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt.clone());
+    let mut btcusdt = crypto_perpetual_ethusdt;
+    btcusdt.id = InstrumentId::from("BTCUSDT-PERP.BINANCE");
+    btcusdt.raw_symbol = Symbol::from("BTCUSDT");
+    btcusdt.base_currency = Currency::from("BTC");
+    let btc_instrument = InstrumentAny::CryptoPerpetual(btcusdt);
+    let unknown_instrument_id = InstrumentId::from("SOLUSDT-PERP.BINANCE");
+
+    exchange
+        .borrow_mut()
+        .add_instrument(eth_instrument.clone())
+        .unwrap();
+    exchange
+        .borrow_mut()
+        .add_instrument(btc_instrument.clone())
+        .unwrap();
+
+    let eth_quote = QuoteTick::new(
+        eth_instrument.id(),
+        Price::from("100.00"),
+        Price::from("101.00"),
+        Quantity::from("10.000"),
+        Quantity::from("10.000"),
+        UnixNanos::from(1),
+        UnixNanos::from(1),
+    );
+    let btc_quote = QuoteTick::new(
+        btc_instrument.id(),
+        Price::from("200.00"),
+        Price::from("201.00"),
+        Quantity::from("10.000"),
+        Quantity::from("10.000"),
+        UnixNanos::from(1),
+        UnixNanos::from(1),
+    );
+    exchange.borrow_mut().process_quote_tick(&eth_quote);
+    exchange.borrow_mut().process_quote_tick(&btc_quote);
+
+    // Both prices are away from their market, so each order rests rather than fills.
+    let eth_bid = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(eth_instrument.id())
+        .client_order_id(ClientOrderId::from("O-RESTING-ETH-BID"))
+        .side(OrderSide::Buy)
+        .price(Price::from("90.00"))
+        .quantity(Quantity::from("1.000"))
+        .build();
+    let btc_ask = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(btc_instrument.id())
+        .client_order_id(ClientOrderId::from("O-RESTING-BTC-ASK"))
+        .side(OrderSide::Sell)
+        .price(Price::from("210.00"))
+        .quantity(Quantity::from("1.000"))
+        .build();
+    submit_matching_option_limit(&exchange, &cache, &eth_bid, UnixNanos::from(2));
+    submit_matching_option_limit(&exchange, &cache, &btc_ask, UnixNanos::from(3));
+
+    let exchange = exchange.borrow();
+
+    // No filter aggregates every matching engine.
+    assert_eq!(exchange.get_open_orders(None).len(), 2);
+    assert_eq!(exchange.get_open_bid_orders(None).len(), 1);
+    assert_eq!(exchange.get_open_ask_orders(None).len(), 1);
+
+    // A known instrument returns only its own orders.
+    assert_eq!(exchange.get_open_orders(Some(eth_instrument.id())).len(), 1);
+    assert_eq!(
+        exchange
+            .get_open_bid_orders(Some(eth_instrument.id()))
+            .len(),
+        1
+    );
+    assert!(
+        exchange
+            .get_open_ask_orders(Some(eth_instrument.id()))
+            .is_empty()
+    );
+    assert_eq!(exchange.get_open_orders(Some(btc_instrument.id())).len(), 1);
+    assert!(
+        exchange
+            .get_open_bid_orders(Some(btc_instrument.id()))
+            .is_empty()
+    );
+    assert_eq!(
+        exchange
+            .get_open_ask_orders(Some(btc_instrument.id()))
+            .len(),
+        1
+    );
+
+    // An instrument with no matching engine returns nothing, rather than falling
+    // through to the unfiltered branch.
+    assert!(
+        exchange
+            .get_open_orders(Some(unknown_instrument_id))
+            .is_empty()
+    );
+    assert!(
+        exchange
+            .get_open_bid_orders(Some(unknown_instrument_id))
+            .is_empty()
+    );
+    assert!(
+        exchange
+            .get_open_ask_orders(Some(unknown_instrument_id))
+            .is_empty()
+    );
+}
+
+#[rstest]
 #[case::option_contract_call(
     matching_option_contract(OptionKind::Call),
     OrderSide::Buy,


### PR DESCRIPTION
## An unknown instrument returns every instrument's orders

`SimulatedExchange::get_open_orders`, `get_open_bid_orders` and `get_open_ask_orders` each pass the caller's `Option<InstrumentId>` through `and_then` over the `matching_engines` lookup, then fall back to aggregating every engine. `and_then` collapses a missing engine into `None`, which is the same value the caller supplies to mean "no filter" - so `Some(unknown_id)` takes the unfiltered branch and returns every instrument's open orders instead of none. `None` and `Some(known_id)` are both correct; only the unmatched filter is wrong, and it is silent, since the caller cannot tell the superset from a real answer.

Each accessor now matches on the caller's `Option` so the two absences stay distinct: a present ID resolves through `map_or_else(Vec::new, ...)`, and only `None` aggregates. Three parallel `match` bodies rather than a shared helper, since abstracting one short branch behind a function parameter would bury the distinction that caused the defect.

## Testing

`test_open_order_accessors_filter_by_instrument_id` registers two instruments on one venue and rests a bid on the first and an ask on the second - a buy limit at 90.00 against a 100/101 market and a sell limit at 210.00 against 200/201, so neither crosses - then queries a third, unregistered instrument ID. It asserts the unfiltered counts, both known IDs including the side-specific empties, and empty for the unknown ID from all three accessors.

The resting orders on two different engines are what make the unknown-ID assertions non-vacuous: against the previous implementation they return two, one and one orders respectively, and the assertions fail. The same fixture pins the multi-engine aggregation and known-ID paths that stay unchanged.

## PS: an unrelated failure on current develop

Not from this branch, but I hit it validating this one and it is cheap to fix. `cargo test --workspace` fails on `node::tests::test_republish_external_msgbus_message_logs_topic_and_error_chain` (`crates/live/src/node/mod.rs`, added in `6624f9bf07`) with `test logger already installed: SetLoggerError(())`.

The test calls `log::set_logger` unconditionally, and that succeeds at most once per process. `NautilusKernel::new` installs the global logger through `init_logging` (`crates/system/src/kernel.rs:361`), so any earlier test in the same binary that calls `LiveNode::build` has already claimed it. Under nextest each test gets its own process and the call always wins, which is why CI is green; a plain in-process `cargo test --workspace` fails deterministically. Running the test alone also passes.

Either the `serial_tests::` convention or tolerating an already-installed logger would settle it.
