### PR TITLE
Retire Polymarket instruments on venue liveness not endDate

### DIFF
--- a/crates/adapters/polymarket/src/data/auto_load.rs
+++ b/crates/adapters/polymarket/src/data/auto_load.rs
@@ -25,7 +25,7 @@ use nautilus_model::{
 use super::{
     PolymarketDataClient,
     instruments::cache_instrument,
-    runtime::{is_instrument_expired, retire_local_instrument_state},
+    runtime::{is_instrument_retirable, retire_local_instrument_state},
     subscriptions::{resolve_token_id_from, sync_ws_subscription_async},
 };
 use crate::{
@@ -216,7 +216,7 @@ impl PolymarketDataClient {
                             continue;
                         }
 
-                        if is_instrument_expired(&inst, clock.get_time_ns()) {
+                        if is_instrument_retirable(&inst, clock.get_time_ns()) {
                             log::debug!("Skipping expired auto-loaded instrument {}", inst.id());
                             retired_expired_ids.insert(inst.id());
                             retire_local_instrument_state(

--- a/crates/adapters/polymarket/src/data/dispatch.rs
+++ b/crates/adapters/polymarket/src/data/dispatch.rs
@@ -1054,6 +1054,7 @@ mod tests {
         market_id: Option<&'a str>,
         condition_id: Option<&'a str>,
         expiration_ns: Option<UnixNanos>,
+        venue_closed: Option<bool>,
     }
 
     fn seed_instrument_with_context(
@@ -1093,6 +1094,13 @@ mod tests {
                 info.insert(
                     "condition_id".to_string(),
                     serde_json::Value::String(condition_id.to_string()),
+                );
+            }
+
+            if let Some(venue_closed) = seed_ctx.venue_closed {
+                info.insert(
+                    "venue_closed".to_string(),
+                    serde_json::Value::Bool(venue_closed),
                 );
             }
 
@@ -1205,6 +1213,22 @@ mod tests {
     fn gamma_market_expired_fixture_value() -> Value {
         serde_json::from_str(include_str!("../../test_data/gamma_market.json"))
             .expect("gamma market fixture json")
+    }
+
+    /// Returns the expired fixture with the venue also reporting the market closed.
+    ///
+    /// Gamma keeps trading many markets past `endDate`, so expiration alone no longer retires an
+    /// instrument. Paths that must reject a dead market need the venue to agree it is dead.
+    fn gamma_market_expired_closed_fixture_value() -> Value {
+        let mut value = gamma_market_expired_fixture_value();
+
+        if let Some(root) = value.as_object_mut() {
+            root.insert("active".to_string(), Value::Bool(false));
+            root.insert("closed".to_string(), Value::Bool(true));
+            root.insert("acceptingOrders".to_string(), Value::Bool(false));
+        }
+
+        value
     }
 
     fn gamma_market_recheck_fixture_value() -> Value {
@@ -2182,6 +2206,7 @@ mod tests {
                 market_id: Some("1778973900"),
                 condition_id: Some("0xCOND-BTC"),
                 expiration_ns: Some(expiration_ns),
+                venue_closed: None,
             },
         );
         let no = seed_instrument_with_context(
@@ -2194,6 +2219,7 @@ mod tests {
                 market_id: Some("1778973900"),
                 condition_id: Some("0xCOND-BTC"),
                 expiration_ns: Some(expiration_ns),
+                venue_closed: None,
             },
         );
 
@@ -2294,6 +2320,7 @@ mod tests {
                 market_id: Some("1778973900"),
                 condition_id: Some("0xCOND-BTC"),
                 expiration_ns: Some(expiration_ns),
+                venue_closed: None,
             },
         );
         let no = seed_instrument_with_context(
@@ -2306,6 +2333,7 @@ mod tests {
                 market_id: Some("1778973900"),
                 condition_id: Some("0xCOND-BTC"),
                 expiration_ns: Some(expiration_ns),
+                venue_closed: None,
             },
         );
 
@@ -3171,7 +3199,7 @@ mod tests {
     async fn auto_load_expired_instrument_retires_without_retrying() {
         let state = ExpiredAutoLoadServerState {
             requests: Arc::new(AtomicUsize::new(0)),
-            response: serde_json::json!([gamma_market_expired_fixture_value()]),
+            response: serde_json::json!([gamma_market_expired_closed_fixture_value()]),
         };
         let addr = start_expired_auto_load_test_server(state.clone()).await;
         let (mut client, _data_rx) = create_test_client(addr);
@@ -3224,6 +3252,92 @@ mod tests {
                 .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
         );
         assert!(!client.instruments.load().contains_key(&instrument_id));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn auto_load_past_end_date_market_open_at_venue_is_carried() {
+        // Regression: Gamma `endDate` is a scheduled end, not the tradeable end. While the venue
+        // still reports the market open the adapter must keep carrying it.
+        let state = ExpiredAutoLoadServerState {
+            requests: Arc::new(AtomicUsize::new(0)),
+            response: serde_json::json!([gamma_market_expired_fixture_value()]),
+        };
+        let addr = start_expired_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 3;
+        client.config.auto_load_retry_delay_initial_secs = 0.0;
+        client.config.auto_load_retry_delay_max_secs = 0.0;
+
+        let instrument_id = fixture_yes_instrument_id();
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("subscribe_quotes should queue auto-load");
+
+        wait_until_async(
+            || {
+                let client = &client;
+                async move { client.instruments.load().contains_key(&instrument_id) }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert!(
+            client.instruments.load().contains_key(&instrument_id),
+            "market open at the venue should be carried despite a past endDate",
+        );
+        assert!(
+            client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES)),
+            "routing metadata should be retained so market data still reaches the client",
+        );
+        assert!(client.active_quote_subs.contains(&instrument_id));
+    }
+
+    #[rstest]
+    fn cached_past_end_date_instrument_open_at_venue_is_subscribable() {
+        // Complements `cached_expired_instrument_live_paths_are_rejected`: the same cached-and-
+        // expired shape must NOT be refused while the venue still reports the market open.
+        let mut client = make_local_test_client();
+        let instrument = seed_instrument_with_context(
+            &make_client_ws_ctx(&client),
+            "0xTOKEN_PAST_END_OPEN",
+            Price::from("0.001"),
+            Quantity::from("0.01"),
+            SeedInstrumentContext {
+                condition_id: Some("0xCOND-PAST-END-OPEN"),
+                expiration_ns: Some(UnixNanos::from(1)),
+                venue_closed: Some(false),
+                ..SeedInstrumentContext::default()
+            },
+        );
+
+        let result = client.subscribe_quotes(SubscribeQuotes::new(
+            instrument.id(),
+            Some(client.client_id),
+            Some(*POLYMARKET_VENUE),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ));
+
+        assert!(
+            result.is_ok(),
+            "subscribe must be allowed while the venue reports the market open: {result:?}",
+        );
+        assert!(client.active_quote_subs.contains(&instrument.id()));
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/data/instruments.rs
+++ b/crates/adapters/polymarket/src/data/instruments.rs
@@ -15,6 +15,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use ahash::{AHashMap, AHashSet};
 use dashmap::DashMap;
 use nautilus_common::{live::get_runtime, messages::DataEvent, providers::InstrumentProvider};
 use nautilus_core::{AtomicMap, UnixNanos, time::AtomicTime};
@@ -24,8 +25,16 @@ use nautilus_model::{
 };
 use ustr::Ustr;
 
-use super::{PolymarketDataClient, runtime::is_instrument_expired};
-use crate::{filters::InstrumentFilter, http::gamma::PolymarketGammaHttpClient};
+use super::{PolymarketDataClient, runtime::is_instrument_retirable};
+use crate::{
+    common::consts::GAMMA_CONDITION_IDS_BATCH_SIZE,
+    filters::{InstrumentFilter, set_venue_closed},
+    http::{gamma::PolymarketGammaHttpClient, query::GetGammaMarketsParams},
+    providers::extract_condition_id,
+};
+
+/// Consecutive liveness lookups a condition must be absent from before it counts as delisted.
+const LIVENESS_MISSES_BEFORE_DELISTED: u32 = 3;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct TokenMeta {
@@ -61,7 +70,7 @@ pub(super) fn cache_instrument_if_active(
     token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
     instrument: &InstrumentAny,
 ) -> bool {
-    if is_instrument_expired(instrument, now_ns) {
+    if is_instrument_retirable(instrument, now_ns) {
         return false;
     }
 
@@ -80,10 +89,24 @@ pub(super) fn cache_and_publish_instruments(
 
     for instrument in instruments {
         if !cache_instrument_if_active(now_ns, instruments_cache, token_meta, &instrument) {
-            log::debug!(
-                "Skipping expired instrument {} during live cache publish",
-                instrument.id()
-            );
+            // A refetch that reports the market closed supersedes the cached copy, which still
+            // carries the older open observation. Drop it so the expiry sweep can reclaim it
+            // rather than waiting for another source to correct the cache.
+            let instrument_id = instrument.id();
+            if instruments_cache.load().contains_key(&instrument_id) {
+                // Only the definition is corrected. Writing `token_meta` here would restore message
+                // routing for a market the venue has closed, and a watchlisted instrument keeps its
+                // cache entry through retirement, so every refresh would re-arm the sweep.
+                instruments_cache.insert(instrument_id, instrument.clone());
+
+                // Publish so the execution client reconciles its lookup state against the
+                // venue-closed definition rather than keeping the older open one.
+                if let Err(e) = data_sender.send(DataEvent::Instrument(instrument)) {
+                    log::warn!("Failed to publish superseded instrument {instrument_id}: {e}");
+                }
+            }
+
+            log::debug!("Skipping expired instrument {instrument_id} during live cache publish");
             continue;
         }
 
@@ -121,6 +144,228 @@ pub(super) async fn refresh_scoped_instruments(
         clock.get_time_ns(),
         refreshed,
     ))
+}
+
+/// Outcome of one venue liveness pass.
+pub(super) struct LivenessRefresh {
+    /// Carried instruments whose cached venue state was updated.
+    pub updated: usize,
+    /// Whether at least one Gamma lookup succeeded, so the caller can defer the next probe.
+    pub probed: bool,
+}
+
+/// Re-observes venue liveness for instruments carried past their expiration.
+///
+/// The scope refresh only covers the configured bootstrap universe, so instruments brought in by
+/// auto-load or new-market discovery would otherwise never have their liveness re-checked. Only
+/// markets already past `endDate` and last reported open are refetched, so the request volume is
+/// bounded by the set actually being carried past their scheduled end.
+///
+/// Only the venue state is taken from the refetch, so a cached definition rebuilt by a
+/// `tick_size_change` keeps its precision. Updated definitions are published as well as cached, so
+/// the global cache the execution client reads sees the same venue state as the data client.
+pub(super) async fn refresh_expired_instrument_liveness(
+    http_client: &PolymarketGammaHttpClient,
+    instruments_cache: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+    data_sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
+    misses: &mut AHashMap<String, u32>,
+    now_ns: UnixNanos,
+) -> LivenessRefresh {
+    // One pass builds the condition index, so marking a delisted condition later does not rescan.
+    let mut carried: AHashMap<String, Vec<InstrumentId>> = AHashMap::new();
+    {
+        let loaded = instruments_cache.load();
+        for (instrument_id, instrument) in loaded.iter() {
+            if !crate::filters::is_expired(instrument, now_ns)
+                || crate::filters::is_retirable(instrument, now_ns)
+            {
+                continue;
+            }
+
+            if let Ok(condition_id) = extract_condition_id(instrument_id) {
+                carried
+                    .entry(condition_id)
+                    .or_default()
+                    .push(*instrument_id);
+            }
+        }
+    }
+
+    if carried.is_empty() {
+        // Nothing to probe is a complete pass, so the caller still defers the next one.
+        return LivenessRefresh {
+            updated: 0,
+            probed: true,
+        };
+    }
+
+    let condition_ids: Vec<String> = carried.keys().cloned().collect();
+    let mut updates: Vec<InstrumentAny> = Vec::new();
+    let mut probed = false;
+
+    for chunk in condition_ids.chunks(GAMMA_CONDITION_IDS_BATCH_SIZE) {
+        let params = GetGammaMarketsParams {
+            condition_ids: Some(chunk.to_vec()),
+            ..Default::default()
+        };
+
+        let (instruments, transient) = match http_client
+            .request_instruments_by_params_with_transient(params)
+            .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                log::warn!(
+                    "Failed to refresh venue liveness for {} condition_id(s): {e:?}",
+                    chunk.len(),
+                );
+                continue;
+            }
+        };
+
+        probed = true;
+        let mut returned = AHashSet::new();
+
+        for instrument in instruments {
+            let Ok(condition_id) = extract_condition_id(&instrument.id()) else {
+                continue;
+            };
+
+            // Only refresh what is already carried, so this never widens the universe.
+            if carried.contains_key(&condition_id) {
+                // Take only the venue state from the refetch. A `tick_size_change` rebuilds the
+                // cached definition, and swapping the Gamma copy in wholesale would revert that
+                // rebuild for a market the venue is still trading.
+                let closed = crate::filters::venue_reports_closed(&instrument).unwrap_or(false);
+                let loaded = instruments_cache.load();
+
+                if let Some(InstrumentAny::BinaryOption(binary)) = loaded.get(&instrument.id()) {
+                    let mut binary = binary.clone();
+                    set_venue_closed(&mut binary, closed);
+                    updates.push(InstrumentAny::BinaryOption(binary));
+                }
+            }
+
+            returned.insert(condition_id);
+        }
+
+        // Gamma omits closed markets unless asked for them, so a condition missing from the
+        // open lookup is either closed or gone. Ask explicitly before deciding: a closed market
+        // is a positive terminal observation and retires now, while a condition absent from both
+        // lookups is only a weak signal and has to repeat before it counts.
+        let missing: Vec<String> = chunk
+            .iter()
+            .filter(|cid| !returned.contains(*cid) && !transient.contains(cid))
+            .cloned()
+            .collect();
+
+        let mut confirmed_closed = AHashSet::new();
+
+        if !missing.is_empty() {
+            let closed_params = GetGammaMarketsParams {
+                condition_ids: Some(missing.clone()),
+                closed: Some(true),
+                ..Default::default()
+            };
+
+            match http_client
+                .request_instruments_by_params(closed_params)
+                .await
+            {
+                Ok(instruments) => {
+                    for instrument in instruments {
+                        if let Ok(condition_id) = extract_condition_id(&instrument.id()) {
+                            confirmed_closed.insert(condition_id);
+                        }
+                    }
+                }
+                Err(e) => log::warn!(
+                    "Failed to confirm closed state for {} condition_id(s): {e:?}",
+                    missing.len(),
+                ),
+            }
+        }
+
+        for condition_id in chunk {
+            if returned.contains(condition_id) || transient.contains(condition_id) {
+                misses.remove(condition_id);
+                continue;
+            }
+
+            if confirmed_closed.contains(condition_id) {
+                misses.remove(condition_id);
+            } else {
+                // Not in either lookup: could be a parse failure or a transient omission, so
+                // require the miss to repeat before treating it as gone.
+                let seen = misses.entry(condition_id.clone()).or_insert(0);
+                *seen += 1;
+
+                if *seen < LIVENESS_MISSES_BEFORE_DELISTED {
+                    log::debug!(
+                        "condition_id={condition_id} absent from both liveness lookups ({seen}/{LIVENESS_MISSES_BEFORE_DELISTED})"
+                    );
+                    continue;
+                }
+            }
+
+            // The streak has served its purpose. Leaving it behind would grow the map for the life
+            // of the process, and would start a re-loaded condition above the threshold so its
+            // first absence retired it with no confirmation at all.
+            misses.remove(condition_id);
+
+            let Some(instrument_ids) = carried.get(condition_id) else {
+                continue;
+            };
+
+            let loaded = instruments_cache.load();
+            for instrument_id in instrument_ids {
+                if let Some(InstrumentAny::BinaryOption(binary)) = loaded.get(instrument_id) {
+                    let mut binary = binary.clone();
+                    set_venue_closed(&mut binary, true);
+                    updates.push(InstrumentAny::BinaryOption(binary));
+                }
+            }
+
+            log::info!(
+                "Venue reports condition_id={condition_id} no longer open: marking {} carried instrument(s) closed",
+                instrument_ids.len(),
+            );
+        }
+    }
+
+    if updates.is_empty() {
+        return LivenessRefresh { updated: 0, probed };
+    }
+
+    // A single clone-and-swap for the whole batch: `AtomicMap::insert` rebuilds the map each call.
+    // Only keys still present are updated, so a result captured before the request completed
+    // cannot resurrect an instrument that the sweep retired in the meantime.
+    instruments_cache.rcu(|map| {
+        for instrument in &updates {
+            let instrument_id = instrument.id();
+            if map.contains_key(&instrument_id) {
+                map.insert(instrument_id, instrument.clone());
+            }
+        }
+    });
+
+    for instrument in &updates {
+        if !instruments_cache.load().contains_key(&instrument.id()) {
+            continue;
+        }
+
+        if let Err(e) = data_sender.send(DataEvent::Instrument(instrument.clone())) {
+            log::warn!(
+                "Failed to publish refreshed instrument {}: {e}",
+                instrument.id()
+            );
+        }
+    }
+
+    LivenessRefresh {
+        updated: updates.len(),
+        probed,
+    }
 }
 
 impl PolymarketDataClient {
@@ -214,11 +459,11 @@ impl PolymarketDataClient {
 #[cfg(test)]
 mod tests {
     use nautilus_common::live::runner::replace_data_event_sender;
-    use nautilus_core::UnixNanos;
+    use nautilus_core::{UnixNanos, time::get_atomic_clock_realtime};
     use nautilus_model::{
         enums::AssetClass,
         identifiers::{ClientId, Symbol},
-        instruments::BinaryOption,
+        instruments::{BinaryOption, stubs::binary_option},
         types::{Currency, Price, Quantity},
     };
     use nautilus_network::{retry::RetryConfig, websocket::config::TransportBackend};
@@ -428,5 +673,566 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing token_meta for {token_id}"));
             assert_eq!(meta.instrument_id, inst.id());
         }
+    }
+
+    fn past_end_date_instrument(raw_symbol: &str, venue_closed: Option<bool>) -> InstrumentAny {
+        let clock = get_atomic_clock_realtime();
+        let mut binary = binary_option();
+        binary.id = InstrumentId::from(format!("{raw_symbol}.POLYMARKET").as_str());
+        binary.raw_symbol = Symbol::new(raw_symbol);
+        binary.currency = Currency::pUSD();
+        binary.activation_ns = UnixNanos::default();
+        binary.expiration_ns =
+            UnixNanos::from(clock.get_time_ns().as_u64().saturating_sub(1_000_000_000));
+
+        let mut info = nautilus_core::Params::new();
+        if let Some(closed) = venue_closed {
+            info.insert("venue_closed".to_string(), serde_json::Value::Bool(closed));
+        }
+        binary.info = Some(info);
+
+        InstrumentAny::BinaryOption(binary)
+    }
+
+    /// Every bootstrap and refresh scope converges on `cache_and_publish_instruments`, so this
+    /// covers `load_all`, `load_ids`, `market_slugs`, `event_slugs`, `event_slug_builder`,
+    /// `series_ids`, the `filters` map, and registered filters in one place.
+    #[rstest]
+    #[case::open_at_venue(Some(false), 1)]
+    #[case::closed_at_venue(Some(true), 0)]
+    #[case::no_venue_state(None, 0)]
+    fn publish_sink_carries_past_end_date_markets_open_at_the_venue(
+        #[case] venue_closed: Option<bool>,
+        #[case] expected_published: usize,
+    ) {
+        let instruments_cache = Arc::new(AtomicMap::new());
+        let token_meta = Arc::new(DashMap::new());
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let instrument = past_end_date_instrument("0xTOKEN_SINK", venue_closed);
+        let instrument_id = instrument.id();
+
+        let published = cache_and_publish_instruments(
+            &instruments_cache,
+            &token_meta,
+            &tx,
+            get_atomic_clock_realtime().get_time_ns(),
+            vec![instrument],
+        );
+
+        assert_eq!(published, expected_published);
+        assert_eq!(
+            instruments_cache.load().contains_key(&instrument_id),
+            expected_published == 1,
+        );
+        assert_eq!(rx.try_recv().is_ok(), expected_published == 1);
+    }
+
+    #[rstest]
+    fn delisted_condition_is_marked_closed_so_it_can_be_reclaimed() {
+        // Backstop: `endDate` used to retire unconditionally. Once liveness drives retirement, a
+        // market Gamma stops listing would otherwise keep its last "open" observation forever and
+        // leak its subscription slot and runtime state.
+        let instruments_cache = Arc::new(AtomicMap::new());
+        let token_meta = Arc::new(DashMap::new());
+
+        let condition_id = "0x00000000000000000000000000000000000000000000000000000000000000ab";
+        let raw_symbol = "0xTOKEN_DELISTED";
+        let mut instrument = past_end_date_instrument(raw_symbol, Some(false));
+        if let InstrumentAny::BinaryOption(binary) = &mut instrument {
+            binary.id =
+                InstrumentId::from(format!("{condition_id}-{raw_symbol}.POLYMARKET").as_str());
+        }
+        cache_instrument(&instruments_cache, &token_meta, &instrument);
+        let instrument_id = instrument.id();
+
+        let now_ns = get_atomic_clock_realtime().get_time_ns();
+        assert!(
+            !crate::filters::is_retirable(
+                instruments_cache
+                    .load()
+                    .get(&instrument_id)
+                    .expect("cached"),
+                now_ns,
+            ),
+            "precondition: the carried instrument is not retirable while last seen open",
+        );
+
+        let InstrumentAny::BinaryOption(mut binary) = instruments_cache
+            .load()
+            .get(&instrument_id)
+            .expect("cached")
+            .clone()
+        else {
+            panic!("expected BinaryOption");
+        };
+        crate::filters::set_venue_closed(&mut binary, true);
+        cache_instrument(
+            &instruments_cache,
+            &token_meta,
+            &InstrumentAny::BinaryOption(binary),
+        );
+
+        assert!(
+            crate::filters::is_retirable(
+                instruments_cache
+                    .load()
+                    .get(&instrument_id)
+                    .expect("cached"),
+                now_ns,
+            ),
+            "a delisted condition must become reclaimable by the expiry sweep",
+        );
+    }
+
+    /// `request_instruments`, `request_instrument` and new-market WS discovery call
+    /// `cache_instrument_if_active` directly rather than going through the publish helper, so the
+    /// shared gate is asserted here on its own.
+    #[rstest]
+    #[case::open_at_venue(Some(false), true)]
+    #[case::closed_at_venue(Some(true), false)]
+    #[case::no_venue_state(None, false)]
+    fn direct_cache_gate_carries_past_end_date_markets_open_at_the_venue(
+        #[case] venue_closed: Option<bool>,
+        #[case] expected_cached: bool,
+    ) {
+        let instruments_cache = Arc::new(AtomicMap::new());
+        let token_meta = Arc::new(DashMap::new());
+
+        let instrument = past_end_date_instrument("0xTOKEN_DIRECT", venue_closed);
+        let instrument_id = instrument.id();
+
+        let cached = cache_instrument_if_active(
+            get_atomic_clock_realtime().get_time_ns(),
+            &instruments_cache,
+            &token_meta,
+            &instrument,
+        );
+
+        assert_eq!(cached, expected_cached);
+        assert_eq!(
+            instruments_cache.load().contains_key(&instrument_id),
+            expected_cached,
+        );
+        assert_eq!(
+            token_meta.contains_key(&Ustr::from("0xTOKEN_DIRECT")),
+            expected_cached,
+            "routing metadata must follow the cache decision",
+        );
+    }
+
+    #[rstest]
+    fn a_wrongly_retired_market_is_readmitted_once_the_venue_reports_it_open() {
+        // Retirement is recoverable, not terminal. If the venue ever reported a market closed in
+        // error, the next observation that reports it open re-admits it. This is what bounds the
+        // cost of trusting `closed`, and it is the behaviour the previous `endDate`-only gate
+        // lacked: there, a refetched market stayed rejected forever.
+        let instruments_cache = Arc::new(AtomicMap::new());
+        let token_meta = Arc::new(DashMap::new());
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let now_ns = get_atomic_clock_realtime().get_time_ns();
+
+        // Venue reports closed, so the sweep retires it and it leaves the cache.
+        let closed = past_end_date_instrument("0xTOKEN_RECOVER", Some(true));
+        let instrument_id = closed.id();
+        assert!(crate::filters::is_retirable(&closed, now_ns));
+        assert_eq!(
+            cache_and_publish_instruments(
+                &instruments_cache,
+                &token_meta,
+                &tx,
+                now_ns,
+                vec![closed],
+            ),
+            0,
+        );
+        assert!(!instruments_cache.load().contains_key(&instrument_id));
+
+        // A later fetch reports the same market open again.
+        let reopened = past_end_date_instrument("0xTOKEN_RECOVER", Some(false));
+        assert_eq!(
+            cache_and_publish_instruments(
+                &instruments_cache,
+                &token_meta,
+                &tx,
+                now_ns,
+                vec![reopened],
+            ),
+            1,
+        );
+
+        assert!(instruments_cache.load().contains_key(&instrument_id));
+        assert!(token_meta.contains_key(&Ustr::from("0xTOKEN_RECOVER")));
+        assert!(
+            rx.try_recv().is_ok(),
+            "re-admission must publish downstream"
+        );
+    }
+
+    const LIVENESS_CONDITION_ID: &str = "0xCONDITION";
+    const LIVENESS_TOKEN_IDS: [&str; 2] = ["111", "222"];
+
+    /// Gamma market payload for the liveness tests, with `endDate` far in the past so every
+    /// instrument parsed from it is carried rather than live.
+    fn liveness_market_json(closed: bool) -> serde_json::Value {
+        serde_json::json!({
+            "id": "1",
+            "conditionId": LIVENESS_CONDITION_ID,
+            "question": "Liveness probe market",
+            "slug": "liveness-probe-market",
+            "endDate": "2020-01-01T00:00:00Z",
+            "active": true,
+            "closed": closed,
+            "acceptingOrders": !closed,
+            "enableOrderBook": true,
+            "clobTokenIds": format!(
+                "[\"{}\", \"{}\"]",
+                LIVENESS_TOKEN_IDS[0], LIVENESS_TOKEN_IDS[1],
+            ),
+            "outcomes": "[\"Yes\", \"No\"]",
+            "orderPriceMinTickSize": 0.01,
+            "orderMinSize": 5,
+        })
+    }
+
+    fn liveness_instruments(closed: bool) -> Vec<InstrumentAny> {
+        let market: crate::http::models::GammaMarket =
+            serde_json::from_value(liveness_market_json(closed)).expect("gamma market");
+        let clock = get_atomic_clock_realtime();
+
+        crate::http::parse::parse_gamma_market(&market)
+            .expect("parse gamma market")
+            .iter()
+            .map(|def| {
+                crate::http::parse::create_instrument_from_def(def, clock.get_time_ns())
+                    .expect("create instrument")
+            })
+            .collect()
+    }
+
+    #[derive(Clone)]
+    struct LivenessServerState {
+        /// Served when the request carries no `closed` filter.
+        open: serde_json::Value,
+        /// Served when the request carries `closed=true`.
+        closed: serde_json::Value,
+        /// Every request fails while set, so a probe that never reaches Gamma can be exercised.
+        fail: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    async fn handle_liveness_markets(
+        axum::extract::State(state): axum::extract::State<LivenessServerState>,
+        axum::extract::RawQuery(query): axum::extract::RawQuery,
+    ) -> axum::response::Response {
+        use axum::response::IntoResponse;
+
+        if state.fail.load(std::sync::atomic::Ordering::SeqCst) {
+            return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+
+        let body = if query.unwrap_or_default().contains("closed=true") {
+            state.closed
+        } else {
+            state.open
+        };
+
+        axum::Json(body).into_response()
+    }
+
+    async fn handle_liveness_markets_keyset(
+        axum::extract::State(state): axum::extract::State<LivenessServerState>,
+        axum::extract::RawQuery(query): axum::extract::RawQuery,
+    ) -> axum::response::Response {
+        use axum::response::IntoResponse;
+
+        if state.fail.load(std::sync::atomic::Ordering::SeqCst) {
+            return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+
+        let markets = if query.unwrap_or_default().contains("closed=true") {
+            state.closed
+        } else {
+            state.open
+        };
+
+        axum::Json(serde_json::json!({"markets": markets})).into_response()
+    }
+
+    async fn start_liveness_test_server(state: LivenessServerState) -> std::net::SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind failed");
+        let addr = listener.local_addr().expect("local_addr");
+        let router = axum::Router::new()
+            .route("/markets", axum::routing::get(handle_liveness_markets))
+            .route(
+                "/markets/keyset",
+                axum::routing::get(handle_liveness_markets_keyset),
+            )
+            .with_state(state);
+
+        tokio::spawn(async move { axum::serve(listener, router).await.expect("serve failed") });
+        addr
+    }
+
+    /// Seeds the cache with the carried instruments and returns everything the refresh needs.
+    #[allow(clippy::type_complexity)]
+    fn liveness_fixture() -> (
+        Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+        tokio::sync::mpsc::UnboundedSender<DataEvent>,
+        tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
+        Vec<InstrumentId>,
+    ) {
+        let instruments_cache: Arc<AtomicMap<InstrumentId, InstrumentAny>> =
+            Arc::new(AtomicMap::new());
+        let token_meta: Arc<DashMap<Ustr, TokenMeta>> = Arc::new(DashMap::new());
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let mut ids = Vec::new();
+        for instrument in liveness_instruments(false) {
+            ids.push(instrument.id());
+            cache_instrument(&instruments_cache, &token_meta, &instrument);
+        }
+
+        (instruments_cache, tx, rx, ids)
+    }
+
+    fn liveness_client(addr: std::net::SocketAddr) -> PolymarketGammaHttpClient {
+        PolymarketGammaHttpClient::new(Some(format!("http://{addr}")), 5, RetryConfig::default())
+            .expect("gamma client")
+    }
+
+    fn venue_closed_in_cache(
+        instruments_cache: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+        instrument_id: &InstrumentId,
+    ) -> Option<bool> {
+        instruments_cache
+            .load()
+            .get(instrument_id)
+            .and_then(crate::filters::venue_reports_closed)
+    }
+
+    /// A close shows up only as absence from the plain `condition_ids` lookup, because Gamma omits
+    /// closed markets unless asked for them. The follow-up `closed=true` lookup turns that into a
+    /// positive observation, which retires on the first pass with no miss streak needed.
+    #[rstest]
+    #[tokio::test]
+    async fn confirmed_closed_condition_retires_on_the_first_pass() {
+        let addr = start_liveness_test_server(LivenessServerState {
+            open: serde_json::json!([]),
+            closed: serde_json::json!([liveness_market_json(true)]),
+            fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        })
+        .await;
+
+        let (instruments_cache, tx, _rx, ids) = liveness_fixture();
+        let mut misses: AHashMap<String, u32> = AHashMap::new();
+        let now_ns = get_atomic_clock_realtime().get_time_ns();
+
+        let refreshed = refresh_expired_instrument_liveness(
+            &liveness_client(addr),
+            &instruments_cache,
+            &tx,
+            &mut misses,
+            now_ns,
+        )
+        .await;
+
+        assert!(refreshed.probed);
+        assert_eq!(refreshed.updated, ids.len());
+
+        for instrument_id in &ids {
+            assert_eq!(
+                venue_closed_in_cache(&instruments_cache, instrument_id),
+                Some(true),
+            );
+        }
+
+        assert!(
+            misses.is_empty(),
+            "a positive observation must not leave a streak behind",
+        );
+    }
+
+    /// Absence from BOTH lookups is a weak signal (a parse failure, a transient omission), so it
+    /// has to repeat before it counts.
+    #[rstest]
+    #[tokio::test]
+    async fn condition_absent_from_both_lookups_retires_only_after_the_threshold() {
+        let addr = start_liveness_test_server(LivenessServerState {
+            open: serde_json::json!([]),
+            closed: serde_json::json!([]),
+            fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        })
+        .await;
+
+        let client = liveness_client(addr);
+        let (instruments_cache, tx, _rx, ids) = liveness_fixture();
+        let mut misses: AHashMap<String, u32> = AHashMap::new();
+        let now_ns = get_atomic_clock_realtime().get_time_ns();
+
+        for pass in 1..LIVENESS_MISSES_BEFORE_DELISTED {
+            let refreshed = refresh_expired_instrument_liveness(
+                &client,
+                &instruments_cache,
+                &tx,
+                &mut misses,
+                now_ns,
+            )
+            .await;
+
+            assert_eq!(refreshed.updated, 0, "must not retire on pass {pass}");
+            assert_eq!(misses.get(LIVENESS_CONDITION_ID), Some(&pass));
+            assert_eq!(
+                venue_closed_in_cache(&instruments_cache, &ids[0]),
+                Some(false),
+            );
+        }
+
+        let refreshed = refresh_expired_instrument_liveness(
+            &client,
+            &instruments_cache,
+            &tx,
+            &mut misses,
+            now_ns,
+        )
+        .await;
+
+        assert_eq!(refreshed.updated, ids.len());
+        assert_eq!(
+            venue_closed_in_cache(&instruments_cache, &ids[0]),
+            Some(true),
+        );
+        assert_eq!(
+            misses.get(LIVENESS_CONDITION_ID),
+            None,
+            "the streak must be cleared at retirement, or a re-loaded condition would be retired \
+             on its first absence with no confirmation",
+        );
+    }
+
+    /// A market the venue still reports open stays carried, and an intermittent miss never
+    /// accumulates into a retirement.
+    #[rstest]
+    #[tokio::test]
+    async fn condition_returned_open_stays_carried_and_clears_its_streak() {
+        let addr = start_liveness_test_server(LivenessServerState {
+            open: serde_json::json!([liveness_market_json(false)]),
+            closed: serde_json::json!([]),
+            fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        })
+        .await;
+
+        let (instruments_cache, tx, _rx, ids) = liveness_fixture();
+        let mut misses: AHashMap<String, u32> = AHashMap::new();
+        misses.insert(LIVENESS_CONDITION_ID.to_string(), 2);
+        let now_ns = get_atomic_clock_realtime().get_time_ns();
+
+        let refreshed = refresh_expired_instrument_liveness(
+            &liveness_client(addr),
+            &instruments_cache,
+            &tx,
+            &mut misses,
+            now_ns,
+        )
+        .await;
+
+        assert!(refreshed.probed);
+        assert_eq!(misses.get(LIVENESS_CONDITION_ID), None);
+
+        for instrument_id in &ids {
+            assert_eq!(
+                venue_closed_in_cache(&instruments_cache, instrument_id),
+                Some(false),
+                "a market the venue still reports open must stay carried",
+            );
+        }
+    }
+
+    /// A probe that never reached Gamma must retire nothing and must not count as a miss, so the
+    /// caller can retry on the next tick instead of deferring for a full interval.
+    #[rstest]
+    #[tokio::test]
+    async fn failed_probe_retires_nothing_and_does_not_defer() {
+        let addr = start_liveness_test_server(LivenessServerState {
+            open: serde_json::json!([]),
+            closed: serde_json::json!([]),
+            fail: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+        })
+        .await;
+
+        let (instruments_cache, tx, _rx, ids) = liveness_fixture();
+        let mut misses: AHashMap<String, u32> = AHashMap::new();
+        let now_ns = get_atomic_clock_realtime().get_time_ns();
+
+        let refreshed = refresh_expired_instrument_liveness(
+            &liveness_client(addr),
+            &instruments_cache,
+            &tx,
+            &mut misses,
+            now_ns,
+        )
+        .await;
+
+        assert!(
+            !refreshed.probed,
+            "a failed probe must not defer the next one"
+        );
+        assert_eq!(refreshed.updated, 0);
+        assert!(misses.is_empty(), "a failed request is not an observation");
+        assert_eq!(
+            venue_closed_in_cache(&instruments_cache, &ids[0]),
+            Some(false),
+        );
+    }
+
+    /// The refresh takes only the venue state from Gamma. A `tick_size_change` rebuilds the cached
+    /// definition, and swapping the Gamma copy in wholesale would revert that rebuild for a market
+    /// the venue is still trading.
+    #[rstest]
+    #[tokio::test]
+    async fn refresh_preserves_a_cached_tick_size_rebuild() {
+        let addr = start_liveness_test_server(LivenessServerState {
+            open: serde_json::json!([liveness_market_json(false)]),
+            closed: serde_json::json!([]),
+            fail: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        })
+        .await;
+
+        let (instruments_cache, tx, _rx, ids) = liveness_fixture();
+        let instrument_id = ids[0];
+
+        // Gamma reports a 0.01 tick; the venue then lowers it over the WebSocket.
+        let rebuilt = {
+            let loaded = instruments_cache.load();
+            let cached = loaded.get(&instrument_id).expect("cached instrument");
+            assert_eq!(cached.price_increment(), Price::from("0.01"));
+            crate::http::parse::rebuild_instrument_with_tick_size(
+                cached,
+                "0.001",
+                UnixNanos::default(),
+                UnixNanos::default(),
+            )
+            .expect("rebuild instrument")
+        };
+        instruments_cache.insert(instrument_id, rebuilt);
+
+        let mut misses: AHashMap<String, u32> = AHashMap::new();
+        refresh_expired_instrument_liveness(
+            &liveness_client(addr),
+            &instruments_cache,
+            &tx,
+            &mut misses,
+            get_atomic_clock_realtime().get_time_ns(),
+        )
+        .await;
+
+        let loaded = instruments_cache.load();
+        let cached = loaded.get(&instrument_id).expect("cached instrument");
+        assert_eq!(
+            cached.price_increment(),
+            Price::from("0.001"),
+            "the liveness refresh must not revert a tick size the venue lowered",
+        );
     }
 }

--- a/crates/adapters/polymarket/src/data/lifecycle.rs
+++ b/crates/adapters/polymarket/src/data/lifecycle.rs
@@ -27,6 +27,7 @@ use nautilus_model::events::PositionEvent;
 use super::{
     PolymarketDataClient,
     dispatch::{WsMessageContext, handle_ws_message},
+    instruments::refresh_expired_instrument_liveness,
     runtime::{retire_expired_local_instruments, seed_token_meta_from_live_instruments},
 };
 use crate::{
@@ -175,6 +176,19 @@ impl PolymarketDataClient {
         };
 
         let watchlist = self.resolve_poll_watchlist.clone();
+        let liveness_http_client = gamma_client.clone();
+        let liveness_data_sender = self.data_sender.clone();
+
+        // Venue liveness moves on the order of minutes, so it is refreshed on the instrument
+        // refresh cadence rather than the much faster resolve-poll tick. Without this the sweep
+        // interval (default 30s) would drive Gamma requests far harder than the venue warrants.
+        let liveness_interval = Duration::from_secs(
+            self.config
+                .update_instruments_interval_mins
+                .filter(|mins| *mins > 0)
+                .unwrap_or(60)
+                .saturating_mul(60),
+        );
 
         if resolve_poll_enabled {
             log::debug!("Polymarket resolve poll task started");
@@ -187,12 +201,44 @@ impl PolymarketDataClient {
         let handle = get_runtime().spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut last_liveness_refresh: Option<tokio::time::Instant> = None;
+            let mut liveness_misses: ahash::AHashMap<String, u32> = ahash::AHashMap::new();
 
             loop {
                 tokio::select! {
                     () = cancellation.cancelled() => break,
                     _ = interval.tick() => {
                         let now_ns = clock.get_time_ns();
+
+                        // Re-observe liveness before sweeping, so a market the venue has closed
+                        // is reclaimed even when it sits outside the configured refresh scope.
+                        if last_liveness_refresh
+                            .is_none_or(|last: tokio::time::Instant| last.elapsed() >= liveness_interval)
+                        {
+                            let refreshed = refresh_expired_instrument_liveness(
+                                &liveness_http_client,
+                                &instruments,
+                                &liveness_data_sender,
+                                &mut liveness_misses,
+                                now_ns,
+                            )
+                            .await;
+
+                            // Only a pass that reached Gamma defers the next probe, so a failed
+                            // one retries on the next tick rather than holding a closed market's
+                            // subscription for another full interval.
+                            if refreshed.probed {
+                                last_liveness_refresh = Some(tokio::time::Instant::now());
+                            }
+
+                            if refreshed.updated > 0 {
+                                log::debug!(
+                                    "Re-observed venue liveness for {} expired Polymarket instrument(s)",
+                                    refreshed.updated,
+                                );
+                            }
+                        }
+
                         retire_expired_local_instruments(
                             now_ns,
                             &instruments,

--- a/crates/adapters/polymarket/src/data/mod.rs
+++ b/crates/adapters/polymarket/src/data/mod.rs
@@ -73,7 +73,7 @@ use self::{
         request_book_snapshot, request_data, request_instrument, request_instruments,
         request_trades,
     },
-    runtime::is_instrument_expired,
+    runtime::is_instrument_retirable,
     subscriptions::{resolve_token_id_from, sync_ws_subscription_async},
 };
 use crate::{
@@ -295,7 +295,7 @@ impl PolymarketDataClient {
             return Ok(());
         };
 
-        if is_instrument_expired(instrument, now_ns) {
+        if is_instrument_retirable(instrument, now_ns) {
             anyhow::bail!(
                 "Instrument {instrument_id} is expired and no longer available for live subscription"
             );
@@ -314,7 +314,7 @@ impl PolymarketDataClient {
             .ok_or_else(|| InstrumentLookupError::not_found(instrument_id))?
             .clone();
 
-        if is_instrument_expired(&instrument, self.clock.get_time_ns()) {
+        if is_instrument_retirable(&instrument, self.clock.get_time_ns()) {
             anyhow::bail!(
                 "Instrument {instrument_id} is expired and no longer available for market data requests"
             );

--- a/crates/adapters/polymarket/src/data/requests.rs
+++ b/crates/adapters/polymarket/src/data/requests.rs
@@ -300,8 +300,12 @@ pub(super) fn request_instrument(client: &PolymarketDataClient, request: Request
         };
 
         if let Some(inst) = instrument {
-            if cache_instrument_if_active(clock.get_time_ns(), &instruments_cache, &token_meta, &inst)
-            {
+            if cache_instrument_if_active(
+                clock.get_time_ns(),
+                &instruments_cache,
+                &token_meta,
+                &inst,
+            ) {
                 // Publish onto the data bus so other clients (e.g. the exec
                 // client's token map) can update from the same fetch.
                 if let Err(e) = sender.send(DataEvent::Instrument(inst.clone())) {

--- a/crates/adapters/polymarket/src/data/runtime.rs
+++ b/crates/adapters/polymarket/src/data/runtime.rs
@@ -34,8 +34,12 @@ use super::{
 };
 use crate::resolve::ResolveWatchEntry;
 
-pub(crate) fn is_instrument_expired(instrument: &InstrumentAny, now_ns: UnixNanos) -> bool {
-    crate::filters::is_expired(instrument, now_ns)
+/// Returns `true` if `instrument` may be retired from local runtime state.
+///
+/// Delegates to [`crate::filters::is_retirable`] so the data and execution clients share one
+/// definition of retirement.
+pub(crate) fn is_instrument_retirable(instrument: &InstrumentAny, now_ns: UnixNanos) -> bool {
+    crate::filters::is_retirable(instrument, now_ns)
 }
 
 pub(crate) fn seed_token_meta_from_live_instruments(
@@ -46,7 +50,7 @@ pub(crate) fn seed_token_meta_from_live_instruments(
     let loaded = instruments.load();
 
     for instrument in loaded.values() {
-        if is_instrument_expired(instrument, now_ns) {
+        if is_instrument_retirable(instrument, now_ns) {
             continue;
         }
 
@@ -202,7 +206,7 @@ pub(crate) async fn retire_expired_local_instruments(
         loaded
             .iter()
             .filter_map(|(instrument_id, instrument)| {
-                is_instrument_expired(instrument, now_ns)
+                is_instrument_retirable(instrument, now_ns)
                     .then_some((*instrument_id, instrument.raw_symbol().as_str().to_string()))
             })
             .collect()
@@ -231,6 +235,20 @@ pub(crate) async fn retire_expired_local_instruments(
         }
 
         expired_ids.push(instrument_id);
+    }
+
+    if !expired_ids.is_empty() {
+        // Dropping a live subscription must be visible: this path was previously silent at every
+        // level, which is what made the endDate defect so hard to diagnose.
+        log::info!(
+            "Retiring {} Polymarket instrument(s) closed at the venue: {}",
+            expired_ids.len(),
+            expired_ids
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
     }
 
     for instrument_id in expired_ids {
@@ -466,5 +484,312 @@ mod tests {
                 .is_empty()
         );
         assert!(!ws_open_tokens.contains(&token_id));
+    }
+
+    #[rstest]
+    fn instrument_before_expiration_is_never_retirable() {
+        let clock = get_atomic_clock_realtime();
+        let mut binary = binary_option();
+        binary.expiration_ns =
+            UnixNanos::from(clock.get_time_ns().as_u64().saturating_add(60_000_000_000));
+        let instrument = InstrumentAny::BinaryOption(binary);
+
+        assert!(!is_instrument_retirable(&instrument, clock.get_time_ns()));
+    }
+
+    #[rstest]
+    fn expired_instrument_open_at_venue_is_retained() {
+        // The defect: the venue keeps trading past `endDate`, so the market must stay carried.
+        let clock = get_atomic_clock_realtime();
+        let instrument =
+            expired_instrument_with_state("0xTOKEN_VENUE", "0xCOND-VENUE", Some(false));
+
+        assert!(!is_instrument_retirable(&instrument, clock.get_time_ns()));
+    }
+
+    #[rstest]
+    fn expired_instrument_closed_at_venue_is_retired() {
+        let clock = get_atomic_clock_realtime();
+        let instrument = expired_instrument_with_state("0xTOKEN_VENUE", "0xCOND-VENUE", Some(true));
+
+        assert!(is_instrument_retirable(&instrument, clock.get_time_ns()));
+    }
+
+    #[rstest]
+    fn expired_instrument_without_venue_state_is_retired() {
+        // Instruments cached before this field existed keep the previous behaviour.
+        let clock = get_atomic_clock_realtime();
+        let instrument = expired_instrument_with_state("0xTOKEN_VENUE", "0xCOND-VENUE", None);
+
+        assert!(is_instrument_retirable(&instrument, clock.get_time_ns()));
+    }
+
+    #[rstest]
+    fn live_venue_payload_past_end_date_is_retained() {
+        // Captured from Gamma on 2026-08-08: `endDate` two months in the past while the venue
+        // still reports the market open and accepting orders.
+        let market: crate::http::models::GammaMarket = serde_json::from_str(include_str!(
+            "../../test_data/gamma_market_past_end_date_open.json"
+        ))
+        .expect("gamma market fixture json");
+
+        assert_eq!(market.end_date.as_deref(), Some("2026-06-01T00:00:00Z"));
+        assert_eq!(market.closed, Some(false));
+        assert_eq!(market.accepting_orders, Some(true));
+
+        let clock = get_atomic_clock_realtime();
+        let defs = crate::http::parse::parse_gamma_market(&market).expect("parse gamma market");
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], clock.get_time_ns())
+                .expect("create instrument");
+
+        assert!(
+            crate::filters::is_expired(&instrument, clock.get_time_ns()),
+            "fixture must be past its endDate for this test to mean anything",
+        );
+        assert_eq!(
+            crate::filters::venue_reports_closed(&instrument),
+            Some(false)
+        );
+        assert!(
+            !is_instrument_retirable(&instrument, clock.get_time_ns()),
+            "a market the venue still trades must not be retired on endDate alone",
+        );
+    }
+
+    /// Builds an expired instrument with an explicit venue state and a chosen token/condition.
+    fn expired_instrument_with_state(
+        raw_symbol: &str,
+        condition_id: &str,
+        venue_closed: Option<bool>,
+    ) -> InstrumentAny {
+        let inst = seed_expired_instrument(raw_symbol, condition_id);
+        let InstrumentAny::BinaryOption(mut binary) = inst else {
+            panic!("expected BinaryOption");
+        };
+
+        let mut info = binary
+            .info
+            .clone()
+            .unwrap_or_else(nautilus_core::Params::new);
+
+        if let Some(closed) = venue_closed {
+            info.insert("venue_closed".to_string(), serde_json::Value::Bool(closed));
+        }
+        binary.info = Some(info);
+
+        InstrumentAny::BinaryOption(binary)
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn sweep_emits_ws_unsubscribe_only_when_venue_reports_closed() {
+        // Evidences the WebSocket teardown directly: the retirement path emits no log at any
+        // level, so the command channel is the observable.
+        for (venue_closed, expect_unsubscribe) in [(Some(false), false), (Some(true), true)] {
+            let instruments = Arc::new(AtomicMap::new());
+            let token_meta = Arc::new(DashMap::new());
+            let order_books = Arc::new(DashMap::new());
+            let last_quotes = Arc::new(DashMap::new());
+            let active_quote_subs = Arc::new(AtomicSet::new());
+            let active_delta_subs = Arc::new(AtomicSet::new());
+            let active_trade_subs = Arc::new(AtomicSet::new());
+            let resolve_poll_watchlist = Arc::new(AtomicMap::new());
+            let pending_snapshot_after_tick_change = Arc::new(AtomicSet::new());
+            let pending_auto_loads = Arc::new(StdMutex::new(AHashSet::new()));
+            let ws_open_tokens = Arc::new(AtomicSet::new());
+            let ws_sub_mutex = Arc::new(tokio::sync::Mutex::new(()));
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<HandlerCommand>();
+            let ws = PolymarketMarketPoolHandle::test_single_shard(tx, &["0xTOKEN_AB"]);
+
+            let inst = expired_instrument_with_state("0xTOKEN_AB", "0xCOND-AB", venue_closed);
+            let instrument_id = inst.id();
+            seed_cached_instrument(&instruments, &token_meta, &inst);
+            seed_runtime_state(
+                &inst,
+                &order_books,
+                &last_quotes,
+                &active_quote_subs,
+                &active_delta_subs,
+                &active_trade_subs,
+                &pending_snapshot_after_tick_change,
+                &pending_auto_loads,
+                &ws_open_tokens,
+            );
+
+            retire_expired_local_instruments(
+                get_atomic_clock_realtime().get_time_ns(),
+                &instruments,
+                &token_meta,
+                &order_books,
+                &last_quotes,
+                &active_quote_subs,
+                &active_delta_subs,
+                &active_trade_subs,
+                &resolve_poll_watchlist,
+                &pending_snapshot_after_tick_change,
+                &pending_auto_loads,
+                &ws_open_tokens,
+                &ws_sub_mutex,
+                &ws,
+            )
+            .await;
+
+            if expect_unsubscribe {
+                match rx
+                    .try_recv()
+                    .expect("venue-closed market should unsubscribe")
+                {
+                    HandlerCommand::UnsubscribeMarket(ids) => {
+                        assert_eq!(ids, vec!["0xTOKEN_AB".to_string()]);
+                    }
+                    other => panic!("unexpected WS command: {other:?}"),
+                }
+                assert!(!instruments.load().contains_key(&instrument_id));
+            } else {
+                assert!(
+                    rx.try_recv().is_err(),
+                    "market open at the venue must not be unsubscribed",
+                );
+                assert!(instruments.load().contains_key(&instrument_id));
+                assert!(token_meta.contains_key(&Ustr::from("0xTOKEN_AB")));
+            }
+        }
+    }
+
+    /// A watchlisted instrument keeps its cache entry through retirement so settlement can still
+    /// read it. A later publish of the same venue-closed definition must correct that entry without
+    /// restoring runtime state, or every refresh would re-arm the sweep for a market the venue has
+    /// already closed and message routing would come back with it.
+    #[rstest]
+    #[tokio::test]
+    async fn superseding_a_watchlisted_instrument_does_not_restore_runtime_state() {
+        let instruments = Arc::new(AtomicMap::new());
+        let token_meta = Arc::new(DashMap::new());
+        let order_books = Arc::new(DashMap::new());
+        let last_quotes = Arc::new(DashMap::new());
+        let active_quote_subs = Arc::new(AtomicSet::new());
+        let active_delta_subs = Arc::new(AtomicSet::new());
+        let active_trade_subs = Arc::new(AtomicSet::new());
+        let resolve_poll_watchlist = Arc::new(AtomicMap::new());
+        let pending_snapshot_after_tick_change = Arc::new(AtomicSet::new());
+        let pending_auto_loads = Arc::new(StdMutex::new(AHashSet::new()));
+        let ws_open_tokens = Arc::new(AtomicSet::new());
+        let ws_sub_mutex = Arc::new(tokio::sync::Mutex::new(()));
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<HandlerCommand>();
+        let ws = PolymarketMarketPoolHandle::test_single_shard(tx, &["0xTOKEN_HELD"]);
+        let (data_tx, _data_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let inst = expired_instrument_with_state("0xTOKEN_HELD", "0xCOND-HELD", Some(true));
+        let instrument_id = inst.id();
+        let token = Ustr::from("0xTOKEN_HELD");
+        seed_cached_instrument(&instruments, &token_meta, &inst);
+        seed_runtime_state(
+            &inst,
+            &order_books,
+            &last_quotes,
+            &active_quote_subs,
+            &active_delta_subs,
+            &active_trade_subs,
+            &pending_snapshot_after_tick_change,
+            &pending_auto_loads,
+            &ws_open_tokens,
+        );
+
+        // An open position pins the instrument, so retirement keeps the cache entry.
+        resolve_poll_watchlist.insert(
+            "0xCOND-HELD".to_string(),
+            ResolveWatchEntry {
+                condition_id: "0xCOND-HELD".to_string(),
+                expiration_ns: inst.expiration_ns().unwrap_or_default(),
+                tracked: ahash::AHashMap::from_iter([(
+                    "0xTOKEN_HELD".to_string(),
+                    crate::resolve::TrackedInstrument {
+                        instrument_id,
+                        token_id: "0xTOKEN_HELD".to_string(),
+                        price_precision: inst.price_precision(),
+                        open_position_ids: AHashSet::new(),
+                    },
+                )]),
+                paused: false,
+            },
+        );
+
+        let sweep = async || {
+            retire_expired_local_instruments(
+                get_atomic_clock_realtime().get_time_ns(),
+                &instruments,
+                &token_meta,
+                &order_books,
+                &last_quotes,
+                &active_quote_subs,
+                &active_delta_subs,
+                &active_trade_subs,
+                &resolve_poll_watchlist,
+                &pending_snapshot_after_tick_change,
+                &pending_auto_loads,
+                &ws_open_tokens,
+                &ws_sub_mutex,
+                &ws,
+            )
+            .await;
+        };
+
+        sweep().await;
+
+        assert!(
+            matches!(rx.try_recv(), Ok(HandlerCommand::UnsubscribeMarket(_))),
+            "the first sweep retires the closed market",
+        );
+        assert!(
+            instruments.load().contains_key(&instrument_id),
+            "a watchlisted instrument keeps its cache entry for settlement",
+        );
+        assert!(!token_meta.contains_key(&token));
+
+        // The same venue-closed definition arrives again from a refresh.
+        crate::data::instruments::cache_and_publish_instruments(
+            &instruments,
+            &token_meta,
+            &data_tx,
+            get_atomic_clock_realtime().get_time_ns(),
+            vec![inst.clone()],
+        );
+
+        assert!(
+            !token_meta.contains_key(&token),
+            "superseding must not restore routing for a market the venue has closed",
+        );
+
+        sweep().await;
+
+        assert!(
+            rx.try_recv().is_err(),
+            "an already retired instrument must not be torn down again",
+        );
+    }
+
+    #[rstest]
+    fn reconnect_reseeds_token_meta_only_for_markets_open_at_the_venue() {
+        // Evidences the reconnect path: seeding is what restores WS message routing.
+        let instruments = Arc::new(AtomicMap::new());
+        let token_meta: Arc<DashMap<Ustr, TokenMeta>> = Arc::new(DashMap::new());
+
+        let open = expired_instrument_with_state("0xTOKEN_OPEN", "0xCOND-OPEN", Some(false));
+        let closed = expired_instrument_with_state("0xTOKEN_CLOSED", "0xCOND-CLOSED", Some(true));
+        let unknown = expired_instrument_with_state("0xTOKEN_UNKNOWN", "0xCOND-UNKNOWN", None);
+        for inst in [&open, &closed, &unknown] {
+            instruments.insert(inst.id(), inst.clone());
+        }
+
+        seed_token_meta_from_live_instruments(
+            get_atomic_clock_realtime().get_time_ns(),
+            &instruments,
+            &token_meta,
+        );
+
+        assert!(token_meta.contains_key(&Ustr::from("0xTOKEN_OPEN")));
+        assert!(!token_meta.contains_key(&Ustr::from("0xTOKEN_CLOSED")));
+        assert!(!token_meta.contains_key(&Ustr::from("0xTOKEN_UNKNOWN")));
     }
 }

--- a/crates/adapters/polymarket/src/execution/lifecycle.rs
+++ b/crates/adapters/polymarket/src/execution/lifecycle.rs
@@ -28,7 +28,7 @@ use nautilus_common::{
     live::{runner::get_exec_event_sender, runtime::get_runtime},
     msgbus::{self, TypedHandler},
 };
-use nautilus_core::{MUTEX_POISONED, collections::AtomicMap, time::AtomicTime};
+use nautilus_core::{MUTEX_POISONED, UnixNanos, collections::AtomicMap, time::AtomicTime};
 use nautilus_model::{
     events::{OrderEventAny, OrderFilled, PositionEvent},
     identifiers::InstrumentId,
@@ -575,6 +575,10 @@ impl PolymarketExecutionClient {
     }
 
     pub(super) fn on_instrument_update(&self, instrument: &InstrumentAny) {
+        // Deliberately unconditional. Execution lookup state is kept for an expired market so
+        // trailing order and fill updates can still be routed; it is reclaimed on a terminal
+        // order or position event once no exposure remains. See
+        // `on_instrument_update_upserts_expired_execution_lookup_state`.
         self.upsert_execution_lookup(instrument);
     }
 }
@@ -700,23 +704,23 @@ fn sync_execution_lookup_for_instrument(
 
     let instrument = cache.instrument(&instrument_id).cloned();
     let retain = instrument.as_ref().is_some_and(|instrument| {
-        if !crate::filters::is_expired(instrument, now_ns) {
-            return true;
-        }
-
-        cache.has_orders_open(
-            Some(&core.venue),
-            Some(&instrument_id),
-            None,
-            Some(&account_id),
-            None,
-        ) || cache.has_positions_open(
-            Some(&core.venue),
-            Some(&instrument_id),
-            None,
-            Some(&account_id),
-            None,
-        )
+        // Passed lazily: this fires on every terminal order event, and a market the venue still
+        // reports open is retained without needing two cache index scans to prove it.
+        should_retain_execution_lookup(instrument, now_ns, || {
+            cache.has_orders_open(
+                Some(&core.venue),
+                Some(&instrument_id),
+                None,
+                Some(&account_id),
+                None,
+            ) || cache.has_positions_open(
+                Some(&core.venue),
+                Some(&instrument_id),
+                None,
+                Some(&account_id),
+                None,
+            )
+        })
     });
 
     drop(cache);
@@ -731,6 +735,20 @@ fn sync_execution_lookup_for_instrument(
         // Instrument not in cache: token key cannot be derived, so drop only the neg-risk entry
         None => neg_risk_index.remove(&instrument_id),
     }
+}
+
+/// Returns `true` if execution lookup state for `instrument` must be kept.
+///
+/// Mirrors the data client's retirement policy so the two clients cannot disagree: Gamma `endDate`
+/// is a scheduled end, so a market the venue still reports open keeps its lookup state even once
+/// `expiration_ns` has passed. Open orders or positions always pin the entry, and are only looked
+/// up when the instrument is otherwise retirable.
+fn should_retain_execution_lookup(
+    instrument: &InstrumentAny,
+    now_ns: UnixNanos,
+    has_open_orders_or_positions: impl FnOnce() -> bool,
+) -> bool {
+    !crate::filters::is_retirable(instrument, now_ns) || has_open_orders_or_positions()
 }
 
 fn is_terminal_order_event(event: &OrderEventAny) -> bool {
@@ -1451,6 +1469,35 @@ mod tests {
                 .expect(MUTEX_POISONED)
                 .processed_fills
                 .contains(&dedup_key)
+        );
+    }
+
+    /// The execution client must not drop lookup state for a market the venue still trades.
+    /// Without this the token to instrument entry disappears and later order updates for that
+    /// market cannot be routed.
+    #[rstest]
+    #[case::open_at_venue_no_exposure(Some(false), false, true)]
+    #[case::closed_at_venue_no_exposure(Some(true), false, false)]
+    #[case::no_venue_state_no_exposure(None, false, false)]
+    #[case::closed_at_venue_with_exposure(Some(true), true, true)]
+    fn execution_lookup_retention_matches_the_data_client_policy(
+        #[case] venue_closed: Option<bool>,
+        #[case] has_open: bool,
+        #[case] expect_retained: bool,
+    ) {
+        let clock = nautilus_core::time::get_atomic_clock_realtime();
+        let mut binary = binary_option();
+        binary.expiration_ns =
+            UnixNanos::from(clock.get_time_ns().as_u64().saturating_sub(1_000_000_000));
+
+        if let Some(closed) = venue_closed {
+            crate::filters::set_venue_closed(&mut binary, closed);
+        }
+        let instrument = InstrumentAny::BinaryOption(binary);
+
+        assert_eq!(
+            should_retain_execution_lookup(&instrument, clock.get_time_ns(), || has_open),
+            expect_retained,
         );
     }
 }

--- a/crates/adapters/polymarket/src/filters.rs
+++ b/crates/adapters/polymarket/src/filters.rs
@@ -18,7 +18,7 @@
 use std::fmt::Debug;
 
 use nautilus_core::UnixNanos;
-use nautilus_model::instruments::{Instrument, InstrumentAny};
+use nautilus_model::instruments::{BinaryOption, Instrument, InstrumentAny};
 
 use crate::{
     http::query::{GetGammaEventsParams, GetGammaMarketsParams, GetSearchParams},
@@ -261,6 +261,52 @@ impl PredicateFilter {
 pub(crate) fn is_expired(instrument: &InstrumentAny, now_ns: UnixNanos) -> bool {
     Instrument::expiration_ns(instrument)
         .is_some_and(|expiration_ns| expiration_ns.as_u64() != 0 && expiration_ns <= now_ns)
+}
+
+/// Returns `true` if `instrument` may be retired from local runtime state.
+///
+/// Gamma `endDate` is a scheduled end, not an observed one: the venue routinely keeps trading a
+/// market past it, so expiration alone cannot decide liveness. An expired instrument is retained
+/// only while the venue positively reports it open. Instruments carrying no venue state, such as
+/// those cached before this field existed, retire on expiration as before.
+///
+/// Retirement keys on the terminal `closed` flag rather than `accepting_orders`, which pauses
+/// transiently during resolution and sports windows.
+///
+/// Both the data client and the execution client gate on this so their views cannot diverge.
+pub(crate) fn is_retirable(instrument: &InstrumentAny, now_ns: UnixNanos) -> bool {
+    if !is_expired(instrument, now_ns) {
+        return false;
+    }
+
+    venue_reports_closed(instrument) != Some(false)
+}
+
+/// Info key carrying the venue's terminal lifecycle state, written at parse time.
+pub(crate) const VENUE_CLOSED_KEY: &str = "venue_closed";
+
+/// Records the venue's terminal lifecycle state on `binary`.
+pub(crate) fn set_venue_closed(binary: &mut BinaryOption, closed: bool) {
+    let mut info = binary.info.clone().unwrap_or_default();
+    info.insert(
+        VENUE_CLOSED_KEY.to_string(),
+        serde_json::Value::Bool(closed),
+    );
+    binary.info = Some(info);
+}
+
+/// Returns whether the venue reported `instrument` closed when it was last fetched.
+///
+/// Returns `None` for instruments built before this field was carried, and for non-binary
+/// variants, so callers can fall back to expiration alone.
+pub(crate) fn venue_reports_closed(instrument: &InstrumentAny) -> Option<bool> {
+    match instrument {
+        InstrumentAny::BinaryOption(binary) => binary
+            .info
+            .as_ref()
+            .and_then(|info| info.get_bool(VENUE_CLOSED_KEY)),
+        _ => None,
+    }
 }
 
 impl Debug for PredicateFilter {

--- a/crates/adapters/polymarket/src/http/parse.rs
+++ b/crates/adapters/polymarket/src/http/parse.rs
@@ -72,6 +72,12 @@ pub struct PolymarketInstrumentDef {
     pub end_date: Option<String>,
     /// Whether the market is active and accepting orders.
     pub active: bool,
+    /// Whether the venue reports the market closed.
+    ///
+    /// This is the terminal lifecycle signal. `accepting_orders` pauses transiently during
+    /// resolution and sports windows, so it must not be used to decide retirement.
+    #[serde(default)]
+    pub venue_closed: bool,
     /// URL slug for the market.
     pub market_slug: Option<String>,
     /// Whether the market uses the neg-risk CTF exchange contract.
@@ -166,6 +172,7 @@ pub fn parse_gamma_market(market: &GammaMarket) -> anyhow::Result<Vec<Polymarket
             start_date: market.start_date.clone(),
             end_date: market.end_date.clone(),
             active,
+            venue_closed: market.closed.unwrap_or(false),
             market_slug: market.market_slug.clone(),
             neg_risk,
             fee_schedule: market.fee_schedule.clone(),
@@ -353,6 +360,13 @@ fn build_info_json(def: &PolymarketInstrumentDef) -> serde_json::Value {
     map.insert(
         "neg_risk".to_string(),
         serde_json::Value::Bool(def.neg_risk),
+    );
+
+    // Terminal lifecycle state as reported by Gamma when this definition was fetched, carried
+    // through so the data client can tell a market the venue still trades from one it has closed
+    map.insert(
+        crate::filters::VENUE_CLOSED_KEY.to_string(),
+        serde_json::Value::Bool(def.venue_closed),
     );
 
     if let Some(fee_schedule) = &def.fee_schedule
@@ -634,6 +648,35 @@ mod tests {
         );
         assert_eq!(info.get_u64("game_id"), None);
         assert_eq!(info.get("fee_schedule"), None);
+        assert_eq!(info.get_bool("venue_closed"), Some(false));
+    }
+
+    #[rstest]
+    #[case(Some(false), Some(true), false)]
+    #[case(Some(true), Some(true), true)]
+    #[case(None, Some(true), false)]
+    // `accepting_orders` pauses transiently and must not affect the terminal signal.
+    #[case(Some(false), Some(false), false)]
+    fn test_create_instrument_info_carries_venue_liveness(
+        #[case] closed: Option<bool>,
+        #[case] accepting_orders: Option<bool>,
+        #[case] expected: bool,
+    ) {
+        let mut market = load_gamma_market("gamma_market.json");
+        market.closed = closed;
+        market.accepting_orders = accepting_orders;
+
+        let defs = parse_gamma_market(&market).unwrap();
+        let instrument =
+            create_instrument_from_def(&defs[0], UnixNanos::from(1_000_000_000u64)).unwrap();
+
+        let binary = match &instrument {
+            InstrumentAny::BinaryOption(b) => b,
+            other => panic!("Expected BinaryOption, was {other:?}"),
+        };
+
+        let info = binary.info.as_ref().expect("info should be Some");
+        assert_eq!(info.get_bool("venue_closed"), Some(expected));
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/resolve/watchlist.rs
+++ b/crates/adapters/polymarket/src/resolve/watchlist.rs
@@ -729,4 +729,70 @@ mod tests {
         );
         assert_eq!(selection.condition_ids, vec!["0xCOND-ACTIVE".to_string()]);
     }
+
+    fn watch_entry_with_expiration(
+        condition_id: &str,
+        token_id: &str,
+        expiration_ns: UnixNanos,
+    ) -> ResolveWatchEntry {
+        let mut tracked = ahash::AHashMap::new();
+        tracked.insert(
+            token_id.to_string(),
+            TrackedInstrument {
+                instrument_id: InstrumentId::from(format!("{token_id}.POLYMARKET").as_str()),
+                token_id: token_id.to_string(),
+                price_precision: 3,
+                open_position_ids: AHashSet::new(),
+            },
+        );
+
+        ResolveWatchEntry {
+            condition_id: condition_id.to_string(),
+            expiration_ns,
+            tracked,
+            paused: false,
+        }
+    }
+
+    #[rstest]
+    fn resolve_watch_eligibility_is_keyed_on_expiration_ns() {
+        // Evidences that resolve polling arms off `expiration_ns`, which is Gamma `endDate`.
+        // For a market the venue keeps trading past `endDate`, polling therefore starts and times
+        // out while the market is still live.
+        let now_ns = UnixNanos::from(10_000_000_000_000u64);
+        let grace_secs: u64 = 10;
+        let max_wait_secs: u64 = 1_800;
+
+        let expired_ns =
+            UnixNanos::from(now_ns.as_u64() - (max_wait_secs + 60).saturating_mul(1_000_000_000));
+        let future_ns = UnixNanos::from(now_ns.as_u64() + 60_000_000_000);
+
+        let mut watchlist = ahash::AHashMap::new();
+        watchlist.insert(
+            "0xCOND-PAST".to_string(),
+            watch_entry_with_expiration("0xCOND-PAST", "0xTOKEN-PAST", expired_ns),
+        );
+        watchlist.insert(
+            "0xCOND-FUTURE".to_string(),
+            watch_entry_with_expiration("0xCOND-FUTURE", "0xTOKEN-FUTURE", future_ns),
+        );
+
+        let selection = collect_resolve_watch_selection(
+            &watchlist,
+            now_ns,
+            grace_secs,
+            max_wait_secs,
+            ResolveWatchSelectionMode::AutoPoll,
+        );
+
+        assert_eq!(
+            selection.skipped_not_expired, 1,
+            "an entry before its expiration is not yet eligible",
+        );
+        assert_eq!(
+            selection.timed_out_watchlist, 1,
+            "an entry past expiration + max_wait has already timed out, even though the venue may \
+             still be trading that market",
+        );
+    }
 }

--- a/crates/adapters/polymarket/test_data/gamma_market_past_end_date_open.json
+++ b/crates/adapters/polymarket/test_data/gamma_market_past_end_date_open.json
@@ -1,0 +1,21 @@
+{
+  "id": "2063130",
+  "conditionId": "0x72af7d77091bd2209f78a45a13876beefc734768177dbc0c8171f515ba1a52a7",
+  "questionID": "0x55ab76d092f682bf5cbb7e14f13ee12f8410ce7cc1b7906f23b8fb56c11f6502",
+  "question": "Will Berhanu Nega be the next Prime Minister of Ethiopia?",
+  "description": "General elections are scheduled to be held in Ethiopia on June 1, 2026.\n\nThis market will resolve to the next individual who officially assumes the office of Prime Minister of Ethiopia following the 2026 General elections.\n\nTo count for resolution, the individual must be officially appointed and sworn in as Prime Minister of Ethiopia. Any interim or caretaker Prime Minister will not count toward the resolution of this market.\n\nIf no such Prime Minister takes office by December 31, 2028, 11:59 PM ET, this market will resolve to \u201cOther\u201d.\n\nThe primary resolution source for this market will be official information from the Government of Ethiopia; however, a consensus of credible reporting may also be used.",
+  "slug": "will-berhanu-nega-be-the-next-prime-minister-of-ethiopia",
+  "startDate": "2026-04-27T21:54:45.451Z",
+  "endDate": "2026-06-01T00:00:00Z",
+  "active": true,
+  "closed": false,
+  "acceptingOrders": true,
+  "enableOrderBook": true,
+  "clobTokenIds": "[\"9700525976462326306802795530553376348116310383328382626789994562350229436531\", \"9684129004308889646536044141330168144866101175836994432446145127310478131443\"]",
+  "outcomes": "[\"Yes\", \"No\"]",
+  "orderPriceMinTickSize": 0.001,
+  "orderMinSize": 5,
+  "negRisk": true,
+  "negRiskMarketID": "0x55ab76d092f682bf5cbb7e14f13ee12f8410ce7cc1b7906f23b8fb56c11f6500",
+  "umaResolutionStatuses": "[]"
+}

--- a/docs/integrations/polymarket.md
+++ b/docs/integrations/polymarket.md
@@ -790,6 +790,41 @@ can expire before the venue finishes hydrating, so budget for that or raise the 
 retry budget is exhausted, a condition still missing on Gamma is logged as a terminal miss and the
 caller must resubscribe after the market becomes available.
 
+### Instrument retirement and venue liveness
+
+Gamma `endDate` is a scheduled end rather than an observed one, and the venue routinely keeps
+trading a market past it. Long-dated markets can run months beyond `endDate` while still accepting
+orders, so `endDate` alone cannot decide whether a market is still tradeable.
+
+The data client therefore retires an instrument only once it is past `expiration_ns` *and* the
+venue reports it closed. The terminal signal is the Gamma `closed` field, captured on every fetch.
+`acceptingOrders` is deliberately not used, because the venue pauses it transiently during
+resolution and sports windows while the market is still live. Instruments cached before this field
+existed carry no venue state and retire on expiration as before.
+
+The execution client gates its lookup retention on the same predicate, so the two clients cannot
+disagree about whether a market is still live.
+
+Because the scope refresh only covers the configured bootstrap universe, instruments brought in by
+auto-load or new-market discovery would otherwise never have their liveness re-checked. The expiry
+sweep therefore refetches any instrument it is carrying past `expiration_ns` by `condition_id`,
+which keeps the `closed` flag current and lets closed markets be reclaimed regardless of how they
+entered the cache. Only markets already past `endDate` and last reported open are refetched, so the
+added request volume is bounded by that set. Only the venue state is taken from the refetch, so a
+definition rebuilt by a `tick_size_change` keeps its precision.
+
+This probe runs on the instrument refresh cadence (`update_instruments_interval_mins`, default 60
+minutes) rather than on every sweep tick, since venue liveness moves on the order of minutes. Gamma
+omits closed markets from a plain `condition_ids` lookup, so a condition missing from it is checked
+again with `closed=true`: a market confirmed closed is retired on that pass, while one absent from
+both lookups is a weaker signal and must repeat across three passes. Worst-case reclaim is therefore
+hours rather than seconds, and a probe that fails to reach Gamma retries on the next tick instead of
+deferring for a full interval.
+
+Setting `update_instruments_interval_mins` to `0` disables the scope refresh but not this liveness
+probe, which stays on the default hourly cadence. Disabling it as well would mean no instrument is
+ever retired.
+
 ### Market resolution events
 
 The Rust data client tracks Polymarket exposure at `condition_id` level so both YES and NO legs


### PR DESCRIPTION
Closes #4689

## Summary

The data client used the Gamma `endDate` field as the only test of liveness. That field is a
scheduled end, and the venue frequently keeps a market open after it. The client thus removed
markets that still traded, and it also refused to load them again.

This change keeps an instrument until two conditions are true: the time is after `expiration_ns`,
and the venue reports the market as closed. The `closed` field supplies the venue state, and the
client reads it at each fetch.

## Details

- The `closed` field goes into the instrument `info` map. Instruments in the cache from before this
  change have no venue state, and they retire on expiration as they did before.
- The expiry sweep re-observes liveness for each carried instrument by `condition_id`. This covers
  markets that auto-load or discovery brought in, which the scope refresh does not touch.
- Gamma does not supply closed markets unless you ask. A condition that is absent from the plain
  lookup thus gets a second lookup with `closed=true`. A market that is confirmed closed retires
  immediately. A condition that is absent from both lookups is a weaker signal, and it must repeat
  three times.
- The probe takes only the venue state from the response. A definition that a `tick_size_change`
  rebuilt thus keeps its precision.
- The probe runs on the instrument refresh interval, not on each sweep tick.
- The execution client uses the same test, so the two clients agree about liveness.
- Retirement now writes an INFO log. The previous path wrote no log at any level.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No PyO3 binding changed, thus the stubs do not change.

## Testing

- [x] I added/updated tests to cover new or changed logic

New tests drive the liveness probe against a mock Gamma server: a market that is confirmed closed,
a condition that is absent from both lookups, a market that stays open, a request that fails, and a
tick size that the venue lowered. Other tests show that settlement and message routing do not
change. `make pre-commit` is green, apart from `test wheel publishing`, which fails in the same way
on a clean `develop`.

I also ran the change against the live venue. The observations are in #4689.

## Limits of the evidence

- Retirement latency includes the propagation delay of Gamma. My measurements are an upper limit,
  not a measurement of this code alone.
- Only unit tests cover the three-lookup limit and the precision behavior. Neither condition
  occurred in the live runs.
- One risk stays open. A condition with empty `clobTokenIds` is held as transient, and thus it does
  not retire. I found no such payload in 500 closed markets, but I also produced no positive
  example, so the sample does not close the question.

