### PR TITLE
Count and surface Polymarket mass-status omissions

### DIFF
--- a/crates/adapters/polymarket/benches/data.rs
+++ b/crates/adapters/polymarket/benches/data.rs
@@ -255,7 +255,7 @@ fn bench_order_fill_maker(c: &mut Criterion) {
             let reports: Vec<_> = trade
                 .maker_orders
                 .iter()
-                .map(|order| {
+                .filter_map(|order| {
                     build_maker_fill_report(
                         order,
                         &trade.id,

--- a/crates/adapters/polymarket/src/execution/parse.rs
+++ b/crates/adapters/polymarket/src/execution/parse.rs
@@ -125,7 +125,7 @@ pub fn parse_order_status_report(
     price_precision: u8,
     size_precision: u8,
     ts_init: UnixNanos,
-) -> OrderStatusReport {
+) -> Option<OrderStatusReport> {
     let venue_order_id = VenueOrderId::from(order.id.as_str());
     let order_side = OrderSide::from(order.side);
     let time_in_force = TimeInForce::from(order.order_type);
@@ -137,15 +137,83 @@ pub fn parse_order_status_report(
     } else {
         OrderStatus::from(order.status)
     };
-    let quantity = Quantity::from_decimal_dp(order.original_size, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
-    let raw_filled_qty = Quantity::from_decimal_dp(order.size_matched, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
-    let filled_qty = snap_filled_qty_to_quantity(quantity, raw_filled_qty, order_status);
-    let price = Price::from_decimal_dp(order.price, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
+    let quantity = match Quantity::from_decimal_dp(order.original_size, size_precision) {
+        Ok(quantity) => quantity,
+        Err(e) => {
+            log::warn!(
+                "Skipping order {venue_order_id}: original_size {} is unrepresentable: {e}",
+                order.original_size,
+            );
+            return None;
+        }
+    };
 
-    let ts_accepted = UnixNanos::from(order.created_at * NANOSECONDS_IN_SECOND);
+    if quantity.is_zero() {
+        log::warn!(
+            "Skipping order {venue_order_id}: original_size {} rounds to zero at precision {size_precision}",
+            order.original_size,
+        );
+        return None;
+    }
+
+    let raw_filled_qty = match Quantity::from_decimal_dp(order.size_matched, size_precision) {
+        Ok(quantity) => quantity,
+        Err(e) => {
+            log::warn!(
+                "Skipping order {venue_order_id}: size_matched {} is unrepresentable: {e}",
+                order.size_matched,
+            );
+            return None;
+        }
+    };
+
+    if order_status == OrderStatus::Filled && raw_filled_qty.is_zero() {
+        log::warn!(
+            "Skipping order {venue_order_id}: Filled status has zero filled_qty after converting size_matched {}",
+            order.size_matched,
+        );
+        return None;
+    }
+    let filled_qty = snap_filled_qty_to_quantity(quantity, raw_filled_qty, order_status);
+
+    let price = match Price::from_decimal_dp(order.price, price_precision) {
+        Ok(price) => price,
+        Err(e) => {
+            log::warn!(
+                "Skipping order {venue_order_id}: price {} is unrepresentable: {e}",
+                order.price,
+            );
+            return None;
+        }
+    };
+
+    if price.as_decimal() <= Decimal::ZERO {
+        log::warn!(
+            "Skipping order {venue_order_id}: price {} is not strictly positive",
+            order.price,
+        );
+        return None;
+    }
+
+    // Binary-option prices lie strictly inside (0, 1); tick bounds vary by market.
+    if price.as_decimal() >= Decimal::ONE {
+        log::warn!(
+            "Skipping order {venue_order_id}: price {} is not strictly below 1",
+            order.price,
+        );
+        return None;
+    }
+
+    let ts_accepted = match order.created_at.checked_mul(NANOSECONDS_IN_SECOND) {
+        Some(nanos) => UnixNanos::from(nanos),
+        None => {
+            log::warn!(
+                "Skipping order {venue_order_id}: created_at {} is unrepresentable",
+                order.created_at,
+            );
+            return None;
+        }
+    };
 
     let mut report = OrderStatusReport::new(
         account_id,
@@ -168,7 +236,7 @@ pub fn parse_order_status_report(
     if let Some(nanos) = order.expiration.as_deref().and_then(parse_expiration_nanos) {
         report.expire_time = Some(UnixNanos::from(nanos));
     }
-    report
+    Some(report)
 }
 
 /// Parses a CLOB V2 `expiration` string into a Unix-nanos value. Returns
@@ -200,14 +268,12 @@ pub fn parse_fill_report(
     taker_fee_rate: Decimal,
     fee_exponent: f64,
     ts_init: UnixNanos,
-) -> FillReport {
+) -> Option<FillReport> {
     let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
     let trade_id = TradeId::from(trade.id.as_str());
     let order_side = OrderSide::from(trade.side);
-    let last_qty = Quantity::from_decimal_dp(trade.size, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
-    let last_px = Price::from_decimal_dp(trade.price, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
+    let last_qty = Quantity::from_decimal_dp(trade.size, size_precision).ok()?;
+    let last_px = Price::from_decimal_dp(trade.price, price_precision).ok()?;
     let liquidity_side = parse_liquidity_side(trade.trader_side);
 
     let commission_value = compute_commission(
@@ -218,10 +284,9 @@ pub fn parse_fill_report(
         liquidity_side,
     );
     let commission = Money::new(commission_value, currency);
+    let ts_event = parse_timestamp(&trade.match_time)?;
 
-    let ts_event = parse_timestamp(&trade.match_time).unwrap_or(ts_init);
-
-    FillReport {
+    Some(FillReport {
         account_id,
         instrument_id,
         venue_order_id,
@@ -237,7 +302,7 @@ pub fn parse_fill_report(
         ts_init,
         client_order_id,
         venue_position_id: None,
-    }
+    })
 }
 
 /// Builds a [`FillReport`] from a [`PolymarketMakerOrder`] and trade-level context.
@@ -260,7 +325,7 @@ pub fn build_maker_fill_report(
     liquidity_side: LiquiditySide,
     ts_event: UnixNanos,
     ts_init: UnixNanos,
-) -> FillReport {
+) -> Option<FillReport> {
     let venue_order_id = VenueOrderId::from(mo.order_id.as_str());
     let fill_trade_id = make_composite_trade_id(trade_id, &mo.order_id);
     let order_side = determine_order_side(
@@ -269,10 +334,8 @@ pub fn build_maker_fill_report(
         taker_asset_id,
         mo.asset_id.as_str(),
     );
-    let last_qty = Quantity::from_decimal_dp(mo.matched_amount, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
-    let last_px = Price::from_decimal_dp(mo.price, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
+    let last_qty = Quantity::from_decimal_dp(mo.matched_amount, size_precision).ok()?;
+    let last_px = Price::from_decimal_dp(mo.price, price_precision).ok()?;
     let commission_value = compute_commission(
         Decimal::ZERO,
         1.0,
@@ -281,7 +344,7 @@ pub fn build_maker_fill_report(
         liquidity_side,
     );
 
-    FillReport {
+    Some(FillReport {
         account_id,
         instrument_id,
         venue_order_id,
@@ -297,7 +360,7 @@ pub fn build_maker_fill_report(
         ts_init,
         client_order_id: None,
         venue_position_id: None,
-    }
+    })
 }
 
 /// Returns the effective taker fee rate for a Polymarket instrument.
@@ -583,11 +646,12 @@ pub fn calculate_market_price(
 /// and RFC3339 strings ("2024-01-01T00:00:00Z").
 pub fn parse_timestamp(ts_str: &str) -> Option<UnixNanos> {
     if let Ok(n) = ts_str.parse::<u64>() {
-        return if n > 1_000_000_000_000 {
-            Some(UnixNanos::from(n * NANOSECONDS_IN_MILLISECOND))
+        let multiplier = if n >= 1_000_000_000_000 {
+            NANOSECONDS_IN_MILLISECOND
         } else {
-            Some(UnixNanos::from(n * NANOSECONDS_IN_SECOND))
+            NANOSECONDS_IN_SECOND
         };
+        return n.checked_mul(multiplier).map(UnixNanos::from);
     }
     let dt = ts_str.parse::<Timestamp>().ok()?;
     Some(UnixNanos::from(u64::try_from(dt.as_nanosecond()).ok()?))
@@ -1218,9 +1282,20 @@ mod tests {
     }
 
     #[rstest]
+    fn test_parse_timestamp_boundary_is_milliseconds() {
+        let ts = parse_timestamp("1000000000000").unwrap();
+        assert_eq!(ts, UnixNanos::from(1_000_000_000_000_000_000u64));
+    }
+
+    #[rstest]
     fn test_parse_timestamp_secs() {
         let ts = parse_timestamp("1703875200").unwrap();
         assert_eq!(ts, UnixNanos::from(1_703_875_200_000_000_000u64));
+    }
+
+    #[rstest]
+    fn test_parse_timestamp_rejects_numeric_overflow() {
+        assert_eq!(parse_timestamp(&u64::MAX.to_string()), None);
     }
 
     #[rstest]
@@ -1263,7 +1338,8 @@ mod tests {
             4,
             6,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("fixture order must be representable");
 
         assert_eq!(report.account_id, account_id);
         assert_eq!(report.instrument_id, instrument_id);
@@ -1283,6 +1359,78 @@ mod tests {
         assert_eq!(report.ts_init, UnixNanos::from(1_000_000_000u64));
         // Fixture has expiration=null which must surface as no expire_time.
         assert_eq!(report.expire_time, None);
+    }
+
+    #[rstest]
+    #[case::zero_original_size(
+        dec!(0),
+        dec!(0.5),
+        PolymarketOrderStatus::Live,
+        dec!(0)
+    )]
+    #[case::subprecision_original_size(
+        dec!(0.0000004),
+        dec!(0.5),
+        PolymarketOrderStatus::Live,
+        dec!(0)
+    )]
+    #[case::zero_price(
+        dec!(100),
+        dec!(0),
+        PolymarketOrderStatus::Live,
+        dec!(0)
+    )]
+    #[case::negative_price(
+        dec!(100),
+        dec!(-0.5),
+        PolymarketOrderStatus::Live,
+        dec!(0)
+    )]
+    #[case::price_at_one(
+        dec!(100),
+        dec!(1),
+        PolymarketOrderStatus::Live,
+        dec!(0)
+    )]
+    #[case::price_above_one(
+        dec!(100),
+        dec!(1.5),
+        PolymarketOrderStatus::Live,
+        dec!(0)
+    )]
+    #[case::filled_without_matched_quantity(
+        dec!(100),
+        dec!(0.5),
+        PolymarketOrderStatus::Matched,
+        dec!(0)
+    )]
+    fn test_parse_order_status_report_rejects_degenerate_values(
+        #[case] original_size: Decimal,
+        #[case] price: Decimal,
+        #[case] status: PolymarketOrderStatus,
+        #[case] size_matched: Decimal,
+    ) {
+        let path = "test_data/http_open_order.json";
+        let content = std::fs::read_to_string(path).expect("Failed to read test data");
+        let mut order: PolymarketOpenOrder =
+            serde_json::from_str(&content).expect("Failed to parse test data");
+        order.original_size = original_size;
+        order.price = price;
+        order.status = status;
+        order.size_matched = size_matched;
+        order.order_type = PolymarketOrderType::GTC;
+
+        let report = parse_order_status_report(
+            &order,
+            InstrumentId::from("TEST-TOKEN.POLYMARKET"),
+            AccountId::from("POLYMARKET-001"),
+            None,
+            4,
+            6,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert!(report.is_none());
     }
 
     // Verifies parse_order_status_report wires `snap_filled_qty_to_quantity`
@@ -1328,7 +1476,8 @@ mod tests {
             3,
             6,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("test order must be representable");
 
         assert_eq!(report.filled_qty, Quantity::new(expected_filled, 6));
         assert_eq!(
@@ -1365,7 +1514,8 @@ mod tests {
             3,
             6,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("test order must be representable");
 
         assert_eq!(report.order_status, OrderStatus::Canceled);
         assert_eq!(report.time_in_force, TimeInForce::Ioc);
@@ -1412,7 +1562,8 @@ mod tests {
             4,
             6,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("test order must be representable");
 
         assert_eq!(report.expire_time, expected);
     }
@@ -1439,13 +1590,68 @@ mod tests {
             Decimal::ZERO,
             1.0,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("fixture timestamp must be valid");
 
         assert_eq!(report.account_id, account_id);
         assert_eq!(report.instrument_id, instrument_id);
         assert_eq!(report.order_side, OrderSide::Buy);
         assert_eq!(report.liquidity_side, LiquiditySide::Taker);
         assert_eq!(report.commission.as_f64(), 0.0);
+    }
+
+    #[rstest]
+    fn test_parse_fill_report_rejects_invalid_match_time() {
+        let path = "test_data/http_trade_report.json";
+        let content = std::fs::read_to_string(path).expect("Failed to read test data");
+        let mut trade: PolymarketTradeReport =
+            serde_json::from_str(&content).expect("Failed to parse test data");
+        trade.match_time = "invalid-match-time".to_string();
+
+        let report = parse_fill_report(
+            &trade,
+            InstrumentId::from("TEST-TOKEN.POLYMARKET"),
+            AccountId::from("POLYMARKET-001"),
+            None,
+            4,
+            6,
+            Currency::pUSD(),
+            Decimal::ZERO,
+            1.0,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert!(report.is_none());
+    }
+
+    #[rstest]
+    #[case::quantity(Decimal::MAX, dec!(0.5))]
+    #[case::price(dec!(25), Decimal::MAX)]
+    fn test_parse_fill_report_rejects_unrepresentable_values(
+        #[case] size: Decimal,
+        #[case] price: Decimal,
+    ) {
+        let path = "test_data/http_trade_report.json";
+        let content = std::fs::read_to_string(path).expect("Failed to read test data");
+        let mut trade: PolymarketTradeReport =
+            serde_json::from_str(&content).expect("Failed to parse test data");
+        trade.size = size;
+        trade.price = price;
+
+        let report = parse_fill_report(
+            &trade,
+            InstrumentId::from("TEST-TOKEN.POLYMARKET"),
+            AccountId::from("POLYMARKET-001"),
+            None,
+            4,
+            6,
+            Currency::pUSD(),
+            Decimal::ZERO,
+            1.0,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert!(report.is_none());
     }
 
     #[rstest]
@@ -1471,7 +1677,8 @@ mod tests {
             dec!(0.03),
             2.0,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("fixture timestamp must be valid");
 
         assert_eq!(report.liquidity_side, LiquiditySide::Taker);
         assert_eq!(report.commission.as_f64(), 0.04688);

--- a/crates/adapters/polymarket/src/execution/reconciliation.rs
+++ b/crates/adapters/polymarket/src/execution/reconciliation.rs
@@ -15,9 +15,11 @@
 
 //! Reconciliation report generation for the Polymarket execution client.
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use anyhow::Context;
-use nautilus_core::{UnixNanos, collections::AtomicMap, time::AtomicTime};
+use nautilus_core::{
+    UnixNanos, collections::AtomicMap, datetime::NANOSECONDS_IN_SECOND, time::AtomicTime,
+};
 use nautilus_model::{
     enums::{LiquiditySide, OrderStatus, PositionSideSpecified},
     identifiers::{AccountId, ClientId, InstrumentId, Venue, VenueOrderId},
@@ -57,14 +59,61 @@ pub(crate) struct FillContext<'a> {
     pub clock: &'static AtomicTime,
 }
 
+/// Counts of venue orders dropped while building order reports.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct OrderBuildDiscards {
+    /// Orders dropped because their instrument is not loaded.
+    pub unmapped_instruments: usize,
+    /// Orders dropped because a quantity or price cannot be represented.
+    pub unrepresentable_orders: usize,
+}
+
+impl OrderBuildDiscards {
+    pub(crate) const fn has_anomalies(&self) -> bool {
+        self.unmapped_instruments > 0 || self.unrepresentable_orders > 0
+    }
+}
+
 /// Counts of confirmed trade evidence dropped while building fill reports.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct FillBuildDiscards {
     /// Fill entries dropped because their instrument is not loaded.
     pub unmapped_instruments: usize,
+    /// Trade rows dropped because their match timestamp cannot be parsed.
+    pub invalid_timestamps: usize,
+    /// Fill entries dropped because quantity or price cannot be represented.
+    pub invalid_values: usize,
     /// Confirmed maker trades dropped because no maker order in the match is
     /// owned by the account.
     pub unowned_maker_trades: usize,
+}
+
+impl FillBuildDiscards {
+    pub(crate) const fn has_anomalies(&self) -> bool {
+        self.unmapped_instruments > 0
+            || self.invalid_timestamps > 0
+            || self.invalid_values > 0
+            || self.unowned_maker_trades > 0
+    }
+}
+
+/// Counts of venue positions dropped while building position reports.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct PositionBuildDiscards {
+    /// Positions dropped because their positive size is below the dust threshold.
+    pub dust_positions: usize,
+    /// Positions dropped because their size is negative or cannot be represented as a quantity.
+    pub unrepresentable_positions: usize,
+    /// Non-flat positions dropped because their average price was outside (0, 1).
+    pub invalid_avg_prices: usize,
+    /// Flat reports withheld because the pass contains order or fill activity for the instrument.
+    pub flat_withheld_activity: usize,
+}
+
+impl PositionBuildDiscards {
+    pub(crate) const fn has_anomalies(&self) -> bool {
+        self.unrepresentable_positions > 0 || self.invalid_avg_prices > 0
+    }
 }
 
 /// Converts trade reports into fill reports: single implementation of maker/taker
@@ -100,6 +149,16 @@ pub(crate) fn build_fill_reports_from_trades(
                 continue;
             }
 
+            let Some(ts_event) = parse_timestamp(&trade.match_time) else {
+                discards.invalid_timestamps += 1;
+                log::warn!(
+                    "Skipping confirmed maker trade {}: invalid match_time {}",
+                    trade.id,
+                    trade.match_time,
+                );
+                continue;
+            };
+
             for mo in &trade.maker_orders {
                 if !mo.is_owned_by(ctx.user_address, ctx.api_key) {
                     continue;
@@ -120,8 +179,6 @@ pub(crate) fn build_fill_reports_from_trades(
                     continue;
                 }
 
-                let ts_event =
-                    parse_timestamp(&trade.match_time).unwrap_or(ctx.clock.get_time_ns());
                 let report = build_maker_fill_report(
                     mo,
                     &trade.id,
@@ -137,7 +194,20 @@ pub(crate) fn build_fill_reports_from_trades(
                     ts_event,
                     ts_init,
                 );
-                reports.push(report);
+
+                match report {
+                    Some(report) => reports.push(report),
+                    None => {
+                        discards.invalid_values += 1;
+                        log::warn!(
+                            "Skipping confirmed maker fill {}-{}: matched_amount {} or price {} is unrepresentable",
+                            trade.id,
+                            mo.order_id,
+                            mo.matched_amount,
+                            mo.price,
+                        );
+                    }
+                }
             }
         } else {
             let token_id = Ustr::from(trade.asset_id.as_str());
@@ -163,6 +233,16 @@ pub(crate) fn build_fill_reports_from_trades(
                 continue;
             }
 
+            if parse_timestamp(&trade.match_time).is_none() {
+                discards.invalid_timestamps += 1;
+                log::warn!(
+                    "Skipping confirmed taker trade {}: invalid match_time {}",
+                    trade.id,
+                    trade.match_time,
+                );
+                continue;
+            }
+
             let report = parse_fill_report(
                 trade,
                 instrument_id,
@@ -175,7 +255,19 @@ pub(crate) fn build_fill_reports_from_trades(
                 fee_exponent,
                 ts_init,
             );
-            reports.push(report);
+
+            match report {
+                Some(report) => reports.push(report),
+                None => {
+                    discards.invalid_values += 1;
+                    log::warn!(
+                        "Skipping confirmed taker trade {}: size {} or price {} is unrepresentable",
+                        trade.id,
+                        trade.size,
+                        trade.price,
+                    );
+                }
+            }
         }
     }
 
@@ -189,9 +281,9 @@ pub(crate) fn build_order_reports_from_orders(
     account_id: AccountId,
     instrument_filter: Option<InstrumentId>,
     ts_init: UnixNanos,
-) -> (Vec<OrderStatusReport>, usize) {
+) -> (Vec<OrderStatusReport>, OrderBuildDiscards) {
     let mut reports = Vec::new();
-    let mut filtered = 0usize;
+    let mut discards = OrderBuildDiscards::default();
 
     for order in orders {
         let token_id = Ustr::from(order.asset_id.as_str());
@@ -199,7 +291,7 @@ pub(crate) fn build_order_reports_from_orders(
         let (instrument_id, price_prec, size_prec) = match instrument {
             Some(i) => (i.id(), i.price_precision(), i.size_precision()),
             None => {
-                filtered += 1;
+                discards.unmapped_instruments += 1;
                 continue;
             }
         };
@@ -219,10 +311,14 @@ pub(crate) fn build_order_reports_from_orders(
             size_prec,
             ts_init,
         );
-        reports.push(report);
+
+        match report {
+            Some(report) => reports.push(report),
+            None => discards.unrepresentable_orders += 1,
+        }
     }
 
-    (reports, filtered)
+    (reports, discards)
 }
 
 /// Applies venue_order_id and time-range filters to fill reports.
@@ -246,53 +342,202 @@ pub(crate) fn apply_fill_filters(
     reports
 }
 
-/// Builds position status reports from Data API positions, filtering dust.
+/// Builds position status reports from Data API positions, filtering positive dust.
 pub(crate) fn build_position_reports(
     positions: &[DataApiPosition],
     account_id: AccountId,
     ts: UnixNanos,
-) -> Vec<PositionStatusReport> {
-    positions
-        .iter()
-        .filter(|p| {
-            if p.size > Decimal::ZERO && p.size < DUST_POSITION_THRESHOLD {
-                log::debug!(
-                    "Filtering dust position: {}-{}, size={}",
+) -> (Vec<PositionStatusReport>, PositionBuildDiscards) {
+    build_position_reports_with_activity(positions, account_id, ts, &AHashSet::new())
+}
+
+/// Builds position reports while withholding stale Flat rows for instruments with pass activity.
+pub(crate) fn build_position_reports_with_activity(
+    positions: &[DataApiPosition],
+    account_id: AccountId,
+    ts: UnixNanos,
+    activity_instruments: &AHashSet<InstrumentId>,
+) -> (Vec<PositionStatusReport>, PositionBuildDiscards) {
+    let mut reports = Vec::new();
+    let mut discards = PositionBuildDiscards::default();
+
+    for p in positions {
+        if p.size < Decimal::ZERO {
+            discards.unrepresentable_positions += 1;
+            log::warn!(
+                "Skipping negative Data API position: condition_id={}, asset={}, size={}",
+                p.condition_id,
+                p.asset,
+                p.size,
+            );
+            continue;
+        }
+
+        if p.size > Decimal::ZERO && p.size < DUST_POSITION_THRESHOLD {
+            log::debug!(
+                "Filtering dust position: {}-{}, size={}",
+                p.condition_id,
+                p.asset,
+                p.size
+            );
+            discards.dust_positions += 1;
+            continue;
+        }
+
+        let instrument_id =
+            InstrumentId::from(format!("{}-{}.POLYMARKET", p.condition_id, p.asset).as_str());
+        let quantity = match Quantity::from_decimal_dp(p.size, USDC_DECIMALS as u8) {
+            Ok(quantity) => quantity,
+            Err(e) => {
+                discards.unrepresentable_positions += 1;
+                log::warn!(
+                    "Skipping invalid Data API position {}-{} size {}: {e}",
                     p.condition_id,
                     p.asset,
-                    p.size
+                    p.size,
                 );
+                continue;
             }
-            p.size >= DUST_POSITION_THRESHOLD
-        })
-        .filter_map(|p| {
-            let instrument_id =
-                InstrumentId::from(format!("{}-{}.POLYMARKET", p.condition_id, p.asset).as_str());
-            let quantity = match Quantity::from_decimal_dp(p.size, USDC_DECIMALS as u8) {
-                Ok(quantity) => quantity,
-                Err(e) => {
-                    log::warn!(
-                        "Skipping invalid Data API position {}-{} size {}: {e}",
-                        p.condition_id,
-                        p.asset,
-                        p.size,
-                    );
-                    return None;
-                }
-            };
-            Some(PositionStatusReport::new(
+        };
+
+        if p.size == Decimal::ZERO {
+            if activity_instruments.contains(&instrument_id) {
+                discards.flat_withheld_activity += 1;
+                log::debug!(
+                    "Withholding Flat Data API position {}-{} due to same-pass order or fill activity",
+                    p.condition_id,
+                    p.asset,
+                );
+                continue;
+            }
+
+            reports.push(PositionStatusReport::new(
                 account_id,
                 instrument_id,
-                PositionSideSpecified::Long,
+                PositionSideSpecified::Flat,
                 quantity,
                 ts,
                 ts,
                 None,
                 None,
-                p.avg_price,
-            ))
-        })
-        .collect()
+                None,
+            ));
+            continue;
+        }
+
+        let avg_price = match p.avg_price {
+            Some(avg_price) if avg_price > Decimal::ZERO && avg_price < Decimal::ONE => {
+                Some(avg_price)
+            }
+            Some(avg_price) => {
+                discards.invalid_avg_prices += 1;
+                log::warn!(
+                    "Skipping Data API position {}-{} with invalid avg_price {avg_price}",
+                    p.condition_id,
+                    p.asset,
+                );
+                continue;
+            }
+            None => None,
+        };
+
+        reports.push(PositionStatusReport::new(
+            account_id,
+            instrument_id,
+            PositionSideSpecified::Long,
+            quantity,
+            ts,
+            ts,
+            None,
+            None,
+            avg_price,
+        ));
+    }
+
+    (reports, discards)
+}
+
+fn mass_status_omission_error(
+    order_discards: &OrderBuildDiscards,
+    fill_discards: &FillBuildDiscards,
+    position_discards: &PositionBuildDiscards,
+) -> Option<String> {
+    if !order_discards.has_anomalies()
+        && !fill_discards.has_anomalies()
+        && !position_discards.has_anomalies()
+    {
+        return None;
+    }
+
+    Some(format!(
+        "Mass status omitted {} unmapped order(s), {} unrepresentable order(s), {} fill(s) with \
+         unmapped instruments, {} fill(s) with invalid timestamps, {} fill(s) with invalid \
+         values, {} unowned maker trade(s), {} unrepresentable position(s), and {} position(s) \
+         with invalid average prices; the returned report carries no count of these omissions",
+        order_discards.unmapped_instruments,
+        order_discards.unrepresentable_orders,
+        fill_discards.unmapped_instruments,
+        fill_discards.invalid_timestamps,
+        fill_discards.invalid_values,
+        fill_discards.unowned_maker_trades,
+        position_discards.unrepresentable_positions,
+        position_discards.invalid_avg_prices,
+    ))
+}
+
+fn mass_status_dust_warning(position_discards: &PositionBuildDiscards) -> Option<String> {
+    (position_discards.dust_positions > 0).then(|| {
+        format!(
+            "{} position(s) below the dust threshold were omitted by policy",
+            position_discards.dust_positions,
+        )
+    })
+}
+
+fn mass_status_flat_withheld_warning(position_discards: &PositionBuildDiscards) -> Option<String> {
+    (position_discards.flat_withheld_activity > 0).then(|| {
+        format!(
+            "Mass status withheld {} Flat position report(s) due to same-pass order or fill activity",
+            position_discards.flat_withheld_activity,
+        )
+    })
+}
+
+fn mass_status_lookback_warning(orders_removed: usize, trades_removed: usize) -> Option<String> {
+    (orders_removed > 0 || trades_removed > 0).then(|| {
+        format!(
+            "Mass-status lookback removed {orders_removed} order row(s) and {trades_removed} trade row(s)"
+        )
+    })
+}
+
+fn filter_orders_to_lookback(orders: &mut Vec<PolymarketOpenOrder>, cutoff: UnixNanos) -> usize {
+    let before = orders.len();
+    orders.retain(|order| {
+        order
+            .created_at
+            .checked_mul(NANOSECONDS_IN_SECOND)
+            .map(UnixNanos::from)
+            .is_none_or(|ts| ts >= cutoff)
+    });
+    before - orders.len()
+}
+
+fn filter_trades_to_lookback(trades: &mut Vec<PolymarketTradeReport>, cutoff: UnixNanos) -> usize {
+    let before = trades.len();
+    trades.retain(|trade| {
+        parse_timestamp(&trade.match_time).is_none_or(|ts_event| ts_event >= cutoff)
+    });
+    before - trades.len()
+}
+
+fn mass_status_cutoff(ts_init: UnixNanos, lookback_mins: Option<u64>) -> Option<UnixNanos> {
+    lookback_mins.map(|mins| {
+        let lookback_ns = mins
+            .saturating_mul(60)
+            .saturating_mul(NANOSECONDS_IN_SECOND);
+        UnixNanos::from(ts_init.as_u64().saturating_sub(lookback_ns))
+    })
 }
 
 /// Full reconciliation mass status generation.
@@ -308,32 +553,29 @@ pub(crate) async fn generate_mass_status(
     lookback_mins: Option<u64>,
 ) -> anyhow::Result<Option<ExecutionMassStatus>> {
     let ts_init = ctx.clock.get_time_ns();
+    let cutoff = mass_status_cutoff(ts_init, lookback_mins);
 
     // Fetch orders
-    let orders = http_client
+    let mut orders = http_client
         .get_orders(GetOrdersParams::default())
         .await
         .context("failed to fetch orders for mass status")?;
+    let orders_before = orders.len();
+    let orders_removed = cutoff.map_or(0, |cutoff| filter_orders_to_lookback(&mut orders, cutoff));
 
-    let (mut order_reports, orders_filtered) =
+    let (mut order_reports, order_discards) =
         build_order_reports_from_orders(&orders, instruments, ctx.account_id, None, ts_init);
 
     // Fetch and parse fill reports
-    let trades = http_client
+    let mut trades = http_client
         .get_trades(GetTradesParams::default())
         .await
         .context("failed to fetch trades for mass status")?;
+    let trades_before = trades.len();
+    let trades_removed = cutoff.map_or(0, |cutoff| filter_trades_to_lookback(&mut trades, cutoff));
 
     let (mut fill_reports, fill_discards) =
         build_fill_reports_from_trades(&trades, ctx, instruments, None, ts_init);
-
-    if fill_discards.unowned_maker_trades > 0 {
-        log::error!(
-            "Mass status is missing {} confirmed maker trade(s) holding no maker order owned by \
-             the account; executed quantity may be understated",
-            fill_discards.unowned_maker_trades,
-        );
-    }
 
     // Snap dust drift on REST fills the same way the WS path does.
     // Commission stays as venue-reported.
@@ -345,42 +587,66 @@ pub(crate) async fn generate_mass_status(
         .await
         .context("failed to fetch positions for mass status")?;
 
-    let position_reports = build_position_reports(&positions, ctx.account_id, ts_init);
+    let activity_instruments = order_reports
+        .iter()
+        .map(|report| report.instrument_id)
+        .chain(fill_reports.iter().map(|report| report.instrument_id))
+        .collect();
+    let (position_reports, position_discards) = build_position_reports_with_activity(
+        &positions,
+        ctx.account_id,
+        ts_init,
+        &activity_instruments,
+    );
 
-    // Apply lookback filter
+    if let Some(message) =
+        mass_status_omission_error(&order_discards, &fill_discards, &position_discards)
+    {
+        log::error!("{message}");
+    }
+
+    if let Some(message) = mass_status_dust_warning(&position_discards) {
+        log::warn!("{message}");
+    }
+
+    if let Some(message) = mass_status_flat_withheld_warning(&position_discards) {
+        log::warn!("{message}");
+    }
+
+    if let Some(message) = mass_status_lookback_warning(orders_removed, trades_removed) {
+        log::warn!("{message}");
+    }
+
     if let Some(mins) = lookback_mins {
-        let now_ns = ctx.clock.get_time_ns();
-        let cutoff_ns = now_ns.as_u64().saturating_sub(mins * 60 * 1_000_000_000);
-        let cutoff = UnixNanos::from(cutoff_ns);
-
-        let orders_before = order_reports.len();
-        order_reports.retain(|r| r.ts_last >= cutoff);
-        let orders_removed = orders_before - order_reports.len();
-
-        let fills_before = fill_reports.len();
-        fill_reports.retain(|r| r.ts_event >= cutoff);
-        let fills_removed = fills_before - fill_reports.len();
-
         log::debug!(
-            "Lookback filter ({}min): orders {}->{} (removed {}), fills {}->{} (removed {})",
+            "Lookback filter ({}min): orders {}->{} (removed {}), trades {}->{} (removed {})",
             mins,
             orders_before,
-            order_reports.len(),
+            orders.len(),
             orders_removed,
-            fills_before,
-            fill_reports.len(),
-            fills_removed,
+            trades_before,
+            trades.len(),
+            trades_removed,
         );
     } else {
         log::debug!(
-            "Generated mass status: {} orders ({} filtered), {} fills ({} instrument-filtered, \
-             {} unowned maker trades), {} positions",
+            "Generated mass status: {} orders ({} instrument-filtered, {} unrepresentable), {} \
+            fills ({} instrument-filtered, {} invalid timestamps, {} invalid values, {} unowned \
+             maker trades), {} positions ({} dust-filtered, {} unrepresentable, {} invalid average \
+             prices, {} Flat reports withheld for activity)",
             order_reports.len(),
-            orders_filtered,
+            order_discards.unmapped_instruments,
+            order_discards.unrepresentable_orders,
             fill_reports.len(),
             fill_discards.unmapped_instruments,
+            fill_discards.invalid_timestamps,
+            fill_discards.invalid_values,
             fill_discards.unowned_maker_trades,
             position_reports.len(),
+            position_discards.dust_positions,
+            position_discards.unrepresentable_positions,
+            position_discards.invalid_avg_prices,
+            position_discards.flat_withheld_activity,
         );
     }
 
@@ -457,6 +723,7 @@ pub(crate) fn normalize_terminal_order_report_quantity(report: &mut OrderStatusR
 
 #[cfg(test)]
 mod tests {
+    use nautilus_core::time::get_atomic_clock_realtime;
     use nautilus_model::{
         enums::{LiquiditySide, OrderSide, OrderStatus, OrderType, TimeInForce},
         identifiers::TradeId,
@@ -465,6 +732,704 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    #[derive(Clone, Copy)]
+    enum UnrepresentableOrderField {
+        OriginalSize,
+        SizeMatched,
+        Price,
+    }
+
+    fn load<T: serde::de::DeserializeOwned>(filename: &str) -> T {
+        let path = format!("test_data/{filename}");
+        let content = std::fs::read_to_string(path).expect("Failed to read test data");
+        serde_json::from_str(&content).expect("Failed to parse test data")
+    }
+
+    fn data_api_position(size: Decimal) -> DataApiPosition {
+        DataApiPosition {
+            asset: "123".to_string(),
+            condition_id: "0xabc".to_string(),
+            size,
+            avg_price: Some(Decimal::new(5, 1)),
+        }
+    }
+
+    #[rstest]
+    fn dust_position_is_counted_when_report_is_omitted() {
+        let position = data_api_position(DUST_POSITION_THRESHOLD / Decimal::from(2));
+
+        let (reports, discards) = build_position_reports(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.dust_positions, 1);
+        assert_eq!(discards.unrepresentable_positions, 0);
+    }
+
+    #[rstest]
+    fn position_at_dust_threshold_is_kept() {
+        let position = data_api_position(DUST_POSITION_THRESHOLD);
+
+        let (reports, discards) = build_position_reports(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(discards, PositionBuildDiscards::default());
+    }
+
+    #[rstest]
+    #[case::negative(Decimal::NEGATIVE_ONE)]
+    #[case::zero(Decimal::ZERO)]
+    #[case::above_one(Decimal::new(15, 1))]
+    fn invalid_avg_price_is_rejected_and_counted(#[case] avg_price: Decimal) {
+        let mut position = data_api_position(Decimal::ONE);
+        position.avg_price = Some(avg_price);
+
+        let (reports, discards) = build_position_reports(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.invalid_avg_prices, 1);
+        assert_eq!(discards.unrepresentable_positions, 0);
+    }
+
+    #[rstest]
+    fn valid_avg_price_is_retained() {
+        let position = data_api_position(Decimal::ONE);
+
+        let (reports, discards) = build_position_reports(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].avg_px_open, Some(Decimal::new(5, 1)));
+        assert_eq!(discards.invalid_avg_prices, 0);
+    }
+
+    #[rstest]
+    fn unrepresentable_position_is_counted_when_report_is_omitted() {
+        let position = data_api_position(Decimal::MAX);
+
+        let (reports, discards) = build_position_reports(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.dust_positions, 0);
+        assert_eq!(discards.unrepresentable_positions, 1);
+    }
+
+    #[rstest]
+    fn negative_position_is_unrepresentable_not_dust() {
+        let position = data_api_position(Decimal::NEGATIVE_ONE);
+
+        let (reports, discards) = build_position_reports(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.dust_positions, 0);
+        assert_eq!(discards.unrepresentable_positions, 1);
+    }
+
+    #[rstest]
+    fn position_discards_accumulate_in_one_build() {
+        let positions = [
+            data_api_position(Decimal::new(5, 3)),
+            data_api_position(Decimal::new(1, 3)),
+            data_api_position(Decimal::NEGATIVE_ONE),
+            data_api_position(Decimal::MAX),
+        ];
+
+        let (reports, discards) = build_position_reports(
+            &positions,
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.dust_positions, 2);
+        assert_eq!(discards.unrepresentable_positions, 2);
+    }
+
+    #[rstest]
+    fn flat_position_is_reported_without_discard_count() {
+        let mut position = data_api_position(Decimal::ZERO);
+        position.avg_price = Some(Decimal::ZERO);
+        let account_id = AccountId::from("POLYMARKET-001");
+        let ts = UnixNanos::from(1);
+
+        let (reports, discards) = build_position_reports(&[position], account_id, ts);
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].account_id, account_id);
+        assert_eq!(
+            reports[0].instrument_id,
+            InstrumentId::from("0xabc-123.POLYMARKET"),
+        );
+        assert_eq!(reports[0].position_side, PositionSideSpecified::Flat);
+        assert!(reports[0].quantity.is_zero());
+        assert_eq!(reports[0].quantity.precision, USDC_DECIMALS as u8);
+        assert_eq!(discards, PositionBuildDiscards::default());
+    }
+
+    #[rstest]
+    fn flat_position_is_withheld_for_same_instrument_activity() {
+        let position = data_api_position(Decimal::ZERO);
+        let activity_instruments =
+            AHashSet::from_iter([InstrumentId::from("0xabc-123.POLYMARKET")]);
+
+        let (reports, discards) = build_position_reports_with_activity(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+            &activity_instruments,
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.flat_withheld_activity, 1);
+        assert_eq!(discards.invalid_avg_prices, 0);
+    }
+
+    #[rstest]
+    fn flat_position_is_reported_when_only_other_instrument_has_activity() {
+        let position = data_api_position(Decimal::ZERO);
+        let activity_instruments =
+            AHashSet::from_iter([InstrumentId::from("0xother-456.POLYMARKET")]);
+
+        let (reports, discards) = build_position_reports_with_activity(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+            &activity_instruments,
+        );
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].position_side, PositionSideSpecified::Flat);
+        assert_eq!(discards, PositionBuildDiscards::default());
+    }
+
+    #[rstest]
+    fn normal_position_has_no_build_discards() {
+        let position = data_api_position(Decimal::ONE);
+
+        let (reports, discards) = build_position_reports(
+            &[position],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(discards, PositionBuildDiscards::default());
+    }
+
+    #[rstest]
+    #[case::original_size(UnrepresentableOrderField::OriginalSize)]
+    #[case::size_matched(UnrepresentableOrderField::SizeMatched)]
+    #[case::price(UnrepresentableOrderField::Price)]
+    fn unrepresentable_order_field_is_counted_without_dropping_normal_order(
+        #[case] field: UnrepresentableOrderField,
+    ) {
+        let normal_order: PolymarketOpenOrder = load("http_open_order.json");
+        let normal_venue_order_id = VenueOrderId::from(normal_order.id.as_str());
+        let mut unrepresentable_order = normal_order.clone();
+        unrepresentable_order.id = "unrepresentable-order".to_string();
+
+        match field {
+            UnrepresentableOrderField::OriginalSize => {
+                unrepresentable_order.original_size = Decimal::MAX;
+            }
+            UnrepresentableOrderField::SizeMatched => {
+                unrepresentable_order.size_matched = Decimal::MAX;
+            }
+            UnrepresentableOrderField::Price => {
+                unrepresentable_order.price = Decimal::MAX;
+            }
+        }
+
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(normal_order.asset_id, instrument);
+
+        let (reports, discards) = build_order_reports_from_orders(
+            &[unrepresentable_order, normal_order],
+            &instruments,
+            AccountId::from("POLYMARKET-001"),
+            None,
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].venue_order_id, normal_venue_order_id);
+        assert_eq!(discards.unmapped_instruments, 0);
+        assert_eq!(discards.unrepresentable_orders, 1);
+    }
+
+    #[rstest]
+    fn filled_order_with_raw_zero_fill_below_snap_threshold_is_counted() {
+        let mut order: PolymarketOpenOrder = load("http_open_order.json");
+        order.original_size = DUST_SNAP_THRESHOLD_DEC / Decimal::from(2);
+        order.size_matched = Decimal::ZERO;
+        order.status = crate::common::enums::PolymarketOrderStatus::Matched;
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(order.asset_id, instrument);
+
+        let (reports, discards) = build_order_reports_from_orders(
+            &[order],
+            &instruments,
+            AccountId::from("POLY-001"),
+            None,
+            UnixNanos::from(1),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.unmapped_instruments, 0);
+        assert_eq!(discards.unrepresentable_orders, 1);
+    }
+
+    #[rstest]
+    #[case::maker(PolymarketLiquiditySide::Maker)]
+    #[case::taker(PolymarketLiquiditySide::Taker)]
+    fn invalid_trade_timestamp_is_counted_and_omitted(
+        #[case] trader_side: PolymarketLiquiditySide,
+    ) {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.trader_side = trader_side;
+        trade.match_time = "invalid-match-time".to_string();
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+            api_key: "00000000-0000-0000-0000-000000000002",
+            pusd: Currency::pUSD(),
+            clock: get_atomic_clock_realtime(),
+        };
+
+        let (reports, discards) = build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.invalid_timestamps, 1);
+        assert_eq!(discards.unmapped_instruments, 0);
+        assert_eq!(discards.unowned_maker_trades, 0);
+    }
+
+    #[rstest]
+    fn unrepresentable_maker_fill_values_are_omitted() {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        trade.maker_orders[0].matched_amount = Decimal::MAX;
+        trade.maker_orders[0].price = Decimal::MAX;
+        let token_id = trade.maker_orders[0].asset_id;
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(token_id, instrument);
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+            api_key: "00000000-0000-0000-0000-000000000002",
+            pusd: Currency::pUSD(),
+            clock: get_atomic_clock_realtime(),
+        };
+
+        let (reports, discards) = build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.invalid_values, 1);
+        assert_eq!(discards.invalid_timestamps, 0);
+        assert_eq!(discards.unmapped_instruments, 0);
+    }
+
+    #[rstest]
+    fn mass_status_lookback_excludes_old_inputs_from_omission_counts() {
+        let cutoff_secs = 2_000_000_000_u64;
+        let cutoff = UnixNanos::from(cutoff_secs * NANOSECONDS_IN_SECOND);
+        let mut order: PolymarketOpenOrder = load("http_open_order.json");
+        order.created_at = cutoff_secs - 1;
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.match_time = (cutoff_secs - 1).to_string();
+        let mut orders = vec![order];
+        let mut trades = vec![trade];
+
+        assert_eq!(filter_orders_to_lookback(&mut orders, cutoff), 1);
+        assert_eq!(filter_trades_to_lookback(&mut trades, cutoff), 1);
+
+        let (order_reports, order_discards) = build_order_reports_from_orders(
+            &orders,
+            &AtomicMap::new(),
+            AccountId::from("POLY-001"),
+            None,
+            cutoff,
+        );
+        let (fill_reports, fill_discards) = build_fill_reports_from_trades(
+            &trades,
+            &FillContext {
+                account_id: AccountId::from("POLY-001"),
+                user_address: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                api_key: "00000000-0000-0000-0000-000000000001",
+                pusd: Currency::pUSD(),
+                clock: get_atomic_clock_realtime(),
+            },
+            &AtomicMap::new(),
+            None,
+            cutoff,
+        );
+
+        assert!(order_reports.is_empty());
+        assert!(fill_reports.is_empty());
+        assert_eq!(order_discards, OrderBuildDiscards::default());
+        assert_eq!(fill_discards, FillBuildDiscards::default());
+    }
+
+    #[rstest]
+    fn mass_status_lookback_keeps_unknown_age_inputs_visible_to_builders() {
+        let cutoff = UnixNanos::from(2_000_000_000_u64 * NANOSECONDS_IN_SECOND);
+        let mut order: PolymarketOpenOrder = load("http_open_order.json");
+        order.created_at = u64::MAX;
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.match_time = "invalid-match-time".to_string();
+        let mut overflowing_trade = trade.clone();
+        overflowing_trade.match_time = u64::MAX.to_string();
+        let mut orders = vec![order];
+        let mut trades = vec![trade, overflowing_trade];
+
+        assert_eq!(filter_orders_to_lookback(&mut orders, cutoff), 0);
+        assert_eq!(filter_trades_to_lookback(&mut trades, cutoff), 0);
+
+        let (_, order_discards) = build_order_reports_from_orders(
+            &orders,
+            &AtomicMap::new(),
+            AccountId::from("POLY-001"),
+            None,
+            cutoff,
+        );
+        let (_, fill_discards) = build_fill_reports_from_trades(
+            &trades,
+            &FillContext {
+                account_id: AccountId::from("POLY-001"),
+                user_address: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+                api_key: "00000000-0000-0000-0000-000000000001",
+                pusd: Currency::pUSD(),
+                clock: get_atomic_clock_realtime(),
+            },
+            &AtomicMap::new(),
+            None,
+            cutoff,
+        );
+
+        assert_eq!(order_discards.unmapped_instruments, 1);
+        assert_eq!(fill_discards.unmapped_instruments, 2);
+    }
+
+    #[rstest]
+    #[case::maximum(u64::MAX)]
+    #[case::milliseconds(1_722_000_000_000)]
+    fn overflowing_order_timestamp_is_counted_as_unrepresentable(#[case] created_at: u64) {
+        let mut order: PolymarketOpenOrder = load("http_open_order.json");
+        order.created_at = created_at;
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(order.asset_id, instrument);
+
+        let (reports, discards) = build_order_reports_from_orders(
+            &[order],
+            &instruments,
+            AccountId::from("POLY-001"),
+            None,
+            UnixNanos::from(1),
+        );
+
+        assert!(reports.is_empty());
+        assert_eq!(discards.unmapped_instruments, 0);
+        assert_eq!(discards.unrepresentable_orders, 1);
+    }
+
+    #[rstest]
+    fn mass_status_cutoff_saturates_absurd_lookback_to_zero() {
+        assert_eq!(
+            mass_status_cutoff(UnixNanos::from(1_000_000_000), Some(u64::MAX)),
+            Some(UnixNanos::from(0)),
+        );
+
+        // This is the smallest minute count whose nanosecond product exceeds u64::MAX.
+        assert_eq!(
+            mass_status_cutoff(UnixNanos::from(100_000_000_000), Some(307_445_735)),
+            Some(UnixNanos::from(0)),
+        );
+
+        assert_eq!(
+            mass_status_cutoff(UnixNanos::from(100_000_000_000), Some(1_u64 << 62)),
+            Some(UnixNanos::from(0)),
+        );
+    }
+
+    #[rstest]
+    fn mass_status_cutoff_subtracts_normal_lookback_exactly() {
+        let ts_init = UnixNanos::from(3_700 * NANOSECONDS_IN_SECOND);
+
+        assert_eq!(
+            mass_status_cutoff(ts_init, Some(60)),
+            Some(UnixNanos::from(100 * NANOSECONDS_IN_SECOND)),
+        );
+        assert_eq!(mass_status_cutoff(ts_init, None), None);
+    }
+
+    #[rstest]
+    fn mass_status_omission_error_is_none_without_anomalies() {
+        assert_eq!(
+            mass_status_omission_error(
+                &OrderBuildDiscards::default(),
+                &FillBuildDiscards::default(),
+                &PositionBuildDiscards::default(),
+            ),
+            None,
+        );
+    }
+
+    #[rstest]
+    #[case::unmapped_order(
+        OrderBuildDiscards {
+            unmapped_instruments: 1,
+            ..OrderBuildDiscards::default()
+        },
+        FillBuildDiscards::default(),
+        PositionBuildDiscards::default(),
+        "1 unmapped order(s)",
+    )]
+    #[case::unrepresentable_order(
+        OrderBuildDiscards {
+            unrepresentable_orders: 1,
+            ..OrderBuildDiscards::default()
+        },
+        FillBuildDiscards::default(),
+        PositionBuildDiscards::default(),
+        "1 unrepresentable order(s)",
+    )]
+    #[case::unmapped_fill_instrument(
+        OrderBuildDiscards::default(),
+        FillBuildDiscards {
+            unmapped_instruments: 1,
+            ..FillBuildDiscards::default()
+        },
+        PositionBuildDiscards::default(),
+        "1 fill(s) with unmapped instruments",
+    )]
+    #[case::invalid_fill_timestamp(
+        OrderBuildDiscards::default(),
+        FillBuildDiscards {
+            invalid_timestamps: 1,
+            ..FillBuildDiscards::default()
+        },
+        PositionBuildDiscards::default(),
+        "1 fill(s) with invalid timestamps",
+    )]
+    #[case::invalid_fill_values(
+        OrderBuildDiscards::default(),
+        FillBuildDiscards {
+            invalid_values: 1,
+            ..FillBuildDiscards::default()
+        },
+        PositionBuildDiscards::default(),
+        "1 fill(s) with invalid values",
+    )]
+    #[case::unowned_maker_trade(
+        OrderBuildDiscards::default(),
+        FillBuildDiscards {
+            unowned_maker_trades: 1,
+            ..FillBuildDiscards::default()
+        },
+        PositionBuildDiscards::default(),
+        "1 unowned maker trade(s)",
+    )]
+    #[case::unrepresentable_position(
+        OrderBuildDiscards::default(),
+        FillBuildDiscards::default(),
+        PositionBuildDiscards {
+            unrepresentable_positions: 1,
+            ..PositionBuildDiscards::default()
+        },
+        "1 unrepresentable position(s)",
+    )]
+    #[case::invalid_position_avg_price(
+        OrderBuildDiscards::default(),
+        FillBuildDiscards::default(),
+        PositionBuildDiscards {
+            invalid_avg_prices: 1,
+            ..PositionBuildDiscards::default()
+        },
+        "1 position(s) with invalid average prices",
+    )]
+    fn each_mass_status_anomaly_produces_an_error_with_its_own_count(
+        #[case] order_discards: OrderBuildDiscards,
+        #[case] fill_discards: FillBuildDiscards,
+        #[case] position_discards: PositionBuildDiscards,
+        #[case] expected: &str,
+    ) {
+        let message =
+            mass_status_omission_error(&order_discards, &fill_discards, &position_discards)
+                .expect("a single anomaly must produce an error message");
+
+        assert!(message.contains(expected), "message was: {message}");
+    }
+
+    #[rstest]
+    fn mass_status_omission_error_keeps_counts_with_their_labels() {
+        let order_discards = OrderBuildDiscards {
+            unmapped_instruments: 1,
+            unrepresentable_orders: 2,
+        };
+        let fill_discards = FillBuildDiscards {
+            unmapped_instruments: 3,
+            invalid_timestamps: 4,
+            ..FillBuildDiscards::default()
+        };
+        let position_discards = PositionBuildDiscards {
+            unrepresentable_positions: 5,
+            ..PositionBuildDiscards::default()
+        };
+
+        let message =
+            mass_status_omission_error(&order_discards, &fill_discards, &position_discards)
+                .expect("nonzero anomalies must produce an error message");
+
+        assert!(message.contains("1 unmapped order(s)"));
+        assert!(message.contains("2 unrepresentable order(s)"));
+        assert!(message.contains("3 fill(s) with unmapped instruments"));
+        assert!(message.contains("4 fill(s) with invalid timestamps"));
+        assert!(message.contains("5 unrepresentable position(s)"));
+        assert!(message.contains("returned report carries no count of these omissions"));
+    }
+
+    #[rstest]
+    #[case::none(0, None)]
+    #[case::one(
+        1,
+        Some(
+            "Mass status withheld 1 Flat position report(s) due to same-pass order or fill activity"
+        )
+    )]
+    fn mass_status_flat_warning_depends_only_on_withheld_count(
+        #[case] flat_withheld_activity: usize,
+        #[case] expected: Option<&str>,
+    ) {
+        let position_discards = PositionBuildDiscards {
+            flat_withheld_activity,
+            invalid_avg_prices: 7,
+            ..PositionBuildDiscards::default()
+        };
+
+        assert_eq!(
+            mass_status_flat_withheld_warning(&position_discards).as_deref(),
+            expected,
+        );
+    }
+
+    #[rstest]
+    #[case::none(0, 0, None)]
+    #[case::orders(
+        2,
+        0,
+        Some("Mass-status lookback removed 2 order row(s) and 0 trade row(s)")
+    )]
+    #[case::trades(
+        0,
+        3,
+        Some("Mass-status lookback removed 0 order row(s) and 3 trade row(s)")
+    )]
+    fn mass_status_lookback_warning_depends_on_removed_counts(
+        #[case] orders_removed: usize,
+        #[case] trades_removed: usize,
+        #[case] expected: Option<&str>,
+    ) {
+        assert_eq!(
+            mass_status_lookback_warning(orders_removed, trades_removed).as_deref(),
+            expected,
+        );
+    }
+
+    #[rstest]
+    fn dust_alone_does_not_produce_an_omission_error() {
+        let position_discards = PositionBuildDiscards {
+            dust_positions: 1,
+            ..PositionBuildDiscards::default()
+        };
+
+        assert_eq!(
+            mass_status_omission_error(
+                &OrderBuildDiscards::default(),
+                &FillBuildDiscards::default(),
+                &position_discards,
+            ),
+            None,
+        );
+    }
+
+    #[rstest]
+    #[case::none(0, None)]
+    #[case::one(
+        1,
+        Some("1 position(s) below the dust threshold were omitted by policy")
+    )]
+    fn mass_status_dust_warning_depends_only_on_dust_count(
+        #[case] dust_positions: usize,
+        #[case] expected: Option<&str>,
+    ) {
+        let position_discards = PositionBuildDiscards {
+            dust_positions,
+            unrepresentable_positions: 7,
+            ..PositionBuildDiscards::default()
+        };
+
+        assert_eq!(
+            mass_status_dust_warning(&position_discards).as_deref(),
+            expected,
+        );
+    }
 
     #[rstest]
     fn caps_order_report_to_confirmed_companion_fills() {

--- a/crates/adapters/polymarket/src/execution/reports.rs
+++ b/crates/adapters/polymarket/src/execution/reports.rs
@@ -38,7 +38,8 @@ use super::{
         weighted_average_price,
     },
     reconciliation::{
-        FillContext, apply_fill_filters, build_fill_reports_from_trades, build_position_reports,
+        FillBuildDiscards, FillContext, OrderBuildDiscards, PositionBuildDiscards,
+        apply_fill_filters, build_fill_reports_from_trades, build_position_reports,
         cap_order_report_filled_qty, confirmed_filled_quantities,
         normalize_terminal_order_report_quantity,
     },
@@ -284,7 +285,7 @@ impl PolymarketExecutionClient {
         self.spawn_task("query_order", async move {
             match http_client.get_order_optional(&venue_order_id).await {
                 Ok(Some(order)) => {
-                    let mut report = parse_order_status_report(
+                    let Some(mut report) = parse_order_status_report(
                         &order,
                         instrument_id,
                         account_id,
@@ -292,7 +293,9 @@ impl PolymarketExecutionClient {
                         price_prec,
                         size_prec,
                         clock.get_time_ns(),
-                    );
+                    ) else {
+                        return Ok(());
+                    };
                     let venue_order_id = VenueOrderId::from(venue_order_id.as_str());
                     let tracked_filled = fill_tracker
                         .get_cumulative_filled(&venue_order_id)
@@ -381,7 +384,7 @@ impl PolymarketExecutionClient {
         };
 
         if let Some(order) = order {
-            let mut report = parse_order_status_report(
+            let Some(mut report) = parse_order_status_report(
                 &order,
                 instrument_id,
                 self.core.account_id,
@@ -389,7 +392,9 @@ impl PolymarketExecutionClient {
                 price_prec,
                 size_prec,
                 self.clock.get_time_ns(),
-            );
+            ) else {
+                return Ok(None);
+            };
             let cached_filled = cmd
                 .client_order_id
                 .and_then(|id| self.core.cache().order(&id).map(|order| order.filled_qty()))
@@ -453,7 +458,7 @@ impl PolymarketExecutionClient {
             .await
             .context("failed to fetch orders")?;
 
-        let (mut reports, _) = super::reconciliation::build_order_reports_from_orders(
+        let (mut reports, discards) = super::reconciliation::build_order_reports_from_orders(
             &orders,
             &self.shared_token_instruments,
             self.core.account_id,
@@ -520,7 +525,7 @@ impl PolymarketExecutionClient {
             reports
         };
 
-        log::debug!("Generated {} order status reports", reports.len());
+        log_order_report_summary(reports.len(), &discards);
         Ok(reports)
     }
 
@@ -535,7 +540,7 @@ impl PolymarketExecutionClient {
             .context("failed to fetch trades")?;
 
         let ctx = self.fill_context();
-        let (mut reports, _) = build_fill_reports_from_trades(
+        let (mut reports, discards) = build_fill_reports_from_trades(
             &trades,
             &ctx,
             &self.shared_token_instruments,
@@ -547,7 +552,7 @@ impl PolymarketExecutionClient {
 
         let reports = apply_fill_filters(reports, cmd.venue_order_id, cmd.start, cmd.end);
 
-        log::debug!("Generated {} fill reports", reports.len());
+        log_fill_report_summary(reports.len(), &discards);
         Ok(reports)
     }
 
@@ -563,13 +568,14 @@ impl PolymarketExecutionClient {
             .context("failed to fetch positions from Data API")?;
 
         let ts_now = self.clock.get_time_ns();
-        let mut reports = build_position_reports(&positions, self.core.account_id, ts_now);
+        let (mut reports, discards) =
+            build_position_reports(&positions, self.core.account_id, ts_now);
 
         if let Some(ref filter_id) = cmd.instrument_id {
             reports.retain(|r| &r.instrument_id == filter_id);
         }
 
-        log::debug!("Generated {} position status reports", reports.len());
+        log_position_report_summary(reports.len(), &discards);
         Ok(reports)
     }
 
@@ -589,6 +595,51 @@ impl PolymarketExecutionClient {
             lookback_mins,
         )
         .await
+    }
+}
+
+fn log_order_report_summary(report_count: usize, discards: &OrderBuildDiscards) {
+    let message = format!(
+        "Generated {report_count} order status report(s); omitted {} unmapped order(s) and {} unrepresentable order(s)",
+        discards.unmapped_instruments, discards.unrepresentable_orders,
+    );
+
+    if discards.has_anomalies() {
+        log::warn!("{message}");
+    } else {
+        log::debug!("{message}");
+    }
+}
+
+fn log_fill_report_summary(report_count: usize, discards: &FillBuildDiscards) {
+    let message = format!(
+        "Generated {report_count} fill report(s); omitted {} fill(s) with unmapped instruments, {} fill(s) with invalid timestamps, {} fill(s) with invalid values, and {} unowned maker trade(s)",
+        discards.unmapped_instruments,
+        discards.invalid_timestamps,
+        discards.invalid_values,
+        discards.unowned_maker_trades,
+    );
+
+    if discards.has_anomalies() {
+        log::warn!("{message}");
+    } else {
+        log::debug!("{message}");
+    }
+}
+
+fn log_position_report_summary(report_count: usize, discards: &PositionBuildDiscards) {
+    let message = format!(
+        "Generated {report_count} position status report(s); omitted {} dust position(s), {} unrepresentable position(s), {} position(s) with invalid average prices, and {} Flat report(s) withheld for activity",
+        discards.dust_positions,
+        discards.unrepresentable_positions,
+        discards.invalid_avg_prices,
+        discards.flat_withheld_activity,
+    );
+
+    if discards.has_anomalies() {
+        log::warn!("{message}");
+    } else {
+        log::debug!("{message}");
     }
 }
 

--- a/crates/adapters/polymarket/src/execution/responses.rs
+++ b/crates/adapters/polymarket/src/execution/responses.rs
@@ -1155,6 +1155,8 @@ mod tests {
             discards,
             crate::execution::reconciliation::FillBuildDiscards {
                 unmapped_instruments: 1,
+                invalid_timestamps: 0,
+                invalid_values: 0,
                 unowned_maker_trades: 0,
             },
         );

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -464,44 +464,48 @@ mod tests {
     }
 
     #[rstest]
-    fn test_build_position_reports_filters_dust_and_zero() {
+    fn test_build_position_reports_retains_zero_and_filters_dust() {
         let positions = load_positions();
         let account_id = AccountId::from("POLYMARKET-001");
-        let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
+        let ts_now = UnixNanos::from(1_000_000_000u64);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let (reports, _) = build_position_reports(&positions, account_id, ts_now);
 
-        // 4 positions: 150.5, 0.0, 42.0, 0.005 (dust)
-        // Only 150.5 and 42.0 pass the DUST_POSITION_THRESHOLD (0.01)
-        assert_eq!(reports.len(), 2);
+        assert_eq!(reports.len(), 3);
         assert!(reports[0].is_long());
-        assert!(reports[1].is_long());
+        assert!(reports[1].is_flat());
+        assert!(reports[1].quantity.is_zero());
+        assert!(reports[2].is_long());
     }
 
     #[rstest]
     fn test_build_position_reports_carries_avg_price() {
         let positions = load_positions();
         let account_id = AccountId::from("POLYMARKET-001");
-        let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
+        let ts_now = UnixNanos::from(1_000_000_000u64);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let (reports, _) = build_position_reports(&positions, account_id, ts_now);
 
-        assert_eq!(reports.len(), 2);
+        assert_eq!(reports.len(), 3);
         assert_eq!(reports[0].avg_px_open, Some(dec!(0.55)));
-        assert_eq!(reports[1].avg_px_open, Some(dec!(0.3)));
+        assert_eq!(reports[1].avg_px_open, None);
+        assert_eq!(reports[2].avg_px_open, Some(dec!(0.3)));
     }
 
     #[rstest]
     fn test_build_position_reports_uses_usdc_precision() {
         let positions = load_positions();
         let account_id = AccountId::from("POLYMARKET-001");
-        let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
+        let ts_now = UnixNanos::from(1_000_000_000u64);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let (reports, _) = build_position_reports(&positions, account_id, ts_now);
 
-        assert_eq!(reports.len(), 2);
-        assert_eq!(reports[0].quantity.precision, USDC_DECIMALS as u8);
-        assert_eq!(reports[1].quantity.precision, USDC_DECIMALS as u8);
+        assert_eq!(reports.len(), 3);
+        assert!(
+            reports
+                .iter()
+                .all(|report| report.quantity.precision == USDC_DECIMALS as u8),
+        );
     }
 
     #[rstest]
@@ -513,9 +517,9 @@ mod tests {
             avg_price: None,
         }];
         let account_id = AccountId::from("POLYMARKET-001");
-        let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
+        let ts_now = UnixNanos::from(1_000_000_000u64);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let (reports, _) = build_position_reports(&positions, account_id, ts_now);
 
         assert_eq!(reports.len(), 1);
         assert_eq!(reports[0].avg_px_open, None);
@@ -577,7 +581,7 @@ mod tests {
                     hash.as_str()
                 };
                 let trade_id = TradeId::new(trade_id_str);
-                let ts_event = nautilus_core::UnixNanos::from(t.timestamp as u64 * 1_000_000_000);
+                let ts_event = UnixNanos::from(t.timestamp as u64 * 1_000_000_000);
 
                 TradeTick::new(
                     instrument_id,
@@ -621,7 +625,7 @@ mod tests {
                     hash.as_str()
                 };
                 let trade_id = TradeId::new(trade_id_str);
-                let ts_event = nautilus_core::UnixNanos::from(t.timestamp as u64 * 1_000_000_000);
+                let ts_event = UnixNanos::from(t.timestamp as u64 * 1_000_000_000);
 
                 TradeTick::new(
                     instrument_id,

--- a/crates/adapters/polymarket/src/websocket/dispatch.rs
+++ b/crates/adapters/polymarket/src/websocket/dispatch.rs
@@ -525,7 +525,7 @@ fn dispatch_maker_fills(
                 continue;
             }
         };
-        let mut report = build_maker_fill_report(
+        let Some(mut report) = build_maker_fill_report(
             mo,
             &trade.id,
             trade.trader_side,
@@ -539,7 +539,16 @@ fn dispatch_maker_fills(
             liquidity_side,
             ts_event,
             ts_init,
-        );
+        ) else {
+            log::warn!(
+                "Skipping maker fill {}-{}: matched_amount {} or price {} is unrepresentable",
+                trade.id,
+                mo.order_id,
+                mo.matched_amount,
+                mo.price,
+            );
+            continue;
+        };
         let maker_venue_order_id = report.venue_order_id;
         report.client_order_id = ctx.pending_submits.client_order_id(&maker_venue_order_id);
         report.last_qty = ctx

--- a/crates/adapters/polymarket/tests/exec_client.rs
+++ b/crates/adapters/polymarket/tests/exec_client.rs
@@ -22,9 +22,10 @@ use std::{
     path::PathBuf,
     rc::Rc,
     sync::{
-        Arc,
+        Arc, Mutex, Once,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    thread::ThreadId,
     time::Duration,
 };
 
@@ -40,6 +41,7 @@ use axum::{
     routing::{delete, get, post},
 };
 use futures_util::StreamExt;
+use log::{Level, LevelFilter, Log, Metadata, Record};
 use nautilus_common::{
     cache::{Cache, INSTRUMENT_NOT_FOUND, InstrumentLookupError},
     clients::ExecutionClient,
@@ -55,7 +57,7 @@ use nautilus_common::{
     },
     testing::wait_until_async,
 };
-use nautilus_core::{UUID4, UnixNanos};
+use nautilus_core::{UUID4, UnixNanos, time::get_atomic_clock_realtime};
 use nautilus_live::ExecutionClientCore;
 use nautilus_model::{
     accounts::{AccountAny, cash::CashAccount},
@@ -65,7 +67,7 @@ use nautilus_model::{
     },
     events::{AccountState, OrderEventAny, OrderPendingCancel},
     identifiers::{
-        AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TraderId,
+        AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TradeId, TraderId,
         VenueOrderId,
     },
     instruments::{BinaryOption, InstrumentAny},
@@ -87,6 +89,7 @@ use nautilus_polymarket::{
     signing::eip712::order_hash,
 };
 use rstest::rstest;
+use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde_json::{Value, json};
 
@@ -125,6 +128,79 @@ enum CancelChunkRetry {
 enum ShutdownAction {
     Stop,
     Disconnect,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MassStatusSeverityCase {
+    Anomaly,
+    DustOnly,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CapturedMassStatusLog {
+    level: Level,
+    message: String,
+    thread_id: ThreadId,
+}
+
+struct MassStatusLogCapture {
+    records: Mutex<Vec<CapturedMassStatusLog>>,
+}
+
+static MASS_STATUS_LOG_CAPTURE: MassStatusLogCapture = MassStatusLogCapture {
+    records: Mutex::new(Vec::new()),
+};
+
+impl Log for MassStatusLogCapture {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        matches!(
+            metadata.target(),
+            "nautilus_polymarket::execution::reconciliation"
+                | "nautilus_polymarket::execution::reports"
+        )
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        self.records.lock().unwrap().push(CapturedMassStatusLog {
+            level: record.level(),
+            message: record.args().to_string(),
+            thread_id: std::thread::current().id(),
+        });
+    }
+
+    fn flush(&self) {}
+}
+
+fn install_mass_status_log_capture() {
+    static INSTALL: Once = Once::new();
+
+    INSTALL.call_once(|| {
+        log::set_logger(&MASS_STATUS_LOG_CAPTURE).expect("test logger already installed");
+        log::set_max_level(LevelFilter::Trace);
+    });
+
+    let thread_id = std::thread::current().id();
+    MASS_STATUS_LOG_CAPTURE
+        .records
+        .lock()
+        .unwrap()
+        .retain(|record| record.thread_id != thread_id);
+}
+
+fn captured_mass_status_logs() -> Vec<CapturedMassStatusLog> {
+    let thread_id = std::thread::current().id();
+    MASS_STATUS_LOG_CAPTURE
+        .records
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|record| record.thread_id == thread_id)
+        .cloned()
+        .collect()
 }
 
 #[derive(Debug)]
@@ -217,6 +293,7 @@ struct TestServerState {
     book_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     single_order_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     trades_response_override: Arc<tokio::sync::Mutex<Option<Value>>>,
+    positions_response_override: Arc<tokio::sync::Mutex<Option<Value>>>,
 }
 
 impl Default for TestServerState {
@@ -265,6 +342,7 @@ impl Default for TestServerState {
             orders_response_override: Arc::new(tokio::sync::Mutex::new(None)),
             single_order_response: Arc::new(tokio::sync::Mutex::new(None)),
             trades_response_override: Arc::new(tokio::sync::Mutex::new(None)),
+            positions_response_override: Arc::new(tokio::sync::Mutex::new(None)),
             book_response: Arc::new(tokio::sync::Mutex::new(Some(json!({
                 "bids": [
                     {"price": "0.48", "size": "100.00"},
@@ -740,7 +818,11 @@ async fn handle_health() -> impl IntoResponse {
     StatusCode::OK
 }
 
-async fn handle_get_positions() -> impl IntoResponse {
+async fn handle_get_positions(State(state): State<TestServerState>) -> impl IntoResponse {
+    if let Some(override_value) = state.positions_response_override.lock().await.as_ref() {
+        return Json(override_value.clone());
+    }
+
     Json(serde_json::json!([]))
 }
 
@@ -801,6 +883,238 @@ async fn test_exec_client_creation() {
     assert_eq!(client.account_id(), AccountId::from("POLYMARKET-001"));
     assert_eq!(client.venue(), *POLYMARKET_VENUE);
     assert_eq!(client.oms_type(), OmsType::Netting);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_mass_status_forwards_lookback_to_order_and_fill_filters() {
+    let now_secs = get_atomic_clock_realtime().get_time_ns().as_u64() / 1_000_000_000;
+    let fresh_order_id = "0xfresh00000000000000000000000000000000000000000000000000000000001";
+    let stale_order_id = "0xstale00000000000000000000000000000000000000000000000000000000001";
+    let mut fresh_order = load_json("http_open_order.json");
+    fresh_order["id"] = json!(fresh_order_id);
+    fresh_order["created_at"] = json!(now_secs);
+    fresh_order["size_matched"] = json!("25.0000");
+    let mut stale_order = fresh_order.clone();
+    stale_order["id"] = json!(stale_order_id);
+    stale_order["created_at"] = json!(1);
+
+    let mut fresh_trade = load_json("http_trade_report.json");
+    fresh_trade["id"] = json!("trade-fresh");
+    fresh_trade["taker_order_id"] = json!(fresh_order_id);
+    fresh_trade["match_time"] = json!(now_secs.to_string());
+    fresh_trade["maker_orders"] = json!([]);
+    let mut stale_trade = fresh_trade.clone();
+    stale_trade["id"] = json!("trade-stale");
+    stale_trade["taker_order_id"] = json!(stale_order_id);
+    stale_trade["match_time"] = json!("1");
+
+    let state = TestServerState::default();
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [fresh_order, stale_order],
+        "next_cursor": "LTE="
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [fresh_trade, stale_trade],
+        "next_cursor": "LTE="
+    }));
+    *state.positions_response_override.lock().await = Some(json!([
+        {
+            "asset": "777",
+            "conditionId": "0xwrap",
+            "size": "5",
+            "avgPrice": "0.5"
+        }
+    ]));
+    let addr = start_mock_server(state).await;
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+
+    let mass_status = client
+        .generate_mass_status(Some(60))
+        .await
+        .unwrap()
+        .expect("mass status payload");
+    let order_reports = mass_status.order_reports();
+    let fill_reports: Vec<_> = mass_status.fill_reports().into_values().flatten().collect();
+
+    assert_eq!(order_reports.len(), 1);
+    assert!(order_reports.contains_key(&VenueOrderId::from(fresh_order_id)));
+    assert!(!order_reports.contains_key(&VenueOrderId::from(stale_order_id)));
+    assert_eq!(fill_reports.len(), 1);
+    assert_eq!(fill_reports[0].trade_id, TradeId::from("trade-fresh"));
+    assert!(
+        fill_reports
+            .iter()
+            .all(|report| report.trade_id != TradeId::from("trade-stale"))
+    );
+
+    let position_reports = mass_status.position_reports();
+    let position_instrument_id = InstrumentId::from("0xwrap-777.POLYMARKET");
+    assert!(position_reports.contains_key(&position_instrument_id));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_mass_status_withholds_flat_with_same_pass_fill() {
+    install_mass_status_log_capture();
+    let now_secs = get_atomic_clock_realtime().get_time_ns().as_u64() / 1_000_000_000;
+    let mut trade = load_json("http_trade_report.json");
+    trade["match_time"] = json!(now_secs.to_string());
+    trade["maker_orders"] = json!([]);
+
+    let state = TestServerState::default();
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [],
+        "next_cursor": "LTE="
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [trade],
+        "next_cursor": "LTE="
+    }));
+    *state.positions_response_override.lock().await = Some(json!([
+        {
+            "asset": "123",
+            "conditionId": "0xabc",
+            "size": "0",
+            "avgPrice": "0"
+        }
+    ]));
+    let addr = start_mock_server(state).await;
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("0xabc-123.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+
+    let mass_status = client
+        .generate_mass_status(None)
+        .await
+        .unwrap()
+        .expect("mass status payload");
+    let fill_reports: Vec<_> = mass_status.fill_reports().into_values().flatten().collect();
+    let logs = captured_mass_status_logs();
+
+    assert_eq!(fill_reports.len(), 1);
+    assert_eq!(fill_reports[0].instrument_id, instrument_id);
+    assert!(!mass_status.position_reports().contains_key(&instrument_id));
+    assert!(logs.iter().any(|record| {
+        record.level == Level::Warn
+            && record.message.contains(
+                "withheld 1 Flat position report(s) due to same-pass order or fill activity",
+            )
+    }));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_mass_status_warns_for_lookback_removals_only_when_nonzero() {
+    install_mass_status_log_capture();
+    let mut order = load_json("http_open_order.json");
+    order["created_at"] = json!(1);
+    let mut trade = load_json("http_trade_report.json");
+    trade["match_time"] = json!("1");
+
+    let state = TestServerState::default();
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [order],
+        "next_cursor": "LTE="
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [trade],
+        "next_cursor": "LTE="
+    }));
+    let addr = start_mock_server(state.clone()).await;
+    let (client, _rx, _cache) = create_test_execution_client(addr);
+
+    client.generate_mass_status(Some(60)).await.unwrap();
+    let logs = captured_mass_status_logs();
+    let matching: Vec<_> = logs
+        .iter()
+        .filter(|record| record.message.contains("lookback removed"))
+        .collect();
+
+    assert_eq!(matching.len(), 1, "matching mass-status logs: {logs:?}");
+    assert_eq!(matching[0].level, Level::Warn);
+    assert!(matching[0].message.contains("1 order row(s)"));
+    assert!(matching[0].message.contains("1 trade row(s)"));
+
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [],
+        "next_cursor": "LTE="
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [],
+        "next_cursor": "LTE="
+    }));
+    install_mass_status_log_capture();
+    client.generate_mass_status(Some(60)).await.unwrap();
+
+    assert!(
+        captured_mass_status_logs()
+            .iter()
+            .all(|record| !record.message.contains("lookback removed"))
+    );
+}
+
+#[rstest]
+#[case::anomaly(MassStatusSeverityCase::Anomaly, Level::Error, "Mass status omitted")]
+#[case::dust_only(
+    MassStatusSeverityCase::DustOnly,
+    Level::Warn,
+    "position(s) below the dust threshold were omitted by policy"
+)]
+#[tokio::test]
+async fn test_generate_mass_status_surfaces_omissions_at_required_level(
+    #[case] severity_case: MassStatusSeverityCase,
+    #[case] expected_level: Level,
+    #[case] message_fragment: &str,
+) {
+    install_mass_status_log_capture();
+    let state = TestServerState::default();
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [],
+        "next_cursor": "LTE="
+    }));
+
+    match severity_case {
+        MassStatusSeverityCase::Anomaly => {
+            *state.orders_response_override.lock().await = Some(json!({
+                "data": [load_json("http_open_order.json")],
+                "next_cursor": "LTE="
+            }));
+            *state.positions_response_override.lock().await = Some(json!([]));
+        }
+        MassStatusSeverityCase::DustOnly => {
+            *state.orders_response_override.lock().await = Some(json!({
+                "data": [],
+                "next_cursor": "LTE="
+            }));
+            *state.positions_response_override.lock().await = Some(json!([
+                {
+                    "asset": "777",
+                    "conditionId": "0xdust",
+                    "size": "0.001",
+                    "avgPrice": "0.5"
+                }
+            ]));
+        }
+    }
+
+    let addr = start_mock_server(state).await;
+    let (client, _rx, _cache) = create_test_execution_client(addr);
+    client.generate_mass_status(None).await.unwrap();
+    let logs = captured_mass_status_logs();
+    let matching: Vec<_> = logs
+        .iter()
+        .filter(|record| record.message.contains(message_fragment))
+        .collect();
+
+    assert_eq!(matching.len(), 1, "matching mass-status logs: {logs:?}");
+    assert_eq!(matching[0].level, expected_level);
 }
 
 #[rstest]
@@ -1183,8 +1497,13 @@ async fn test_exec_client_get_account_after_cache_add() {
 #[tokio::test]
 async fn test_generate_order_status_reports_empty_without_instruments() {
     let state = TestServerState::default();
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [load_json("http_open_order.json")],
+        "next_cursor": "LTE="
+    }));
     let addr = start_mock_server(state).await;
     let (client, _rx, _cache) = create_test_execution_client(addr);
+    install_mass_status_log_capture();
 
     let cmd = GenerateOrderStatusReports {
         command_id: UUID4::new(),
@@ -1203,6 +1522,10 @@ async fn test_generate_order_status_reports_empty_without_instruments() {
 
     // Without loaded instruments, orders cannot be resolved to instrument IDs
     assert!(reports.is_empty());
+    let logs = captured_mass_status_logs();
+    assert!(logs.iter().any(|record| {
+        record.level == Level::Warn && record.message.contains("1 unmapped order(s)")
+    }));
 }
 
 #[rstest]
@@ -1274,6 +1597,7 @@ async fn test_generate_fill_reports_empty_without_instruments() {
     let state = TestServerState::default();
     let addr = start_mock_server(state).await;
     let (client, _rx, _cache) = create_test_execution_client(addr);
+    install_mass_status_log_capture();
 
     let cmd = GenerateFillReports {
         command_id: UUID4::new(),
@@ -1291,14 +1615,30 @@ async fn test_generate_fill_reports_empty_without_instruments() {
     let reports = client.generate_fill_reports(cmd).await.unwrap();
 
     assert!(reports.is_empty());
+    let logs = captured_mass_status_logs();
+    assert!(logs.iter().any(|record| {
+        record.level == Level::Warn
+            && record
+                .message
+                .contains("1 fill(s) with unmapped instruments")
+    }));
 }
 
 #[rstest]
 #[tokio::test]
-async fn test_generate_position_status_reports_always_empty() {
+async fn test_generate_position_status_reports_warns_for_omitted_position() {
     let state = TestServerState::default();
+    *state.positions_response_override.lock().await = Some(json!([
+        {
+            "asset": "123",
+            "conditionId": "0xabc",
+            "size": Decimal::MAX.to_string(),
+            "avgPrice": "0.5"
+        }
+    ]));
     let addr = start_mock_server(state).await;
     let (client, _rx, _cache) = create_test_execution_client(addr);
+    install_mass_status_log_capture();
 
     let cmd = GeneratePositionStatusReports {
         command_id: UUID4::new(),
@@ -1314,8 +1654,11 @@ async fn test_generate_position_status_reports_always_empty() {
 
     let reports = client.generate_position_status_reports(&cmd).await.unwrap();
 
-    // Polymarket has no position endpoint
     assert!(reports.is_empty());
+    let logs = captured_mass_status_logs();
+    assert!(logs.iter().any(|record| {
+        record.level == Level::Warn && record.message.contains("1 unrepresentable position(s)")
+    }));
 }
 
 #[rstest]

--- a/docs/integrations/polymarket.md
+++ b/docs/integrations/polymarket.md
@@ -589,6 +589,18 @@ create an inferred fill. Runtime order checks fetch confirmed trade history when
 more matched quantity than the local order and WebSocket fill tracker contain. Unpaired fill reports
 retain the normal fill-only path.
 
+Reconciliation omits and counts any order or position it cannot represent rather than coercing it.
+Order prices must lie strictly inside `(0, 1)`; only the unit bound is enforced because tick size
+varies per market. A non-zero position with an average price outside `(0, 1)` is rejected and counted
+because the live reconciliation engine cannot create that position without an open average price.
+Dust holdings are omitted by policy and counted separately from malformed venue data.
+
+Explicit zero-size venue rows emit `Flat` position reports so stale cached positions can close. A
+`Flat` report is withheld and counted when the same mass-status pass contains an order or fill report
+for that instrument, because the separate Data API positions indexer can lag current CLOB activity.
+Mass-status lookback filtering is based on the local clock; any order or trade rows removed by the
+lookback are counted in an aggregated warning for visibility into clock skew and policy filtering.
+
 ### Single-order recovery from trades
 
 `/data/order/{id}` can return live or terminal orders. When it returns no order for a known ID,


### PR DESCRIPTION
## Summary

The Polymarket adapter omitted venue orders and positions it could not represent - and holdings it filters as dust - from the mass status it returned, still reported success, and let no count of either omission reach the report. A mass status could be silently partial: an order the venue holds could be absent from the report with the pass still succeeding.

This PR makes omission visible and rejects what cannot be represented:

- Every dropped or degenerate input row is counted exactly once and surfaced in one aggregated per-pass message. Anomalies (unmapped instruments, unrepresentable orders or positions, invalid fill timestamps or values, unowned maker trades, invalid average prices) emit one `error!` per pass; policy dust, withheld Flat reports, and lookback removals `warn!`. The polled order, fill, and position report routes log the same omission counts (warn on any anomaly).
- Unrepresentable order and fill quantities, prices outside the binary unit interval, terminal filled orders with no matched quantity, negative position sizes, and non-zero positions with a missing-interval average price are rejected and counted instead of being coerced into present-but-wrong reports (a zeroed report asserts a state the venue never reported; a position report without an open average price is silently dropped by the live reconciliation engine).
- The mass-status lookback applies to fetched orders and trades before building reports, with saturating cutoff arithmetic; rows with unparsable timestamps are retained so their parsers count them. Removed rows are counted in an aggregated warning, since the cutoff follows the local clock and clock skew otherwise silently filters venue-current rows.
- Explicitly zero-size venue positions now produce `Flat` position reports, so a startup mass status can close a stale cached position (previously the closed position row was dropped and the stale cache entry survived startup indefinitely). Positive dust remains omitted and counted.

## Behavior changes

- Flat position reports are now emitted for explicit zero-size rows (previously dropped). The netting consumer treats them as authoritative zero and closes any stale cached position.
- A Flat report is withheld and counted when the same mass-status pass contains an order or fill report for that instrument, because the Data API positions indexer is a separate service that can lag current CLOB activity; without this guard a stale zero row could close a live position.
- Non-zero positions with an average price outside `(0, 1)` are rejected and counted (previously the average price was cleared and the position retained, which the engine then dropped silently).
- Degenerate values that were previously coerced (zeroed) into reports are now rejected and counted.

## Test plan

- `cargo nextest run -p nautilus-polymarket`: 1,364 passed, 0 skipped (new: per-anomaly counting, flat-withhold guard, invalid-value rejection for taker and maker fills, invalid-average-price rejection, lookback-removal warning, per-pass log severity, polled-route omission summaries).
- `cargo clippy -p nautilus-polymarket --all-targets -- -D warnings`: clean. `prek run --all-files`: all hooks pass.
- Negative controls: each new test was confirmed to fail with its production change reverted, then restored.

## Notes

- This PR and the settlement-pending-fills PR (#4692) both edit `execution/reconciliation.rs` (different concerns: omission counting vs fill building). They are independent and either order merges; the second may need a small rebase, which we will handle promptly.
