### PR TITLE
Reconcile Polymarket settlement-pending fills and their corrections

### DIFF
--- a/crates/adapters/polymarket/src/common/fifo_ext.rs
+++ b/crates/adapters/polymarket/src/common/fifo_ext.rs
@@ -1,0 +1,122 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Loud insertion helpers for bounded correction and identity caches.
+
+use std::{fmt::Debug, hash::Hash};
+
+use nautilus_common::cache::fifo::{FifoCache, FifoCacheMap};
+
+/// Adds `id` to the cache, warning when the insertion evicts the oldest entry.
+pub(crate) fn add_to_fifo_with_eviction_warn<T, const N: usize>(
+    cache: &mut FifoCache<T, N>,
+    id: T,
+    what: &str,
+) -> bool
+where
+    T: Clone + Debug + Eq + Hash,
+{
+    let will_evict = cache.len() == N && !cache.contains(&id);
+
+    if will_evict {
+        log::warn!("{what} cache is at capacity ({N}); evicting its oldest entry");
+    }
+
+    cache.add(id);
+    will_evict
+}
+
+/// Inserts `key` into the cache, warning when the insertion evicts the oldest entry.
+pub(crate) fn add_to_fifo_map_with_eviction_warn<K, V, const N: usize>(
+    cache: &mut FifoCacheMap<K, V, N>,
+    key: K,
+    value: V,
+    what: &str,
+) -> bool
+where
+    K: Clone + Debug + Eq + Hash,
+{
+    let will_evict = cache.len() == N && !cache.contains_key(&key);
+
+    if will_evict {
+        log::warn!("{what} cache is at capacity ({N}); evicting its oldest entry");
+    }
+
+    cache.insert(key, value);
+    will_evict
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_common::cache::fifo::{FifoCache, FifoCacheMap};
+    use rstest::rstest;
+
+    use super::{add_to_fifo_map_with_eviction_warn, add_to_fifo_with_eviction_warn};
+    use crate::common::test_logger::{capture_start, records_since};
+
+    #[rstest]
+    fn fifo_insertions_warn_only_when_they_evict() {
+        let log_start = capture_start();
+        let mut cache = FifoCache::<u8, 1>::default();
+
+        add_to_fifo_with_eviction_warn(&mut cache, 1, "test FIFO");
+        add_to_fifo_with_eviction_warn(&mut cache, 1, "test FIFO");
+
+        assert!(
+            records_since(log_start)
+                .iter()
+                .all(|(_, message)| !message.contains("test FIFO cache"))
+        );
+
+        add_to_fifo_with_eviction_warn(&mut cache, 2, "test FIFO");
+
+        let records = records_since(log_start)
+            .into_iter()
+            .filter(|(_, message)| message.contains("test FIFO cache"))
+            .collect::<Vec<_>>();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, log::Level::Warn);
+        assert!(records[0].1.contains("test FIFO cache is at capacity (1)"));
+    }
+
+    #[rstest]
+    fn fifo_map_insertions_warn_only_when_they_evict() {
+        let log_start = capture_start();
+        let mut cache = FifoCacheMap::<u8, u8, 1>::default();
+
+        add_to_fifo_map_with_eviction_warn(&mut cache, 1, 10, "test FIFO map");
+        add_to_fifo_map_with_eviction_warn(&mut cache, 1, 20, "test FIFO map");
+
+        assert!(
+            records_since(log_start)
+                .iter()
+                .all(|(_, message)| !message.contains("test FIFO map cache"))
+        );
+
+        add_to_fifo_map_with_eviction_warn(&mut cache, 2, 30, "test FIFO map");
+
+        let records = records_since(log_start)
+            .into_iter()
+            .filter(|(_, message)| message.contains("test FIFO map cache"))
+            .collect::<Vec<_>>();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, log::Level::Warn);
+        assert!(
+            records[0]
+                .1
+                .contains("test FIFO map cache is at capacity (1)")
+        );
+    }
+}

--- a/crates/adapters/polymarket/src/common/mod.rs
+++ b/crates/adapters/polymarket/src/common/mod.rs
@@ -22,3 +22,8 @@ pub mod models;
 pub mod parse;
 pub mod retry;
 pub mod urls;
+
+pub(crate) mod fifo_ext;
+
+#[cfg(test)]
+pub(crate) mod test_logger;

--- a/crates/adapters/polymarket/src/common/test_logger.rs
+++ b/crates/adapters/polymarket/src/common/test_logger.rs
@@ -1,0 +1,63 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at http://www.gnu.org/licenses/lgpl-3.0.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Shared log capture for adapter unit tests.
+
+use std::sync::{Mutex, Once};
+
+#[derive(Debug)]
+struct CaptureLogger {
+    records: Mutex<Vec<(log::Level, String)>>,
+}
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        self.records
+            .lock()
+            .expect("capture logger mutex poisoned")
+            .push((record.level(), record.args().to_string()));
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger {
+    records: Mutex::new(Vec::new()),
+};
+static LOGGER_INIT: Once = Once::new();
+
+pub(crate) fn capture_start() -> usize {
+    LOGGER_INIT.call_once(|| {
+        log::set_logger(&LOGGER).expect("test logger already installed");
+        log::set_max_level(log::LevelFilter::Trace);
+    });
+    LOGGER
+        .records
+        .lock()
+        .expect("capture logger mutex poisoned")
+        .len()
+}
+
+pub(crate) fn records_since(start: usize) -> Vec<(log::Level, String)> {
+    LOGGER
+        .records
+        .lock()
+        .expect("capture logger mutex poisoned")[start..]
+        .to_vec()
+}

--- a/crates/adapters/polymarket/src/execution/identity.rs
+++ b/crates/adapters/polymarket/src/execution/identity.rs
@@ -32,6 +32,8 @@ use nautilus_model::{
     orders::{Order, OrderAny},
 };
 
+use crate::common::fifo_ext::{add_to_fifo_map_with_eviction_warn, add_to_fifo_with_eviction_warn};
+
 /// Identity fields captured at submit so the cache-free WS dispatch can build order events.
 ///
 /// `trader_id` and `account_id` are client-wide constants threaded from the dispatch context,
@@ -85,6 +87,7 @@ struct RegistryInner {
     identities: FifoCacheMap<VenueOrderId, OrderIdentity, 10_000>,
     client_to_venue: FifoCacheMap<ClientOrderId, VenueOrderId, 10_000>,
     accepted: FifoCache<VenueOrderId, 10_000>,
+    evictions: u64,
 }
 
 impl OrderIdentityRegistry {
@@ -95,10 +98,22 @@ impl OrderIdentityRegistry {
         identity: OrderIdentity,
     ) {
         let mut guard = self.inner.lock().expect(MUTEX_POISONED);
-        guard.identities.insert(venue_order_id, identity);
-        guard
-            .client_to_venue
-            .insert(identity.client_order_id, venue_order_id);
+
+        let identity_evicted = add_to_fifo_map_with_eviction_warn(
+            &mut guard.identities,
+            venue_order_id,
+            identity,
+            "order-identity",
+        );
+        let client_mapping_evicted = add_to_fifo_map_with_eviction_warn(
+            &mut guard.client_to_venue,
+            identity.client_order_id,
+            venue_order_id,
+            "client-to-venue identity",
+        );
+        guard.evictions = guard
+            .evictions
+            .saturating_add(u64::from(identity_evicted) + u64::from(client_mapping_evicted));
     }
 
     /// Returns the identity for a tracked order, if known.
@@ -121,16 +136,27 @@ impl OrderIdentityRegistry {
             .copied()
     }
 
+    #[must_use]
+    pub(crate) fn has_evictions(&self) -> bool {
+        self.inner.lock().expect(MUTEX_POISONED).evictions > 0
+    }
+
     /// Marks acceptance as emitted, returning `true` only when this call newly marks it.
     ///
     /// Callers emit `OrderAccepted` only on a `true` result, so acceptance is emitted once
     /// across the submit confirmation and the WS stream.
     pub(crate) fn mark_accepted(&self, venue_order_id: VenueOrderId) -> bool {
         let mut guard = self.inner.lock().expect(MUTEX_POISONED);
+
         if guard.accepted.contains(&venue_order_id) {
             false
         } else {
-            guard.accepted.add(venue_order_id);
+            let evicted = add_to_fifo_with_eviction_warn(
+                &mut guard.accepted,
+                venue_order_id,
+                "accepted order-identity",
+            );
+            guard.evictions = guard.evictions.saturating_add(u64::from(evicted));
             true
         }
     }

--- a/crates/adapters/polymarket/src/execution/lifecycle.rs
+++ b/crates/adapters/polymarket/src/execution/lifecycle.rs
@@ -656,8 +656,7 @@ async fn run_heartbeats(
 fn polymarket_trade_key(info: Option<&IndexMap<Ustr, Ustr>>) -> Option<String> {
     let info = info?;
     let trade_id = info.get(&Ustr::from("id"))?;
-    let taker_order_id = info.get(&Ustr::from("taker_order_id"))?;
-    Some(format!("{trade_id}-{taker_order_id}"))
+    Some(trade_id.to_string())
 }
 
 fn upsert_execution_lookup(
@@ -1114,7 +1113,7 @@ mod tests {
 
         client.load_orders_from_cache();
 
-        let key = "trade-restart-V-001";
+        let key = "trade-restart";
         let identity = client
             .order_identities
             .get(&venue_order_id)
@@ -1407,8 +1406,7 @@ mod tests {
             .ws_dispatch_state
             .lock()
             .expect(MUTEX_POISONED)
-            .processed_fills
-            .add("trade-1".to_string());
+            .restore_matched_trade("trade-1".to_string(), Vec::new());
 
         client.reset_client();
 
@@ -1439,8 +1437,7 @@ mod tests {
             .ws_dispatch_state
             .lock()
             .expect(MUTEX_POISONED)
-            .processed_fills
-            .add(dedup_key.clone());
+            .restore_matched_trade(dedup_key.clone(), Vec::new());
 
         client.stop_client();
 

--- a/crates/adapters/polymarket/src/execution/order_fill_tracker.rs
+++ b/crates/adapters/polymarket/src/execution/order_fill_tracker.rs
@@ -17,22 +17,26 @@
 
 use std::sync::Mutex;
 
+use ahash::AHashSet;
 use indexmap::IndexMap;
 use nautilus_common::cache::fifo::{FifoCache, FifoCacheMap};
 use nautilus_core::MUTEX_POISONED;
-#[cfg(test)]
-use nautilus_model::identifiers::InstrumentId;
 use nautilus_model::{
-    enums::OrderSide,
+    enums::{LiquiditySide, OrderSide, OrderType},
     events::OrderFilled,
-    identifiers::{ClientOrderId, VenueOrderId},
+    identifiers::{ClientOrderId, InstrumentId, StrategyId, TradeId, VenueOrderId},
     reports::{FillReport, OrderStatusReport},
-    types::Quantity,
+    types::{Money, Price, Quantity},
 };
 use rust_decimal::Decimal;
 use ustr::Ustr;
 
-use crate::common::consts::DUST_SNAP_THRESHOLD_DEC;
+use crate::common::{
+    consts::DUST_SNAP_THRESHOLD_DEC,
+    fifo_ext::{add_to_fifo_map_with_eviction_warn, add_to_fifo_with_eviction_warn},
+};
+
+const MAX_DEFERRED_NO_EVIDENCE_TRADES: usize = 10_000;
 
 /// Cumulative fill state for a single order.
 #[derive(Debug, Clone, Copy)]
@@ -45,14 +49,56 @@ struct OrderFillState {
 #[derive(Clone, Debug)]
 pub(crate) struct FillCorrectionMetadata {
     pub correction_key: String,
+    pub trade_id: TradeId,
     pub info: Option<IndexMap<Ustr, Ustr>>,
     pub is_confirmed: bool,
+    pub track_fill: bool,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct BufferedFill {
     pub report: FillReport,
     pub correction: Option<FillCorrectionMetadata>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AppliedPendingFill {
+    pub venue_order_id: VenueOrderId,
+    pub instrument_id: InstrumentId,
+    /// The applied fill's own ID, including the composite ID used for maker fills.
+    pub trade_id: TradeId,
+    /// Captured before identity-registry eviction can make the void unaddressable.
+    pub client_order_id: Option<ClientOrderId>,
+    pub strategy_id: Option<StrategyId>,
+    pub order_type: Option<OrderType>,
+    pub order_side: OrderSide,
+    pub last_qty: Quantity,
+    pub last_px: Price,
+    pub commission: Money,
+    pub liquidity_side: LiquiditySide,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ResolveView {
+    pub cumulative_filled: Quantity,
+}
+
+impl From<&FillReport> for AppliedPendingFill {
+    fn from(report: &FillReport) -> Self {
+        Self {
+            venue_order_id: report.venue_order_id,
+            instrument_id: report.instrument_id,
+            trade_id: report.trade_id,
+            client_order_id: report.client_order_id,
+            strategy_id: None,
+            order_type: None,
+            order_side: report.order_side,
+            last_qty: report.last_qty,
+            last_px: report.last_px,
+            commission: report.commission,
+            liquidity_side: report.liquidity_side,
+        }
+    }
 }
 
 /// Registration map plus the fill and order-report buffers, all under one mutex.
@@ -69,6 +115,13 @@ struct TrackerInner {
     voided_trades: FifoCache<String, 10_000>,
     confirmed_trades: FifoCache<String, 10_000>,
     applied_buffered_fills: FifoCacheMap<String, Vec<OrderFilled>, 10_000>,
+    applied_buffered_fill_evictions: u64,
+    failed_trades: FifoCache<TradeId, 10_000>,
+    rest_applied_pending_fills: FifoCacheMap<TradeId, Vec<AppliedPendingFill>, 10_000>,
+    rest_applied_pending_staging: FifoCacheMap<TradeId, Vec<AppliedPendingFill>, 10_000>,
+    rest_applied_pending_fill_evictions: u64,
+    rest_applied_trade_orders: FifoCacheMap<String, Vec<VenueOrderId>, 10_000>,
+    deferred_no_evidence_trades: IndexMap<TradeId, ()>,
 }
 
 /// Tracks per-order fill accumulation, detects dust residuals, and buffers WS messages that arrive
@@ -98,11 +151,12 @@ impl OrderFillTrackerMap {
     ) {
         let mut state = new_order_state(submitted_qty, order_side);
         state.cumulative_filled = filled_qty;
-        self.inner
-            .lock()
-            .expect(MUTEX_POISONED)
-            .orders
-            .insert(venue_order_id, state);
+        add_to_fifo_map_with_eviction_warn(
+            &mut self.inner.lock().expect(MUTEX_POISONED).orders,
+            venue_order_id,
+            state,
+            "order fill-state",
+        );
     }
 
     /// Returns true if the order has been registered (accepted).
@@ -127,6 +181,26 @@ impl OrderFillTrackerMap {
             Some(s) => !s.cumulative_filled.is_zero(),
             None => true, // Removed = already settled
         }
+    }
+
+    /// Runs a terminal resolver only while the tracked order remains unfilled.
+    pub(crate) fn resolve_if_unfilled<F>(&self, venue_order_id: &VenueOrderId, resolve: F) -> bool
+    where
+        F: FnOnce(ResolveView),
+    {
+        let guard = self.inner.lock().expect(MUTEX_POISONED);
+        let Some(state) = guard.orders.get(venue_order_id) else {
+            return false;
+        };
+
+        if !state.cumulative_filled.is_zero() {
+            return false;
+        }
+
+        resolve(ResolveView {
+            cumulative_filled: state.cumulative_filled,
+        });
+        true
     }
 
     /// Returns the cumulative filled quantity for an order, if tracked.
@@ -162,7 +236,9 @@ impl OrderFillTrackerMap {
     ) -> Option<FillReport> {
         let mut guard = self.inner.lock().expect(MUTEX_POISONED);
         if guard.orders.get(&venue_order_id).is_some() {
-            record_fill_in(&mut guard.orders, &venue_order_id, report.last_qty);
+            if correction.track_fill {
+                record_fill_in(&mut guard.orders, &venue_order_id, report.last_qty);
+            }
             Some(report)
         } else {
             push_buffered(
@@ -209,9 +285,12 @@ impl OrderFillTrackerMap {
         order_side: OrderSide,
     ) -> Vec<BufferedFill> {
         let mut guard = self.inner.lock().expect(MUTEX_POISONED);
-        guard
-            .orders
-            .insert(venue_order_id, new_order_state(submitted_qty, order_side));
+        add_to_fifo_map_with_eviction_warn(
+            &mut guard.orders,
+            venue_order_id,
+            new_order_state(submitted_qty, order_side),
+            "order fill-state",
+        );
         take_and_prepare_fills(&mut guard, venue_order_id, client_order_id)
     }
 
@@ -230,9 +309,12 @@ impl OrderFillTrackerMap {
         if !guard.pending_fills.contains_key(&venue_order_id) {
             return None;
         }
-        guard
-            .orders
-            .insert(venue_order_id, new_order_state(submitted_qty, order_side));
+        add_to_fifo_map_with_eviction_warn(
+            &mut guard.orders,
+            venue_order_id,
+            new_order_state(submitted_qty, order_side),
+            "order fill-state",
+        );
         Some(take_and_prepare_fills(
             &mut guard,
             venue_order_id,
@@ -284,12 +366,31 @@ impl OrderFillTrackerMap {
         };
 
         let mut guard = self.inner.lock().expect(MUTEX_POISONED);
-        if guard.voided_trades.contains(&correction.correction_key) {
-            reverse_fill_in(&mut guard.orders, &fill.venue_order_id, fill.last_qty);
+        let was_rest_applied = guard
+            .rest_applied_pending_fills
+            .get(&correction.trade_id)
+            .is_some_and(|fills| {
+                fills
+                    .iter()
+                    .any(|applied| applied.venue_order_id == fill.venue_order_id)
+            })
+            || guard
+                .rest_applied_trade_orders
+                .get(&correction.correction_key)
+                .is_some_and(|venue_order_ids| venue_order_ids.contains(&fill.venue_order_id));
+
+        if guard.voided_trades.contains(&correction.correction_key) || was_rest_applied {
+            if correction.track_fill {
+                reverse_fill_in(&mut guard.orders, &fill.venue_order_id, fill.last_qty);
+            }
             return false;
         }
 
-        let new_qty = buy_overfill_bump_in(&mut guard.orders, &fill.venue_order_id);
+        let new_qty = if correction.track_fill {
+            buy_overfill_bump_in(&mut guard.orders, &fill.venue_order_id)
+        } else {
+            None
+        };
         emit(fill.clone(), new_qty);
 
         if let Some(fills) = guard
@@ -298,9 +399,22 @@ impl OrderFillTrackerMap {
         {
             fills.push(fill);
         } else {
-            guard
-                .applied_buffered_fills
-                .insert(correction.correction_key.clone(), vec![fill]);
+            let TrackerInner {
+                applied_buffered_fills,
+                applied_buffered_fill_evictions,
+                ..
+            } = &mut *guard;
+            let evicted = add_to_fifo_map_with_eviction_warn(
+                applied_buffered_fills,
+                correction.correction_key.clone(),
+                vec![fill],
+                "applied buffered-fill evidence",
+            );
+
+            if evicted {
+                *applied_buffered_fill_evictions =
+                    applied_buffered_fill_evictions.saturating_add(1);
+            }
         }
         true
     }
@@ -310,7 +424,7 @@ impl OrderFillTrackerMap {
         let key = correction_key.to_string();
         let mut guard = self.inner.lock().expect(MUTEX_POISONED);
         guard.confirmed_trades.remove(&key);
-        guard.voided_trades.add(key.clone());
+        add_to_fifo_with_eviction_warn(&mut guard.voided_trades, key.clone(), "voided-trade");
         let fills = guard
             .applied_buffered_fills
             .remove(&key)
@@ -322,12 +436,39 @@ impl OrderFillTrackerMap {
         fills
     }
 
-    pub(crate) fn mark_trade_confirmed(&self, correction_key: &str) {
+    pub(crate) fn keep_buffered_trade_retryable(&self, correction_key: &str) {
         self.inner
             .lock()
             .expect(MUTEX_POISONED)
-            .confirmed_trades
-            .add(correction_key.to_string());
+            .voided_trades
+            .remove(&correction_key.to_string());
+    }
+
+    pub(crate) fn mark_trade_confirmed(&self, correction_key: &str) {
+        add_to_fifo_with_eviction_warn(
+            &mut self.inner.lock().expect(MUTEX_POISONED).confirmed_trades,
+            correction_key.to_string(),
+            "confirmed-trade",
+        );
+    }
+
+    pub(crate) fn mark_trade_rest_applied(
+        &self,
+        correction_key: &str,
+        fills: &[AppliedPendingFill],
+    ) {
+        let venue_order_ids = fills.iter().map(|fill| fill.venue_order_id).collect();
+
+        add_to_fifo_map_with_eviction_warn(
+            &mut self
+                .inner
+                .lock()
+                .expect(MUTEX_POISONED)
+                .rest_applied_trade_orders,
+            correction_key.to_string(),
+            venue_order_ids,
+            "REST-applied trade-order",
+        );
     }
 
     #[must_use]
@@ -337,6 +478,33 @@ impl OrderFillTrackerMap {
             .expect(MUTEX_POISONED)
             .confirmed_trades
             .contains(&correction_key.to_string())
+    }
+
+    #[must_use]
+    pub(crate) fn has_correction_evidence_evictions(&self) -> bool {
+        let guard = self.inner.lock().expect(MUTEX_POISONED);
+        guard.applied_buffered_fill_evictions > 0 || guard.rest_applied_pending_fill_evictions > 0
+    }
+
+    pub(crate) fn defer_trade_without_evidence(&self, trade_id: TradeId) {
+        let mut guard = self.inner.lock().expect(MUTEX_POISONED);
+
+        if guard.deferred_no_evidence_trades.contains_key(&trade_id) {
+            return;
+        }
+
+        if guard.deferred_no_evidence_trades.len() == MAX_DEFERRED_NO_EVIDENCE_TRADES
+            && let Some((evicted, ())) = guard.deferred_no_evidence_trades.shift_remove_index(0)
+        {
+            log::error!("Evicted deferred no-evidence trade mark for {evicted}");
+        }
+
+        guard.deferred_no_evidence_trades.insert(trade_id, ());
+    }
+
+    pub(crate) fn clear_no_evidence_deferral(&self, trade_id: &TradeId) {
+        let mut guard = self.inner.lock().expect(MUTEX_POISONED);
+        let _ = guard.deferred_no_evidence_trades.shift_remove(trade_id);
     }
 
     pub(crate) fn reverse_fill(&self, venue_order_id: &VenueOrderId, quantity: Quantity) {
@@ -360,6 +528,118 @@ impl OrderFillTrackerMap {
             report.last_qty =
                 snap_fill_qty_in(&guard.orders, &report.venue_order_id, report.last_qty);
         }
+    }
+
+    pub(crate) fn begin_rest_applied_pending_pass(&self) {
+        self.inner
+            .lock()
+            .expect(MUTEX_POISONED)
+            .rest_applied_pending_staging
+            .clear();
+    }
+
+    pub(crate) fn note_failed_trade(&self, trade_id: &TradeId) {
+        add_to_fifo_with_eviction_warn(
+            &mut self.inner.lock().expect(MUTEX_POISONED).failed_trades,
+            *trade_id,
+            "failed-trade",
+        );
+    }
+
+    pub(crate) fn record_rest_applied_pending_fills(
+        &self,
+        fills: &[(TradeId, AppliedPendingFill)],
+    ) -> AHashSet<TradeId> {
+        let mut guard = self.inner.lock().expect(MUTEX_POISONED);
+        let withheld = fills
+            .iter()
+            .filter(|(trade_id, _)| guard.failed_trades.contains(trade_id))
+            .map(|(trade_id, _)| *trade_id)
+            .collect::<AHashSet<_>>();
+        let TrackerInner {
+            rest_applied_pending_staging,
+            rest_applied_pending_fill_evictions,
+            ..
+        } = &mut *guard;
+
+        for (trade_id, fill) in fills
+            .iter()
+            .filter(|(trade_id, _)| !withheld.contains(trade_id))
+        {
+            let mut staged = rest_applied_pending_staging
+                .remove(trade_id)
+                .unwrap_or_default();
+            staged.push(fill.clone());
+            let evicted = add_to_fifo_map_with_eviction_warn(
+                rest_applied_pending_staging,
+                *trade_id,
+                staged,
+                "REST pending-fill evidence",
+            );
+
+            if evicted {
+                *rest_applied_pending_fill_evictions =
+                    rest_applied_pending_fill_evictions.saturating_add(1);
+            }
+        }
+
+        let mut merged = std::mem::take(&mut guard.rest_applied_pending_fills);
+
+        // Fresh entries must displace carried evidence before bounded insertion can evict them.
+        for (trade_id, _) in fills.iter().filter(|(trade_id, _)| {
+            !withheld.contains(trade_id)
+                && guard.rest_applied_pending_staging.contains_key(trade_id)
+        }) {
+            merged.remove(trade_id);
+        }
+
+        let TrackerInner {
+            rest_applied_pending_staging,
+            rest_applied_pending_fill_evictions,
+            ..
+        } = &mut *guard;
+
+        for (trade_id, _) in fills
+            .iter()
+            .filter(|(trade_id, _)| !withheld.contains(trade_id))
+        {
+            if let Some(staged) = rest_applied_pending_staging.remove(trade_id) {
+                let evicted = add_to_fifo_map_with_eviction_warn(
+                    &mut merged,
+                    *trade_id,
+                    staged,
+                    "REST pending-fill evidence",
+                );
+
+                if evicted {
+                    *rest_applied_pending_fill_evictions =
+                        rest_applied_pending_fill_evictions.saturating_add(1);
+                }
+            }
+        }
+
+        guard.rest_applied_pending_fills = merged;
+        guard.rest_applied_pending_staging.clear();
+
+        withheld
+    }
+
+    pub(crate) fn rest_applied_pending_fills(&self, trade_id: &TradeId) -> Vec<AppliedPendingFill> {
+        self.inner
+            .lock()
+            .expect(MUTEX_POISONED)
+            .rest_applied_pending_fills
+            .get(trade_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn clear_rest_applied_pending_trade(&self, trade_id: &TradeId) {
+        self.inner
+            .lock()
+            .expect(MUTEX_POISONED)
+            .rest_applied_pending_fills
+            .remove(trade_id);
     }
 
     /// Snap a single fill qty DOWN to `submitted_qty` when the venue reports
@@ -507,7 +787,13 @@ fn take_and_prepare_fills(
             buffered.report.client_order_id = client_order_id;
             buffered.report.last_qty =
                 snap_fill_qty_in(&inner.orders, &venue_order_id, buffered.report.last_qty);
-            record_fill_in(&mut inner.orders, &venue_order_id, buffered.report.last_qty);
+            if buffered
+                .correction
+                .as_ref()
+                .is_none_or(|correction| correction.track_fill)
+            {
+                record_fill_in(&mut inner.orders, &venue_order_id, buffered.report.last_qty);
+            }
             buffered
         })
         .collect()
@@ -521,7 +807,7 @@ fn push_buffered<V>(
     if let Some(values) = buffer.get_mut(&venue_order_id) {
         values.push(value);
     } else {
-        buffer.insert(venue_order_id, vec![value]);
+        add_to_fifo_map_with_eviction_warn(buffer, venue_order_id, vec![value], "pending buffer");
     }
 }
 
@@ -537,11 +823,12 @@ impl OrderFillTrackerMap {
         _size_precision: u8,
         _price_precision: u8,
     ) {
-        self.inner
-            .lock()
-            .expect(MUTEX_POISONED)
-            .orders
-            .insert(venue_order_id, new_order_state(submitted_qty, order_side));
+        add_to_fifo_map_with_eviction_warn(
+            &mut self.inner.lock().expect(MUTEX_POISONED).orders,
+            venue_order_id,
+            new_order_state(submitted_qty, order_side),
+            "order fill-state",
+        );
     }
 
     /// Returns the registered submitted quantity for an order, if tracked.
@@ -675,9 +962,29 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::common::test_logger::{capture_start, records_since};
 
     fn pusd() -> Currency {
         Currency::pUSD()
+    }
+
+    fn applied_pending_fill(
+        venue_order_id: VenueOrderId,
+        last_qty: Quantity,
+    ) -> AppliedPendingFill {
+        AppliedPendingFill {
+            venue_order_id,
+            instrument_id: InstrumentId::from("TEST-1.POLYMARKET"),
+            trade_id: TradeId::from("T-EVIDENCE"),
+            client_order_id: None,
+            strategy_id: None,
+            order_type: None,
+            order_side: OrderSide::Buy,
+            last_qty,
+            last_px: Price::from("0.55"),
+            commission: Money::new(1.25, pusd()),
+            liquidity_side: LiquiditySide::Taker,
+        }
     }
 
     #[rstest]
@@ -733,8 +1040,10 @@ mod tests {
             report.clone(),
             FillCorrectionMetadata {
                 correction_key: correction_key.to_string(),
+                trade_id: report.trade_id,
                 info: None,
                 is_confirmed: false,
+                track_fill: true,
             },
         );
         let prior_fills = tracker.void_buffered_trade(correction_key);
@@ -924,6 +1233,259 @@ mod tests {
     }
 
     #[rstest]
+    fn test_rest_applied_pending_fill_evidence_retains_untouched_trades() {
+        let tracker = OrderFillTrackerMap::new();
+        let first_trade = TradeId::from("trade-first");
+        let second_trade = TradeId::from("trade-second");
+        let first_order = VenueOrderId::from("order-first");
+        let second_order = VenueOrderId::from("order-second");
+        let first_qty = Quantity::from("714.285710");
+        let second_qty = Quantity::from("25.000000");
+        let first_fill = applied_pending_fill(first_order, first_qty);
+        let second_fill = applied_pending_fill(second_order, second_qty);
+
+        tracker.begin_rest_applied_pending_pass();
+        let withheld = tracker.record_rest_applied_pending_fills(&[
+            (first_trade, first_fill.clone()),
+            (first_trade, second_fill.clone()),
+        ]);
+
+        assert!(withheld.is_empty());
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&first_trade),
+            vec![first_fill.clone(), second_fill.clone()],
+        );
+
+        tracker.begin_rest_applied_pending_pass();
+
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&first_trade),
+            vec![first_fill.clone(), second_fill.clone()],
+        );
+
+        let withheld =
+            tracker.record_rest_applied_pending_fills(&[(second_trade, second_fill.clone())]);
+
+        assert!(withheld.is_empty());
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&first_trade),
+            vec![first_fill, second_fill.clone()],
+        );
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&second_trade),
+            vec![second_fill],
+        );
+
+        tracker.clear_rest_applied_pending_trade(&second_trade);
+
+        assert!(tracker.rest_applied_pending_fills(&second_trade).is_empty());
+    }
+
+    #[rstest]
+    fn test_failed_trade_withheld_in_later_pass_keeps_prior_evidence() {
+        let tracker = OrderFillTrackerMap::new();
+        let trade_id = TradeId::from("trade-failed-later");
+        let prior_fill = applied_pending_fill(
+            VenueOrderId::from("order-prior"),
+            Quantity::from("10.000000"),
+        );
+        let withheld_fill = applied_pending_fill(
+            VenueOrderId::from("order-withheld"),
+            Quantity::from("20.000000"),
+        );
+
+        tracker.begin_rest_applied_pending_pass();
+        tracker.record_rest_applied_pending_fills(&[(trade_id, prior_fill.clone())]);
+        tracker.note_failed_trade(&trade_id);
+        tracker.begin_rest_applied_pending_pass();
+        let withheld = tracker.record_rest_applied_pending_fills(&[(trade_id, withheld_fill)]);
+
+        assert_eq!(withheld, AHashSet::from_iter([trade_id]));
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&trade_id),
+            vec![prior_fill],
+        );
+    }
+
+    #[rstest]
+    fn test_later_pass_without_trade_keeps_prior_evidence() {
+        let tracker = OrderFillTrackerMap::new();
+        let prior_trade = TradeId::from("trade-prior");
+        let fresh_trade = TradeId::from("trade-fresh");
+        let prior_fill = applied_pending_fill(
+            VenueOrderId::from("order-prior"),
+            Quantity::from("10.000000"),
+        );
+        let fresh_fill = applied_pending_fill(
+            VenueOrderId::from("order-fresh"),
+            Quantity::from("20.000000"),
+        );
+
+        tracker.begin_rest_applied_pending_pass();
+        tracker.record_rest_applied_pending_fills(&[(prior_trade, prior_fill.clone())]);
+        tracker.begin_rest_applied_pending_pass();
+        tracker.record_rest_applied_pending_fills(&[(fresh_trade, fresh_fill.clone())]);
+
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&prior_trade),
+            vec![prior_fill],
+        );
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&fresh_trade),
+            vec![fresh_fill],
+        );
+    }
+
+    #[rstest]
+    fn test_later_pass_fills_fully_replace_same_trade_evidence() {
+        let tracker = OrderFillTrackerMap::new();
+        let trade_id = TradeId::from("trade-replaced");
+        let prior_fill = applied_pending_fill(
+            VenueOrderId::from("order-prior"),
+            Quantity::from("10.000000"),
+        );
+        let replacement_fill = applied_pending_fill(
+            VenueOrderId::from("order-replacement"),
+            Quantity::from("20.000000"),
+        );
+
+        tracker.begin_rest_applied_pending_pass();
+        tracker.record_rest_applied_pending_fills(&[(trade_id, prior_fill)]);
+        tracker.begin_rest_applied_pending_pass();
+        tracker.record_rest_applied_pending_fills(&[(trade_id, replacement_fill.clone())]);
+
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&trade_id),
+            vec![replacement_fill],
+        );
+    }
+
+    #[rstest]
+    fn test_cleared_trade_does_not_return_in_later_pass() {
+        let tracker = OrderFillTrackerMap::new();
+        let cleared_trade = TradeId::from("trade-cleared");
+        let fresh_trade = TradeId::from("trade-fresh");
+        let cleared_fill = applied_pending_fill(
+            VenueOrderId::from("order-cleared"),
+            Quantity::from("10.000000"),
+        );
+        let fresh_fill = applied_pending_fill(
+            VenueOrderId::from("order-fresh"),
+            Quantity::from("20.000000"),
+        );
+
+        tracker.begin_rest_applied_pending_pass();
+        tracker.record_rest_applied_pending_fills(&[(cleared_trade, cleared_fill)]);
+        tracker.clear_rest_applied_pending_trade(&cleared_trade);
+        tracker.begin_rest_applied_pending_pass();
+        tracker.record_rest_applied_pending_fills(&[(fresh_trade, fresh_fill)]);
+
+        assert!(
+            tracker
+                .rest_applied_pending_fills(&cleared_trade)
+                .is_empty()
+        );
+    }
+
+    #[rstest]
+    fn test_failed_trade_note_withholds_atomic_rest_evidence() {
+        let tracker = OrderFillTrackerMap::new();
+        let failed_trade = TradeId::from("trade-failed");
+        let retained_trade = TradeId::from("trade-retained");
+        let failed_fill = applied_pending_fill(
+            VenueOrderId::from("order-failed"),
+            Quantity::from("10.000000"),
+        );
+        let retained_fill = applied_pending_fill(
+            VenueOrderId::from("order-retained"),
+            Quantity::from("20.000000"),
+        );
+
+        tracker.note_failed_trade(&failed_trade);
+        tracker.begin_rest_applied_pending_pass();
+        let withheld = tracker.record_rest_applied_pending_fills(&[
+            (failed_trade, failed_fill),
+            (retained_trade, retained_fill.clone()),
+        ]);
+
+        assert_eq!(withheld.len(), 1);
+        assert!(withheld.contains(&failed_trade));
+        assert!(tracker.rest_applied_pending_fills(&failed_trade).is_empty());
+        assert_eq!(
+            tracker.rest_applied_pending_fills(&retained_trade),
+            vec![retained_fill],
+        );
+    }
+
+    #[rstest]
+    fn test_single_pass_over_capacity_evicts_earliest_evidence() {
+        let tracker = OrderFillTrackerMap::new();
+        let fills: Vec<(TradeId, AppliedPendingFill)> = (0..10_001)
+            .map(|i| {
+                (
+                    TradeId::from(format!("trade-{i}").as_str()),
+                    applied_pending_fill(
+                        VenueOrderId::from(format!("order-{i}").as_str()),
+                        Quantity::from("1.000000"),
+                    ),
+                )
+            })
+            .collect();
+
+        tracker.begin_rest_applied_pending_pass();
+        let withheld = tracker.record_rest_applied_pending_fills(&fills);
+
+        assert!(withheld.is_empty());
+        assert!(
+            tracker
+                .rest_applied_pending_fills(&TradeId::from("trade-0"))
+                .is_empty()
+        );
+        assert!(
+            !tracker
+                .rest_applied_pending_fills(&TradeId::from("trade-1"))
+                .is_empty()
+        );
+        assert!(
+            !tracker
+                .rest_applied_pending_fills(&TradeId::from("trade-10000"))
+                .is_empty()
+        );
+    }
+
+    #[rstest]
+    fn test_deferred_no_evidence_trade_eviction_is_bounded_and_errors() {
+        let tracker = OrderFillTrackerMap::new();
+        let log_start = capture_start();
+
+        for index in 0..=MAX_DEFERRED_NO_EVIDENCE_TRADES {
+            tracker.defer_trade_without_evidence(TradeId::from(
+                format!("deferred-trade-{index}").as_str(),
+            ));
+        }
+
+        let guard = tracker.inner.lock().expect(MUTEX_POISONED);
+        assert_eq!(
+            guard.deferred_no_evidence_trades.len(),
+            MAX_DEFERRED_NO_EVIDENCE_TRADES
+        );
+        assert!(
+            !guard
+                .deferred_no_evidence_trades
+                .contains_key(&TradeId::from("deferred-trade-0"))
+        );
+        drop(guard);
+
+        let matching_logs = records_since(log_start)
+            .into_iter()
+            .filter(|(_, message)| message.contains("deferred no-evidence trade mark"))
+            .collect::<Vec<_>>();
+        assert_eq!(matching_logs.len(), 1);
+        assert_eq!(matching_logs[0].0, log::Level::Error);
+        assert!(matching_logs[0].1.contains("deferred-trade-0"));
+    }
+
+    #[rstest]
     fn test_record_fill_accumulates() {
         let tracker = OrderFillTrackerMap::new();
         let vid = VenueOrderId::from("order-1");
@@ -1108,6 +1670,32 @@ mod tests {
 
         let filled = tracker.get_cumulative_filled(&vid);
         assert_eq!(filled, Some(Quantity::new(50.0, 6)));
+    }
+
+    #[rstest]
+    fn test_resolve_if_unfilled_holds_tracker_lock_through_closure() {
+        use std::cell::Cell;
+
+        let tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from("order-atomic-resolve");
+        tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            InstrumentId::from("TEST.POLYMARKET"),
+            6,
+            2,
+        );
+        let ran = Cell::new(false);
+
+        let resolved = tracker.resolve_if_unfilled(&venue_order_id, |view| {
+            assert_eq!(view.cumulative_filled, Quantity::zero(6));
+            assert!(tracker.inner.try_lock().is_err());
+            ran.set(true);
+        });
+
+        assert!(resolved);
+        assert!(ran.get());
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/execution/parse.rs
+++ b/crates/adapters/polymarket/src/execution/parse.rs
@@ -15,6 +15,7 @@
 
 //! Parsing functions for Polymarket execution reports.
 
+use alloy_primitives::{hex, keccak256};
 use jiff::Timestamp;
 use nautilus_core::{
     UUID4, UnixNanos,
@@ -64,6 +65,24 @@ pub fn resolve_order_status(
     }
 }
 
+/// Applies terminal status rules that depend on the matched quantity.
+pub fn resolve_matched_order_status(
+    status: PolymarketOrderStatus,
+    order_type: PolymarketOrderType,
+    event_type: PolymarketEventType,
+    size_matched: Decimal,
+    original_size: Decimal,
+) -> OrderStatus {
+    if status == PolymarketOrderStatus::Matched
+        && order_type == PolymarketOrderType::FAK
+        && size_matched < original_size
+    {
+        return OrderStatus::Canceled;
+    }
+
+    resolve_order_status(status, event_type)
+}
+
 /// Determines the order side for a fill based on trader role and asset matching.
 ///
 /// Polymarket uses a unified order book where complementary tokens (YES/NO) can match
@@ -101,19 +120,16 @@ pub fn determine_order_side(
 /// trade message with a single ID for all fills. This creates a unique trade ID
 /// per fill by combining the trade ID with part of the venue order ID.
 ///
-/// Format: `{trade_id[..27]}-{venue_order_id[last 8]}` = 36 chars.
+/// Format: `{trade_id[..19]}-{keccak256(trade_id|venue_order_id)[..8]}` = 36 chars.
 pub fn make_composite_trade_id(trade_id: &str, venue_order_id: &str) -> TradeId {
-    let prefix_len = trade_id.len().min(27);
-    let suffix_len = venue_order_id.len().min(8);
-    let suffix_start = venue_order_id.len().saturating_sub(suffix_len);
-    TradeId::from(
-        format!(
-            "{}-{}",
-            &trade_id[..prefix_len],
-            &venue_order_id[suffix_start..]
-        )
-        .as_str(),
-    )
+    let prefix_len = trade_id.len().min(19);
+    let mut preimage = Vec::with_capacity(trade_id.len() + venue_order_id.len() + 1);
+    preimage.extend_from_slice(trade_id.as_bytes());
+    preimage.push(b'|');
+    preimage.extend_from_slice(venue_order_id.as_bytes());
+    let digest = keccak256(preimage);
+    let hex16 = hex::encode(&digest[..8]);
+    TradeId::from(format!("{}-{hex16}", &trade_id[..prefix_len]).as_str())
 }
 
 /// Parses a [`PolymarketOpenOrder`] into an [`OrderStatusReport`].
@@ -129,14 +145,13 @@ pub fn parse_order_status_report(
     let venue_order_id = VenueOrderId::from(order.id.as_str());
     let order_side = OrderSide::from(order.side);
     let time_in_force = TimeInForce::from(order.order_type);
-    let order_status = if order.status == PolymarketOrderStatus::Matched
-        && order.order_type == PolymarketOrderType::FAK
-        && order.size_matched < order.original_size
-    {
-        OrderStatus::Canceled
-    } else {
-        OrderStatus::from(order.status)
-    };
+    let order_status = resolve_matched_order_status(
+        order.status,
+        order.order_type,
+        PolymarketEventType::Placement,
+        order.size_matched,
+        order.original_size,
+    );
     let quantity = Quantity::from_decimal_dp(order.original_size, size_precision)
         .unwrap_or_else(|_| Quantity::zero(size_precision));
     let raw_filled_qty = Quantity::from_decimal_dp(order.size_matched, size_precision)
@@ -200,14 +215,17 @@ pub fn parse_fill_report(
     taker_fee_rate: Decimal,
     fee_exponent: f64,
     ts_init: UnixNanos,
-) -> FillReport {
+) -> Option<FillReport> {
     let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
     let trade_id = TradeId::from(trade.id.as_str());
     let order_side = OrderSide::from(trade.side);
-    let last_qty = Quantity::from_decimal_dp(trade.size, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
-    let last_px = Price::from_decimal_dp(trade.price, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
+    let (last_qty, last_px) = parse_fill_values(
+        &trade.id,
+        trade.size,
+        trade.price,
+        price_precision,
+        size_precision,
+    )?;
     let liquidity_side = parse_liquidity_side(trade.trader_side);
 
     let commission_value = compute_commission(
@@ -221,7 +239,7 @@ pub fn parse_fill_report(
 
     let ts_event = parse_timestamp(&trade.match_time).unwrap_or(ts_init);
 
-    FillReport {
+    Some(FillReport {
         account_id,
         instrument_id,
         venue_order_id,
@@ -237,7 +255,52 @@ pub fn parse_fill_report(
         ts_init,
         client_order_id,
         venue_position_id: None,
+    })
+}
+
+pub(crate) fn parse_fill_values(
+    trade_id: &str,
+    raw_qty: Decimal,
+    raw_px: Decimal,
+    price_precision: u8,
+    size_precision: u8,
+) -> Option<(Quantity, Price)> {
+    let last_qty = match Quantity::from_decimal_dp(raw_qty, size_precision) {
+        Ok(quantity) => quantity,
+        Err(e) => {
+            log::warn!("Skipping trade {trade_id}: last_qty {raw_qty} is unrepresentable: {e}");
+            return None;
+        }
+    };
+
+    if last_qty.is_zero() {
+        log::warn!(
+            "Skipping trade {trade_id}: last_qty raw value {raw_qty} rounds to zero at precision {size_precision}",
+        );
+        return None;
     }
+
+    let last_px = match Price::from_decimal_dp(raw_px, price_precision) {
+        Ok(price) => price,
+        Err(e) => {
+            log::warn!("Skipping trade {trade_id}: last_px {raw_px} is unrepresentable: {e}");
+            return None;
+        }
+    };
+
+    if last_px.as_decimal() <= Decimal::ZERO {
+        log::warn!(
+            "Skipping trade {trade_id}: last_px raw value {raw_px} is not strictly positive",
+        );
+        return None;
+    }
+
+    if last_px.as_decimal() >= Decimal::ONE {
+        log::warn!("Skipping trade {trade_id}: last_px raw value {raw_px} is not strictly below 1");
+        return None;
+    }
+
+    Some((last_qty, last_px))
 }
 
 /// Builds a [`FillReport`] from a [`PolymarketMakerOrder`] and trade-level context.
@@ -1418,6 +1481,37 @@ mod tests {
     }
 
     #[rstest]
+    #[case::zero_quantity(dec!(0), dec!(0.5))]
+    #[case::subprecision_quantity(dec!(0.0000004), dec!(0.5))]
+    #[case::zero_price(dec!(1), dec!(0))]
+    #[case::negative_price(dec!(1), dec!(-0.5))]
+    #[case::unit_price(dec!(1), dec!(1))]
+    #[case::above_unit_price(dec!(1), dec!(1.5))]
+    fn test_parse_fill_values_rejects_degenerate_values(
+        #[case] raw_qty: Decimal,
+        #[case] raw_px: Decimal,
+    ) {
+        assert!(parse_fill_values("trade-degenerate", raw_qty, raw_px, 4, 6).is_none());
+    }
+
+    #[rstest]
+    fn test_parse_fill_values_parses_valid_values() {
+        let (quantity, price) = parse_fill_values("trade-valid", dec!(1.25), dec!(0.5), 4, 6)
+            .expect("valid fill values must parse");
+
+        assert_eq!(quantity, Quantity::from("1.250000"));
+        assert_eq!(price, Price::from("0.5000"));
+    }
+
+    #[rstest]
+    fn test_parse_fill_values_retains_fine_tick_upper_price() {
+        let (_, price) = parse_fill_values("trade-fine-tick", dec!(1), dec!(0.9995), 4, 6)
+            .expect("a price inside the unit bound must parse");
+
+        assert_eq!(price, Price::from("0.9995"));
+    }
+
+    #[rstest]
     fn test_parse_fill_report_from_fixture() {
         let path = "test_data/http_trade_report.json";
         let content = std::fs::read_to_string(path).expect("Failed to read test data");
@@ -1439,7 +1533,8 @@ mod tests {
             Decimal::ZERO,
             1.0,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("fixture fill must be representable");
 
         assert_eq!(report.account_id, account_id);
         assert_eq!(report.instrument_id, instrument_id);
@@ -1471,7 +1566,8 @@ mod tests {
             dec!(0.03),
             2.0,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("fixture fill must be representable");
 
         assert_eq!(report.liquidity_side, LiquiditySide::Taker);
         assert_eq!(report.commission.as_f64(), 0.04688);
@@ -1544,15 +1640,17 @@ mod tests {
         let trade_id = "trade-abc123";
         let venue_order_id = "order-xyz789";
         let result = make_composite_trade_id(trade_id, venue_order_id);
-        assert_eq!(result.as_str(), "trade-abc123-r-xyz789");
+        assert_eq!(result.as_str(), "trade-abc123-b324813fc79c5a80");
     }
 
     #[rstest]
-    fn test_make_composite_trade_id_truncates_long_ids() {
-        let trade_id = "a]".repeat(30);
-        let venue_order_id = "b".repeat(20);
-        let result = make_composite_trade_id(&trade_id, &venue_order_id);
-        assert!(result.as_str().len() <= 36);
+    fn test_make_composite_trade_id_uses_full_capacity_for_long_ids() {
+        let result = make_composite_trade_id(
+            "abcdefghijklmnopqrstuvwxyz0123456789",
+            "maker-order-00000000",
+        );
+        assert_eq!(result.as_str(), "abcdefghijklmnopqrs-5703f9d675da99ba");
+        assert_eq!(result.as_str().len(), 36);
     }
 
     #[rstest]
@@ -1560,13 +1658,13 @@ mod tests {
         let trade_id = "t123";
         let venue_order_id = "ab";
         let result = make_composite_trade_id(trade_id, venue_order_id);
-        assert_eq!(result.as_str(), "t123-ab");
+        assert_eq!(result.as_str(), "t123-c37ab51b9b75ac63");
     }
 
     #[rstest]
-    fn test_make_composite_trade_id_uniqueness() {
-        let id_a = make_composite_trade_id("same-trade", "order-aaa");
-        let id_b = make_composite_trade_id("same-trade", "order-bbb");
+    fn test_make_composite_trade_id_distinguishes_shared_suffix() {
+        let id_a = make_composite_trade_id("same-trade", "maker-leg-a-deadbeef");
+        let id_b = make_composite_trade_id("same-trade", "maker-leg-b-deadbeef");
         assert_ne!(id_a, id_b);
     }
 

--- a/crates/adapters/polymarket/src/execution/reconciliation.rs
+++ b/crates/adapters/polymarket/src/execution/reconciliation.rs
@@ -15,12 +15,14 @@
 
 //! Reconciliation report generation for the Polymarket execution client.
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use anyhow::Context;
-use nautilus_core::{UnixNanos, collections::AtomicMap, time::AtomicTime};
+use nautilus_core::{
+    UnixNanos, collections::AtomicMap, datetime::NANOSECONDS_IN_SECOND, time::AtomicTime,
+};
 use nautilus_model::{
     enums::{LiquiditySide, OrderStatus, PositionSideSpecified},
-    identifiers::{AccountId, ClientId, InstrumentId, Venue, VenueOrderId},
+    identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, TradeId, Venue, VenueOrderId},
     instruments::{Instrument, InstrumentAny},
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
     types::{Currency, Quantity},
@@ -29,10 +31,11 @@ use rust_decimal::Decimal;
 use ustr::Ustr;
 
 use super::{
-    order_fill_tracker::OrderFillTrackerMap,
+    identity::OrderIdentity,
+    order_fill_tracker::{AppliedPendingFill, OrderFillTrackerMap},
     parse::{
         build_maker_fill_report, instrument_fee_exponent, instrument_taker_fee, parse_fill_report,
-        parse_order_status_report, parse_timestamp,
+        parse_fill_values, parse_order_status_report, parse_timestamp,
     },
 };
 use crate::{
@@ -57,14 +60,40 @@ pub(crate) struct FillContext<'a> {
     pub clock: &'static AtomicTime,
 }
 
-/// Counts of confirmed trade evidence dropped while building fill reports.
+#[derive(Clone, Copy)]
+pub(crate) enum PendingFillPolicy<'a> {
+    /// Mass status: emit pending-trade fills only when the fill's
+    /// `venue_order_id` is in the paired order-report set; count the rest.
+    PairedWith(&'a AHashSet<VenueOrderId>),
+    /// Runtime singular checks: confirmed trades only (pending settlement must
+    /// not create an inferred fill).
+    ConfirmedOnly,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct FillBuildOutput {
+    pub fills: Vec<FillReport>,
+    pub discards: FillBuildDiscards,
+    /// Summed `last_qty` of emitted pending-sourced fills per order.
+    pub pending_filled_by_order: AHashMap<VenueOrderId, Decimal>,
+    /// Raw venue trade ID paired with each emitted pending fill's report index.
+    pub pending_fill_sources: Vec<(usize, TradeId)>,
+}
+
+/// Counts of trade evidence dropped while building fill reports.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct FillBuildDiscards {
     /// Fill entries dropped because their instrument is not loaded.
     pub unmapped_instruments: usize,
+    /// Fill entries dropped because a quantity or price cannot be represented.
+    pub unrepresentable_fills: usize,
+    /// Duplicate non-failed venue trades dropped by raw trade ID.
+    pub duplicate_trades: usize,
     /// Confirmed maker trades dropped because no maker order in the match is
     /// owned by the account.
     pub unowned_maker_trades: usize,
+    /// Settlement-pending fills dropped because no order report pairs with them.
+    pub unpaired_pending_fills: usize,
 }
 
 /// Converts trade reports into fill reports: single implementation of maker/taker
@@ -74,13 +103,33 @@ pub(crate) fn build_fill_reports_from_trades(
     ctx: &FillContext<'_>,
     instruments: &AtomicMap<Ustr, InstrumentAny>,
     instrument_filter: Option<InstrumentId>,
+    pending_policy: PendingFillPolicy<'_>,
     ts_init: UnixNanos,
-) -> (Vec<FillReport>, FillBuildDiscards) {
-    let mut reports = Vec::new();
-    let mut discards = FillBuildDiscards::default();
+) -> FillBuildOutput {
+    let mut output = FillBuildOutput::default();
+    let mut seen_raw_trade_ids = AHashSet::new();
 
     for trade in trades {
-        if trade.status != PolymarketTradeStatus::Confirmed {
+        if trade.status == PolymarketTradeStatus::Failed {
+            continue;
+        }
+
+        let raw_trade_id = TradeId::from(trade.id.as_str());
+
+        if seen_raw_trade_ids.contains(&raw_trade_id) {
+            log::debug!("Skipping duplicate venue trade {}", trade.id);
+            output.discards.duplicate_trades += 1;
+            continue;
+        }
+
+        let is_pending = trade.status.is_pending_settlement();
+
+        if is_pending && matches!(pending_policy, PendingFillPolicy::ConfirmedOnly) {
+            log::debug!(
+                "Skipping settlement-pending trade {} with status {:?} under confirmed-only policy",
+                trade.id,
+                trade.status,
+            );
             continue;
         }
 
@@ -92,10 +141,14 @@ pub(crate) fn build_fill_reports_from_trades(
                 .iter()
                 .any(|mo| mo.is_owned_by(ctx.user_address, ctx.api_key))
             {
-                discards.unowned_maker_trades += 1;
+                if trade.status == PolymarketTradeStatus::Confirmed {
+                    output.discards.unowned_maker_trades += 1;
+                }
+
                 log::debug!(
-                    "Confirmed maker trade {} holds no maker order owned by the account",
+                    "Maker trade {} with status {:?} holds no maker order owned by the account",
                     trade.id,
+                    trade.status,
                 );
                 continue;
             }
@@ -109,7 +162,7 @@ pub(crate) fn build_fill_reports_from_trades(
                 let (instrument_id, price_prec, size_prec) = match instrument {
                     Some(i) => (i.id(), i.price_precision(), i.size_precision()),
                     None => {
-                        discards.unmapped_instruments += 1;
+                        output.discards.unmapped_instruments += 1;
                         continue;
                     }
                 };
@@ -117,6 +170,19 @@ pub(crate) fn build_fill_reports_from_trades(
                 if let Some(filter_id) = instrument_filter
                     && instrument_id != filter_id
                 {
+                    continue;
+                }
+
+                if parse_fill_values(
+                    &trade.id,
+                    mo.matched_amount,
+                    mo.price,
+                    price_prec,
+                    size_prec,
+                )
+                .is_none()
+                {
+                    output.discards.unrepresentable_fills += 1;
                     continue;
                 }
 
@@ -137,7 +203,14 @@ pub(crate) fn build_fill_reports_from_trades(
                     ts_event,
                     ts_init,
                 );
-                reports.push(report);
+                push_fill_report(
+                    report,
+                    raw_trade_id,
+                    is_pending,
+                    &pending_policy,
+                    &mut seen_raw_trade_ids,
+                    &mut output,
+                );
             }
         } else {
             let token_id = Ustr::from(trade.asset_id.as_str());
@@ -152,7 +225,7 @@ pub(crate) fn build_fill_reports_from_trades(
                         instrument_fee_exponent(&i),
                     ),
                     None => {
-                        discards.unmapped_instruments += 1;
+                        output.discards.unmapped_instruments += 1;
                         continue;
                     }
                 };
@@ -163,7 +236,7 @@ pub(crate) fn build_fill_reports_from_trades(
                 continue;
             }
 
-            let report = parse_fill_report(
+            let Some(report) = parse_fill_report(
                 trade,
                 instrument_id,
                 ctx.account_id,
@@ -174,12 +247,112 @@ pub(crate) fn build_fill_reports_from_trades(
                 taker_fee_rate,
                 fee_exponent,
                 ts_init,
+            ) else {
+                output.discards.unrepresentable_fills += 1;
+                continue;
+            };
+            push_fill_report(
+                report,
+                raw_trade_id,
+                is_pending,
+                &pending_policy,
+                &mut seen_raw_trade_ids,
+                &mut output,
             );
-            reports.push(report);
         }
     }
 
-    (reports, discards)
+    output
+}
+
+fn push_fill_report(
+    report: FillReport,
+    raw_trade_id: TradeId,
+    is_pending: bool,
+    pending_policy: &PendingFillPolicy<'_>,
+    seen_raw_trade_ids: &mut AHashSet<TradeId>,
+    output: &mut FillBuildOutput,
+) {
+    if is_pending {
+        let PendingFillPolicy::PairedWith(paired_order_ids) = pending_policy else {
+            return;
+        };
+
+        if !paired_order_ids.contains(&report.venue_order_id) {
+            output.discards.unpaired_pending_fills += 1;
+            log::debug!(
+                "Settlement-pending fill {} for order {} omitted because no order report pairs with it",
+                report.trade_id,
+                report.venue_order_id,
+            );
+            return;
+        }
+
+        *output
+            .pending_filled_by_order
+            .entry(report.venue_order_id)
+            .or_default() += report.last_qty.as_decimal();
+        output
+            .pending_fill_sources
+            .push((output.fills.len(), raw_trade_id));
+    }
+
+    seen_raw_trade_ids.insert(raw_trade_id);
+    output.fills.push(report);
+}
+
+fn record_rest_applied_pending_fills(
+    fill_tracker: &OrderFillTrackerMap,
+    fill_reports: &[FillReport],
+    pending_fill_sources: &[(usize, TradeId)],
+    resolve_order_identity: &impl Fn(&VenueOrderId) -> Option<OrderIdentity>,
+) -> AHashSet<TradeId> {
+    let applied_fills = pending_fill_sources
+        .iter()
+        .map(|(report_index, trade_id)| {
+            let mut applied_fill = AppliedPendingFill::from(&fill_reports[*report_index]);
+
+            if let Some(identity) = resolve_order_identity(&applied_fill.venue_order_id) {
+                applied_fill.client_order_id = Some(identity.client_order_id);
+                applied_fill.strategy_id = Some(identity.strategy_id);
+                applied_fill.order_type = Some(identity.order_type);
+            }
+            (*trade_id, applied_fill)
+        })
+        .collect::<Vec<_>>();
+
+    fill_tracker.record_rest_applied_pending_fills(&applied_fills)
+}
+
+fn remove_withheld_pending_fills(
+    fill_reports: &mut Vec<FillReport>,
+    pending_fill_sources: &[(usize, TradeId)],
+    pending_filled_by_order: &mut AHashMap<VenueOrderId, Decimal>,
+    withheld_trade_ids: &AHashSet<TradeId>,
+) {
+    let withheld_report_indices = pending_fill_sources
+        .iter()
+        .filter(|(_, trade_id)| withheld_trade_ids.contains(trade_id))
+        .map(|(report_index, _)| *report_index)
+        .collect::<AHashSet<_>>();
+    pending_filled_by_order.clear();
+
+    for (report_index, _) in pending_fill_sources
+        .iter()
+        .filter(|(_, trade_id)| !withheld_trade_ids.contains(trade_id))
+    {
+        let report = &fill_reports[*report_index];
+        *pending_filled_by_order
+            .entry(report.venue_order_id)
+            .or_default() += report.last_qty.as_decimal();
+    }
+
+    let mut report_index = 0;
+    fill_reports.retain(|_| {
+        let retain = !withheld_report_indices.contains(&report_index);
+        report_index += 1;
+        retain
+    });
 }
 
 /// Converts open orders into order status reports.
@@ -187,6 +360,7 @@ pub(crate) fn build_order_reports_from_orders(
     orders: &[PolymarketOpenOrder],
     instruments: &AtomicMap<Ustr, InstrumentAny>,
     account_id: AccountId,
+    resolve_client_order_id: impl Fn(&VenueOrderId) -> Option<ClientOrderId>,
     instrument_filter: Option<InstrumentId>,
     ts_init: UnixNanos,
 ) -> (Vec<OrderStatusReport>, usize) {
@@ -210,11 +384,12 @@ pub(crate) fn build_order_reports_from_orders(
             continue;
         }
 
+        let venue_order_id = VenueOrderId::from(order.id.as_str());
         let report = parse_order_status_report(
             order,
             instrument_id,
             account_id,
-            None,
+            resolve_client_order_id(&venue_order_id),
             price_prec,
             size_prec,
             ts_init,
@@ -295,6 +470,35 @@ pub(crate) fn build_position_reports(
         .collect()
 }
 
+fn filter_orders_to_lookback(orders: &mut Vec<PolymarketOpenOrder>, cutoff: UnixNanos) -> usize {
+    let before = orders.len();
+    orders.retain(|order| {
+        order
+            .created_at
+            .checked_mul(NANOSECONDS_IN_SECOND)
+            .map(UnixNanos::from)
+            .is_none_or(|ts| ts >= cutoff)
+    });
+    before - orders.len()
+}
+
+fn filter_trades_to_lookback(trades: &mut Vec<PolymarketTradeReport>, cutoff: UnixNanos) -> usize {
+    let before = trades.len();
+    trades.retain(|trade| {
+        parse_timestamp(&trade.match_time).is_none_or(|ts_event| ts_event >= cutoff)
+    });
+    before - trades.len()
+}
+
+fn mass_status_cutoff(ts_init: UnixNanos, lookback_mins: Option<u64>) -> Option<UnixNanos> {
+    lookback_mins.map(|mins| {
+        let lookback_ns = mins
+            .saturating_mul(60)
+            .saturating_mul(NANOSECONDS_IN_SECOND);
+        UnixNanos::from(ts_init.as_u64().saturating_sub(lookback_ns))
+    })
+}
+
 /// Full reconciliation mass status generation.
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn generate_mass_status(
@@ -305,33 +509,71 @@ pub(crate) async fn generate_mass_status(
     ctx: &FillContext<'_>,
     client_id: ClientId,
     venue: Venue,
+    resolve_order_identity: impl Fn(&VenueOrderId) -> Option<OrderIdentity>,
+    is_fill_applied: impl Fn(&FillReport, &[PolymarketTradeReport]) -> bool,
     lookback_mins: Option<u64>,
 ) -> anyhow::Result<Option<ExecutionMassStatus>> {
+    fill_tracker.begin_rest_applied_pending_pass();
     let ts_init = ctx.clock.get_time_ns();
+    let cutoff = mass_status_cutoff(ts_init, lookback_mins);
 
     // Fetch orders
-    let orders = http_client
+    let mut orders = http_client
         .get_orders(GetOrdersParams::default())
         .await
         .context("failed to fetch orders for mass status")?;
+    let orders_before = orders.len();
+    let orders_removed = cutoff.map_or(0, |cutoff| filter_orders_to_lookback(&mut orders, cutoff));
 
-    let (mut order_reports, orders_filtered) =
-        build_order_reports_from_orders(&orders, instruments, ctx.account_id, None, ts_init);
+    let (mut order_reports, orders_filtered) = build_order_reports_from_orders(
+        &orders,
+        instruments,
+        ctx.account_id,
+        |venue_order_id| {
+            resolve_order_identity(venue_order_id).map(|identity| identity.client_order_id)
+        },
+        None,
+        ts_init,
+    );
+    let paired_order_ids = order_reports
+        .iter()
+        .map(|report| report.venue_order_id)
+        .collect::<AHashSet<_>>();
 
     // Fetch and parse fill reports
-    let trades = http_client
+    let mut trades = http_client
         .get_trades(GetTradesParams::default())
         .await
         .context("failed to fetch trades for mass status")?;
+    let trades_before = trades.len();
+    let trades_removed = cutoff.map_or(0, |cutoff| filter_trades_to_lookback(&mut trades, cutoff));
 
-    let (mut fill_reports, fill_discards) =
-        build_fill_reports_from_trades(&trades, ctx, instruments, None, ts_init);
+    let FillBuildOutput {
+        fills: mut fill_reports,
+        discards: fill_discards,
+        mut pending_filled_by_order,
+        pending_fill_sources,
+    } = build_fill_reports_from_trades(
+        &trades,
+        ctx,
+        instruments,
+        None,
+        PendingFillPolicy::PairedWith(&paired_order_ids),
+        ts_init,
+    );
 
     if fill_discards.unowned_maker_trades > 0 {
         log::error!(
             "Mass status is missing {} confirmed maker trade(s) holding no maker order owned by \
              the account; executed quantity may be understated",
             fill_discards.unowned_maker_trades,
+        );
+    }
+
+    if fill_discards.unpaired_pending_fills > 0 {
+        log::warn!(
+            "{} settlement-pending fill(s) were omitted because no order report pairs with them; quantities may be understated until the trades confirm",
+            fill_discards.unpaired_pending_fills,
         );
     }
 
@@ -347,44 +589,59 @@ pub(crate) async fn generate_mass_status(
 
     let position_reports = build_position_reports(&positions, ctx.account_id, ts_init);
 
-    // Apply lookback filter
     if let Some(mins) = lookback_mins {
-        let now_ns = ctx.clock.get_time_ns();
-        let cutoff_ns = now_ns.as_u64().saturating_sub(mins * 60 * 1_000_000_000);
-        let cutoff = UnixNanos::from(cutoff_ns);
-
-        let orders_before = order_reports.len();
-        order_reports.retain(|r| r.ts_last >= cutoff);
-        let orders_removed = orders_before - order_reports.len();
-
-        let fills_before = fill_reports.len();
-        fill_reports.retain(|r| r.ts_event >= cutoff);
-        let fills_removed = fills_before - fill_reports.len();
-
         log::debug!(
-            "Lookback filter ({}min): orders {}->{} (removed {}), fills {}->{} (removed {})",
+            "Lookback filter ({}min): orders {}->{} (removed {}), trades {}->{} (removed {})",
             mins,
             orders_before,
-            order_reports.len(),
+            orders.len(),
             orders_removed,
-            fills_before,
-            fill_reports.len(),
-            fills_removed,
+            trades_before,
+            trades.len(),
+            trades_removed,
         );
     } else {
         log::debug!(
             "Generated mass status: {} orders ({} filtered), {} fills ({} instrument-filtered, \
-             {} unowned maker trades), {} positions",
+             {} unrepresentable, {} duplicate venue trades, {} unowned maker trades, {} unpaired \
+             settlement-pending fills), {} positions",
             order_reports.len(),
             orders_filtered,
             fill_reports.len(),
             fill_discards.unmapped_instruments,
+            fill_discards.unrepresentable_fills,
+            fill_discards.duplicate_trades,
             fill_discards.unowned_maker_trades,
+            fill_discards.unpaired_pending_fills,
             position_reports.len(),
         );
     }
 
-    cap_order_reports_to_confirmed_fills(&mut order_reports, &fill_reports);
+    let withheld_trade_ids = record_rest_applied_pending_fills(
+        fill_tracker,
+        &fill_reports,
+        &pending_fill_sources,
+        &resolve_order_identity,
+    );
+    remove_withheld_pending_fills(
+        &mut fill_reports,
+        &pending_fill_sources,
+        &mut pending_filled_by_order,
+        &withheld_trade_ids,
+    );
+    cap_order_reports_to_reported_fills(
+        &mut order_reports,
+        &fill_reports,
+        &pending_filled_by_order,
+    );
+
+    let fills_before_applied_check = fill_reports.len();
+    fill_reports.retain(|fill| !is_fill_applied(fill, &trades));
+    let applied_fills = fills_before_applied_check - fill_reports.len();
+
+    if applied_fills > 0 {
+        log::debug!("Skipped {applied_fills} REST fill report(s) already applied to cached orders",);
+    }
 
     let mut mass_status = ExecutionMassStatus::new(client_id, ctx.account_id, venue, ts_init, None);
 
@@ -395,44 +652,61 @@ pub(crate) async fn generate_mass_status(
     Ok(Some(mass_status))
 }
 
-fn cap_order_reports_to_confirmed_fills(
+fn cap_order_reports_to_reported_fills(
     order_reports: &mut [OrderStatusReport],
     fill_reports: &[FillReport],
+    pending_filled_by_order: &AHashMap<VenueOrderId, Decimal>,
 ) {
-    let confirmed_by_order = confirmed_filled_quantities(fill_reports);
+    let reported_by_order = reported_filled_quantities(fill_reports);
 
     for report in order_reports {
         let local_filled = Quantity::zero(report.quantity.precision);
-        cap_order_report_filled_qty(
+        cap_order_report_filled_qty_without_normalization(
             report,
             local_filled,
-            confirmed_by_order.get(&report.venue_order_id).copied(),
+            reported_by_order.get(&report.venue_order_id).copied(),
         );
+
+        if !pending_filled_by_order
+            .get(&report.venue_order_id)
+            .is_some_and(|quantity| !quantity.is_zero())
+        {
+            normalize_terminal_order_report_quantity(report);
+        }
     }
 }
 
-pub(crate) fn confirmed_filled_quantities(
+pub(crate) fn reported_filled_quantities(
     fill_reports: &[FillReport],
 ) -> AHashMap<VenueOrderId, Decimal> {
-    let mut confirmed_by_order = AHashMap::new();
+    let mut reported_by_order = AHashMap::new();
+
     for fill in fill_reports {
-        *confirmed_by_order.entry(fill.venue_order_id).or_default() += fill.last_qty.as_decimal();
+        *reported_by_order.entry(fill.venue_order_id).or_default() += fill.last_qty.as_decimal();
     }
 
-    confirmed_by_order
+    reported_by_order
 }
 
 pub(crate) fn cap_order_report_filled_qty(
     report: &mut OrderStatusReport,
     local_filled: Quantity,
-    confirmed_filled: Option<Decimal>,
+    reported_filled: Option<Decimal>,
 ) {
-    let confirmed_filled = confirmed_filled
+    cap_order_report_filled_qty_without_normalization(report, local_filled, reported_filled);
+    normalize_terminal_order_report_quantity(report);
+}
+
+fn cap_order_report_filled_qty_without_normalization(
+    report: &mut OrderStatusReport,
+    local_filled: Quantity,
+    reported_filled: Option<Decimal>,
+) {
+    let reported_filled = reported_filled
         .and_then(|qty| Quantity::from_decimal_dp(qty, report.quantity.precision).ok())
         .unwrap_or_else(|| Quantity::zero(report.quantity.precision));
-    let capped = report.filled_qty.min(local_filled.max(confirmed_filled));
+    let capped = report.filled_qty.min(local_filled.max(reported_filled));
     report.filled_qty = capped;
-    normalize_terminal_order_report_quantity(report);
 }
 
 pub(crate) fn normalize_terminal_order_report_quantity(report: &mut OrderStatusReport) {
@@ -446,7 +720,7 @@ pub(crate) fn normalize_terminal_order_report_quantity(report: &mut OrderStatusR
     let leaves = report.quantity.as_decimal() - report.filled_qty.as_decimal();
     if leaves < DUST_SNAP_THRESHOLD_DEC {
         log::debug!(
-            "Normalizing terminal order report {} quantity from {} to confirmed fills {}",
+            "Normalizing terminal order report {} quantity from {} to reported fills {}",
             report.venue_order_id,
             report.quantity,
             report.filled_qty,
@@ -457,14 +731,222 @@ pub(crate) fn normalize_terminal_order_report_quantity(report: &mut OrderStatusR
 
 #[cfg(test)]
 mod tests {
+    use nautilus_core::time::get_atomic_clock_realtime;
     use nautilus_model::{
         enums::{LiquiditySide, OrderSide, OrderStatus, OrderType, TimeInForce},
-        identifiers::TradeId,
+        identifiers::{ClientOrderId, StrategyId, TradeId},
         types::{Money, Price},
     };
     use rstest::rstest;
 
     use super::*;
+
+    fn instruments_with_asset(asset_id: Ustr) -> AtomicMap<Ustr, InstrumentAny> {
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(asset_id, instrument);
+        instruments
+    }
+
+    fn fill_context() -> FillContext<'static> {
+        FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: get_atomic_clock_realtime(),
+        }
+    }
+
+    fn order_identity(client_order_id: ClientOrderId) -> OrderIdentity {
+        OrderIdentity {
+            client_order_id,
+            strategy_id: StrategyId::from("S-EVIDENCE-RESOLVED"),
+            instrument_id: InstrumentId::from("TEST.POLYMARKET"),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::Fok,
+        }
+    }
+
+    #[rstest]
+    fn order_reports_include_resolved_client_order_id() {
+        let order: PolymarketOpenOrder = load("http_open_order.json");
+        let venue_order_id = VenueOrderId::from(order.id.as_str());
+        let client_order_id = ClientOrderId::from("O-RESOLVED");
+        let mut external_order = order.clone();
+        external_order.id = "V-EXTERNAL".to_string();
+        let instruments = instruments_with_asset(order.asset_id);
+
+        let (reports, filtered) = build_order_reports_from_orders(
+            &[order, external_order],
+            &instruments,
+            AccountId::from("POLY-001"),
+            |candidate| (candidate == &venue_order_id).then_some(client_order_id),
+            None,
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(filtered, 0);
+        assert_eq!(reports.len(), 2);
+        assert_eq!(reports[0].client_order_id, Some(client_order_id));
+        assert_eq!(reports[1].client_order_id, None);
+    }
+
+    #[rstest]
+    fn mass_status_records_post_snap_pending_fill_evidence() {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        trade.size = Decimal::from_str_exact("714.285714").unwrap();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let instruments = instruments_with_asset(trade.asset_id);
+        let paired_order_ids = AHashSet::from_iter([venue_order_id]);
+        let mut output = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            None,
+            PendingFillPolicy::PairedWith(&paired_order_ids),
+            UnixNanos::from(1),
+        );
+        let fill_tracker = OrderFillTrackerMap::new();
+        let applied_qty = Quantity::from("714.285710");
+        fill_tracker.register(
+            venue_order_id,
+            applied_qty,
+            OrderSide::Buy,
+            output.fills[0].instrument_id,
+            6,
+            2,
+        );
+        fill_tracker.begin_rest_applied_pending_pass();
+
+        fill_tracker.snap_fill_reports(&mut output.fills);
+        let withheld = record_rest_applied_pending_fills(
+            &fill_tracker,
+            &output.fills,
+            &output.pending_fill_sources,
+            &|_| None,
+        );
+
+        assert!(withheld.is_empty());
+        assert_eq!(output.fills[0].last_qty, applied_qty);
+        assert_eq!(
+            fill_tracker.rest_applied_pending_fills(&trade_id),
+            vec![AppliedPendingFill::from(&output.fills[0])],
+        );
+    }
+
+    #[rstest]
+    fn mass_status_records_resolved_order_identity_in_pending_fill_evidence() {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let client_order_id = ClientOrderId::from("O-EVIDENCE-RESOLVED");
+        let instruments = instruments_with_asset(trade.asset_id);
+        let paired_order_ids = AHashSet::from_iter([venue_order_id]);
+        let output = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            None,
+            PendingFillPolicy::PairedWith(&paired_order_ids),
+            UnixNanos::from(1),
+        );
+        let fill_tracker = OrderFillTrackerMap::new();
+        let identity = order_identity(client_order_id);
+
+        let withheld = record_rest_applied_pending_fills(
+            &fill_tracker,
+            &output.fills,
+            &output.pending_fill_sources,
+            &|candidate| (candidate == &venue_order_id).then_some(identity),
+        );
+
+        assert!(withheld.is_empty());
+        let recorded = &fill_tracker.rest_applied_pending_fills(&trade_id)[0];
+        assert_eq!(recorded.client_order_id, Some(client_order_id));
+        assert_eq!(recorded.strategy_id, Some(identity.strategy_id));
+        assert_eq!(recorded.order_type, Some(identity.order_type));
+    }
+
+    #[rstest]
+    fn mass_status_withholds_failed_pending_fill_before_order_cap() {
+        let order: PolymarketOpenOrder = load("http_open_order.json");
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        trade.size = Decimal::from_str_exact("714.285714").unwrap();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let instruments = instruments_with_asset(trade.asset_id);
+        let (mut order_reports, _) = build_order_reports_from_orders(
+            &[order],
+            &instruments,
+            AccountId::from("POLY-001"),
+            |_| None,
+            None,
+            UnixNanos::from(1),
+        );
+        let paired_order_ids = order_reports
+            .iter()
+            .map(|report| report.venue_order_id)
+            .collect::<AHashSet<_>>();
+        let mut output = build_fill_reports_from_trades(
+            &[trade],
+            &fill_context(),
+            &instruments,
+            None,
+            PendingFillPolicy::PairedWith(&paired_order_ids),
+            UnixNanos::from(1),
+        );
+        let fill_tracker = OrderFillTrackerMap::new();
+        let applied_qty = Quantity::from("714.285710");
+        fill_tracker.register(
+            venue_order_id,
+            applied_qty,
+            OrderSide::Buy,
+            output.fills[0].instrument_id,
+            6,
+            2,
+        );
+        fill_tracker.note_failed_trade(&trade_id);
+        fill_tracker.begin_rest_applied_pending_pass();
+
+        fill_tracker.snap_fill_reports(&mut output.fills);
+        let withheld = record_rest_applied_pending_fills(
+            &fill_tracker,
+            &output.fills,
+            &output.pending_fill_sources,
+            &|_| None,
+        );
+        remove_withheld_pending_fills(
+            &mut output.fills,
+            &output.pending_fill_sources,
+            &mut output.pending_filled_by_order,
+            &withheld,
+        );
+        cap_order_reports_to_reported_fills(
+            &mut order_reports,
+            &output.fills,
+            &output.pending_filled_by_order,
+        );
+
+        assert_eq!(withheld, AHashSet::from_iter([trade_id]));
+        assert!(output.fills.is_empty());
+        assert!(output.pending_filled_by_order.is_empty());
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+        assert_eq!(order_reports.len(), 1);
+        assert_eq!(order_reports[0].filled_qty, Quantity::zero(4));
+    }
 
     #[rstest]
     fn caps_order_report_to_confirmed_companion_fills() {
@@ -504,7 +986,7 @@ mod tests {
             None,
         )];
 
-        cap_order_reports_to_confirmed_fills(&mut reports, &fills);
+        cap_order_reports_to_reported_fills(&mut reports, &fills, &AHashMap::new());
 
         assert_eq!(reports[0].filled_qty, Quantity::from("4.0000"));
     }
@@ -552,9 +1034,385 @@ mod tests {
             None,
         )];
 
-        cap_order_reports_to_confirmed_fills(&mut reports, &fills);
+        cap_order_reports_to_reported_fills(&mut reports, &fills, &AHashMap::new());
 
         assert_eq!(reports[0].quantity, Quantity::from(expected_quantity));
         assert_eq!(reports[0].filled_qty, Quantity::from(confirmed));
+    }
+
+    #[rstest]
+    fn pending_fill_caps_filled_quantity_without_normalizing_order_quantity() {
+        let account_id = AccountId::from("POLY-001");
+        let instrument_id = InstrumentId::from("TEST.POLYMARKET");
+        let venue_order_id = VenueOrderId::from("V-PENDING-DUST");
+        let mut reports = vec![OrderStatusReport::new(
+            account_id,
+            instrument_id,
+            None,
+            venue_order_id,
+            OrderSide::Buy,
+            OrderType::Limit,
+            TimeInForce::Gtc,
+            OrderStatus::Filled,
+            Quantity::from("100.000"),
+            Quantity::from("100.000"),
+            UnixNanos::from(1),
+            UnixNanos::from(1),
+            UnixNanos::from(1),
+            None,
+        )];
+        let fills = vec![FillReport::new(
+            account_id,
+            instrument_id,
+            venue_order_id,
+            TradeId::from("T-PENDING-DUST"),
+            OrderSide::Buy,
+            Quantity::from("99.995"),
+            Price::from("0.5000"),
+            Money::zero(Currency::pUSD()),
+            LiquiditySide::Taker,
+            None,
+            None,
+            UnixNanos::from(1),
+            UnixNanos::from(1),
+            None,
+        )];
+        let pending_filled_by_order =
+            AHashMap::from_iter([(venue_order_id, Decimal::from_str_exact("99.995").unwrap())]);
+
+        cap_order_reports_to_reported_fills(&mut reports, &fills, &pending_filled_by_order);
+
+        assert_eq!(reports[0].filled_qty, Quantity::from("99.995"));
+        assert_eq!(reports[0].quantity, Quantity::from("100.000"));
+    }
+
+    fn load<T: serde::de::DeserializeOwned>(filename: &str) -> T {
+        let path = format!("test_data/{filename}");
+        let content = std::fs::read_to_string(path).expect("Failed to read test data");
+        serde_json::from_str(&content).expect("Failed to parse test data")
+    }
+
+    #[rstest]
+    #[case(PolymarketTradeStatus::Matched)]
+    #[case(PolymarketTradeStatus::Mined)]
+    #[case(PolymarketTradeStatus::Retrying)]
+    fn paired_pending_taker_trade_reaches_fills_and_cap(#[case] status: PolymarketTradeStatus) {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = status;
+
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let paired_order_ids =
+            AHashSet::from_iter([VenueOrderId::from(trade.taker_order_id.as_str())]);
+        let output = build_fill_reports_from_trades(
+            &[trade.clone()],
+            &ctx,
+            &instruments,
+            None,
+            PendingFillPolicy::PairedWith(&paired_order_ids),
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(output.fills.len(), 1);
+        assert_eq!(output.fills[0].trade_id, TradeId::from(trade.id.as_str()),);
+
+        let mut reports = vec![OrderStatusReport::new(
+            ctx.account_id,
+            output.fills[0].instrument_id,
+            None,
+            VenueOrderId::from(trade.taker_order_id.as_str()),
+            OrderSide::Buy,
+            OrderType::Limit,
+            TimeInForce::Gtc,
+            OrderStatus::Filled,
+            output.fills[0].last_qty,
+            output.fills[0].last_qty,
+            UnixNanos::from(1),
+            UnixNanos::from(1),
+            UnixNanos::from(1),
+            None,
+        )];
+
+        cap_order_reports_to_reported_fills(
+            &mut reports,
+            &output.fills,
+            &output.pending_filled_by_order,
+        );
+
+        assert_eq!(reports[0].filled_qty, output.fills[0].last_qty);
+    }
+
+    #[rstest]
+    fn paired_pending_owned_maker_trade_emits_venue_identity() {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        trade.id = "123456789012345678901234567-12345678".to_string();
+        trade.maker_orders[0].order_id = "12345678".to_string();
+        let owned_maker = trade.maker_orders[0].clone();
+
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(owned_maker.asset_id, instrument);
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: &owned_maker.maker_address,
+            api_key: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+        let paired_order_ids =
+            AHashSet::from_iter([VenueOrderId::from(owned_maker.order_id.as_str())]);
+
+        let output = build_fill_reports_from_trades(
+            &[trade.clone()],
+            &ctx,
+            &instruments,
+            None,
+            PendingFillPolicy::PairedWith(&paired_order_ids),
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(output.fills.len(), 1);
+        assert_eq!(
+            output.fills[0].trade_id,
+            TradeId::from("1234567890123456789-864e38ffec393d64"),
+        );
+    }
+
+    #[rstest]
+    fn unpaired_pending_fill_is_counted_and_omitted() {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = PolymarketTradeStatus::Matched;
+
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let output = build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            PendingFillPolicy::PairedWith(&AHashSet::new()),
+            UnixNanos::from(1),
+        );
+
+        assert!(output.fills.is_empty());
+        assert_eq!(output.discards.unpaired_pending_fills, 1);
+        assert!(output.pending_filled_by_order.is_empty());
+    }
+
+    #[rstest]
+    fn confirmed_fill_is_not_pairing_gated() {
+        let trade: PolymarketTradeReport = load("http_trade_report.json");
+
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let output = build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            PendingFillPolicy::PairedWith(&AHashSet::new()),
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(output.fills.len(), 1);
+        assert_eq!(output.discards.unpaired_pending_fills, 0);
+        assert!(output.pending_filled_by_order.is_empty());
+    }
+
+    #[rstest]
+    fn confirmed_only_omits_pending_fill_without_a_discard() {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = PolymarketTradeStatus::Matched;
+
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let output = build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            PendingFillPolicy::ConfirmedOnly,
+            UnixNanos::from(1),
+        );
+
+        assert!(output.fills.is_empty());
+        assert_eq!(output.discards, FillBuildDiscards::default());
+        assert!(output.pending_filled_by_order.is_empty());
+    }
+
+    #[rstest]
+    fn confirmed_redelivery_after_pending_skip_is_emitted() {
+        let mut pending: PolymarketTradeReport = load("http_trade_report.json");
+        pending.status = PolymarketTradeStatus::Matched;
+        let mut confirmed = pending.clone();
+        confirmed.status = PolymarketTradeStatus::Confirmed;
+        let instruments = instruments_with_asset(pending.asset_id);
+
+        let output = build_fill_reports_from_trades(
+            &[pending, confirmed],
+            &fill_context(),
+            &instruments,
+            None,
+            PendingFillPolicy::ConfirmedOnly,
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(output.fills.len(), 1);
+        assert_eq!(output.discards.duplicate_trades, 0);
+    }
+
+    #[rstest]
+    fn duplicate_trade_id_is_counted_and_emitted_once() {
+        let trade: PolymarketTradeReport = load("http_trade_report.json");
+        let trade_id = TradeId::from(trade.id.as_str());
+        let instruments = instruments_with_asset(trade.asset_id);
+
+        let output = build_fill_reports_from_trades(
+            &[trade.clone(), trade],
+            &fill_context(),
+            &instruments,
+            None,
+            PendingFillPolicy::ConfirmedOnly,
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(output.fills.len(), 1);
+        assert_eq!(output.fills[0].trade_id, trade_id);
+        assert_eq!(output.discards.duplicate_trades, 1);
+    }
+
+    #[rstest]
+    fn valid_row_after_unrepresentable_row_is_emitted() {
+        let mut corrupt: PolymarketTradeReport = load("http_trade_report.json");
+        let valid = corrupt.clone();
+        corrupt.size = Decimal::NEGATIVE_ONE;
+        let instruments = instruments_with_asset(valid.asset_id);
+
+        let output = build_fill_reports_from_trades(
+            &[corrupt, valid],
+            &fill_context(),
+            &instruments,
+            None,
+            PendingFillPolicy::ConfirmedOnly,
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(output.fills.len(), 1);
+        assert_eq!(output.discards.unrepresentable_fills, 1);
+        assert_eq!(output.discards.duplicate_trades, 0);
+    }
+
+    #[rstest]
+    fn confirmed_redelivery_after_unpaired_pending_is_emitted() {
+        let mut pending: PolymarketTradeReport = load("http_trade_report.json");
+        pending.status = PolymarketTradeStatus::Matched;
+        let mut confirmed = pending.clone();
+        confirmed.status = PolymarketTradeStatus::Confirmed;
+        let instruments = instruments_with_asset(pending.asset_id);
+
+        let output = build_fill_reports_from_trades(
+            &[pending, confirmed],
+            &fill_context(),
+            &instruments,
+            None,
+            PendingFillPolicy::PairedWith(&AHashSet::new()),
+            UnixNanos::from(1),
+        );
+
+        assert_eq!(output.fills.len(), 1);
+        assert_eq!(output.discards.unpaired_pending_fills, 1);
+        assert_eq!(output.discards.duplicate_trades, 0);
+    }
+
+    #[rstest]
+    #[case(PolymarketTradeStatus::Matched)]
+    #[case(PolymarketTradeStatus::Mined)]
+    #[case(PolymarketTradeStatus::Retrying)]
+    #[case(PolymarketTradeStatus::Failed)]
+    fn unowned_non_confirmed_maker_trade_is_not_counted(#[case] status: PolymarketTradeStatus) {
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = status;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+
+        let market: crate::http::models::GammaMarket = load("gamma_market.json");
+        let defs = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&defs[0], UnixNanos::from(1)).unwrap();
+
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x000000000000000000000000000000000000dead",
+            api_key: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let output = build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            PendingFillPolicy::ConfirmedOnly,
+            UnixNanos::from(1),
+        );
+
+        assert!(output.fills.is_empty());
+        assert_eq!(output.discards.unowned_maker_trades, 0);
     }
 }

--- a/crates/adapters/polymarket/src/execution/reports.rs
+++ b/crates/adapters/polymarket/src/execution/reports.rs
@@ -13,6 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use ahash::AHashSet;
 use anyhow::Context;
 use nautilus_common::messages::execution::{
     GenerateFillReports, GenerateOrderStatusReport, GenerateOrderStatusReports,
@@ -22,7 +23,7 @@ use nautilus_core::{UnixNanos, collections::AtomicMap, time::AtomicTime};
 use nautilus_live::ExecutionEventEmitter;
 use nautilus_model::{
     enums::{OrderStatus, OrderType, TimeInForce},
-    identifiers::{ClientOrderId, InstrumentId, VenueOrderId},
+    identifiers::{ClientOrderId, InstrumentId, TradeId, VenueOrderId},
     instruments::{Instrument, InstrumentAny},
     orders::Order,
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
@@ -33,20 +34,22 @@ use ustr::Ustr;
 
 use super::{
     PolymarketExecutionClient,
+    identity::OrderIdentity,
     parse::{
-        parse_balance_allowance, parse_order_status_report, sum_filled_quantity,
-        weighted_average_price,
+        make_composite_trade_id, parse_balance_allowance, parse_order_status_report,
+        sum_filled_quantity, weighted_average_price,
     },
     reconciliation::{
-        FillContext, apply_fill_filters, build_fill_reports_from_trades, build_position_reports,
-        cap_order_report_filled_qty, confirmed_filled_quantities,
-        normalize_terminal_order_report_quantity,
+        FillContext, PendingFillPolicy, apply_fill_filters, build_fill_reports_from_trades,
+        build_position_reports, cap_order_report_filled_qty,
+        normalize_terminal_order_report_quantity, reported_filled_quantities,
     },
 };
 use crate::{
     common::{consts::DUST_SNAP_THRESHOLD_DEC, enums::SignatureType},
     http::{
         clob::PolymarketClobHttpClient,
+        models::PolymarketTradeReport,
         query::{GetBalanceAllowanceParams, GetTradesParams},
     },
 };
@@ -139,13 +142,15 @@ impl PolymarketExecutionClient {
             return Ok(Some(report));
         }
 
-        let (mut order_fills, _) = build_fill_reports_from_trades(
+        let mut order_fills = build_fill_reports_from_trades(
             &trades,
             &ctx,
             &self.shared_token_instruments,
             Some(instrument_id),
+            PendingFillPolicy::ConfirmedOnly,
             ts_init,
-        );
+        )
+        .fills;
         order_fills.retain(|f| f.venue_order_id == venue_order_id);
         self.fill_tracker.snap_fill_reports(&mut order_fills);
 
@@ -280,6 +285,11 @@ impl PolymarketExecutionClient {
         let cached_filled = cache
             .order(&client_order_id)
             .map_or_else(|| Quantity::zero(size_prec), |order| order.filled_qty());
+        let applied_trade_ids = cache
+            .order(&client_order_id)
+            .map_or_else(AHashSet::new, |order| {
+                order.trade_ids().into_iter().copied().collect()
+            });
 
         self.spawn_task("query_order", async move {
             match http_client.get_order_optional(&venue_order_id).await {
@@ -298,7 +308,7 @@ impl PolymarketExecutionClient {
                         .get_cumulative_filled(&venue_order_id)
                         .unwrap_or_else(|| Quantity::zero(size_prec));
                     let local_filled = cached_filled.max(tracked_filled);
-                    let confirmed_filled = if report.filled_qty > local_filled {
+                    let reported_filled = if report.filled_qty > local_filled {
                         let ctx = FillContext {
                             account_id,
                             user_address: &user_address,
@@ -307,34 +317,56 @@ impl PolymarketExecutionClient {
                             clock,
                         };
 
-                        match fetch_confirmed_fill_reports(
+                        match fetch_fill_reports(
                             &http_client,
                             &ctx,
                             &token_instruments,
                             GetTradesParams::default(),
                             Some(instrument_id),
+                            PendingFillPolicy::ConfirmedOnly,
                             clock.get_time_ns(),
                         )
                         .await
                         {
-                            Ok(fills) => confirmed_filled_quantities(&fills)
-                                .get(&venue_order_id)
-                                .copied(),
+                            Ok(mut fetched) => {
+                                fetched
+                                    .fills
+                                    .retain(|fill| fill.venue_order_id == venue_order_id);
+                                let reported_filled = reported_filled_quantities(&fetched.fills)
+                                    .get(&venue_order_id)
+                                    .copied();
+                                let mut skipped = 0;
+
+                                for fill in fetched.fills {
+                                    if rest_fill_was_applied(
+                                        &applied_trade_ids,
+                                        &fill,
+                                        &fetched.trades,
+                                    ) {
+                                        skipped += 1;
+                                        continue;
+                                    }
+
+                                    emitter.send_fill_report(fill);
+                                }
+
+                                if skipped > 0 {
+                                    log::debug!(
+                                        "Skipped {skipped} REST fill report(s) already applied to order {venue_order_id}",
+                                    );
+                                }
+
+                                reported_filled
+                            }
                             Err(e) => {
-                                log::warn!(
-                                    "Failed to fetch confirmed fills for order {venue_order_id}: {e}"
-                                );
+                                log::warn!("Failed to fetch fills for order {venue_order_id}: {e}");
                                 None
                             }
                         }
                     } else {
                         None
                     };
-                    cap_order_report_filled_qty(
-                        &mut report,
-                        local_filled,
-                        confirmed_filled,
-                    );
+                    cap_order_report_filled_qty(&mut report, local_filled, reported_filled);
                     emitter.send_order_status_report(report);
                 }
                 Ok(None) => {
@@ -405,31 +437,30 @@ impl PolymarketExecutionClient {
                 .get_cumulative_filled(&venue_order_id)
                 .unwrap_or_else(|| Quantity::zero(size_prec));
             let local_filled = cached_filled.max(tracked_filled);
-            let confirmed_filled = if report.filled_qty > local_filled {
-                match fetch_confirmed_fill_reports(
+            let reported_filled = if report.filled_qty > local_filled {
+                match fetch_fill_reports(
                     &self.http_client,
                     &self.fill_context(),
                     &self.shared_token_instruments,
                     GetTradesParams::default(),
                     Some(instrument_id),
+                    PendingFillPolicy::ConfirmedOnly,
                     self.clock.get_time_ns(),
                 )
                 .await
                 {
-                    Ok(fills) => confirmed_filled_quantities(&fills)
+                    Ok(fetched) => reported_filled_quantities(&fetched.fills)
                         .get(&venue_order_id)
                         .copied(),
                     Err(e) => {
-                        log::warn!(
-                            "Failed to fetch confirmed fills for order {venue_order_id}: {e}"
-                        );
+                        log::warn!("Failed to fetch fills for order {venue_order_id}: {e}");
                         None
                     }
                 }
             } else {
                 None
             };
-            cap_order_report_filled_qty(&mut report, local_filled, confirmed_filled);
+            cap_order_report_filled_qty(&mut report, local_filled, reported_filled);
             return Ok(Some(report));
         }
 
@@ -457,31 +488,38 @@ impl PolymarketExecutionClient {
             &orders,
             &self.shared_token_instruments,
             self.core.account_id,
+            |venue_order_id| {
+                self.order_identities
+                    .get(venue_order_id)
+                    .map(|identity| identity.client_order_id)
+                    .or_else(|| self.core.cache().client_order_id(venue_order_id).copied())
+            },
             cmd.instrument_id,
             self.clock.get_time_ns(),
         );
 
-        let needs_confirmed_fills = reports.iter().any(|report| {
+        let needs_reported_fills = reports.iter().any(|report| {
             let cached_filled = report
                 .client_order_id
                 .and_then(|id| self.core.cache().order(&id).map(|order| order.filled_qty()))
                 .unwrap_or_else(|| Quantity::zero(report.quantity.precision));
             report.filled_qty > cached_filled
         });
-        let confirmed_fills = if needs_confirmed_fills {
-            match fetch_confirmed_fill_reports(
+        let reported_fills = if needs_reported_fills {
+            match fetch_fill_reports(
                 &self.http_client,
                 &self.fill_context(),
                 &self.shared_token_instruments,
                 GetTradesParams::default(),
                 cmd.instrument_id,
+                PendingFillPolicy::ConfirmedOnly,
                 self.clock.get_time_ns(),
             )
             .await
             {
-                Ok(fills) => confirmed_filled_quantities(&fills),
+                Ok(fetched) => reported_filled_quantities(&fetched.fills),
                 Err(e) => {
-                    log::warn!("Failed to fetch confirmed fills for open-order check: {e}");
+                    log::warn!("Failed to fetch fills for open-order check: {e}");
                     Default::default()
                 }
             }
@@ -507,7 +545,7 @@ impl PolymarketExecutionClient {
             cap_order_report_filled_qty(
                 report,
                 cached_filled.max(tracked_filled),
-                confirmed_fills.get(&report.venue_order_id).copied(),
+                reported_fills.get(&report.venue_order_id).copied(),
             );
         }
 
@@ -535,13 +573,15 @@ impl PolymarketExecutionClient {
             .context("failed to fetch trades")?;
 
         let ctx = self.fill_context();
-        let (mut reports, _) = build_fill_reports_from_trades(
+        let mut reports = build_fill_reports_from_trades(
             &trades,
             &ctx,
             &self.shared_token_instruments,
             cmd.instrument_id,
+            PendingFillPolicy::ConfirmedOnly,
             self.clock.get_time_ns(),
-        );
+        )
+        .fills;
 
         self.fill_tracker.snap_fill_reports(&mut reports);
 
@@ -586,6 +626,27 @@ impl PolymarketExecutionClient {
             &ctx,
             self.core.client_id,
             self.core.venue,
+            |venue_order_id| {
+                self.order_identities.get(venue_order_id).or_else(|| {
+                    let cache = self.core.cache();
+                    let client_order_id = cache.client_order_id(venue_order_id)?;
+                    cache
+                        .order(client_order_id)
+                        .map(|order| OrderIdentity::from_order(&order))
+                })
+            },
+            |fill, trades| {
+                let cache = self.core.cache();
+                let client_order_id = fill
+                    .client_order_id
+                    .or_else(|| cache.client_order_id(&fill.venue_order_id).copied());
+                let Some(order) = client_order_id.and_then(|id| cache.order(&id)) else {
+                    return false;
+                };
+                let applied_trade_ids = order.trade_ids().into_iter().copied().collect();
+
+                rest_fill_was_applied(&applied_trade_ids, fill, trades)
+            },
             lookback_mins,
         )
         .await
@@ -609,21 +670,72 @@ fn recovered_terminal_order_status(
     }
 }
 
-async fn fetch_confirmed_fill_reports(
+struct FetchedFillReports {
+    fills: Vec<FillReport>,
+    trades: Vec<PolymarketTradeReport>,
+}
+
+async fn fetch_fill_reports(
     http_client: &PolymarketClobHttpClient,
     ctx: &FillContext<'_>,
     token_instruments: &AtomicMap<Ustr, InstrumentAny>,
     params: GetTradesParams,
     instrument_id: Option<InstrumentId>,
+    pending_policy: PendingFillPolicy<'_>,
     ts_init: UnixNanos,
-) -> anyhow::Result<Vec<FillReport>> {
+) -> anyhow::Result<FetchedFillReports> {
     let trades = http_client
         .get_trades(params)
         .await
-        .context("failed to fetch confirmed trades")?;
-    let (reports, _) =
-        build_fill_reports_from_trades(&trades, ctx, token_instruments, instrument_id, ts_init);
-    Ok(reports)
+        .context("failed to fetch trades")?;
+    let output = build_fill_reports_from_trades(
+        &trades,
+        ctx,
+        token_instruments,
+        instrument_id,
+        pending_policy,
+        ts_init,
+    );
+    Ok(FetchedFillReports {
+        fills: output.fills,
+        trades,
+    })
+}
+
+fn rest_fill_was_applied(
+    applied_trade_ids: &AHashSet<TradeId>,
+    fill: &FillReport,
+    trades: &[PolymarketTradeReport],
+) -> bool {
+    if applied_trade_ids.contains(&fill.trade_id) {
+        return true;
+    }
+
+    trades.iter().any(|trade| {
+        trade
+            .maker_orders
+            .iter()
+            .any(|maker| maker.order_id == fill.venue_order_id.as_str())
+            && make_composite_trade_id(&trade.id, fill.venue_order_id.as_str()) == fill.trade_id
+            && applied_trade_ids.contains(&make_legacy_composite_trade_id(
+                &trade.id,
+                fill.venue_order_id.as_str(),
+            ))
+    })
+}
+
+// Remove after persisted pre-hash trade IDs no longer require upgrade compatibility.
+fn make_legacy_composite_trade_id(trade_id: &str, venue_order_id: &str) -> TradeId {
+    let trade_prefix_len = trade_id.len().min(27);
+    let order_suffix_start = venue_order_id.len().saturating_sub(8);
+    TradeId::from(
+        format!(
+            "{}-{}",
+            &trade_id[..trade_prefix_len],
+            &venue_order_id[order_suffix_start..],
+        )
+        .as_str(),
+    )
 }
 
 pub(crate) fn get_pusd_currency() -> Currency {

--- a/crates/adapters/polymarket/src/execution/responses.rs
+++ b/crates/adapters/polymarket/src/execution/responses.rs
@@ -38,7 +38,7 @@ use super::{
     submitter::OrderSubmitter,
     types::BatchLimitOrderContext,
 };
-use crate::http::query::OrderResponse;
+use crate::http::{models::PolymarketOpenOrder, query::OrderResponse};
 
 #[expect(clippy::too_many_arguments)]
 pub(super) async fn handle_batch_order_responses(
@@ -747,6 +747,7 @@ pub(super) async fn check_fok_status(
     tokio::time::sleep(FOK_CHECK_DELAY).await;
 
     let venue_order_id = VenueOrderId::from(order_id);
+
     if fill_tracker.has_fills_or_settled(&venue_order_id) {
         return;
     }
@@ -765,63 +766,97 @@ pub(super) async fn check_fok_status(
         }
     };
 
-    let order_status = OrderStatus::from(venue_order.status);
-    let ts_now = clock.get_time_ns();
+    resolve_fok_rest_status(
+        order_id,
+        &venue_order,
+        order,
+        fill_tracker,
+        emitter,
+        account_id,
+        size_precision,
+        price_precision,
+        clock,
+    );
+}
 
-    match order_status {
-        OrderStatus::Rejected => {
-            log::debug!("FOK order {order_id} resolved via REST as Rejected");
-            emitter.emit_order_rejected(order, "FOK order unfilled", ts_now, false);
-        }
-        OrderStatus::Canceled => {
-            log::debug!("FOK order {order_id} resolved via REST as Canceled");
-            emitter.emit_order_canceled(order, Some(venue_order_id), ts_now);
-        }
-        OrderStatus::Expired => {
-            log::debug!("FOK order {order_id} resolved via REST as Expired");
-            emitter.emit_order_expired(order, Some(venue_order_id), ts_now);
-        }
-        OrderStatus::Filled => {
-            let quantity = Quantity::from_decimal_dp(venue_order.original_size, size_precision)
-                .unwrap_or_else(|_| Quantity::zero(size_precision));
-            let filled_qty = Quantity::from_decimal_dp(venue_order.size_matched, size_precision)
-                .unwrap_or_else(|_| Quantity::zero(size_precision));
-            let confirmed_filled = fill_tracker
-                .get_cumulative_filled(&venue_order_id)
-                .unwrap_or_else(|| Quantity::zero(size_precision));
-            let price = Price::from_decimal_dp(venue_order.price, price_precision)
-                .unwrap_or_else(|_| Price::zero(price_precision));
+#[expect(clippy::too_many_arguments)]
+fn resolve_fok_rest_status(
+    order_id: &str,
+    venue_order: &PolymarketOpenOrder,
+    order: &OrderAny,
+    fill_tracker: &OrderFillTrackerMap,
+    emitter: &ExecutionEventEmitter,
+    account_id: AccountId,
+    size_precision: u8,
+    price_precision: u8,
+    clock: &'static AtomicTime,
+) {
+    let venue_order_id = VenueOrderId::from(order_id);
+    let resolved = fill_tracker.resolve_if_unfilled(&venue_order_id, |view| {
+        let order_status = OrderStatus::from(venue_order.status);
+        let ts_now = clock.get_time_ns();
 
-            let mut report = OrderStatusReport::new(
-                account_id,
-                order.instrument_id(),
-                Some(order.client_order_id()),
-                venue_order_id,
-                order.order_side(),
-                OrderType::Limit,
-                TimeInForce::Fok,
-                order_status,
-                quantity,
-                filled_qty,
-                ts_now,
-                ts_now,
-                ts_now,
-                None,
-            );
-            report.price = Some(price);
-            cap_order_report_filled_qty(&mut report, confirmed_filled, None);
+        match order_status {
+            OrderStatus::Rejected => {
+                log::debug!("FOK order {order_id} resolved via REST as Rejected");
+                emitter.emit_order_rejected(order, "FOK order unfilled", ts_now, false);
+            }
+            OrderStatus::Canceled => {
+                log::debug!("FOK order {order_id} resolved via REST as Canceled");
+                emitter.emit_order_canceled(order, Some(venue_order_id), ts_now);
+            }
+            OrderStatus::Expired => {
+                log::debug!("FOK order {order_id} resolved via REST as Expired");
+                emitter.emit_order_expired(order, Some(venue_order_id), ts_now);
+            }
+            OrderStatus::Filled => {
+                let quantity =
+                    Quantity::from_decimal_dp(venue_order.original_size, size_precision)
+                        .unwrap_or_else(|_| Quantity::zero(size_precision));
+                let filled_qty =
+                    Quantity::from_decimal_dp(venue_order.size_matched, size_precision)
+                        .unwrap_or_else(|_| Quantity::zero(size_precision));
+                let price = Price::from_decimal_dp(venue_order.price, price_precision)
+                    .unwrap_or_else(|_| Price::zero(price_precision));
 
-            log::debug!(
-                "FOK order {order_id} resolved via REST as Filled; deferring fill quantity until confirmation"
-            );
-            emitter.send_order_status_report(report);
+                let mut report = OrderStatusReport::new(
+                    account_id,
+                    order.instrument_id(),
+                    Some(order.client_order_id()),
+                    venue_order_id,
+                    order.order_side(),
+                    OrderType::Limit,
+                    TimeInForce::Fok,
+                    order_status,
+                    quantity,
+                    filled_qty,
+                    ts_now,
+                    ts_now,
+                    ts_now,
+                    None,
+                );
+                report.price = Some(price);
+                cap_order_report_filled_qty(&mut report, view.cumulative_filled, None);
+
+                log::debug!(
+                    "FOK order {order_id} resolved via REST as Filled; deferring fill quantity until confirmation"
+                );
+                emitter.send_order_status_report(report);
+            }
+            _ => {}
         }
-        _ => {}
+    });
+
+    if !resolved {
+        log::debug!(
+            "FOK order {order_id} received a fill while REST status was pending; WS will resolve it"
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use ahash::AHashSet;
     use nautilus_common::messages::ExecutionEvent;
     use nautilus_core::{UnixNanos, collections::AtomicMap};
     use nautilus_model::{
@@ -930,6 +965,46 @@ mod tests {
             None,
             None,
         ))
+    }
+
+    #[rstest]
+    fn test_fok_rest_resolution_defers_when_fill_arrives_after_response() {
+        let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+        let order = test_limit_order("O-FOK-RACE", instrument_id);
+        let mut venue_order: crate::http::models::PolymarketOpenOrder =
+            load("http_open_order.json");
+        venue_order.status = crate::common::enums::PolymarketOrderStatus::Matched;
+        let venue_order_id = VenueOrderId::from(venue_order.id.as_str());
+        let fill_tracker = Arc::new(OrderFillTrackerMap::new());
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.0000"),
+            OrderSide::Buy,
+            instrument_id,
+            4,
+            4,
+        );
+        let (emitter, mut receiver) = test_emitter();
+
+        assert!(!fill_tracker.has_fills_or_settled(&venue_order_id));
+        let concurrent_tracker = Arc::clone(&fill_tracker);
+        let fill_thread = std::thread::spawn(move || {
+            concurrent_tracker.record_fill(&venue_order_id, Quantity::from("25.0000"));
+        });
+        fill_thread.join().unwrap();
+        resolve_fok_rest_status(
+            venue_order.id.as_str(),
+            &venue_order,
+            &order,
+            &fill_tracker,
+            &emitter,
+            AccountId::from("POLY-001"),
+            4,
+            4,
+            nautilus_core::time::get_atomic_clock_realtime(),
+        );
+
+        assert!(receiver.try_recv().is_err());
     }
 
     #[rstest]
@@ -1043,8 +1118,41 @@ mod tests {
     #[case(PolymarketTradeStatus::Matched)]
     #[case(PolymarketTradeStatus::Mined)]
     #[case(PolymarketTradeStatus::Retrying)]
-    #[case(PolymarketTradeStatus::Failed)]
-    fn test_non_confirmed_rest_trade_does_not_generate_fill_report(
+    fn test_paired_pending_rest_trade_generates_fill_report(#[case] status: PolymarketTradeStatus) {
+        let instrument = test_instrument();
+        let mut trade: crate::http::models::PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = status;
+
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = crate::execution::reconciliation::FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+        let paired_order_ids =
+            AHashSet::from_iter([VenueOrderId::from(trade.taker_order_id.as_str())]);
+
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
+            &[trade.clone()],
+            &ctx,
+            &instruments,
+            None,
+            crate::execution::reconciliation::PendingFillPolicy::PairedWith(&paired_order_ids),
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert_eq!(output.fills.len(), 1);
+        assert_eq!(output.fills[0].trade_id, TradeId::from(trade.id.as_str()));
+    }
+
+    #[rstest]
+    #[case(PolymarketTradeStatus::Matched)]
+    #[case(PolymarketTradeStatus::Mined)]
+    #[case(PolymarketTradeStatus::Retrying)]
+    fn test_confirmed_only_pending_rest_trade_does_not_generate_fill_report(
         #[case] status: PolymarketTradeStatus,
     ) {
         let instrument = test_instrument();
@@ -1061,15 +1169,48 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, _) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
             None,
+            crate::execution::reconciliation::PendingFillPolicy::ConfirmedOnly,
             UnixNanos::from(1_000_000_000u64),
         );
 
-        assert!(reports.is_empty());
+        assert!(output.fills.is_empty());
+        assert_eq!(
+            output.discards,
+            crate::execution::reconciliation::FillBuildDiscards::default(),
+        );
+    }
+
+    #[rstest]
+    fn test_failed_rest_trade_does_not_generate_fill_report() {
+        let instrument = test_instrument();
+        let mut trade: crate::http::models::PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = PolymarketTradeStatus::Failed;
+
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let ctx = crate::execution::reconciliation::FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        };
+
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
+            &[trade],
+            &ctx,
+            &instruments,
+            None,
+            crate::execution::reconciliation::PendingFillPolicy::ConfirmedOnly,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert!(output.fills.is_empty());
     }
 
     #[rstest]
@@ -1104,25 +1245,26 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, discards) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
             None,
+            crate::execution::reconciliation::PendingFillPolicy::ConfirmedOnly,
             UnixNanos::from(1_000_000_000u64),
         );
 
         assert_eq!(
-            reports.len(),
+            output.fills.len(),
             1,
             "the account's own confirmed maker fill must be reported",
         );
-        assert_eq!(reports[0].venue_order_id, expected_venue_order_id);
+        assert_eq!(output.fills[0].venue_order_id, expected_venue_order_id);
         assert_eq!(
-            discards.unowned_maker_trades, 0,
+            output.discards.unowned_maker_trades, 0,
             "entry-level skips of foreign entries in an owned trade are not trade drops",
         );
-        assert_eq!(discards.unmapped_instruments, 0);
+        assert_eq!(output.discards.unmapped_instruments, 0);
     }
 
     #[rstest]
@@ -1142,20 +1284,23 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, discards) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
             None,
+            crate::execution::reconciliation::PendingFillPolicy::ConfirmedOnly,
             UnixNanos::from(1_000_000_000u64),
         );
 
-        assert_eq!(reports.len(), 0);
+        assert_eq!(output.fills.len(), 0);
         assert_eq!(
-            discards,
+            output.discards,
             crate::execution::reconciliation::FillBuildDiscards {
                 unmapped_instruments: 1,
                 unowned_maker_trades: 0,
+                unpaired_pending_fills: 0,
+                ..Default::default()
             },
         );
     }
@@ -1178,20 +1323,21 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, discards) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
             None,
+            crate::execution::reconciliation::PendingFillPolicy::ConfirmedOnly,
             UnixNanos::from(1_000_000_000u64),
         );
 
-        assert!(reports.is_empty());
+        assert!(output.fills.is_empty());
         assert_eq!(
-            discards.unowned_maker_trades, 1,
+            output.discards.unowned_maker_trades, 1,
             "a confirmed maker trade dropped whole must be counted, not silent",
         );
-        assert_eq!(discards.unmapped_instruments, 0);
+        assert_eq!(output.discards.unmapped_instruments, 0);
     }
 
     #[rstest]
@@ -1402,8 +1548,10 @@ mod tests {
                     ),
                     FillCorrectionMetadata {
                         correction_key: correction_key.to_string(),
+                        trade_id: TradeId::from("trade-1"),
                         info: None,
                         is_confirmed: false,
+                        track_fill: true,
                     },
                 )
                 .is_none()

--- a/crates/adapters/polymarket/src/websocket/dispatch.rs
+++ b/crates/adapters/polymarket/src/websocket/dispatch.rs
@@ -27,6 +27,7 @@
 
 use std::str::FromStr;
 
+use ahash::AHashSet;
 use indexmap::IndexMap;
 use nautilus_common::cache::fifo::{FifoCache, FifoCacheMap};
 use nautilus_core::{UUID4, UnixNanos, collections::AtomicMap, time::AtomicTime};
@@ -37,7 +38,7 @@ use nautilus_model::{
         OrderAccepted, OrderCanceled, OrderEventAny, OrderExpired, OrderFillVoided, OrderFilled,
         OrderRejected, OrderUpdated,
     },
-    identifiers::{AccountId, TradeId, VenueOrderId},
+    identifiers::{AccountId, StrategyId, TradeId, VenueOrderId},
     instruments::{Instrument, InstrumentAny},
     reports::{FillReport, OrderStatusReport},
     types::{Money, Price, Quantity},
@@ -55,15 +56,18 @@ use crate::{
             PolymarketLiquiditySide, PolymarketOrderSide, PolymarketOrderStatus,
             PolymarketOrderType, PolymarketTradeStatus,
         },
+        fifo_ext::{add_to_fifo_map_with_eviction_warn, add_to_fifo_with_eviction_warn},
         models::PolymarketMakerOrder,
     },
     execution::{
         get_pusd_currency,
         identity::{OrderIdentity, OrderIdentityRegistry},
-        order_fill_tracker::{BufferedFill, FillCorrectionMetadata, OrderFillTrackerMap},
+        order_fill_tracker::{
+            AppliedPendingFill, BufferedFill, FillCorrectionMetadata, OrderFillTrackerMap,
+        },
         parse::{
             build_maker_fill_report, compute_commission, determine_order_side,
-            instrument_fee_exponent, instrument_taker_fee, parse_liquidity_side,
+            instrument_fee_exponent, instrument_taker_fee, parse_fill_values, parse_liquidity_side,
         },
         pending::PendingSubmitTracker,
     },
@@ -73,11 +77,31 @@ use crate::{
 #[derive(Debug)]
 pub(crate) struct AccountRefreshRequest;
 
+#[cfg(test)]
+std::thread_local! {
+    static VOID_FAILED_AFTER_BUFFERED_EVIDENCE_REMOVAL: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+fn run_void_failed_after_buffered_evidence_removal() {
+    VOID_FAILED_AFTER_BUFFERED_EVIDENCE_REMOVAL.with(|hook| {
+        if let Some(hook) = hook.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
 /// Mutable state retained across user WebSocket stream generations.
 #[derive(Debug, Default)]
 pub(crate) struct WsDispatchState {
     pub processed_fills: FifoCache<String, 10_000>,
     matched_fills: FifoCacheMap<String, Vec<OrderFilled>, 10_000>,
+    matched_fill_evictions: u64,
+    raw_applied_fills: FifoCacheMap<String, Vec<FillReport>, 10_000>,
+    raw_applied_fill_evictions: u64,
+    consumed_legs: FifoCacheMap<String, AHashSet<VenueOrderId>, 10_000>,
+    ws_dedup_evictions: u64,
     voided_trades: FifoCache<String, 10_000>,
     confirmed_trades: FifoCache<String, 10_000>,
     pending_terminal_orders: FifoCacheMap<VenueOrderId, PendingTerminalOrder, 10_000>,
@@ -89,14 +113,80 @@ pub(crate) struct WsDispatchState {
 
 impl WsDispatchState {
     pub(crate) fn restore_matched_trade(&mut self, key: String, fills: Vec<OrderFilled>) {
-        self.processed_fills.add(key.clone());
-        self.matched_fills.insert(key, fills);
+        self.add_processed_trade(key.clone());
+        self.add_matched_trade(key, fills);
     }
 
     pub(crate) fn restore_voided_trade(&mut self, key: String) {
-        self.processed_fills.add(key.clone());
+        self.add_processed_trade(key.clone());
         self.matched_fills.remove(&key);
-        self.voided_trades.add(key);
+        add_to_fifo_with_eviction_warn(&mut self.voided_trades, key, "WS voided-trade");
+    }
+
+    fn add_processed_trade(&mut self, key: String) {
+        let evicted =
+            add_to_fifo_with_eviction_warn(&mut self.processed_fills, key, "WS processed-trade");
+
+        if evicted {
+            self.ws_dedup_evictions = self.ws_dedup_evictions.saturating_add(1);
+        }
+    }
+
+    fn add_consumed_legs(&mut self, key: String, consumed: AHashSet<VenueOrderId>) {
+        let evicted = add_to_fifo_map_with_eviction_warn(
+            &mut self.consumed_legs,
+            key,
+            consumed,
+            "WS consumed-leg",
+        );
+
+        if evicted {
+            self.ws_dedup_evictions = self.ws_dedup_evictions.saturating_add(1);
+        }
+    }
+
+    fn add_matched_trade(&mut self, key: String, fills: Vec<OrderFilled>) {
+        if let Some(held) = self.matched_fills.get_mut(&key) {
+            held.extend(fills);
+            return;
+        }
+
+        let evicted = add_to_fifo_map_with_eviction_warn(
+            &mut self.matched_fills,
+            key,
+            fills,
+            "WS matched-fill evidence",
+        );
+
+        if evicted {
+            self.matched_fill_evictions = self.matched_fill_evictions.saturating_add(1);
+            self.ws_dedup_evictions = self.ws_dedup_evictions.saturating_add(1);
+        }
+    }
+
+    fn keep_raw_fill_retryable(&mut self, key: String, report: FillReport) {
+        self.processed_fills.remove(&key);
+        self.consumed_legs.remove(&key);
+
+        if let Some(fills) = self.raw_applied_fills.get_mut(&key) {
+            if !fills.iter().any(|fill| {
+                fill.venue_order_id == report.venue_order_id && fill.trade_id == report.trade_id
+            }) {
+                fills.push(report);
+            }
+            return;
+        }
+
+        let evicted = add_to_fifo_map_with_eviction_warn(
+            &mut self.raw_applied_fills,
+            key,
+            vec![report],
+            "WS raw applied-fill evidence",
+        );
+
+        if evicted {
+            self.raw_applied_fill_evictions = self.raw_applied_fill_evictions.saturating_add(1);
+        }
     }
 }
 
@@ -164,8 +254,12 @@ fn dispatch_order_update(
     let venue_order_id = VenueOrderId::from(order.id.as_str());
 
     let ts_init = ctx.clock.get_time_ns();
-    let mut report =
-        build_ws_order_status_report(order, instrument, ctx.account_id, ts_event, ts_init);
+    let Some(mut report) =
+        build_ws_order_status_report(order, instrument, ctx.account_id, ts_event, ts_init)
+    else {
+        salvage_terminal_order_update(order, instrument, venue_order_id, ts_event, ctx);
+        return;
+    };
     let local_client_order_id = ctx.pending_submits.client_order_id(&venue_order_id);
     let mut is_accepted = ctx.fill_tracker.contains(&venue_order_id);
     report.client_order_id = local_client_order_id;
@@ -206,9 +300,12 @@ fn dispatch_order_update(
     // Saved regardless of acceptance state so that cancels arriving during
     // the HTTP round-trip are available once the order is later accepted.
     if report.order_status == OrderStatus::Canceled {
-        state
-            .terminal_cancel_reports
-            .insert(venue_order_id, report.clone());
+        add_to_fifo_map_with_eviction_warn(
+            &mut state.terminal_cancel_reports,
+            venue_order_id,
+            report.clone(),
+            "WS terminal-cancel-report",
+        );
     }
 
     // Tracked own orders route through order events; externally-managed orders
@@ -221,7 +318,17 @@ fn dispatch_order_update(
             Some(identity) => {
                 emit_buffered_order_filled(&identity, &fill, ctx);
             }
-            None => ctx.emitter.send_fill_report(fill.report),
+            None => {
+                let correction_key = fill
+                    .correction
+                    .as_ref()
+                    .map(|correction| correction.correction_key.clone());
+                ctx.emitter.send_fill_report(fill.report.clone());
+
+                if let Some(correction_key) = correction_key {
+                    state.keep_raw_fill_retryable(correction_key, fill.report);
+                }
+            }
         }
     }
 
@@ -244,12 +351,14 @@ fn dispatch_order_update(
     if order.status == PolymarketOrderStatus::Matched
         && let Some(trade_ids) = order.associate_trades.clone().filter(|ids| !ids.is_empty())
     {
-        state.pending_terminal_orders.insert(
+        add_to_fifo_map_with_eviction_warn(
+            &mut state.pending_terminal_orders,
             venue_order_id,
             PendingTerminalOrder {
                 trade_ids,
                 ts_event,
             },
+            "WS pending-terminal-order",
         );
         emit_quantity_normalization_if_ready(venue_order_id, ctx, state);
     }
@@ -362,10 +471,10 @@ fn dispatch_trade_update(
     ctx: &WsDispatchContext<'_>,
     state: &mut WsDispatchState,
 ) -> Option<AccountRefreshRequest> {
-    let dedup_key = format!("{}-{}", trade.id, trade.taker_order_id);
+    let dedup_key = trade.id.clone();
+
     if trade.status == PolymarketTradeStatus::Failed {
-        void_failed_trade(trade, dedup_key, ctx, state);
-        return Some(AccountRefreshRequest);
+        return void_failed_trade(trade, dedup_key, ctx, state).then_some(AccountRefreshRequest);
     }
 
     if matches!(
@@ -385,13 +494,44 @@ fn dispatch_trade_update(
     }
 
     let is_confirmed = trade.status == PolymarketTradeStatus::Confirmed;
-    dispatch_trade_fills(trade, &dedup_key, is_confirmed, ctx, state);
+    let trade_id = TradeId::from(trade.id.as_str());
+    let rest_applied_fills = ctx.fill_tracker.rest_applied_pending_fills(&trade_id);
+    let rest_applied_order_ids = rest_applied_fills
+        .iter()
+        .map(|fill| fill.venue_order_id)
+        .collect::<AHashSet<_>>();
+
+    if is_confirmed && !rest_applied_fills.is_empty() {
+        ctx.fill_tracker
+            .mark_trade_rest_applied(&dedup_key, &rest_applied_fills);
+    }
+
+    let fully_processed = dispatch_trade_fills(
+        trade,
+        &dedup_key,
+        is_confirmed,
+        &rest_applied_order_ids,
+        ctx,
+        state,
+    );
 
     if !is_confirmed {
         return None;
     }
 
+    if !fully_processed {
+        log::debug!(
+            "Deferring confirmation of trade {} until a corrected redelivery applies its remaining fills",
+            trade.id,
+        );
+        return None;
+    }
+
     confirm_trade(trade, &dedup_key, ctx, state);
+
+    if !rest_applied_fills.is_empty() {
+        ctx.fill_tracker.clear_rest_applied_pending_trade(&trade_id);
+    }
     Some(AccountRefreshRequest)
 }
 
@@ -400,12 +540,21 @@ fn void_failed_trade(
     dedup_key: String,
     ctx: &WsDispatchContext<'_>,
     state: &mut WsDispatchState,
-) {
+) -> bool {
     if state.voided_trades.contains(&dedup_key) {
-        return;
+        return true;
     }
 
+    let trade_id = TradeId::from(trade.id.as_str());
+    ctx.fill_tracker.note_failed_trade(&trade_id);
+    let rest_applied_fills = ctx.fill_tracker.rest_applied_pending_fills(&trade_id);
+    let Some(message_derived_reports) =
+        build_message_derived_fill_void_reports(trade, &rest_applied_fills, ctx)
+    else {
+        return false;
+    };
     let direct_fills = state.matched_fills.remove(&dedup_key).unwrap_or_default();
+
     for fill in &direct_fills {
         ctx.fill_tracker
             .reverse_fill(&fill.venue_order_id, fill.last_qty);
@@ -413,13 +562,144 @@ fn void_failed_trade(
 
     let mut fills = direct_fills;
     fills.extend(ctx.fill_tracker.void_buffered_trade(&dedup_key));
-    for fill in fills {
-        emit_order_fill_voided(&fill, trade, Some(fill.event_id), ctx);
+    #[cfg(test)]
+    run_void_failed_after_buffered_evidence_removal();
+
+    if fills.is_empty() && message_derived_reports.is_empty() {
+        if state.raw_applied_fills.contains_key(&dedup_key)
+            || state.matched_fill_evictions > 0
+            || state.raw_applied_fill_evictions > 0
+            || ctx.order_identities.has_evictions()
+            || ctx.fill_tracker.has_correction_evidence_evictions()
+        {
+            ctx.fill_tracker.defer_trade_without_evidence(trade_id);
+            ctx.fill_tracker.keep_buffered_trade_retryable(&dedup_key);
+            log::warn!(
+                "Cannot safely ignore failed trade {} with no addressable applied fill to void because correction state is incomplete or may have been evicted; leaving the trade retryable",
+                trade.id,
+            );
+            return false;
+        }
+
+        log::warn!(
+            "Ignoring failed trade {}: no fill was applied for this trade, or correction evidence was lost to restart/eviction",
+            trade.id,
+        );
+        state.add_processed_trade(dedup_key);
+        return true;
+    }
+    let evidence_venue_order_ids = message_derived_reports
+        .iter()
+        .map(|(report, _, _)| report.venue_order_id)
+        .collect::<AHashSet<_>>();
+    fills.retain(|fill| !evidence_venue_order_ids.contains(&fill.venue_order_id));
+
+    for fill in &fills {
+        emit_order_fill_voided(fill, trade, Some(fill.event_id), ctx);
     }
 
-    state.processed_fills.add(dedup_key.clone());
-    state.voided_trades.add(dedup_key);
+    for (report, strategy_id, order_type) in &message_derived_reports {
+        emit_message_derived_fill_void(report, *strategy_id, *order_type, trade, ctx);
+    }
+
+    ctx.fill_tracker.clear_no_evidence_deferral(&trade_id);
+
+    state.add_processed_trade(dedup_key.clone());
+    state.consumed_legs.remove(&dedup_key);
+    state.raw_applied_fills.remove(&dedup_key);
+    add_to_fifo_with_eviction_warn(&mut state.voided_trades, dedup_key, "WS voided-trade");
     state.confirmed_trades.remove(&trade.id);
+    ctx.fill_tracker.clear_rest_applied_pending_trade(&trade_id);
+    true
+}
+
+fn build_message_derived_fill_void_reports(
+    trade: &PolymarketUserTrade,
+    applied_fills: &[AppliedPendingFill],
+    ctx: &WsDispatchContext<'_>,
+) -> Option<Vec<(FillReport, StrategyId, OrderType)>> {
+    let ts_event = parse_timestamp_ms(&trade.timestamp).unwrap_or_else(|_| ctx.clock.get_time_ns());
+    let ts_init = ctx.clock.get_time_ns();
+    let mut reports = Vec::with_capacity(applied_fills.len());
+
+    for applied_fill in applied_fills {
+        let (Some(client_order_id), Some(strategy_id), Some(order_type)) = (
+            applied_fill.client_order_id,
+            applied_fill.strategy_id,
+            applied_fill.order_type,
+        ) else {
+            log::error!(
+                "Deferring failed trade {} fill void for venue order {} because its recorded identity is incomplete",
+                trade.id,
+                applied_fill.venue_order_id,
+            );
+            return None;
+        };
+
+        reports.push((
+            FillReport {
+                account_id: ctx.account_id,
+                instrument_id: applied_fill.instrument_id,
+                venue_order_id: applied_fill.venue_order_id,
+                trade_id: applied_fill.trade_id,
+                order_side: applied_fill.order_side,
+                last_qty: applied_fill.last_qty,
+                last_px: applied_fill.last_px,
+                commission: applied_fill.commission,
+                liquidity_side: applied_fill.liquidity_side,
+                avg_px: None,
+                report_id: UUID4::new(),
+                ts_event,
+                ts_init,
+                client_order_id: Some(client_order_id),
+                venue_position_id: None,
+            },
+            strategy_id,
+            order_type,
+        ));
+    }
+
+    Some(reports)
+}
+
+fn emit_message_derived_fill_void(
+    report: &FillReport,
+    strategy_id: StrategyId,
+    order_type: OrderType,
+    trade: &PolymarketUserTrade,
+    ctx: &WsDispatchContext<'_>,
+) {
+    let client_order_id = report
+        .client_order_id
+        .expect("message-derived void identity was prevalidated");
+    let ts_event = parse_timestamp_ms(&trade.timestamp).unwrap_or_else(|_| ctx.clock.get_time_ns());
+    let voided = OrderFillVoided::new(
+        ctx.emitter.trader_id(),
+        strategy_id,
+        report.instrument_id,
+        client_order_id,
+        report.venue_order_id,
+        ctx.account_id,
+        Ustr::from(&format!("{}-FAILED-{client_order_id}", trade.id)),
+        report.trade_id,
+        report.last_qty,
+        Some(report.commission),
+        report.order_side,
+        order_type,
+        report.last_px,
+        get_pusd_currency(),
+        report.liquidity_side,
+        None,
+        Some(Ustr::from("FAILED")),
+        trade_fill_info(trade),
+        UUID4::new(),
+        ts_event,
+        ctx.clock.get_time_ns(),
+        false,
+        false,
+    );
+    ctx.emitter
+        .send_order_event(OrderEventAny::FillVoided(voided));
 }
 
 fn has_unknown_trade_instrument(trade: &PolymarketUserTrade, ctx: &WsDispatchContext<'_>) -> bool {
@@ -440,24 +720,63 @@ fn dispatch_trade_fills(
     trade: &PolymarketUserTrade,
     dedup_key: &String,
     is_confirmed: bool,
+    rest_applied_order_ids: &AHashSet<VenueOrderId>,
     ctx: &WsDispatchContext<'_>,
     state: &mut WsDispatchState,
-) {
+) -> bool {
     if state.processed_fills.contains(dedup_key) {
         log::debug!("Duplicate fill skipped: {dedup_key}");
-        return;
+        return true;
     }
 
-    state.processed_fills.add(dedup_key.clone());
-    let fills = if trade.trader_side == PolymarketLiquiditySide::Maker {
-        dispatch_maker_fills(trade, dedup_key, is_confirmed, ctx, state)
+    let consumed_before = state
+        .consumed_legs
+        .get(dedup_key)
+        .cloned()
+        .unwrap_or_default();
+    let (fills, any_invalid, consumed_now) = if trade.trader_side == PolymarketLiquiditySide::Maker
+    {
+        dispatch_maker_fills(
+            trade,
+            dedup_key,
+            is_confirmed,
+            rest_applied_order_ids,
+            &consumed_before,
+            ctx,
+            state,
+        )
     } else {
-        dispatch_taker_fill(trade, dedup_key, is_confirmed, ctx, state)
+        dispatch_taker_fill(
+            trade,
+            dedup_key,
+            is_confirmed,
+            rest_applied_order_ids,
+            &consumed_before,
+            ctx,
+            state,
+        )
     };
 
-    if !fills.is_empty() {
-        state.matched_fills.insert(dedup_key.clone(), fills);
+    if !consumed_now.is_empty() {
+        if let Some(consumed) = state.consumed_legs.get_mut(dedup_key) {
+            consumed.extend(consumed_now);
+        } else {
+            state.add_consumed_legs(dedup_key.clone(), consumed_now.into_iter().collect());
+        }
     }
+
+    if !fills.is_empty() {
+        state.add_matched_trade(dedup_key.clone(), fills);
+    }
+
+    if any_invalid {
+        return false;
+    }
+
+    state.raw_applied_fills.remove(dedup_key);
+
+    state.add_processed_trade(dedup_key.clone());
+    true
 }
 
 fn confirm_trade(
@@ -468,7 +787,12 @@ fn confirm_trade(
 ) {
     let ts_event = parse_timestamp_ms(&trade.timestamp).unwrap_or_else(|_| ctx.clock.get_time_ns());
     ctx.fill_tracker.mark_trade_confirmed(dedup_key);
-    state.confirmed_trades.add(trade.id.clone());
+    add_to_fifo_with_eviction_warn(
+        &mut state.confirmed_trades,
+        trade.id.clone(),
+        "WS confirmed-trade",
+    );
+
     if trade.trader_side == PolymarketLiquiditySide::Maker {
         for order in trade
             .maker_orders
@@ -495,18 +819,36 @@ fn dispatch_maker_fills(
     trade: &PolymarketUserTrade,
     correction_key: &str,
     is_confirmed: bool,
+    rest_applied_order_ids: &AHashSet<VenueOrderId>,
+    consumed_legs: &AHashSet<VenueOrderId>,
     ctx: &WsDispatchContext<'_>,
-    state: &WsDispatchState,
-) -> Vec<OrderFilled> {
-    let user_orders: Vec<_> = trade
+    state: &mut WsDispatchState,
+) -> (Vec<OrderFilled>, bool, Vec<VenueOrderId>) {
+    let replay_risk = state.ws_dedup_evictions > 0;
+    let owned_orders: Vec<_> = trade
         .maker_orders
         .iter()
         .filter(|order| is_user_maker_order(order, ctx))
         .collect();
 
-    if user_orders.is_empty() {
+    if owned_orders.is_empty() {
         log::warn!("No matching maker orders for user in trade: {}", trade.id);
-        return Vec::new();
+        return (Vec::new(), true, Vec::new());
+    }
+
+    let user_orders: Vec<_> = owned_orders
+        .into_iter()
+        .filter(|order| {
+            !rest_applied_order_ids.contains(&VenueOrderId::from(order.order_id.as_str()))
+        })
+        .collect();
+
+    if user_orders.is_empty() {
+        log::debug!(
+            "All owned maker fills for trade {} were already applied via REST reconciliation",
+            trade.id,
+        );
+        return (Vec::new(), false, Vec::new());
     }
 
     let instruments = ctx.token_instruments.load();
@@ -515,16 +857,49 @@ fn dispatch_maker_fills(
     let ts_event = parse_timestamp_ms(&trade.timestamp).unwrap_or_else(|_| ctx.clock.get_time_ns());
     let ts_init = ctx.clock.get_time_ns();
     let mut fills = Vec::new();
+    let mut any_invalid = false;
+    let mut consumed_now = Vec::new();
 
     for mo in user_orders {
+        let maker_venue_order_id = VenueOrderId::from(mo.order_id.as_str());
+
+        if consumed_legs.contains(&maker_venue_order_id) {
+            log::debug!(
+                "Skipping already-applied maker leg {maker_venue_order_id} of trade {}",
+                trade.id,
+            );
+            continue;
+        }
+
         let asset_id = Ustr::from(mo.asset_id.as_str());
         let instrument = match instruments.get(&asset_id) {
             Some(i) => i,
             None => {
                 log::warn!("Unknown asset_id in maker order: {asset_id}");
+                any_invalid = true;
                 continue;
             }
         };
+        let price_precision = instrument.price_precision();
+        let size_precision = instrument.size_precision();
+
+        if parse_fill_values(
+            &trade.id,
+            mo.matched_amount,
+            mo.price,
+            price_precision,
+            size_precision,
+        )
+        .is_none()
+        {
+            log::warn!(
+                "Skipping live maker fill for trade {} with invalid quantity or price",
+                trade.id,
+            );
+            any_invalid = true;
+            continue;
+        }
+
         let mut report = build_maker_fill_report(
             mo,
             &trade.id,
@@ -533,26 +908,34 @@ fn dispatch_maker_fills(
             trade.asset_id.as_str(),
             ctx.account_id,
             instrument.id(),
-            instrument.price_precision(),
-            instrument.size_precision(),
+            price_precision,
+            size_precision,
             crate::execution::get_pusd_currency(),
             liquidity_side,
             ts_event,
             ts_init,
         );
-        let maker_venue_order_id = report.venue_order_id;
         report.client_order_id = ctx.pending_submits.client_order_id(&maker_venue_order_id);
         report.last_qty = ctx
             .fill_tracker
             .snap_fill_qty(&maker_venue_order_id, report.last_qty);
+        let track_fill = !replay_risk || !ctx.fill_tracker.contains(&maker_venue_order_id);
+
+        if !track_fill {
+            log::error!(
+                "WS dedup evidence was evicted; emitting unknown maker trade {correction_key} for {maker_venue_order_id} without updating local fill accumulation or order quantity",
+            );
+        }
 
         if let Some(report) = ctx.fill_tracker.accept_or_buffer_fill(
             maker_venue_order_id,
             report,
             FillCorrectionMetadata {
                 correction_key: correction_key.to_string(),
+                trade_id: TradeId::from(trade.id.as_str()),
                 info: fill_info.clone(),
                 is_confirmed,
+                track_fill,
             },
         ) {
             match ctx.order_identities.get(&maker_venue_order_id) {
@@ -562,14 +945,22 @@ fn dispatch_maker_fills(
                         &report,
                         fill_info.clone(),
                         ctx,
+                        track_fill,
                     ));
+                    consumed_now.push(maker_venue_order_id);
                 }
-                None => ctx.emitter.send_fill_report(report),
+                None => {
+                    ctx.emitter.send_fill_report(report.clone());
+                    state.keep_raw_fill_retryable(correction_key.to_string(), report);
+                    any_invalid = true;
+                }
             }
             reemit_terminal_cancel(maker_venue_order_id, state, ctx);
+        } else {
+            consumed_now.push(maker_venue_order_id);
         }
     }
-    fills
+    (fills, any_invalid, consumed_now)
 }
 
 fn is_user_maker_order(order: &PolymarketMakerOrder, ctx: &WsDispatchContext<'_>) -> bool {
@@ -580,19 +971,77 @@ fn dispatch_taker_fill(
     trade: &PolymarketUserTrade,
     correction_key: &str,
     is_confirmed: bool,
+    rest_applied_order_ids: &AHashSet<VenueOrderId>,
+    consumed_legs: &AHashSet<VenueOrderId>,
     ctx: &WsDispatchContext<'_>,
-    state: &WsDispatchState,
-) -> Vec<OrderFilled> {
+    state: &mut WsDispatchState,
+) -> (Vec<OrderFilled>, bool, Vec<VenueOrderId>) {
+    let replay_risk = state.ws_dedup_evictions > 0;
+    let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+
+    if rest_applied_order_ids.contains(&venue_order_id) {
+        return (Vec::new(), false, Vec::new());
+    }
+
+    if consumed_legs.contains(&venue_order_id) {
+        log::debug!(
+            "Skipping already-applied taker fill {venue_order_id} of trade {}",
+            trade.id,
+        );
+        return (Vec::new(), false, Vec::new());
+    }
+
     let instruments = ctx.token_instruments.load();
     let instrument = match instruments.get(&trade.asset_id) {
         Some(i) => i,
         None => {
             log::warn!("Unknown asset_id in trade: {}", trade.asset_id);
-            return Vec::new();
+            return (Vec::new(), true, Vec::new());
         }
     };
 
-    let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+    let raw_size = match Decimal::from_str(&trade.size) {
+        Ok(size) => size,
+        Err(e) => {
+            log::warn!(
+                "Skipping live taker fill for trade {} with invalid size {}: {e}",
+                trade.id,
+                trade.size,
+            );
+            return (Vec::new(), true, Vec::new());
+        }
+    };
+
+    let raw_price = match Decimal::from_str(&trade.price) {
+        Ok(price) => price,
+        Err(e) => {
+            log::warn!(
+                "Skipping live taker fill for trade {} with invalid price {}: {e}",
+                trade.id,
+                trade.price,
+            );
+            return (Vec::new(), true, Vec::new());
+        }
+    };
+    let price_precision = instrument.price_precision();
+    let size_precision = instrument.size_precision();
+
+    if parse_fill_values(
+        &trade.id,
+        raw_size,
+        raw_price,
+        price_precision,
+        size_precision,
+    )
+    .is_none()
+    {
+        log::warn!(
+            "Skipping live taker fill for trade {} with invalid quantity or price",
+            trade.id,
+        );
+        return (Vec::new(), true, Vec::new());
+    }
+
     let liquidity_side = parse_liquidity_side(trade.trader_side);
     let ts_event = parse_timestamp_ms(&trade.timestamp).unwrap_or_else(|_| ctx.clock.get_time_ns());
     let ts_init = ctx.clock.get_time_ns();
@@ -609,27 +1058,41 @@ fn dispatch_taker_fill(
     report.last_qty = ctx
         .fill_tracker
         .snap_fill_qty(&venue_order_id, report.last_qty);
+    let track_fill = !replay_risk || !ctx.fill_tracker.contains(&venue_order_id);
+
+    if !track_fill {
+        log::error!(
+            "WS dedup evidence was evicted; emitting unknown taker trade {correction_key} for {venue_order_id} without updating local fill accumulation or order quantity",
+        );
+    }
 
     if let Some(report) = ctx.fill_tracker.accept_or_buffer_fill(
         venue_order_id,
         report,
         FillCorrectionMetadata {
             correction_key: correction_key.to_string(),
+            trade_id: TradeId::from(trade.id.as_str()),
             info: trade_fill_info(trade),
             is_confirmed,
+            track_fill,
         },
     ) {
         match ctx.order_identities.get(&venue_order_id) {
             Some(identity) => {
-                let fill = emit_order_filled(&identity, &report, trade_fill_info(trade), ctx);
+                let fill =
+                    emit_order_filled(&identity, &report, trade_fill_info(trade), ctx, track_fill);
                 reemit_terminal_cancel(venue_order_id, state, ctx);
-                return vec![fill];
+                return (vec![fill], false, vec![venue_order_id]);
             }
-            None => ctx.emitter.send_fill_report(report),
+            None => {
+                ctx.emitter.send_fill_report(report.clone());
+                state.keep_raw_fill_retryable(correction_key.to_string(), report);
+                reemit_terminal_cancel(venue_order_id, state, ctx);
+                return (Vec::new(), true, Vec::new());
+            }
         }
-        reemit_terminal_cancel(venue_order_id, state, ctx);
     }
-    Vec::new()
+    (Vec::new(), false, vec![venue_order_id])
 }
 
 /// Re-emits a saved cancel report after a fill to restore terminal state.
@@ -661,16 +1124,15 @@ fn reemit_terminal_cancel(
     }
 }
 
+/// Returns `None` when the payload's quantity or price fields cannot be represented.
 fn build_ws_order_status_report(
     order: &PolymarketUserOrder,
     instrument: &InstrumentAny,
     account_id: AccountId,
     ts_event: UnixNanos,
     ts_init: UnixNanos,
-) -> OrderStatusReport {
+) -> Option<OrderStatusReport> {
     let venue_order_id = VenueOrderId::from(order.id.as_str());
-    let order_status =
-        crate::execution::parse::resolve_order_status(order.status, order.event_type);
     let order_side = OrderSide::from(order.side);
     let time_in_force = TimeInForce::from(order.order_type);
     let size_precision = instrument.size_precision();
@@ -680,13 +1142,65 @@ fn build_ws_order_status_report(
         .ok()
         .map(|size| original_size_to_shares(size, price_dec, order.side, order.order_type))
         .and_then(|d| Quantity::from_decimal_dp(d, size_precision).ok())
-        .unwrap_or_else(|| Quantity::zero(size_precision));
-    let filled_qty = Decimal::from_str(&order.size_matched)
-        .ok()
-        .and_then(|d| Quantity::from_decimal_dp(d, size_precision).ok())
-        .unwrap_or_else(|| Quantity::zero(size_precision));
-    let price = Price::from_decimal_dp(price_dec, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
+        .filter(|quantity| !quantity.is_zero());
+
+    let Some(quantity) = quantity else {
+        log::warn!(
+            "Skipping order update {venue_order_id}: original_size {} is unrepresentable or zero",
+            order.original_size,
+        );
+        return None;
+    };
+
+    // The venue omits size_matched until a match occurs.
+    let filled_qty = if order.size_matched.is_empty() {
+        Some(Quantity::zero(size_precision))
+    } else {
+        Decimal::from_str(&order.size_matched)
+            .ok()
+            .and_then(|d| Quantity::from_decimal_dp(d, size_precision).ok())
+    };
+
+    let Some(filled_qty) = filled_qty else {
+        log::warn!(
+            "Skipping order update {venue_order_id}: size_matched {} is unrepresentable",
+            order.size_matched,
+        );
+        return None;
+    };
+
+    let order_status = crate::execution::parse::resolve_matched_order_status(
+        order.status,
+        order.order_type,
+        order.event_type,
+        filled_qty.as_decimal(),
+        quantity.as_decimal(),
+    );
+
+    if order_status == OrderStatus::Filled && filled_qty.is_zero() {
+        log::warn!(
+            "Skipping order update {venue_order_id}: status Filled carries a zero matched quantity",
+        );
+        return None;
+    }
+
+    // Market order types can omit the price; the quantity remains authoritative.
+    let price = if order.price.is_empty() {
+        Some(Price::zero(price_precision))
+    } else {
+        Decimal::from_str(&order.price)
+            .ok()
+            .and_then(|d| Price::from_decimal_dp(d, price_precision).ok())
+            .filter(|price| price.as_decimal() > Decimal::ZERO && price.as_decimal() < Decimal::ONE)
+    };
+
+    let Some(price) = price else {
+        log::warn!(
+            "Skipping order update {venue_order_id}: price {} is unrepresentable or outside (0, 1)",
+            order.price,
+        );
+        return None;
+    };
 
     let mut report = OrderStatusReport::new(
         account_id,
@@ -705,7 +1219,7 @@ fn build_ws_order_status_report(
         None,
     );
     report.price = Some(price);
-    report
+    Some(report)
 }
 
 /// Converts a venue-reported `original_size` on a user-channel order message into shares.
@@ -874,10 +1388,13 @@ fn emit_order_filled(
     fill: &FillReport,
     info: Option<IndexMap<Ustr, Ustr>>,
     ctx: &WsDispatchContext<'_>,
+    allow_overfill_bump: bool,
 ) -> OrderFilled {
     ensure_accepted(identity, fill.venue_order_id, fill.ts_event, ctx);
 
-    if let Some(new_qty) = ctx.fill_tracker.buy_overfill_bump(&fill.venue_order_id) {
+    if allow_overfill_bump
+        && let Some(new_qty) = ctx.fill_tracker.buy_overfill_bump(&fill.venue_order_id)
+    {
         emit_buy_overfill_update(identity, fill.venue_order_id, new_qty, fill.ts_event, ctx);
     }
 
@@ -1034,6 +1551,62 @@ fn emit_terminal_quantity_update(
         .send_order_event(OrderEventAny::Updated(updated));
 }
 
+fn salvage_terminal_order_update(
+    order: &PolymarketUserOrder,
+    instrument: &InstrumentAny,
+    venue_order_id: VenueOrderId,
+    ts_event: UnixNanos,
+    ctx: &WsDispatchContext<'_>,
+) {
+    let invalid_price = !order.price.is_empty()
+        && Decimal::from_str(&order.price)
+            .ok()
+            .and_then(|price| Price::from_decimal_dp(price, instrument.price_precision()).ok())
+            .is_none_or(|price| {
+                price.as_decimal() <= Decimal::ZERO || price.as_decimal() >= Decimal::ONE
+            });
+    let is_partial_fak_match = order.status == PolymarketOrderStatus::Matched
+        && order.order_type == PolymarketOrderType::FAK
+        && invalid_price
+        && Decimal::from_str(&order.size_matched)
+            .ok()
+            .zip(Decimal::from_str(&order.original_size).ok())
+            .is_some_and(|(size_matched, original_size)| size_matched < original_size);
+    let order_status = if is_partial_fak_match {
+        OrderStatus::Canceled
+    } else {
+        crate::execution::parse::resolve_order_status(order.status, order.event_type)
+    };
+
+    if !matches!(
+        order_status,
+        OrderStatus::Canceled | OrderStatus::Expired | OrderStatus::Rejected
+    ) {
+        return;
+    }
+
+    let Some(identity) = ctx.order_identities.get(&venue_order_id) else {
+        return;
+    };
+
+    log::warn!(
+        "Recovering terminal status {order_status:?} for {venue_order_id} from an order update with unrepresentable values",
+    );
+
+    match order_status {
+        OrderStatus::Canceled => {
+            ensure_accepted(&identity, venue_order_id, ts_event, ctx);
+            emit_order_canceled(&identity, venue_order_id, ts_event, ctx);
+        }
+        OrderStatus::Expired => {
+            ensure_accepted(&identity, venue_order_id, ts_event, ctx);
+            emit_order_expired(&identity, venue_order_id, ts_event, ctx);
+        }
+        OrderStatus::Rejected => emit_order_rejected(&identity, "REJECTED", ts_event, ctx),
+        _ => {}
+    }
+}
+
 fn emit_order_canceled(
     identity: &OrderIdentity,
     venue_order_id: VenueOrderId,
@@ -1103,22 +1676,34 @@ fn emit_order_rejected(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
     use nautilus_common::messages::{ExecutionEvent, ExecutionReport};
     use nautilus_core::time::AtomicTime;
     use nautilus_model::{
         enums::{AccountType, OrderStatus},
         events::OrderEventAny,
         identifiers::{ClientOrderId, InstrumentId, StrategyId, TraderId},
-        orders::{Order, builder::OrderTestBuilder},
+        orders::{Order, OrderError, builder::OrderTestBuilder},
         types::Currency,
     };
     use rstest::rstest;
     use rust_decimal_macros::dec;
 
     use super::*;
-    use crate::http::{
-        models::GammaMarket,
-        parse::{create_instrument_from_def, parse_gamma_market},
+    use crate::{
+        common::{
+            enums::PolymarketOrderType,
+            test_logger::{capture_start, records_since},
+        },
+        execution::parse::make_composite_trade_id,
+        http::{
+            models::GammaMarket,
+            parse::{create_instrument_from_def, parse_gamma_market},
+        },
     };
 
     /// Registers a tracked-order identity so the dispatch routes the order through events.
@@ -1163,6 +1748,75 @@ mod tests {
         )
     }
 
+    fn record_applied_pending_fill(
+        fill_tracker: &OrderFillTrackerMap,
+        trade_id: TradeId,
+        venue_order_id: VenueOrderId,
+        last_qty: Quantity,
+        client_order_id: &str,
+    ) -> AppliedPendingFill {
+        let fill = AppliedPendingFill {
+            venue_order_id,
+            instrument_id: test_instrument().id(),
+            trade_id,
+            client_order_id: Some(ClientOrderId::from(client_order_id)),
+            strategy_id: Some(StrategyId::from("S-001")),
+            order_type: Some(OrderType::Limit),
+            order_side: OrderSide::Buy,
+            last_qty,
+            last_px: Price::from("0.50"),
+            commission: Money::zero(get_pusd_currency()),
+            liquidity_side: LiquiditySide::Taker,
+        };
+        record_applied_pending_fills(fill_tracker, &[(trade_id, fill.clone())]);
+        fill
+    }
+
+    fn record_applied_pending_fills(
+        fill_tracker: &OrderFillTrackerMap,
+        fills: &[(TradeId, AppliedPendingFill)],
+    ) {
+        fill_tracker.begin_rest_applied_pending_pass();
+        let withheld = fill_tracker.record_rest_applied_pending_fills(fills);
+        assert!(withheld.is_empty());
+    }
+
+    fn test_order_filled(
+        venue_order_id: VenueOrderId,
+        trade_id: TradeId,
+        client_order_id: &str,
+    ) -> OrderFilled {
+        OrderFilled::new(
+            TraderId::from("TESTER-001"),
+            StrategyId::from("S-001"),
+            InstrumentId::from("TEST.POLYMARKET"),
+            ClientOrderId::from(client_order_id),
+            venue_order_id,
+            AccountId::from("POLY-001"),
+            trade_id,
+            OrderSide::Buy,
+            OrderType::Limit,
+            Quantity::from("1.000000"),
+            Price::from("0.50"),
+            get_pusd_currency(),
+            LiquiditySide::Taker,
+            UUID4::new(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            false,
+            None,
+            Some(Money::zero(get_pusd_currency())),
+            None,
+        )
+    }
+
+    fn second_owned_maker_order(trade: &PolymarketUserTrade) -> PolymarketMakerOrder {
+        let mut order = trade.maker_orders[0].clone();
+        order.order_id =
+            "0xmaker02maker02maker02maker02maker02maker02maker02maker02maker02maker02".to_string();
+        order
+    }
+
     #[rstest]
     fn test_build_ws_order_status_report() {
         let order: PolymarketUserOrder = load("ws_user_order_placement.json");
@@ -1176,7 +1830,8 @@ mod tests {
             AccountId::from("POLY-001"),
             ts_event,
             ts_init,
-        );
+        )
+        .unwrap();
 
         assert_eq!(report.order_side, OrderSide::Buy);
         assert_eq!(report.order_type, OrderType::Limit);
@@ -1203,7 +1858,8 @@ mod tests {
             AccountId::from("POLY-001"),
             ts_event,
             ts_init,
-        );
+        )
+        .unwrap();
 
         assert_eq!(report.order_status, OrderStatus::Canceled);
     }
@@ -1294,7 +1950,8 @@ mod tests {
             AccountId::from("POLY-001"),
             UnixNanos::from(1_000_000_000u64),
             UnixNanos::from(2_000_000_000u64),
-        );
+        )
+        .expect("FOK BUY order update must build a report");
 
         assert_eq!(
             report.quantity.as_decimal(),
@@ -1410,6 +2067,228 @@ mod tests {
             report.price.map(|price| price.as_decimal()),
             Some(dec!(0.01))
         );
+    }
+
+    #[rstest]
+    fn test_build_ws_order_status_report_partial_fak_maps_to_canceled() {
+        let mut order: PolymarketUserOrder = load("ws_user_order_placement.json");
+        order.status = PolymarketOrderStatus::Matched;
+        order.order_type = PolymarketOrderType::FAK;
+        order.original_size = "10".to_string();
+        order.size_matched = "4".to_string();
+        let instrument = test_instrument();
+
+        let report = build_ws_order_status_report(
+            &order,
+            &instrument,
+            AccountId::from("POLY-001"),
+            UnixNanos::from(1_000_000_000u64),
+            UnixNanos::from(2_000_000_000u64),
+        )
+        .unwrap();
+
+        assert_eq!(report.order_status, OrderStatus::Canceled);
+        assert_eq!(report.filled_qty, Quantity::from("4.000000"));
+    }
+
+    #[rstest]
+    fn test_build_ws_order_status_report_full_fak_stays_filled() {
+        let mut order: PolymarketUserOrder = load("ws_user_order_placement.json");
+        order.status = PolymarketOrderStatus::Matched;
+        order.order_type = PolymarketOrderType::FAK;
+        // A SELL signs shares as its maker amount, so original_size needs no conversion.
+        order.side = PolymarketOrderSide::Sell;
+        order.original_size = "10".to_string();
+        order.size_matched = "10".to_string();
+        let instrument = test_instrument();
+
+        let report = build_ws_order_status_report(
+            &order,
+            &instrument,
+            AccountId::from("POLY-001"),
+            UnixNanos::from(1_000_000_000u64),
+            UnixNanos::from(2_000_000_000u64),
+        )
+        .unwrap();
+
+        assert_eq!(report.order_status, OrderStatus::Filled);
+    }
+
+    #[rstest]
+    fn test_build_ws_order_status_report_rejects_filled_with_zero_matched() {
+        let mut order: PolymarketUserOrder = load("ws_user_order_placement.json");
+        order.status = PolymarketOrderStatus::Matched;
+        order.order_type = PolymarketOrderType::GTC;
+        order.original_size = "10".to_string();
+        order.size_matched = "0".to_string();
+        let instrument = test_instrument();
+
+        assert!(
+            build_ws_order_status_report(
+                &order,
+                &instrument,
+                AccountId::from("POLY-001"),
+                UnixNanos::from(1_000_000_000u64),
+                UnixNanos::from(2_000_000_000u64),
+            )
+            .is_none()
+        );
+    }
+
+    #[rstest]
+    fn test_corrupt_terminal_order_update_still_closes_the_order() {
+        let mut order: PolymarketUserOrder = load("ws_user_order_placement.json");
+        order.status = PolymarketOrderStatus::Canceled;
+        order.original_size = "abc".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(order.id.as_str());
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-CORRUPT-TERMINAL",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Order(order), &ctx, &mut state);
+
+        match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Canceled(event)) => {
+                assert_eq!(event.venue_order_id, Some(venue_order_id));
+            }
+            other => panic!("expected terminal cancel, was {other:?}"),
+        }
+    }
+
+    #[rstest]
+    #[case::partial_fak(PolymarketOrderType::FAK, true)]
+    #[case::partial_gtc(PolymarketOrderType::GTC, false)]
+    fn test_corrupt_partial_matched_order_salvages_only_fak_as_canceled(
+        #[case] order_type: PolymarketOrderType,
+        #[case] expect_canceled: bool,
+    ) {
+        let mut order: PolymarketUserOrder = load("ws_user_order_placement.json");
+        order.status = PolymarketOrderStatus::Matched;
+        order.order_type = order_type;
+        order.original_size = "100".to_string();
+        order.size_matched = "50".to_string();
+        order.price = "NaN".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(order.id.as_str());
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-CORRUPT-PARTIAL-MATCHED",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Order(order), &ctx, &mut state);
+
+        if expect_canceled {
+            match receiver.try_recv().expect("expected salvaged cancellation") {
+                ExecutionEvent::Order(OrderEventAny::Canceled(canceled)) => {
+                    assert_eq!(canceled.venue_order_id, Some(venue_order_id));
+                    assert_eq!(
+                        canceled.client_order_id,
+                        ClientOrderId::from("O-CORRUPT-PARTIAL-MATCHED")
+                    );
+                }
+                other => panic!("expected salvaged cancellation, was {other:?}"),
+            }
+        }
+
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_corrupt_order_update_does_not_register_zero_submitted_qty() {
+        let mut order: PolymarketUserOrder = load("ws_user_order_placement.json");
+        order.original_size = "abc".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(order.asset_id, instrument);
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(order.id.as_str());
+        let pending_submits = PendingSubmitTracker::default();
+        pending_submits.insert(venue_order_id, ClientOrderId::from("O-CORRUPT-SUBMIT"));
+        let order_identities = OrderIdentityRegistry::default();
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Order(order), &ctx, &mut state);
+
+        assert!(!fill_tracker.contains(&venue_order_id));
+        assert!(receiver.try_recv().is_err());
     }
 
     #[rstest]
@@ -1596,6 +2475,73 @@ mod tests {
     }
 
     #[rstest]
+    fn test_maker_trade_without_owned_leg_retries_corrected_delivery() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let owned_order = trade.maker_orders[0].clone();
+        let venue_order_id = VenueOrderId::from(owned_order.order_id.as_str());
+        trade.maker_orders[0].maker_address =
+            "0x0000000000000000000000000000000000000001".to_string();
+        trade.maker_orders[0].owner = "foreign-api-key".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(owned_order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-MAKER-CORRECTED-OWNERSHIP",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &owned_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(receiver.try_recv().is_err());
+        assert!(!state.processed_fills.contains(&trade.id));
+
+        trade.status = PolymarketTradeStatus::Confirmed;
+        trade.maker_orders[0] = owned_order.clone();
+        let confirmed =
+            dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        let fill = match receiver.try_recv().expect("expected corrected maker fill") {
+            ExecutionEvent::Order(OrderEventAny::Filled(fill)) => fill,
+            other => panic!("expected corrected maker fill, was {other:?}"),
+        };
+        assert_eq!(fill.venue_order_id, venue_order_id);
+        assert!(confirmed.is_some());
+        assert!(state.processed_fills.contains(&trade.id));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
     fn test_dispatch_trade_dedup() {
         let trade: PolymarketUserTrade = load("ws_user_trade.json");
         let instrument = test_instrument();
@@ -1630,6 +2576,42 @@ mod tests {
         // Second dispatch should be deduped, no additional fill
         let _ = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
         assert_eq!(fill_tracker.pending_fills_for(&venue_order_id).len(), 1);
+    }
+
+    #[rstest]
+    fn test_restored_raw_trade_id_suppresses_websocket_redelivery() {
+        let trade: PolymarketUserTrade = load("ws_user_trade.json");
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument);
+        let fill_tracker = OrderFillTrackerMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+        let raw_trade_id = trade.id.clone();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        state.restore_matched_trade(raw_trade_id.clone(), Vec::new());
+
+        let refresh = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        assert!(refresh.is_some());
+        assert!(state.processed_fills.contains(&raw_trade_id));
+        assert!(fill_tracker.pending_fills_for(&venue_order_id).is_empty());
+        assert!(receiver.try_recv().is_err());
     }
 
     #[rstest]
@@ -1748,27 +2730,14 @@ mod tests {
             other => panic!("expected matched fill, was {other:?}"),
         };
         trade.status = crate::common::enums::PolymarketTradeStatus::Failed;
-        let failed = dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let failed = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
         let voided = match receiver.try_recv().unwrap() {
             ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
             other => panic!("expected failed fill correction, was {other:?}"),
         };
 
-        let mut failed_first_state = WsDispatchState::default();
-        let failed_first = dispatch_user_message(
-            &UserWsMessage::Trade(trade.clone()),
-            &ctx,
-            &mut failed_first_state,
-        );
-        let dedup_key = format!("{}-{}", trade.id, trade.taker_order_id);
-        trade.status = crate::common::enums::PolymarketTradeStatus::Matched;
-        let matched_after_failure =
-            dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut failed_first_state);
-
         assert!(matched.is_none());
         assert!(failed.is_some());
-        assert!(failed_first.is_some());
-        assert!(matched_after_failure.is_none());
         assert_eq!(voided.trade_id, filled.trade_id);
         assert_eq!(voided.voided_qty, filled.last_qty);
         assert_eq!(voided.commission_voided, filled.commission);
@@ -1779,8 +2748,1859 @@ mod tests {
             fill_tracker.get_cumulative_filled(&venue_order_id),
             Some(Quantity::zero(instrument.size_precision()))
         );
-        assert!(failed_first_state.processed_fills.contains(&dedup_key));
-        assert!(failed_first_state.is_voided_trade(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_taker_trade_uses_recorded_applied_quantity() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = crate::common::enums::PolymarketTradeStatus::Failed;
+        trade.size = "714.285714".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_qty = Quantity::from("714.285710");
+        record_applied_pending_fill(
+            &fill_tracker,
+            trade_id,
+            venue_order_id,
+            applied_qty,
+            "O-REST-FAILED",
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-REST-FAILED",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        let failed = dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected message-derived fill correction, was {other:?}"),
+        };
+        let duplicate =
+            dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let dedup_key = trade.id;
+
+        assert!(failed.is_some());
+        assert!(duplicate.is_some());
+        assert_eq!(voided.venue_order_id, venue_order_id);
+        assert_eq!(voided.trade_id, trade_id);
+        assert_eq!(voided.voided_qty, applied_qty);
+        assert!(state.processed_fills.contains(&dedup_key));
+        assert!(state.is_voided_trade(&dedup_key));
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_taker_trade_voids_carried_rest_evidence_without_ws_fill() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = crate::common::enums::PolymarketTradeStatus::Failed;
+        trade.size = "714.285714".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_qty = Quantity::from("714.285710");
+        let applied_fill = record_applied_pending_fill(
+            &fill_tracker,
+            trade_id,
+            venue_order_id,
+            applied_qty,
+            "O-REST-FAILED",
+        );
+        let later_trade_id = TradeId::from("later-rest-trade");
+        let later_venue_order_id = VenueOrderId::from("later-rest-order");
+        record_applied_pending_fill(
+            &fill_tracker,
+            later_trade_id,
+            later_venue_order_id,
+            Quantity::from("5.000000"),
+            "O-LATER-REST-EVIDENCE",
+        );
+
+        assert_eq!(
+            fill_tracker.rest_applied_pending_fills(&trade_id),
+            vec![applied_fill],
+        );
+
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-REST-FAILED",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        let failed = dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected message-derived fill correction, was {other:?}"),
+        };
+        let duplicate =
+            dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let dedup_key = trade.id;
+
+        assert!(failed.is_some());
+        assert!(duplicate.is_some());
+        assert_eq!(voided.venue_order_id, venue_order_id);
+        assert_eq!(voided.trade_id, trade_id);
+        assert_eq!(voided.voided_qty, applied_qty);
+        assert!(state.processed_fills.contains(&dedup_key));
+        assert!(state.is_voided_trade(&dedup_key));
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_identity_incomplete_evidence_void_stays_retryable() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Failed;
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_fill = AppliedPendingFill {
+            venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id,
+            client_order_id: None,
+            strategy_id: None,
+            order_type: None,
+            order_side: OrderSide::Buy,
+            last_qty: Quantity::from("25.000000"),
+            last_px: Price::from("0.50"),
+            commission: Money::zero(get_pusd_currency()),
+            liquidity_side: LiquiditySide::Taker,
+        };
+        record_applied_pending_fills(&fill_tracker, &[(trade_id, applied_fill.clone())]);
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-REST-IDENTITY-EVICTED",
+        );
+
+        for index in 0..10_000 {
+            let eviction_venue_order_id = VenueOrderId::from(format!("V-EVICT-{index}").as_str());
+            let eviction_client_order_id = format!("O-EVICT-{index}");
+            register_identity(
+                &order_identities,
+                eviction_venue_order_id,
+                instrument.id(),
+                &eviction_client_order_id,
+            );
+        }
+
+        assert!(order_identities.get(&venue_order_id).is_none());
+
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+        let dedup_key = trade.id.clone();
+
+        let deferred =
+            dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(deferred.is_none());
+        assert!(!state.processed_fills.contains(&dedup_key));
+        assert!(!state.is_voided_trade(&dedup_key));
+        assert_eq!(
+            fill_tracker.rest_applied_pending_fills(&trade_id),
+            vec![applied_fill.clone()],
+        );
+        assert!(receiver.try_recv().is_err());
+
+        let redelivered = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        assert!(redelivered.is_none());
+        assert!(!state.processed_fills.contains(&dedup_key));
+        assert!(!state.is_voided_trade(&dedup_key));
+        assert_eq!(
+            fill_tracker.rest_applied_pending_fills(&trade_id),
+            vec![applied_fill],
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_taker_trade_uses_full_recorded_fill_fidelity() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Failed;
+        trade.price = "0.75".to_string();
+        trade.fee_rate_bps = "250".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_fill = AppliedPendingFill {
+            venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id,
+            client_order_id: Some(ClientOrderId::from("O-REST-FIDELITY")),
+            strategy_id: Some(StrategyId::from("S-001")),
+            order_type: Some(OrderType::Limit),
+            order_side: OrderSide::Buy,
+            last_qty: Quantity::from("17.000000"),
+            last_px: Price::from("0.33"),
+            commission: Money::new(1.125, get_pusd_currency()),
+            liquidity_side: LiquiditySide::Maker,
+        };
+        record_applied_pending_fills(&fill_tracker, &[(trade_id, applied_fill.clone())]);
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-REST-FIDELITY",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected fidelity fill correction, was {other:?}"),
+        };
+        assert_eq!(voided.venue_order_id, venue_order_id);
+        assert_eq!(voided.voided_qty, applied_fill.last_qty);
+        assert_eq!(voided.last_px, applied_fill.last_px);
+        assert_eq!(voided.commission_voided, Some(applied_fill.commission));
+        assert_eq!(voided.liquidity_side, applied_fill.liquidity_side);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_corrected_maker_redelivery_emits_only_the_dropped_leg() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let first_order = trade.maker_orders[0].clone();
+        let mut second_order = second_owned_maker_order(&trade);
+        second_order.matched_amount = Decimal::ZERO;
+        trade.maker_orders.push(second_order.clone());
+        let first_venue_order_id = VenueOrderId::from(first_order.order_id.as_str());
+        let second_venue_order_id = VenueOrderId::from(second_order.order_id.as_str());
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(first_order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+
+        for venue_order_id in [first_venue_order_id, second_venue_order_id] {
+            fill_tracker.register(
+                venue_order_id,
+                Quantity::from("100.000000"),
+                OrderSide::Buy,
+                instrument.id(),
+                instrument.size_precision(),
+                instrument.price_precision(),
+            );
+        }
+
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            first_venue_order_id,
+            instrument.id(),
+            "O-LEG-VALID",
+        );
+        register_identity(
+            &order_identities,
+            second_venue_order_id,
+            instrument.id(),
+            "O-LEG-CORRUPT",
+        );
+        order_identities.mark_accepted(first_venue_order_id);
+        order_identities.mark_accepted(second_venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &first_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        let first_fill = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected first maker leg fill, was {other:?}"),
+        };
+        assert_eq!(first_fill.venue_order_id, first_venue_order_id);
+        assert!(receiver.try_recv().is_err());
+
+        trade.status = PolymarketTradeStatus::Confirmed;
+        trade.maker_orders[1].matched_amount = Decimal::from_str("7").unwrap();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let second_fill = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected corrected maker leg fill, was {other:?}"),
+        };
+        assert_eq!(second_fill.venue_order_id, second_venue_order_id);
+        assert_eq!(second_fill.last_qty, Quantity::from("7.000000"));
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&first_venue_order_id),
+            Some(first_fill.last_qty),
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_all_invalid_confirmed_defers_terminal_normalization_until_corrected() {
+        let mut order: PolymarketUserOrder = load("ws_user_order_placement.json");
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let maker_order = trade.maker_orders[0].clone();
+        let venue_order_id = VenueOrderId::from(maker_order.order_id.as_str());
+        order.id = maker_order.order_id.clone();
+        order.status = PolymarketOrderStatus::Matched;
+        order.associate_trades = Some(vec![trade.id.clone()]);
+        order.original_size = "100".to_string();
+        order.size_matched = "99.995".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(maker_order.asset_id, instrument.clone());
+        token_instruments.insert(order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-DEFERRED-NORMALIZATION",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &maker_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Order(order), &ctx, &mut state);
+
+        while receiver.try_recv().is_ok() {}
+
+        trade.status = PolymarketTradeStatus::Confirmed;
+        trade.maker_orders[0].matched_amount = Decimal::ZERO;
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(receiver.try_recv().is_err());
+
+        trade.maker_orders[0].matched_amount = Decimal::from_str("99.995").unwrap();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let fill = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected corrected maker fill, was {other:?}"),
+        };
+        assert_eq!(fill.last_qty, Quantity::from("99.995000"));
+
+        let updated = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Updated(event)) => event,
+            other => panic!("expected terminal quantity normalization, was {other:?}"),
+        };
+        assert_eq!(updated.quantity, Quantity::from("99.995000"));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_maker_trade_voids_union_of_ws_and_rest_orders() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let first_order = trade.maker_orders[0].clone();
+        let second_order = second_owned_maker_order(&trade);
+        let first_venue_order_id = VenueOrderId::from(first_order.order_id.as_str());
+        let second_venue_order_id = VenueOrderId::from(second_order.order_id.as_str());
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(first_order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        fill_tracker.register(
+            first_venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            first_venue_order_id,
+            instrument.id(),
+            "O-UNION-WS",
+        );
+        register_identity(
+            &order_identities,
+            second_venue_order_id,
+            instrument.id(),
+            "O-UNION-REST",
+        );
+        order_identities.mark_accepted(first_venue_order_id);
+        order_identities.mark_accepted(second_venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &first_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let ws_fill = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected maker fill, was {other:?}"),
+        };
+        trade.maker_orders.push(second_order);
+        let trade_id = TradeId::from(trade.id.as_str());
+        let rest_fill = AppliedPendingFill {
+            venue_order_id: second_venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id: make_composite_trade_id(&trade.id, second_venue_order_id.as_str()),
+            client_order_id: Some(ClientOrderId::from("O-UNION-REST")),
+            strategy_id: Some(StrategyId::from("S-001")),
+            order_type: Some(OrderType::Limit),
+            order_side: OrderSide::Buy,
+            last_qty: Quantity::from("11.000000"),
+            last_px: Price::from("0.42"),
+            commission: Money::new(1.25, get_pusd_currency()),
+            liquidity_side: LiquiditySide::Maker,
+        };
+        record_applied_pending_fills(&fill_tracker, &[(trade_id, rest_fill.clone())]);
+        trade.status = PolymarketTradeStatus::Failed;
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let first_void = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected first fill correction, was {other:?}"),
+        };
+        let second_void = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected second fill correction, was {other:?}"),
+        };
+        let rest_void = if first_void.venue_order_id == second_venue_order_id {
+            first_void
+        } else {
+            second_void
+        };
+
+        assert_eq!(ws_fill.venue_order_id, first_venue_order_id);
+        assert_eq!(rest_void.venue_order_id, second_venue_order_id);
+        assert_eq!(rest_void.voided_qty, rest_fill.last_qty);
+        assert_eq!(rest_void.last_px, rest_fill.last_px);
+        assert_eq!(rest_void.commission_voided, Some(rest_fill.commission));
+        assert_eq!(rest_void.liquidity_side, rest_fill.liquidity_side);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_union_voids_evidence_order_despite_unknown_payload_asset() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let first_order = trade.maker_orders[0].clone();
+        let mut second_order = second_owned_maker_order(&trade);
+        second_order.asset_id = Ustr::from("missing-union-asset");
+        let first_venue_order_id = VenueOrderId::from(first_order.order_id.as_str());
+        let second_venue_order_id = VenueOrderId::from(second_order.order_id.as_str());
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(first_order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        fill_tracker.register(
+            first_venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            first_venue_order_id,
+            instrument.id(),
+            "O-UNION-DEFER-WS",
+        );
+        register_identity(
+            &order_identities,
+            second_venue_order_id,
+            instrument.id(),
+            "O-UNION-DEFER-REST",
+        );
+        order_identities.mark_accepted(first_venue_order_id);
+        order_identities.mark_accepted(second_venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &first_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+        let dedup_key = trade.id.clone();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let ws_fill = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected maker fill, was {other:?}"),
+        };
+        trade.maker_orders.push(second_order);
+        let trade_id = TradeId::from(trade.id.as_str());
+        let rest_fill = AppliedPendingFill {
+            venue_order_id: second_venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id: make_composite_trade_id(&trade.id, second_venue_order_id.as_str()),
+            client_order_id: Some(ClientOrderId::from("O-UNION-DEFER-REST")),
+            strategy_id: Some(StrategyId::from("S-001")),
+            order_type: Some(OrderType::Limit),
+            order_side: OrderSide::Buy,
+            last_qty: Quantity::from("9.000000"),
+            last_px: Price::from("0.41"),
+            commission: Money::new(0.75, get_pusd_currency()),
+            liquidity_side: LiquiditySide::Maker,
+        };
+        record_applied_pending_fills(&fill_tracker, &[(trade_id, rest_fill.clone())]);
+        trade.status = PolymarketTradeStatus::Failed;
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        let first_void = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected first fill correction, was {other:?}"),
+        };
+        let second_void = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected second fill correction, was {other:?}"),
+        };
+        let (rest_void, ws_void) = if first_void.venue_order_id == second_venue_order_id {
+            (&first_void, &second_void)
+        } else {
+            (&second_void, &first_void)
+        };
+
+        assert_eq!(rest_void.venue_order_id, second_venue_order_id);
+        assert_eq!(rest_void.voided_qty, rest_fill.last_qty);
+        assert_eq!(rest_void.last_px, rest_fill.last_px);
+        assert_eq!(ws_void.venue_order_id, first_venue_order_id);
+        assert_eq!(ws_void.voided_qty, ws_fill.last_qty);
+        assert_eq!(state.matched_fill_count(&dedup_key), 0);
+        assert!(state.is_voided_trade(&dedup_key));
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&first_venue_order_id),
+            Some(Quantity::zero(instrument.size_precision())),
+        );
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+        assert!(receiver.try_recv().is_err());
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_without_evidence_allows_redelivery_after_evidence_appears() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = crate::common::enums::PolymarketTradeStatus::Failed;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let maker_order = trade.maker_orders[0].clone();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(maker_order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(maker_order.order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_qty = Quantity::from("25.000000");
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-MAKER-REST-FAILED",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &maker_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let dedup_key = trade.id.clone();
+
+        assert!(state.processed_fills.contains(&dedup_key));
+        assert!(!state.is_voided_trade(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+
+        let noted_fill = AppliedPendingFill {
+            venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id: make_composite_trade_id(&trade.id, venue_order_id.as_str()),
+            client_order_id: Some(ClientOrderId::from("O-MAKER-REST-FAILED")),
+            strategy_id: Some(StrategyId::from("S-001")),
+            order_type: Some(OrderType::Limit),
+            order_side: OrderSide::Buy,
+            last_qty: applied_qty,
+            last_px: Price::from("0.50"),
+            commission: Money::zero(get_pusd_currency()),
+            liquidity_side: LiquiditySide::Maker,
+        };
+        fill_tracker.begin_rest_applied_pending_pass();
+        let withheld = fill_tracker.record_rest_applied_pending_fills(&[(trade_id, noted_fill)]);
+        assert_eq!(withheld, AHashSet::from_iter([trade_id]));
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+
+        let fill_tracker = OrderFillTrackerMap::new();
+        record_applied_pending_fill(
+            &fill_tracker,
+            trade_id,
+            venue_order_id,
+            applied_qty,
+            "O-MAKER-REST-FAILED",
+        );
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &maker_order.maker_address,
+            user_api_key: "test-key",
+        };
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected redelivered fill correction, was {other:?}"),
+        };
+        assert_eq!(voided.venue_order_id, venue_order_id);
+        assert_eq!(voided.voided_qty, applied_qty);
+        assert!(state.is_voided_trade(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_fresh_failed_trade_without_evidence_warns_once_and_is_processed() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.id = "fresh-failed-no-evidence".to_string();
+        trade.status = PolymarketTradeStatus::Failed;
+        let token_instruments = AtomicMap::new();
+        let fill_tracker = OrderFillTrackerMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let emitter = test_emitter();
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+        let log_start = capture_start();
+
+        let refresh = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        assert!(refresh.is_some());
+        assert!(
+            state
+                .processed_fills
+                .contains(&"fresh-failed-no-evidence".to_string())
+        );
+        let matching_logs = records_since(log_start)
+            .into_iter()
+            .filter(|(_, message)| message.contains("fresh-failed-no-evidence"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matching_logs,
+            vec![(
+                log::Level::Warn,
+                "Ignoring failed trade fresh-failed-no-evidence: no fill was applied for this trade, or correction evidence was lost to restart/eviction"
+                    .to_string(),
+            )],
+        );
+    }
+
+    #[rstest]
+    fn test_failed_trade_with_evicted_rest_evidence_stays_retryable() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Failed;
+        let trade_id = TradeId::from(trade.id.as_str());
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let instrument_id = test_instrument().id();
+        let mut applied_fills = Vec::with_capacity(10_001);
+        applied_fills.push((
+            trade_id,
+            AppliedPendingFill {
+                venue_order_id,
+                instrument_id,
+                trade_id,
+                client_order_id: None,
+                strategy_id: None,
+                order_type: None,
+                order_side: OrderSide::Buy,
+                last_qty: Quantity::from("1.000000"),
+                last_px: Price::from("0.50"),
+                commission: Money::zero(get_pusd_currency()),
+                liquidity_side: LiquiditySide::Taker,
+            },
+        ));
+
+        for index in 0..10_000 {
+            let evidence_trade_id = TradeId::from(format!("REST-EVICT-{index}").as_str());
+            applied_fills.push((
+                evidence_trade_id,
+                AppliedPendingFill {
+                    venue_order_id: VenueOrderId::from(format!("REST-ORDER-{index}").as_str()),
+                    instrument_id,
+                    trade_id: evidence_trade_id,
+                    client_order_id: None,
+                    strategy_id: None,
+                    order_type: None,
+                    order_side: OrderSide::Buy,
+                    last_qty: Quantity::from("1.000000"),
+                    last_px: Price::from("0.50"),
+                    commission: Money::zero(get_pusd_currency()),
+                    liquidity_side: LiquiditySide::Taker,
+                },
+            ));
+        }
+
+        record_applied_pending_fills(&fill_tracker, &applied_fills);
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+
+        let token_instruments = AtomicMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+        let dedup_key = trade.id.clone();
+
+        let deferred = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        assert!(deferred.is_none());
+        assert!(!state.processed_fills.contains(&dedup_key));
+        assert!(!state.is_voided_trade(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_trade_with_evicted_buffered_evidence_stays_retryable() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Failed;
+        let trade_id = TradeId::from(trade.id.as_str());
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let dedup_key = trade.id.clone();
+        let target_fill = test_order_filled(venue_order_id, trade_id, "O-BUFFERED-EVICTED");
+        let target_correction = FillCorrectionMetadata {
+            correction_key: dedup_key.clone(),
+            trade_id,
+            info: None,
+            is_confirmed: false,
+            track_fill: true,
+        };
+        let fill_tracker = OrderFillTrackerMap::new();
+        assert!(fill_tracker.emit_buffered_fill(
+            target_fill.clone(),
+            Some(&target_correction),
+            |_, _| {},
+        ));
+
+        for index in 0..10_000 {
+            let correction_key = format!("BUFFERED-EVICT-{index}");
+            let correction = FillCorrectionMetadata {
+                correction_key,
+                trade_id: TradeId::from(format!("BUFFERED-TRADE-{index}").as_str()),
+                info: None,
+                is_confirmed: false,
+                track_fill: true,
+            };
+            let fill = test_order_filled(
+                VenueOrderId::from(format!("BUFFERED-ORDER-{index}").as_str()),
+                correction.trade_id,
+                "O-BUFFERED-EVICTION-FILLER",
+            );
+            assert!(fill_tracker.emit_buffered_fill(fill, Some(&correction), |_, _| {}));
+        }
+
+        let token_instruments = AtomicMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        let deferred =
+            dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(deferred.is_none());
+        assert!(!state.processed_fills.contains(&dedup_key));
+        assert!(!state.is_voided_trade(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+        assert!(fill_tracker.emit_buffered_fill(
+            target_fill.clone(),
+            Some(&target_correction),
+            |_, _| {},
+        ));
+
+        let retried = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected retried buffered fill correction, was {other:?}"),
+        };
+
+        assert!(retried.is_some());
+        assert_eq!(voided.trade_id, target_fill.trade_id);
+        assert!(state.processed_fills.contains(&dedup_key));
+        assert!(state.is_voided_trade(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_trade_removes_buffered_evidence_before_empty_decision() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Failed;
+        let trade_id = TradeId::from(trade.id.as_str());
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let dedup_key = trade.id.clone();
+        let correction = FillCorrectionMetadata {
+            correction_key: dedup_key.clone(),
+            trade_id,
+            info: None,
+            is_confirmed: false,
+            track_fill: true,
+        };
+        let fill_tracker = Arc::new(OrderFillTrackerMap::new());
+        let hook_tracker = Arc::clone(&fill_tracker);
+        let buffered_fill_landed = Arc::new(AtomicBool::new(false));
+        let hook_buffered_fill_landed = Arc::clone(&buffered_fill_landed);
+        VOID_FAILED_AFTER_BUFFERED_EVIDENCE_REMOVAL.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                let fill = test_order_filled(venue_order_id, trade_id, "O-RACING-BUFFERED-FILL");
+                let landed = hook_tracker.emit_buffered_fill(fill, Some(&correction), |_, _| {});
+                hook_buffered_fill_landed.store(landed, Ordering::SeqCst);
+            }));
+        });
+
+        let token_instruments = AtomicMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        let refresh = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        assert!(refresh.is_some());
+        assert!(!buffered_fill_landed.load(Ordering::SeqCst));
+        assert!(state.processed_fills.contains(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_trade_with_evicted_evidence_survives_rest_passes() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Failed;
+        let trade_id = TradeId::from(trade.id.as_str());
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let dedup_key = trade.id.clone();
+        let target_fill = test_order_filled(venue_order_id, trade_id, "O-MATCHED-EVICTED");
+        let mut state = WsDispatchState::default();
+        state.restore_matched_trade(dedup_key.clone(), vec![target_fill]);
+
+        for index in 0..10_000 {
+            let eviction_key = format!("MATCHED-EVICT-{index}");
+            let fill = test_order_filled(
+                VenueOrderId::from(format!("MATCHED-ORDER-{index}").as_str()),
+                TradeId::from(format!("MATCHED-TRADE-{index}").as_str()),
+                "O-MATCHED-EVICTION-FILLER",
+            );
+            state.restore_matched_trade(eviction_key, vec![fill]);
+        }
+
+        assert_eq!(state.matched_fill_count(&dedup_key), 0);
+
+        let token_instruments = AtomicMap::new();
+        let fill_tracker = OrderFillTrackerMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+
+        let deferred =
+            dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(deferred.is_none());
+        assert!(!state.processed_fills.contains(&dedup_key));
+        assert!(!state.is_voided_trade(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+
+        let still_deferred =
+            dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(still_deferred.is_none());
+        assert!(!state.processed_fills.contains(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+
+        for _ in 0..5 {
+            fill_tracker.begin_rest_applied_pending_pass();
+            let withheld = fill_tracker.record_rest_applied_pending_fills(&[]);
+
+            assert!(withheld.is_empty());
+
+            let retried =
+                dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+            assert!(retried.is_none());
+            assert!(!state.processed_fills.contains(&dedup_key));
+            assert!(!state.is_voided_trade(&dedup_key));
+            assert!(receiver.try_recv().is_err());
+        }
+    }
+
+    #[rstest]
+    fn test_evidence_void_carries_the_composite_trade_id_of_the_applied_fill() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Failed;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        let fill_tracker = OrderFillTrackerMap::new();
+        let maker_order = trade.maker_orders[0].clone();
+        let venue_order_id = VenueOrderId::from(maker_order.order_id.as_str());
+        let raw_trade_id = TradeId::from(trade.id.as_str());
+        let composite_trade_id = make_composite_trade_id(&trade.id, maker_order.order_id.as_str());
+
+        assert_ne!(composite_trade_id, raw_trade_id);
+
+        let applied_fill = AppliedPendingFill {
+            venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id: composite_trade_id,
+            client_order_id: Some(ClientOrderId::from("O-COMPOSITE-VOID")),
+            strategy_id: Some(StrategyId::from("S-001")),
+            order_type: Some(OrderType::Limit),
+            order_side: OrderSide::Buy,
+            last_qty: Quantity::from("12.000000"),
+            last_px: Price::from("0.40"),
+            commission: Money::zero(get_pusd_currency()),
+            liquidity_side: LiquiditySide::Maker,
+        };
+        record_applied_pending_fills(&fill_tracker, &[(raw_trade_id, applied_fill)]);
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-COMPOSITE-VOID",
+        );
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &maker_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected evidence-derived fill correction, was {other:?}"),
+        };
+
+        assert_eq!(voided.trade_id, composite_trade_id);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_evidence_void_uses_recorded_identity_after_identity_eviction() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Failed;
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let client_order_id = ClientOrderId::from("O-EVICTED-IDENTITY");
+        let strategy_id = StrategyId::from("S-EVICTED-IDENTITY");
+        let order_type = OrderType::Market;
+        let applied_fill = AppliedPendingFill {
+            venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id,
+            client_order_id: Some(client_order_id),
+            strategy_id: Some(strategy_id),
+            order_type: Some(order_type),
+            order_side: OrderSide::Buy,
+            last_qty: Quantity::from("25.000000"),
+            last_px: Price::from("0.40"),
+            commission: Money::zero(get_pusd_currency()),
+            liquidity_side: LiquiditySide::Taker,
+        };
+        record_applied_pending_fills(&fill_tracker, &[(trade_id, applied_fill)]);
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected evidence-derived fill correction, was {other:?}"),
+        };
+
+        assert_eq!(voided.client_order_id, client_order_id);
+        assert_eq!(voided.strategy_id, strategy_id);
+        assert_eq!(voided.order_type, order_type);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_trade_with_corrupt_taker_order_id_voids_ws_held_fill() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-CORRUPT-TAKER-KEY",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let ws_fill = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected taker fill, was {other:?}"),
+        };
+
+        trade.status = PolymarketTradeStatus::Failed;
+        trade.taker_order_id = "0xCORRUPT".to_string();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected fill correction, was {other:?}"),
+        };
+        assert_eq!(voided.venue_order_id, venue_order_id);
+        assert_eq!(voided.voided_qty, ws_fill.last_qty);
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&venue_order_id),
+            Some(Quantity::zero(instrument.size_precision())),
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_trade_with_evidence_voids_without_payload_instrument() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = crate::common::enums::PolymarketTradeStatus::Failed;
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_qty = Quantity::from("25.000000");
+        let applied_fill = record_applied_pending_fill(
+            &fill_tracker,
+            trade_id,
+            venue_order_id,
+            applied_qty,
+            "O-REST-REPLAY",
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-REST-REPLAY",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+        let dedup_key = trade.id.clone();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected evidence-derived fill correction, was {other:?}"),
+        };
+        assert_eq!(voided.voided_qty, applied_qty);
+        assert_eq!(voided.last_px, applied_fill.last_px);
+        assert!(state.processed_fills.contains(&dedup_key));
+        assert!(state.is_voided_trade(&dedup_key));
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_failed_trade_with_ws_and_evidence_for_same_order_voids_evidence_values() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-WS-VS-EVIDENCE",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        let ws_fill = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected taker fill, was {other:?}"),
+        };
+
+        let evidence_fill = AppliedPendingFill {
+            venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id,
+            client_order_id: Some(ClientOrderId::from("O-WS-VS-EVIDENCE")),
+            strategy_id: Some(StrategyId::from("S-001")),
+            order_type: Some(OrderType::Limit),
+            order_side: OrderSide::Buy,
+            last_qty: ws_fill.last_qty,
+            last_px: Price::from("0.40"),
+            commission: Money::zero(get_pusd_currency()),
+            liquidity_side: LiquiditySide::Taker,
+        };
+        record_applied_pending_fills(&fill_tracker, &[(trade_id, evidence_fill.clone())]);
+        trade.status = PolymarketTradeStatus::Failed;
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let voided = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::FillVoided(event)) => event,
+            other => panic!("expected evidence-derived fill correction, was {other:?}"),
+        };
+        assert_eq!(voided.last_px, evidence_fill.last_px);
+        assert_eq!(voided.voided_qty, evidence_fill.last_qty);
+        assert!(receiver.try_recv().is_err());
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&venue_order_id),
+            Some(Quantity::zero(instrument.size_precision())),
+        );
+    }
+
+    #[rstest]
+    fn test_invalid_matched_then_valid_confirmed_emits_fill_once() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        let valid_size = trade.size.clone();
+        trade.size = "0".to_string();
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-INVALID-THEN-VALID",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+        let dedup_key = trade.id.clone();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(!state.processed_fills.contains(&dedup_key));
+        assert!(receiver.try_recv().is_err());
+
+        trade.status = PolymarketTradeStatus::Confirmed;
+        trade.size = valid_size;
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let fill = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected fill after corrected redelivery, was {other:?}"),
+        };
+        assert_eq!(fill.venue_order_id, venue_order_id);
+        assert!(state.processed_fills.contains(&dedup_key));
+    }
+
+    #[rstest]
+    fn test_confirmed_trade_with_rest_evidence_does_not_reemit_fill() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = crate::common::enums::PolymarketTradeStatus::Confirmed;
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_qty = Quantity::from("25.000000");
+        fill_tracker.restore_order(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            applied_qty,
+            OrderSide::Buy,
+        );
+        record_applied_pending_fill(
+            &fill_tracker,
+            trade_id,
+            venue_order_id,
+            applied_qty,
+            "O-REST-CONFIRMED",
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-REST-CONFIRMED",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+        let dedup_key = trade.id.clone();
+
+        let refresh = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        assert!(refresh.is_some());
+        assert!(state.processed_fills.contains(&dedup_key));
+        assert!(fill_tracker.is_trade_confirmed(&dedup_key));
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&venue_order_id),
+            Some(applied_qty),
+        );
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_confirmed_maker_trade_suppresses_only_evidence_order_without_matched() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Confirmed;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let first_order = trade.maker_orders[0].clone();
+        let second_order = second_owned_maker_order(&trade);
+        trade.maker_orders.push(second_order.clone());
+        let first_venue_order_id = VenueOrderId::from(first_order.order_id.as_str());
+        let second_venue_order_id = VenueOrderId::from(second_order.order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_qty = Quantity::from("25.000000");
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(first_order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        fill_tracker.restore_order(
+            first_venue_order_id,
+            Quantity::from("100.000000"),
+            applied_qty,
+            OrderSide::Buy,
+        );
+        fill_tracker.register(
+            second_venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let applied_fill = AppliedPendingFill {
+            venue_order_id: first_venue_order_id,
+            instrument_id: instrument.id(),
+            trade_id: make_composite_trade_id(&trade.id, first_venue_order_id.as_str()),
+            client_order_id: Some(ClientOrderId::from("O-CONFIRMED-EVIDENCE")),
+            strategy_id: Some(StrategyId::from("S-001")),
+            order_type: Some(OrderType::Limit),
+            order_side: OrderSide::Buy,
+            last_qty: applied_qty,
+            last_px: Price::from("0.50"),
+            commission: Money::zero(get_pusd_currency()),
+            liquidity_side: LiquiditySide::Maker,
+        };
+        record_applied_pending_fills(&fill_tracker, &[(trade_id, applied_fill)]);
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            first_venue_order_id,
+            instrument.id(),
+            "O-CONFIRMED-EVIDENCE",
+        );
+        register_identity(
+            &order_identities,
+            second_venue_order_id,
+            instrument.id(),
+            "O-CONFIRMED-UNCOVERED",
+        );
+        order_identities.mark_accepted(first_venue_order_id);
+        order_identities.mark_accepted(second_venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &first_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let filled = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected uncovered confirmed maker fill, was {other:?}"),
+        };
+        assert_eq!(filled.venue_order_id, second_venue_order_id);
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&first_venue_order_id),
+            Some(applied_qty),
+        );
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&second_venue_order_id),
+            Some(applied_qty),
+        );
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_confirmed_rest_evidence_suppresses_buffered_ws_fill() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = crate::common::enums::PolymarketTradeStatus::Matched;
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_qty = Quantity::from("25.000000");
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            "O-REST-BUFFERED",
+        );
+        order_identities.mark_accepted(venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        assert_eq!(fill_tracker.pending_fills_for(&venue_order_id).len(), 1);
+        assert!(receiver.try_recv().is_err());
+
+        record_applied_pending_fill(
+            &fill_tracker,
+            trade_id,
+            venue_order_id,
+            applied_qty,
+            "O-REST-BUFFERED",
+        );
+        trade.status = crate::common::enums::PolymarketTradeStatus::Confirmed;
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let buffered = fill_tracker.register_and_take_pending_fills(
+            venue_order_id,
+            Some(ClientOrderId::from("O-REST-BUFFERED")),
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+        );
+        let identity = order_identities.get(&venue_order_id).unwrap();
+        emit_buffered_order_filled(&identity, &buffered[0], &ctx);
+
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&venue_order_id),
+            Some(Quantity::zero(6)),
+        );
+        assert!(
+            fill_tracker
+                .rest_applied_pending_fills(&trade_id)
+                .is_empty()
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_confirmed_rest_evidence_suppresses_only_applied_maker_fill() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = crate::common::enums::PolymarketTradeStatus::Matched;
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        let first_order = trade.maker_orders[0].clone();
+        let mut second_order = first_order.clone();
+        second_order.order_id =
+            "0xmaker02maker02maker02maker02maker02maker02maker02maker02maker02maker02".to_string();
+        trade.maker_orders.push(second_order.clone());
+        let instrument = test_instrument();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(first_order.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let first_venue_order_id = VenueOrderId::from(first_order.order_id.as_str());
+        let second_venue_order_id = VenueOrderId::from(second_order.order_id.as_str());
+        let trade_id = TradeId::from(trade.id.as_str());
+        let applied_qty = Quantity::from("25.000000");
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            first_venue_order_id,
+            instrument.id(),
+            "O-REST-MAKER-1",
+        );
+        register_identity(
+            &order_identities,
+            second_venue_order_id,
+            instrument.id(),
+            "O-REST-MAKER-2",
+        );
+        order_identities.mark_accepted(first_venue_order_id);
+        order_identities.mark_accepted(second_venue_order_id);
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &first_order.maker_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        assert_eq!(
+            fill_tracker.pending_fills_for(&first_venue_order_id).len(),
+            1,
+        );
+        assert_eq!(
+            fill_tracker.pending_fills_for(&second_venue_order_id).len(),
+            1,
+        );
+
+        record_applied_pending_fill(
+            &fill_tracker,
+            trade_id,
+            first_venue_order_id,
+            applied_qty,
+            "O-REST-MAKER-1",
+        );
+        trade.status = crate::common::enums::PolymarketTradeStatus::Confirmed;
+        dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        let first_buffered = fill_tracker.register_and_take_pending_fills(
+            first_venue_order_id,
+            Some(ClientOrderId::from("O-REST-MAKER-1")),
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+        );
+        let first_identity = order_identities.get(&first_venue_order_id).unwrap();
+        emit_buffered_order_filled(&first_identity, &first_buffered[0], &ctx);
+        let second_buffered = fill_tracker.register_and_take_pending_fills(
+            second_venue_order_id,
+            Some(ClientOrderId::from("O-REST-MAKER-2")),
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+        );
+        let second_identity = order_identities.get(&second_venue_order_id).unwrap();
+        emit_buffered_order_filled(&second_identity, &second_buffered[0], &ctx);
+
+        let filled = match receiver.try_recv().unwrap() {
+            ExecutionEvent::Order(OrderEventAny::Filled(event)) => event,
+            other => panic!("expected uncovered maker fill, was {other:?}"),
+        };
+
+        assert_eq!(filled.venue_order_id, second_venue_order_id);
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&first_venue_order_id),
+            Some(Quantity::zero(6)),
+        );
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&second_venue_order_id),
+            Some(applied_qty),
+        );
         assert!(receiver.try_recv().is_err());
     }
 
@@ -1821,8 +4641,9 @@ mod tests {
     }
 
     #[rstest]
-    fn test_dispatch_late_fill_falls_back_to_report_after_identity_eviction() {
-        let trade: PolymarketUserTrade = load("ws_user_trade.json");
+    fn test_identity_evicted_raw_fill_stays_retryable_when_trade_fails() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
         let market: GammaMarket = load("gamma_market_sports_market_money_line.json");
         let defs = parse_gamma_market(&market).unwrap();
         let instrument =
@@ -1907,6 +4728,66 @@ mod tests {
         );
         assert_eq!(report.commission.currency, Currency::pUSD());
         assert!(receiver.try_recv().is_err());
+        assert!(!state.processed_fills.contains(&trade.id));
+
+        trade.status = PolymarketTradeStatus::Failed;
+        let failed = dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(failed.is_none());
+        assert!(!state.processed_fills.contains(&trade.id));
+        assert!(!state.is_voided_trade(&trade.id));
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&venue_order_id),
+            Some(report.last_qty),
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_identity_eviction_defers_failed_trade_without_fill_evidence() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.id = "failed-after-identity-eviction".to_string();
+        trade.status = PolymarketTradeStatus::Failed;
+        let instrument = test_instrument();
+        let order_identities = OrderIdentityRegistry::default();
+        register_identity(
+            &order_identities,
+            VenueOrderId::from("V-IDENTITY-EVICTED"),
+            instrument.id(),
+            "O-IDENTITY-EVICTED",
+        );
+
+        for index in 0..10_000 {
+            register_identity(
+                &order_identities,
+                VenueOrderId::from(format!("V-IDENTITY-FILLER-{index}").as_str()),
+                instrument.id(),
+                format!("O-IDENTITY-FILLER-{index}").as_str(),
+            );
+        }
+
+        let token_instruments = AtomicMap::new();
+        let fill_tracker = OrderFillTrackerMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        let emitter = test_emitter();
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        let failed = dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(failed.is_none());
+        assert!(!state.processed_fills.contains(&trade.id));
+        assert!(!state.is_voided_trade(&trade.id));
     }
 
     #[rstest]
@@ -2072,7 +4953,11 @@ mod tests {
             user_api_key: "test-key",
         };
         let mut state = WsDispatchState::default();
-        state.confirmed_trades.add("trade-0xfill1".to_string());
+        add_to_fifo_with_eviction_warn(
+            &mut state.confirmed_trades,
+            "trade-0xfill1".to_string(),
+            "WS confirmed-trade",
+        );
 
         dispatch_user_message(&UserWsMessage::Order(order), &ctx, &mut state);
 
@@ -2463,6 +5348,67 @@ mod tests {
 
         assert_eq!(order.status(), expected_order_status);
         assert_eq!(order.filled_qty().as_decimal(), dec!(25));
+    }
+
+    #[rstest]
+    fn test_identity_absent_buffered_raw_fill_becomes_retryable() {
+        let order: PolymarketUserOrder = load("ws_user_order_matched.json");
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        let instrument = test_instrument();
+        let venue_order_id = VenueOrderId::from(order.id.as_str());
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(order.asset_id, instrument);
+        let fill_tracker = OrderFillTrackerMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        pending_submits.insert(venue_order_id, ClientOrderId::from("O-BUFFERED-RAW"));
+        let order_identities = OrderIdentityRegistry::default();
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+        assert!(receiver.try_recv().is_err());
+
+        dispatch_user_message(&UserWsMessage::Order(order), &ctx, &mut state);
+
+        match receiver
+            .try_recv()
+            .expect("expected buffered raw fill report")
+        {
+            ExecutionEvent::Report(ExecutionReport::Fill(report)) => {
+                assert_eq!(report.venue_order_id, venue_order_id);
+                assert_eq!(report.trade_id, TradeId::from(trade.id.as_str()));
+            }
+            other => panic!("expected buffered raw fill report, was {other:?}"),
+        }
+
+        match receiver.try_recv().expect("expected matched order report") {
+            ExecutionEvent::Report(ExecutionReport::Order(report)) => {
+                assert_eq!(report.venue_order_id, venue_order_id);
+            }
+            other => panic!("expected matched order report, was {other:?}"),
+        }
+        assert!(!state.processed_fills.contains(&trade.id));
+
+        trade.status = PolymarketTradeStatus::Failed;
+        let failed = dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(failed.is_none());
+        assert!(!state.processed_fills.contains(&trade.id));
+        assert!(receiver.try_recv().is_err());
     }
 
     /// Replays the exact 5-message WS sequence from issue #3797.
@@ -3078,6 +6024,130 @@ mod tests {
             }
             other => panic!("expected filled event, was {other:?}"),
         }
+    }
+
+    #[rstest]
+    fn test_replayed_fill_after_ws_dedup_eviction_does_not_bump_quantity() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        trade.size = "60.000000".to_string();
+        let instrument = test_instrument();
+        let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.asset_id, instrument.clone());
+        let fill_tracker = OrderFillTrackerMap::new();
+        fill_tracker.register(
+            venue_order_id,
+            Quantity::from("100.000000"),
+            OrderSide::Buy,
+            instrument.id(),
+            instrument.size_precision(),
+            instrument.price_precision(),
+        );
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let client_order_id = ClientOrderId::from("O-REPLAY-EVICTED");
+        register_identity(
+            &order_identities,
+            venue_order_id,
+            instrument.id(),
+            client_order_id.as_str(),
+        );
+        let mut emitter = test_emitter();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        emitter.set_sender(sender);
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: "0xtest",
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        let accepted = match receiver.try_recv().expect("expected accepted event") {
+            ExecutionEvent::Order(OrderEventAny::Accepted(accepted)) => accepted,
+            other => panic!("expected accepted event, was {other:?}"),
+        };
+        let first_fill = match receiver.try_recv().expect("expected first fill") {
+            ExecutionEvent::Order(OrderEventAny::Filled(fill)) => fill,
+            other => panic!("expected first fill, was {other:?}"),
+        };
+        assert_eq!(first_fill.last_qty, Quantity::from("60.000000"));
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&venue_order_id),
+            Some(Quantity::from("60.000000")),
+        );
+
+        let mut engine_order = OrderTestBuilder::new(OrderType::Limit)
+            .instrument_id(instrument.id())
+            .client_order_id(client_order_id)
+            .strategy_id(StrategyId::from("S-001"))
+            .side(OrderSide::Buy)
+            .price(Price::from("0.5"))
+            .quantity(Quantity::from("100.000000"))
+            .build();
+        engine_order
+            .apply(OrderEventAny::Accepted(accepted))
+            .expect("accepted event must apply");
+        engine_order
+            .apply(OrderEventAny::Filled(first_fill.clone()))
+            .expect("first fill must apply");
+
+        for index in 0..10_000 {
+            let key = format!("newer-trade-{index}");
+            let filler_venue_order_id = VenueOrderId::from(format!("newer-order-{index}").as_str());
+            state.restore_matched_trade(
+                key.clone(),
+                vec![test_order_filled(
+                    filler_venue_order_id,
+                    TradeId::from(key.as_str()),
+                    "O-REPLAY-FILLER",
+                )],
+            );
+            add_to_fifo_map_with_eviction_warn(
+                &mut state.consumed_legs,
+                key,
+                AHashSet::from_iter([filler_venue_order_id]),
+                "WS consumed-leg",
+            );
+        }
+
+        assert!(!state.processed_fills.contains(&trade.id));
+        assert_eq!(state.matched_fill_count(&trade.id), 0);
+        assert!(!state.consumed_legs.contains_key(&trade.id));
+
+        trade.status = PolymarketTradeStatus::Confirmed;
+        let confirmed = dispatch_user_message(&UserWsMessage::Trade(trade), &ctx, &mut state);
+
+        assert!(confirmed.is_some());
+        assert_eq!(
+            fill_tracker.get_cumulative_filled(&venue_order_id),
+            Some(Quantity::from("60.000000")),
+        );
+        assert_eq!(
+            fill_tracker.submitted_qty(&venue_order_id),
+            Some(Quantity::from("100.000000")),
+        );
+        let replayed_fill = match receiver.try_recv().expect("expected replayed fill") {
+            ExecutionEvent::Order(OrderEventAny::Filled(fill)) => fill,
+            other => panic!("expected replayed fill without quantity update, was {other:?}"),
+        };
+        assert_eq!(replayed_fill.trade_id, first_fill.trade_id);
+        let duplicate = engine_order.apply(OrderEventAny::Filled(replayed_fill));
+        assert!(matches!(
+            duplicate,
+            Err(OrderError::DuplicateFill(trade_id)) if trade_id == first_fill.trade_id
+        ));
+        assert_eq!(engine_order.quantity(), Quantity::from("100.000000"));
+        assert_eq!(engine_order.filled_qty(), Quantity::from("60.000000"));
+        assert!(receiver.try_recv().is_err());
     }
 
     // Unmatched -> Rejected (placement never became live); CanceledMarketResolved -> Expired

--- a/crates/adapters/polymarket/tests/exec_client.rs
+++ b/crates/adapters/polymarket/tests/exec_client.rs
@@ -22,7 +22,7 @@ use std::{
     path::PathBuf,
     rc::Rc,
     sync::{
-        Arc,
+        Arc, Mutex, Once,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
@@ -33,7 +33,7 @@ use axum::{
     body::Bytes,
     extract::{
         Query, State,
-        ws::{WebSocket, WebSocketUpgrade},
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Json, Response},
@@ -60,15 +60,15 @@ use nautilus_live::ExecutionClientCore;
 use nautilus_model::{
     accounts::{AccountAny, cash::CashAccount},
     enums::{
-        AccountType, AssetClass, OmsType, OrderSide, OrderStatus, OrderType, TimeInForce,
-        TriggerType,
+        AccountType, AssetClass, LiquiditySide, OmsType, OrderSide, OrderStatus, OrderType,
+        TimeInForce, TriggerType,
     },
     events::{AccountState, OrderEventAny, OrderPendingCancel},
     identifiers::{
-        AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TraderId,
+        AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TradeId, TraderId,
         VenueOrderId,
     },
-    instruments::{BinaryOption, InstrumentAny},
+    instruments::{BinaryOption, Instrument, InstrumentAny},
     orders::{
         LimitOrder, MarketOrder, Order, OrderAny, OrderList, OrderTestBuilder,
         stubs::TestOrderEventStubs,
@@ -105,6 +105,51 @@ const DEFAULT_ACCEPTED_ORDER_ID: &str =
     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
 const CANCEL_ALREADY_DONE_ORDER_ID: &str =
     "0xb816482a1234567890abcdef1234567890abcdef1234567890abcdef12345678";
+
+#[derive(Debug)]
+struct CaptureLogger {
+    records: Mutex<Vec<(log::Level, String)>>,
+}
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        self.records
+            .lock()
+            .expect("capture logger mutex poisoned")
+            .push((record.level(), record.args().to_string()));
+    }
+
+    fn flush(&self) {}
+}
+
+static CAPTURE_LOGGER: CaptureLogger = CaptureLogger {
+    records: Mutex::new(Vec::new()),
+};
+static CAPTURE_LOGGER_INIT: Once = Once::new();
+
+fn capture_log_start() -> usize {
+    CAPTURE_LOGGER_INIT.call_once(|| {
+        log::set_logger(&CAPTURE_LOGGER).expect("test logger already installed");
+        log::set_max_level(log::LevelFilter::Debug);
+    });
+    CAPTURE_LOGGER
+        .records
+        .lock()
+        .expect("capture logger mutex poisoned")
+        .len()
+}
+
+fn captured_logs_since(start: usize) -> Vec<(log::Level, String)> {
+    CAPTURE_LOGGER
+        .records
+        .lock()
+        .expect("capture logger mutex poisoned")[start..]
+        .to_vec()
+}
 
 #[derive(Clone, Copy, Debug)]
 enum ShutdownCancelMode {
@@ -217,6 +262,8 @@ struct TestServerState {
     book_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     single_order_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     trades_response_override: Arc<tokio::sync::Mutex<Option<Value>>>,
+    ws_outbound: Arc<tokio::sync::Mutex<Vec<Value>>>,
+    ws_sent_count: Arc<tokio::sync::Mutex<usize>>,
 }
 
 impl Default for TestServerState {
@@ -265,6 +312,8 @@ impl Default for TestServerState {
             orders_response_override: Arc::new(tokio::sync::Mutex::new(None)),
             single_order_response: Arc::new(tokio::sync::Mutex::new(None)),
             trades_response_override: Arc::new(tokio::sync::Mutex::new(None)),
+            ws_outbound: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            ws_sent_count: Arc::new(tokio::sync::Mutex::new(0)),
             book_response: Arc::new(tokio::sync::Mutex::new(Some(json!({
                 "bids": [
                     {"price": "0.48", "size": "100.00"},
@@ -637,12 +686,39 @@ async fn record_canceled_order_ids(state: &TestServerState, response: &Value) {
     }
 }
 
-async fn handle_user_upgrade(ws: WebSocketUpgrade) -> Response {
-    ws.on_upgrade(handle_user_socket)
+async fn handle_user_upgrade(
+    ws: WebSocketUpgrade,
+    State(state): State<TestServerState>,
+) -> Response {
+    ws.on_upgrade(move |socket| handle_user_socket(socket, state))
 }
 
-async fn handle_user_socket(mut socket: WebSocket) {
-    while socket.next().await.is_some() {}
+async fn handle_user_socket(mut socket: WebSocket, state: TestServerState) {
+    let mut sent = 0usize;
+
+    loop {
+        tokio::select! {
+            inbound = socket.next() => {
+                if inbound.is_none() {
+                    return;
+                }
+            }
+            () = tokio::time::sleep(Duration::from_millis(5)) => {
+                let outbound = state.ws_outbound.lock().await.clone();
+
+                while sent < outbound.len() {
+                    let payload = outbound[sent].to_string();
+
+                    if socket.send(Message::Text(payload.into())).await.is_err() {
+                        return;
+                    }
+
+                    sent += 1;
+                    *state.ws_sent_count.lock().await = sent;
+                }
+            }
+        }
+    }
 }
 
 async fn handle_cancel_all(State(state): State<TestServerState>) -> Response {
@@ -788,6 +864,501 @@ async fn start_mock_server(state: TestServerState) -> SocketAddr {
     .await;
 
     addr
+}
+
+async fn submit_tracked_order(
+    client: &PolymarketExecutionClient,
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    cache: &Rc<RefCell<Cache>>,
+    instrument_id: InstrumentId,
+    client_order_id: &str,
+) {
+    let order = make_limit_order(
+        client_order_id,
+        instrument_id,
+        OrderSide::Buy,
+        false,
+        false,
+        false,
+        TimeInForce::Gtc,
+    );
+    cache
+        .borrow_mut()
+        .add_order(order.clone(), None, None, false)
+        .unwrap();
+    client
+        .submit_order(make_submit_cmd(&order, instrument_id))
+        .unwrap();
+    assert_order_event(recv_order_execution_event(rx).await, "Submitted");
+    assert_order_event(recv_order_execution_event(rx).await, "Accepted");
+}
+
+async fn recv_order_execution_event(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+) -> ExecutionEvent {
+    loop {
+        let event = recv_execution_event(rx).await;
+
+        if matches!(event, ExecutionEvent::Order(_)) {
+            return event;
+        }
+    }
+}
+
+fn maker_recovery_trade(venue_order_id: &str, trade_id: &str, quantity: &str) -> Value {
+    let mut trade = load_json("http_trade_report.json");
+    let mut maker_order = trade["maker_orders"][0].clone();
+    maker_order["order_id"] = json!(venue_order_id);
+    maker_order["maker_address"] = json!("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+    maker_order["owner"] = json!("test_api_key");
+    maker_order["matched_amount"] = json!(quantity);
+    trade["id"] = json!(trade_id);
+    trade["trader_side"] = json!("MAKER");
+    trade["maker_orders"] = json!([maker_order]);
+    trade
+}
+
+fn cache_legacy_maker_fill(
+    cache: &Rc<RefCell<Cache>>,
+    instrument: &InstrumentAny,
+    venue_order_id: &str,
+    client_order_id: &str,
+    legacy_trade_id: TradeId,
+) {
+    let mut order = make_limit_order_at_price_and_quantity(
+        client_order_id,
+        instrument.id(),
+        OrderSide::Buy,
+        false,
+        false,
+        false,
+        TimeInForce::Gtc,
+        Price::from("0.5000"),
+        Quantity::from("10.0000"),
+    );
+    cache
+        .borrow_mut()
+        .add_order(order.clone(), None, None, false)
+        .unwrap();
+    submit_and_accept_order(cache, &mut order, venue_order_id);
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        instrument,
+        Some(legacy_trade_id),
+        None,
+        Some(Price::from("0.5000")),
+        Some(Quantity::from("4.0000")),
+        Some(LiquiditySide::Maker),
+        None,
+        None,
+        Some(AccountId::from("POLYMARKET-001")),
+    );
+    cache.borrow_mut().update_order(&filled).unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_mass_status_skips_legacy_applied_maker_fill_but_keeps_new_fill() {
+    let venue_order_id = "0xmaker01maker01maker01maker01maker01maker01maker01maker01maker01maker01";
+    let legacy_trade_id = TradeId::from("123456789012345678901234567-1maker01");
+    let first_trade_id = "123456789012345678901234567FIRST";
+    let second_trade_id = "223456789012345678901234567OTHER";
+    let mut open_order = load_json("http_open_order.json");
+    open_order["id"] = json!(venue_order_id);
+    open_order["original_size"] = json!("10.0000");
+    open_order["size_matched"] = json!("6.0000");
+    let state = TestServerState::default();
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [open_order],
+        "next_cursor": "LTE="
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [
+            maker_recovery_trade(venue_order_id, first_trade_id, "4.0000"),
+            maker_recovery_trade(venue_order_id, second_trade_id, "2.0000")
+        ],
+        "next_cursor": "LTE="
+    }));
+    let addr = start_mock_server(state).await;
+    let (mut client, _rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument.clone());
+    cache_legacy_maker_fill(
+        &cache,
+        &instrument,
+        venue_order_id,
+        "O-LEGACY-MASS",
+        legacy_trade_id,
+    );
+
+    let mass_status = client
+        .generate_mass_status(None)
+        .await
+        .unwrap()
+        .expect("mass status payload");
+    let fills: Vec<_> = mass_status.fill_reports().into_values().flatten().collect();
+
+    assert_eq!(fills.len(), 1);
+    assert_eq!(fills[0].last_qty, Quantity::from("2.0000"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_skips_legacy_applied_maker_fill_but_emits_new_fill() {
+    let venue_order_id = "0xmaker01maker01maker01maker01maker01maker01maker01maker01maker01maker01";
+    let legacy_trade_id = TradeId::from("123456789012345678901234567-1maker01");
+    let first_trade_id = "123456789012345678901234567FIRST";
+    let second_trade_id = "223456789012345678901234567OTHER";
+    let mut open_order = load_json("http_open_order.json");
+    open_order["id"] = json!(venue_order_id);
+    open_order["original_size"] = json!("10.0000");
+    open_order["size_matched"] = json!("6.0000");
+    let state = TestServerState::default();
+    *state.single_order_response.lock().await = Some(open_order);
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [
+            maker_recovery_trade(venue_order_id, first_trade_id, "4.0000"),
+            maker_recovery_trade(venue_order_id, second_trade_id, "2.0000")
+        ],
+        "next_cursor": "LTE="
+    }));
+    let addr = start_mock_server(state).await;
+    let (mut client, mut rx, cache) = create_test_execution_client(addr);
+    client.start().unwrap();
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument.clone());
+    let client_order_id = ClientOrderId::from("O-LEGACY-QUERY");
+    cache_legacy_maker_fill(
+        &cache,
+        &instrument,
+        venue_order_id,
+        client_order_id.as_str(),
+        legacy_trade_id,
+    );
+    let cmd = QueryOrder::new(
+        TraderId::from("TESTER-001"),
+        Some(*POLYMARKET_CLIENT_ID),
+        StrategyId::from("S-001"),
+        instrument_id,
+        client_order_id,
+        Some(VenueOrderId::from(venue_order_id)),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.query_order(cmd).unwrap();
+
+    let fill = match recv_execution_event(&mut rx).await {
+        ExecutionEvent::Report(ExecutionReport::Fill(fill)) => fill,
+        other => panic!("Expected new Fill report, was {other:?}"),
+    };
+    assert_eq!(fill.last_qty, Quantity::from("2.0000"));
+    assert_order_status_report(recv_execution_event(&mut rx).await, OrderStatus::Accepted);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_emits_and_counts_only_fills_for_queried_order() {
+    let queried_venue_order_id =
+        "0xmaker01maker01maker01maker01maker01maker01maker01maker01maker01maker01";
+    let other_venue_order_id =
+        "0xmaker02maker02maker02maker02maker02maker02maker02maker02maker02maker02";
+    let queried_legacy_trade_id = TradeId::from("123456789012345678901234567-1maker01");
+    let other_legacy_trade_id = TradeId::from("323456789012345678901234567-2maker02");
+    let queried_applied_trade_id = "123456789012345678901234567FIRST";
+    let queried_new_trade_id = "223456789012345678901234567SECOND";
+    let other_trade_id = "323456789012345678901234567OTHER";
+    let mut open_order = load_json("http_open_order.json");
+    open_order["id"] = json!(queried_venue_order_id);
+    open_order["original_size"] = json!("10.0000");
+    open_order["size_matched"] = json!("6.0000");
+    let state = TestServerState::default();
+    *state.single_order_response.lock().await = Some(open_order);
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [
+            maker_recovery_trade(
+                queried_venue_order_id,
+                queried_applied_trade_id,
+                "4.0000",
+            ),
+            maker_recovery_trade(queried_venue_order_id, queried_new_trade_id, "2.0000"),
+            maker_recovery_trade(other_venue_order_id, other_trade_id, "3.0000"),
+        ],
+        "next_cursor": "LTE="
+    }));
+    let addr = start_mock_server(state).await;
+    let (mut client, mut rx, cache) = create_test_execution_client(addr);
+    client.start().unwrap();
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument.clone());
+    let queried_client_order_id = ClientOrderId::from("O-QUERY-ONLY-A");
+    cache_legacy_maker_fill(
+        &cache,
+        &instrument,
+        queried_venue_order_id,
+        queried_client_order_id.as_str(),
+        queried_legacy_trade_id,
+    );
+    cache_legacy_maker_fill(
+        &cache,
+        &instrument,
+        other_venue_order_id,
+        "O-QUERY-OTHER-B",
+        other_legacy_trade_id,
+    );
+    let log_start = capture_log_start();
+    let cmd = QueryOrder::new(
+        TraderId::from("TESTER-001"),
+        Some(*POLYMARKET_CLIENT_ID),
+        StrategyId::from("S-001"),
+        instrument_id,
+        queried_client_order_id,
+        Some(VenueOrderId::from(queried_venue_order_id)),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.query_order(cmd).unwrap();
+
+    let fill = match recv_execution_event(&mut rx).await {
+        ExecutionEvent::Report(ExecutionReport::Fill(fill)) => fill,
+        other => panic!("expected queried-order fill report, was {other:?}"),
+    };
+    assert_eq!(
+        fill.venue_order_id,
+        VenueOrderId::from(queried_venue_order_id)
+    );
+    assert_eq!(fill.last_qty, Quantity::from("2.0000"));
+    assert_order_status_report(recv_execution_event(&mut rx).await, OrderStatus::Accepted);
+    assert!(
+        rx.try_recv().is_err(),
+        "other-order fill must not be emitted"
+    );
+
+    let skipped_message =
+        format!("Skipped 1 REST fill report(s) already applied to order {queried_venue_order_id}",);
+    let matching_logs = captured_logs_since(log_start)
+        .into_iter()
+        .filter(|(_, message)| message == &skipped_message)
+        .collect::<Vec<_>>();
+    assert_eq!(matching_logs, vec![(log::Level::Debug, skipped_message)]);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_mass_status_withholds_pending_fills_for_a_failed_trade() {
+    let venue_order_id = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+    let trade_id = "trade-0xabcdef1234";
+    let now_secs = nautilus_core::time::get_atomic_clock_realtime()
+        .get_time_ns()
+        .as_u64()
+        / 1_000_000_000;
+
+    let mut matched_trade_msg = load_json("ws_user_trade_msg.json");
+    matched_trade_msg["status"] = json!("MATCHED");
+    let mut failed_trade_msg = matched_trade_msg.clone();
+    failed_trade_msg["status"] = json!("FAILED");
+
+    let mut open_order = load_json("http_open_order.json");
+    open_order["id"] = json!(venue_order_id);
+    open_order["created_at"] = json!(now_secs);
+    open_order["size_matched"] = json!("25.0000");
+
+    let mut pending_trade = load_json("http_trade_report.json");
+    pending_trade["id"] = json!(trade_id);
+    pending_trade["status"] = json!("MATCHED");
+    pending_trade["taker_order_id"] = json!(venue_order_id);
+    pending_trade["match_time"] = json!(now_secs.to_string());
+    pending_trade["maker_orders"] = json!([]);
+
+    let state = TestServerState::default();
+    *state.order_response.lock().await = Some(load_json("http_order_response_ok.json"));
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [open_order],
+        "next_cursor": "LTE="
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [pending_trade],
+        "next_cursor": "LTE="
+    }));
+    let addr = start_mock_server(state.clone()).await;
+    let (mut client, mut rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    add_test_account_to_cache(&cache, AccountId::from("POLYMARKET-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    submit_tracked_order(&client, &mut rx, &cache, instrument_id, "O-WITHHELD-TRADE").await;
+
+    state
+        .ws_outbound
+        .lock()
+        .await
+        .extend([matched_trade_msg, failed_trade_msg]);
+
+    loop {
+        if let ExecutionEvent::Order(OrderEventAny::FillVoided(voided)) =
+            recv_order_execution_event(&mut rx).await
+        {
+            assert_eq!(voided.venue_order_id, VenueOrderId::from(venue_order_id));
+            break;
+        }
+    }
+
+    let mass_status = client
+        .generate_mass_status(Some(60))
+        .await
+        .unwrap()
+        .expect("mass status payload");
+    let fill_count = mass_status.fill_reports().into_values().flatten().count();
+    let order_reports = mass_status.order_reports();
+    let order_report = order_reports
+        .get(&VenueOrderId::from(venue_order_id))
+        .expect("order report for the failed trade's order");
+
+    assert_eq!(fill_count, 0);
+    assert!(order_report.filled_qty.is_zero());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_generate_mass_status_snaps_pending_fills_to_the_submitted_quantity() {
+    let venue_order_id = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+    let now_secs = nautilus_core::time::get_atomic_clock_realtime()
+        .get_time_ns()
+        .as_u64()
+        / 1_000_000_000;
+
+    let mut open_order = load_json("http_open_order.json");
+    open_order["id"] = json!(venue_order_id);
+    open_order["created_at"] = json!(now_secs);
+    open_order["size_matched"] = json!("10.0001");
+
+    let mut pending_trade = load_json("http_trade_report.json");
+    pending_trade["id"] = json!("trade-snap");
+    pending_trade["status"] = json!("MATCHED");
+    pending_trade["taker_order_id"] = json!(venue_order_id);
+    pending_trade["match_time"] = json!(now_secs.to_string());
+    pending_trade["size"] = json!("10.0001");
+    pending_trade["maker_orders"] = json!([]);
+
+    let state = TestServerState::default();
+    *state.order_response.lock().await = Some(load_json("http_order_response_ok.json"));
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [open_order],
+        "next_cursor": "LTE="
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [pending_trade],
+        "next_cursor": "LTE="
+    }));
+    let addr = start_mock_server(state).await;
+    let (mut client, mut rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    add_test_account_to_cache(&cache, AccountId::from("POLYMARKET-001"));
+    client.start().unwrap();
+
+    submit_tracked_order(&client, &mut rx, &cache, instrument_id, "O-SNAP-PENDING").await;
+
+    let mass_status = client
+        .generate_mass_status(Some(60))
+        .await
+        .unwrap()
+        .expect("mass status payload");
+    let fill_reports: Vec<_> = mass_status.fill_reports().into_values().flatten().collect();
+
+    assert_eq!(fill_reports.len(), 1);
+    assert_eq!(fill_reports[0].last_qty, Quantity::new(10.0, 4));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_failed_trade_voids_the_snapped_quantity_recorded_as_evidence() {
+    let venue_order_id = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+    let now_secs = nautilus_core::time::get_atomic_clock_realtime()
+        .get_time_ns()
+        .as_u64()
+        / 1_000_000_000;
+
+    let mut open_order = load_json("http_open_order.json");
+    open_order["id"] = json!(venue_order_id);
+    open_order["created_at"] = json!(now_secs);
+    open_order["size_matched"] = json!("10.0001");
+
+    let mut pending_trade = load_json("http_trade_report.json");
+    pending_trade["id"] = json!("trade-0xabcdef1234");
+    pending_trade["status"] = json!("MATCHED");
+    pending_trade["taker_order_id"] = json!(venue_order_id);
+    pending_trade["match_time"] = json!(now_secs.to_string());
+    pending_trade["size"] = json!("10.0001");
+    pending_trade["maker_orders"] = json!([]);
+
+    let mut failed_trade_msg = load_json("ws_user_trade_msg.json");
+    failed_trade_msg["status"] = json!("FAILED");
+
+    let state = TestServerState::default();
+    *state.order_response.lock().await = Some(load_json("http_order_response_ok.json"));
+    *state.orders_response_override.lock().await = Some(json!({
+        "data": [open_order],
+        "next_cursor": "LTE="
+    }));
+    *state.trades_response_override.lock().await = Some(json!({
+        "data": [pending_trade],
+        "next_cursor": "LTE="
+    }));
+    let addr = start_mock_server(state.clone()).await;
+    let (mut client, mut rx, cache) = create_test_execution_client(addr);
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    add_test_account_to_cache(&cache, AccountId::from("POLYMARKET-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    submit_tracked_order(
+        &client,
+        &mut rx,
+        &cache,
+        instrument_id,
+        "O-SNAPPED-EVIDENCE",
+    )
+    .await;
+
+    client
+        .generate_mass_status(Some(60))
+        .await
+        .unwrap()
+        .expect("mass status payload");
+
+    state.ws_outbound.lock().await.push(failed_trade_msg);
+
+    let voided = loop {
+        if let ExecutionEvent::Order(OrderEventAny::FillVoided(voided)) =
+            recv_order_execution_event(&mut rx).await
+        {
+            break voided;
+        }
+    };
+
+    assert_eq!(voided.venue_order_id, VenueOrderId::from(venue_order_id));
+    assert_eq!(voided.voided_qty, Quantity::new(10.0, 4));
 }
 
 #[rstest]
@@ -1207,7 +1778,7 @@ async fn test_generate_order_status_reports_empty_without_instruments() {
 
 #[rstest]
 #[tokio::test]
-async fn test_generate_order_status_reports_recovers_confirmed_rest_fill() {
+async fn test_generate_order_status_reports_caps_from_rest_fill_without_emitting_it() {
     let venue_order_id_str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
     let state = TestServerState::default();
     let mut order = load_json("http_open_orders_page.json")["data"][0].clone();
@@ -1225,7 +1796,8 @@ async fn test_generate_order_status_reports_recovers_confirmed_rest_fill() {
         "0.5000",
     ));
     let addr = start_mock_server(state.clone()).await;
-    let (mut client, _rx, cache) = create_test_execution_client(addr);
+    let (mut client, mut rx, cache) = create_test_execution_client(addr);
+    client.start().unwrap();
 
     let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
     add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
@@ -1263,6 +1835,7 @@ async fn test_generate_order_status_reports_recovers_confirmed_rest_fill() {
     assert_eq!(reports.len(), 1);
     assert_eq!(reports[0].order_status, OrderStatus::Filled);
     assert_eq!(reports[0].filled_qty, Quantity::from("10.0000"));
+    assert!(rx.try_recv().is_err());
     let query = state.last_query.lock().await;
     assert!(!query.contains_key("after"));
     assert!(!query.contains_key("before"));
@@ -2725,6 +3298,24 @@ fn assert_order_status_report(event: ExecutionEvent, expected_status: OrderStatu
             other => panic!("Expected Order report, was {other:?}"),
         },
         other => panic!("Expected Report event, was {other:?}"),
+    }
+}
+
+fn assert_recovery_fill_report(
+    event: ExecutionEvent,
+    venue_order_id: &str,
+    last_qty: &str,
+    last_px: &str,
+) {
+    match event {
+        ExecutionEvent::Report(ExecutionReport::Fill(report)) => {
+            assert_eq!(report.venue_order_id, VenueOrderId::from(venue_order_id));
+            assert_eq!(report.trade_id, TradeId::from("trade-recovery"));
+            assert_eq!(report.last_qty, Quantity::from(last_qty));
+            assert_eq!(report.last_px, Price::from(last_px));
+            assert!(report.commission.is_zero());
+        }
+        other => panic!("Expected Fill report, was {other:?}"),
     }
 }
 
@@ -6579,6 +7170,54 @@ async fn test_query_order_does_not_block_within_runtime() {
         .unwrap()
         .unwrap();
     assert_order_status_report(event, OrderStatus::Accepted);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_emits_confirmed_fill_before_status_report() {
+    let venue_order_id_str = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+    let state = TestServerState::default();
+    let mut order = load_json("http_open_order.json");
+    order["id"] = Value::String(venue_order_id_str.to_string());
+    order["status"] = Value::String("MATCHED".to_string());
+    order["original_size"] = Value::String("10.0000".to_string());
+    order["size_matched"] = Value::String("10.0000".to_string());
+    *state.single_order_response.lock().await = Some(order);
+    *state.trades_response_override.lock().await = Some(recovery_trades_response(
+        venue_order_id_str,
+        "10.0000",
+        "0.5000",
+    ));
+    let addr = start_mock_server(state).await;
+    let (mut client, mut rx, cache) = create_test_execution_client(addr);
+    client.start().unwrap();
+
+    let instrument_id = InstrumentId::from("TEST-TOKEN.POLYMARKET");
+    add_instrument_to_cache_with_size_precision(&cache, instrument_id, 4);
+    let instrument = cache.borrow().instrument(&instrument_id).unwrap().clone();
+    client.on_instrument(instrument);
+    let cmd = QueryOrder::new(
+        TraderId::from("TESTER-001"),
+        Some(*POLYMARKET_CLIENT_ID),
+        StrategyId::from("S-001"),
+        instrument_id,
+        ClientOrderId::from("O-QUERY-CONFIRMED"),
+        Some(VenueOrderId::from(venue_order_id_str)),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    );
+
+    client.query_order(cmd).unwrap();
+
+    assert_recovery_fill_report(
+        recv_execution_event(&mut rx).await,
+        venue_order_id_str,
+        "10.0000",
+        "0.5000",
+    );
+    assert_order_status_report(recv_execution_event(&mut rx).await, OrderStatus::Filled);
 }
 
 #[rstest]

--- a/docs/integrations/polymarket.md
+++ b/docs/integrations/polymarket.md
@@ -495,11 +495,25 @@ Trades on Polymarket can have the following statuses:
 Once a trade is initially matched, subsequent status updates arrive through the user WebSocket.
 The execution adapter emits one `OrderFilled` at `MATCHED`. It treats `MINED` and `RETRYING` as
 settlement updates without emitting another fill. `CONFIRMED` records finality and refreshes the
-account. If the trade reaches `FAILED`, the adapter emits one `OrderFillVoided` for each locally
-applied fill and refreshes the account. The correction does not relist the failed quantity, but it
-preserves any maker-order remainder that was already working. An execution-complete order becomes
-`VOIDED`. Matched WebSocket fills retain the raw trade fields in the `info` field of the
-`OrderFilled` event.
+account. If the trade reaches `FAILED`, the adapter emits one `OrderFillVoided` for each applied
+venue order in the union of WebSocket-local state and the most recent REST mass-status
+pending-fill pass. REST evidence retains the applied quantity, price, commission, and liquidity
+side so the correction exactly matches the applied fill. While a mass-status pass is in progress,
+live evidence from the preceding pass remains available. A concurrent failure notes the trade so
+the atomic record step withholds that trade's pending fill reports before order quantities are
+capped and the mass status is emitted.
+
+This evidence is in memory. After a process restart, a `FAILED` update cannot void a pending fill
+that a previous process applied. A failure observed while the user WebSocket is disconnected can
+also remain unseen because reconnection does not replay the failed trade and mass status skips
+failed trades. Position reconciliation covers the resulting drift. The correction does not relist
+the failed quantity, but it preserves any maker-order remainder that was already working. An
+execution-complete order becomes `VOIDED`. Matched WebSocket fills retain the raw trade fields in
+the `info` field of the `OrderFilled` event. When the order identity or recorded evidence for a
+correction is unavailable, for example after a bounded-cache eviction, the adapter defers the
+correction loudly instead of emitting one built on defaults. Deferrals remain retry-eligible
+across mass-status passes. If no fill evidence or eviction signal is present, the adapter warns
+that evidence may have been lost to a restart or eviction before ignoring the failed update.
 
 ### Trade ID derivation
 
@@ -508,8 +522,12 @@ The adapter derives a deterministic `TradeId` from the asset ID, side, price,
 size, and timestamp via the Rust `determine_trade_id` function using FNV-1a.
 For execution fills, taker reports use the venue's trade `id` in both REST reconciliation and the
 user WebSocket, so the same fill deduplicates across sources. A maker trade can fill more than one
-of the user's resting orders, so maker reports combine the venue trade ID with the maker venue
-order ID. The same venue event yields the same trade ID across replays.
+of the user's resting orders, so maker reports combine a readable prefix of the venue trade ID
+with 16 hexadecimal characters of a keccak256 hash over the full trade and venue order IDs,
+staying within the 36-character `TradeId` limit; two maker legs cannot collide when their venue
+order IDs happen to share a suffix. The same venue event yields the same trade ID across replays.
+REST reconciliation does not re-emit a fill the cached order already holds under either the
+current derivation or the pre-upgrade truncation format, so an upgrade does not re-apply fills.
 For historical Data API trades, the loader uses
 `{transactionHash[-24:]}-{asset[-4:]}-{seq:06d}` to distinguish fills in one transaction.
 
@@ -581,13 +599,14 @@ the adapter recovers a cached individual order from trade history if its termina
 was missed. Only `CONFIRMED` trades contribute to recovered fills; pending and failed settlement
 states do not.
 
-Mass-status reconciliation pairs each order report with its venue fill reports. It applies the
-real fills first to preserve trade IDs and commissions, then infers only any residual quantity
-needed to reach the venue-reported status. REST order reports cap matched quantity to the greater
-of locally applied fills and authenticated `CONFIRMED` trade history, so pending settlement cannot
-create an inferred fill. Runtime order checks fetch confirmed trade history when the venue reports
-more matched quantity than the local order and WebSocket fill tracker contain. Unpaired fill reports
-retain the normal fill-only path.
+Mass-status reconciliation includes settlement-pending (`MATCHED`, `MINED`, or `RETRYING`) fills
+only when their venue order IDs have paired order reports in the same pass. It applies these real
+fills, with their venue trade IDs and commissions, before inferring only any residual quantity
+needed to reach the venue-reported status. Unpaired pending fills are omitted until they confirm.
+Singular and runtime order checks remain confirmed-only when capping matched quantity, so pending
+settlement cannot create an inferred fill. Runtime order checks fetch confirmed trade history when
+the venue reports more matched quantity than the local order and WebSocket fill tracker contain.
+Confirmed unpaired fill reports retain the normal fill-only path.
 
 ### Single-order recovery from trades
 


### PR DESCRIPTION
## Summary

The Polymarket adapter discarded non-confirmed trades with no fill report, no counter and no log, and capped order filled quantity against confirmed fills with a zero local-filled floor. A matched-but-unconfirmed trade understated filled quantity; restoring the quantity without the fill would have converted the understatement into a double count when the venue's later confirmation applied on top of an inferred fill.

This PR reports settlement-pending fills and completes their correction path:

- **Settlement-pending fills flow with identity.** MATCHED trades produce fill reports carrying the venue trade id, price, fee and liquidity side, paired with their order reports, so the quantity is restored and the venue's later CONFIRMED update reconciles by trade id instead of stacking. Runtime routes stay confirmed-only; the mass status emits pending fills only paired with an order report, counting and warning on unpaired ones (routine during settlement-window restarts).
- **Withhold-before-cap.** Lookback filtering applies to fetched inputs before building reports, and pending fills are recorded and withheld before the order cap, so a FAILED-noted fill neither ships nor props up filled quantity.
- **FAILED trades void completely and atomically.** The void covers the per-venue-order union of WebSocket-local fills and REST-applied evidence. Evidence is identity-complete: it records the applied fill's own trade id (composite for maker legs), client order id, strategy and order type at apply time, so the correction matches what the engine indexed. When identity or evidence may be incomplete (identity-registry, matched-fill, raw-fill or evidence-cache eviction), the adapter defers loudly and keeps the trade retry-eligible instead of emitting a correction built on defaults; **deferrals never expire on mass-status passes** and are bounded, with one `error!` if the bound evicts. A FAILED trade with no applied fill and no eviction signal is ignored with a warning (previously debug). Correction state keys on the venue trade id alone in dispatch and at restart restore; consumption is tracked per maker leg so an invalid leg — or a maker payload holding no owned leg — leaves its trade retry-eligible without re-emitting applied legs; confirmation side effects defer until a trade is fully processed; corrupt order updates carrying a terminal status still close the order, and a corrupt partial-FAK MATCHED is salvaged as Canceled when `size_matched` parses below `original_size`. Every bounded correction, dedup and identity insert warns on eviction.
- **Replay after dedup eviction cannot double count.** After a WebSocket dedup-cache eviction, a redelivered fill for a tracker-registered order is still emitted for engine-side trade-id dedup but no longer re-accumulates adapter fill quantity or triggers a BUY overfill bump, so the replay is rejected by the engine without having enlarged the order first.
- **WS order prevalidation.** Order updates with unrepresentable sizes or prices outside the binary unit interval are rejected (previously zero-coerced); market-order updates that omit the price or the matched size remain accepted, matching current venue behavior; one shared helper owns the partial-FAK-to-Canceled mapping across REST and WS.
- **Bulk order reports resolve `client_order_id`** from the identity registry with a cache fallback. Previously every bulk report carried `None`, so periodic reconciliation ignored venue-returned orders entirely (and with `open_check_open_only: false` could synthesize `NOT_FOUND_AT_VENUE` rejections for orders the venue did return).
- **Order polling emits exact fills for the queried order only.** The singular `query_order` route emits the fetched confirmed fills belonging to the queried order before the capped status report (FIFO channel, ordering tested), so the engine applies real fills instead of inferring one synthetic fill with a fabricated trade id and no commission. Fills belonging to other orders on the same instrument are filtered out.
- **Collision-resistant maker composite trade ids.** Readable trade prefix plus 16 hex chars of `keccak256(trade_id | venue_order_id)` within the 36-char `TradeId` limit, replacing a truncation under which two maker legs sharing an order-id suffix collided and one leg was silently dropped.

## Behavior changes

- WS order updates with unrepresentable quantity/price are now dropped with a warning instead of reported with zero-coerced values.
- Bulk open-order polling intentionally does **not** emit fills (see notes).
- Maker composite trade id format changes for new fills (see upgrade note).
- Deferral semantics change: safety deferrals for FAILED corrections no longer expire when a mass-status pass completes without re-recording the trade; they remain retry-eligible (bounded, loud on eviction).

## Known limitations

Introduced by this PR:

- REST pending-fill evidence is in-memory; a restart before settlement loses the correction identity for REST-applied pending fills, and the later FAILED is ignored with a warning instead of voiding (documented in the integration guide).
- The replay guard above is deliberately conservative: once any WS dedup eviction has occurred, subsequent fills for tracker-registered orders update the engine but not the adapter's cumulative tracker or overfill bumps until the next mass-status pass re-syncs. Mass-status REST passes rebuild tracker truth, so the divergence is bounded and self-healing.

Pre-existing, changed only in reach:

- An evidence-derived void for a fill the engine never applied (possible only when the manager is configured with `reconciliation_instrument_ids` or `filtered_client_order_ids` exclusions) still relies on the model's unknown-fill void acceptance; this PR adds a second void source reaching that path. Tightening the acceptance is core-crate work we intend to propose separately. Default configurations are unaffected.
- The bulk open-order route still reduces fetched fills to a cumulative quantity (the engine may infer a synthetic fill on that route). The engine-side inference was unreachable at base because bulk reports carried no `client_order_id`; resolving it here makes the route live, so this limitation is newly activated, not merely inherited. Fixing it requires a consumer-side ordering change, intended as a separate proposal.
- A void for an order purged from the cache after closing cannot be addressed (engine-side retention policy, unchanged).

## Upgrade note

Cached orders with maker fills persisted under the old composite format would not dedup against re-emitted fills after upgrade. The REST paths therefore check both the new and the legacy derivation against the cached order's applied fills before emitting; WS redeliveries are suppressed by restored correction state, which keys on the raw venue trade id and is format-independent.

## Test plan

- `cargo nextest run -p nautilus-polymarket`: 1,389 passed, 0 skipped, including real-client WebSocket integration tests driving the full mass-status lifecycle (withhold-before-cap, snap-to-submitted, snapped-evidence-void) and the new correction-semantics tests (deferral survival across passes, identity-eviction deferral, no-owned-leg retry, replay-after-eviction suppression, partial-FAK salvage).
- `cargo clippy -p nautilus-polymarket --all-targets -- -D warnings`: clean. `prek run --all-files`: all hooks pass.
- Each fix carries a regression test confirmed to fail with its production change reverted, then restored.

## Notes

- This PR and the mass-status omission-counting PR (#4691) both edit `execution/reconciliation.rs` (different concerns). They are independent and either order merges; the second may need a small rebase, which we will handle promptly.
