### PR TITLE
Count and surface dropped venue position reports in live reconciliation

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -20,7 +20,14 @@
 
 #[cfg(feature = "node")]
 use std::collections::HashSet;
-use std::{cell::RefCell, fmt::Debug, rc::Rc, str::FromStr, sync::LazyLock, time::Duration};
+use std::{
+    cell::{Cell, RefCell},
+    fmt::Debug,
+    rc::Rc,
+    str::FromStr,
+    sync::LazyLock,
+    time::Duration,
+};
 
 use indexmap::{IndexMap, IndexSet};
 use nautilus_common::{
@@ -89,6 +96,17 @@ static TAG_RECONCILIATION: LazyLock<Ustr> = LazyLock::new(|| Ustr::from("RECONCI
 pub type InstrumentAccountKey = (InstrumentId, AccountId);
 type FillKey = (AccountId, InstrumentId, TradeId);
 
+enum CrossZeroLegReportError {
+    Quantity,
+    Price,
+}
+
+fn position_reconciliation_applied(events: &[OrderEventAny]) -> bool {
+    events
+        .iter()
+        .any(|event| matches!(event, OrderEventAny::Filled(_)))
+}
+
 #[expect(clippy::too_many_arguments)]
 fn build_cross_zero_leg_report(
     instrument: &InstrumentAny,
@@ -100,16 +118,18 @@ fn build_cross_zero_leg_report(
     tag: &str,
     ts_now: UnixNanos,
     venue_ts_last: UnixNanos,
-) -> Option<OrderStatusReport> {
-    let order_qty = Quantity::from_decimal_dp(quantity, instrument.size_precision()).ok()?;
-    let fill_price = Price::from_decimal_dp(avg_px, instrument.price_precision()).ok();
+) -> Result<OrderStatusReport, CrossZeroLegReportError> {
+    let order_qty = Quantity::from_decimal_dp(quantity, instrument.size_precision())
+        .map_err(|_| CrossZeroLegReportError::Quantity)?;
+    let fill_price = Price::from_decimal_dp(avg_px, instrument.price_precision())
+        .map_err(|_| CrossZeroLegReportError::Price)?;
     let venue_order_id = create_position_reconciliation_venue_order_id(
         account_id,
         instrument_id,
         order_side,
         OrderType::Market,
         order_qty,
-        fill_price,
+        Some(fill_price),
         None,
         Some(tag),
         venue_ts_last,
@@ -133,7 +153,7 @@ fn build_cross_zero_leg_report(
     )
     .with_avg_px(avg_px);
 
-    Some(report)
+    Ok(report)
 }
 
 /// Execution clients responsible for reporting one cached entity.
@@ -160,6 +180,10 @@ pub struct ReconciliationResult {
     pub events: Vec<OrderEventAny>,
     /// External orders that need to be registered with execution clients.
     pub external_orders: Vec<ExternalOrderMetadata>,
+    /// Venue position reports dropped during reconciliation.
+    pub position_reports_dropped: usize,
+    /// Venue position reports that produced at least one applied fill.
+    pub positions_created: usize,
 }
 
 /// Result of inflight order checks containing terminal events and intermediate queries.
@@ -409,6 +433,8 @@ pub struct ExecutionManager {
     missing_order_coverage_warnings: IndexSet<ClientOrderId>,
     unresolved_order_coverage: IndexSet<ClientOrderId>,
     targeted_order_queries: IndexSet<ClientOrderId>,
+    position_reports_dropped: Cell<usize>,
+    unreconcilable_cached_positions: Cell<usize>,
 }
 
 impl Debug for ExecutionManager {
@@ -448,6 +474,8 @@ impl ExecutionManager {
             missing_order_coverage_warnings: IndexSet::new(),
             unresolved_order_coverage: IndexSet::new(),
             targeted_order_queries: IndexSet::new(),
+            position_reports_dropped: Cell::new(0),
+            unreconcilable_cached_positions: Cell::new(0),
         }
     }
 
@@ -492,6 +520,9 @@ impl ExecutionManager {
         mass_status: ExecutionMassStatus,
         exec_engine: Rc<RefCell<ExecutionEngine>>,
     ) -> ReconciliationResult {
+        self.position_reports_dropped.set(0);
+        self.unreconcilable_cached_positions.set(0);
+
         // Publish raw reports before any state mutation (including fill adjustment
         // below, which can synthesise replacement order/fill reports). The
         // execution engine's per-report `reconcile_*` entry points are bypassed by
@@ -534,6 +565,7 @@ impl ExecutionManager {
             color = LogColor::Blue
         );
 
+        let mass_status = self.gate_mass_status_position_reports(&mass_status);
         let retained_fill_state = self.retained_fill_state();
         let reported_fill_keys: IndexSet<(AccountId, InstrumentId, TradeId)> = mass_status
             .fill_reports()
@@ -972,15 +1004,19 @@ impl ExecutionManager {
                 for report in reports {
                     if let Some(position_events) = self.reconcile_position_report(
                         &report,
-                        mass_status.account_id,
                         &instruments_with_unattributed_fills,
                         &positions_with_fills,
                     ) {
+                        let position_created = position_reconciliation_applied(&position_events);
+
                         for event in position_events {
                             exec_engine.borrow_mut().process(&event);
                             events.push(event);
                         }
-                        positions_created += 1;
+
+                        if position_created {
+                            positions_created += 1;
+                        }
                     }
                 }
             }
@@ -998,14 +1034,19 @@ impl ExecutionManager {
             log::debug!("{orders_skipped_filtered} orders skipped (filtered by config)");
         }
 
+        let position_reports_dropped = self.position_reports_dropped.get();
+        let unreconcilable_cached_positions = self.unreconcilable_cached_positions.get();
+
         log::info!(
             color = LogColor::Blue as u8;
-            "Reconciliation complete for {venue}: reconciled={orders_reconciled}, external={external_orders_created}, open={open_orders_initialized}, fills={fills_applied}, positions={positions_created}, skipped={orders_skipped_duplicate}, filtered={orders_skipped_filtered}",
+            "Reconciliation complete for {venue}: reconciled={orders_reconciled}, external={external_orders_created}, open={open_orders_initialized}, fills={fills_applied}, positions={positions_created}, skipped={orders_skipped_duplicate}, filtered={orders_skipped_filtered}, position_reports_dropped={position_reports_dropped}, unreconcilable_cached_positions={unreconcilable_cached_positions}",
         );
 
         ReconciliationResult {
             events,
             external_orders,
+            position_reports_dropped,
+            positions_created,
         }
     }
 
@@ -1866,6 +1907,9 @@ impl ExecutionManager {
         queried_clients: &IndexSet<ClientId>,
         failed_clients: &IndexSet<ClientId>,
     ) -> Vec<OrderEventAny> {
+        self.position_reports_dropped.set(0);
+        self.unreconcilable_cached_positions.set(0);
+
         log::debug!("Checking position consistency between cached-state and venues");
 
         let mut venue_positions: IndexMap<InstrumentAccountKey, Vec<PositionStatusReport>> =
@@ -2001,6 +2045,8 @@ impl ExecutionManager {
             .collect();
         self.position_reconciliation_states
             .retain(|k, _| active_keys.contains(k));
+
+        self.finish_position_report_reconciliation_pass();
 
         events
     }
@@ -2192,6 +2238,18 @@ impl ExecutionManager {
             .get(client_order_id)
             .copied()
             .unwrap_or(0)
+    }
+
+    /// Returns the drop count recorded during the latest position-reconciliation pass.
+    #[must_use]
+    pub fn position_reports_dropped(&self) -> usize {
+        self.position_reports_dropped.get()
+    }
+
+    /// Returns the cached-position anomaly count from the latest reconciliation pass.
+    #[must_use]
+    pub fn unreconcilable_cached_positions(&self) -> usize {
+        self.unreconcilable_cached_positions.get()
     }
 
     /// Observes a local order event and updates tracking state.
@@ -2425,6 +2483,127 @@ impl ExecutionManager {
         self.cache.borrow().instrument(instrument_id).cloned()
     }
 
+    fn record_position_report_drop(&self, instrument_id: InstrumentId, reason: &str) {
+        log::debug!("Dropping venue position report for {instrument_id}: {reason}");
+        self.position_reports_dropped
+            .set(self.position_reports_dropped.get() + 1);
+    }
+
+    fn record_unreconcilable_cached_positions(
+        &self,
+        instrument_id: InstrumentId,
+        position_count: usize,
+        reason: &str,
+    ) {
+        log::debug!(
+            "Cached position(s) for {instrument_id} could not be reconciled without a venue report: {reason}"
+        );
+        self.unreconcilable_cached_positions
+            .set(self.unreconcilable_cached_positions.get() + position_count);
+    }
+
+    fn record_position_reconciliation_failure(
+        &self,
+        instrument_id: InstrumentId,
+        venue_report_received: bool,
+        cached_position_count: usize,
+        reason: &str,
+    ) {
+        if venue_report_received {
+            self.record_position_report_drop(instrument_id, reason);
+        } else {
+            self.record_unreconcilable_cached_positions(
+                instrument_id,
+                cached_position_count,
+                reason,
+            );
+        }
+    }
+
+    fn validate_position_reconciliation_account(
+        &self,
+        account_id: AccountId,
+        instrument_id: InstrumentId,
+    ) -> bool {
+        if self.cache.borrow().account(&account_id).is_some() {
+            return true;
+        }
+
+        self.record_position_report_drop(
+            instrument_id,
+            &format!("reporting account {account_id} is not in the cache"),
+        );
+        false
+    }
+
+    fn gate_mass_status_position_reports(
+        &self,
+        mass_status: &ExecutionMassStatus,
+    ) -> ExecutionMassStatus {
+        let mut gated_mass_status = ExecutionMassStatus::new(
+            mass_status.client_id,
+            mass_status.account_id,
+            mass_status.venue,
+            mass_status.ts_init,
+            Some(mass_status.report_id),
+        );
+        gated_mass_status.add_order_reports(mass_status.order_reports().into_values().collect());
+        gated_mass_status
+            .add_fill_reports(mass_status.fill_reports().into_values().flatten().collect());
+
+        for report in mass_status.position_reports().into_values().flatten() {
+            let account_validation_required = if report.signed_decimal_qty == Decimal::ZERO {
+                let cache = self.cache.borrow();
+                cache.instrument(&report.instrument_id).is_some()
+                    || !cache
+                        .positions_open(
+                            None,
+                            Some(&report.instrument_id),
+                            None,
+                            Some(&report.account_id),
+                            None,
+                        )
+                        .is_empty()
+            } else {
+                true
+            };
+
+            if account_validation_required
+                && !self.validate_position_reconciliation_account(
+                    report.account_id,
+                    report.instrument_id,
+                )
+            {
+                continue;
+            }
+
+            gated_mass_status.add_position_reports(vec![report]);
+        }
+
+        gated_mass_status
+    }
+
+    fn finish_position_report_reconciliation_pass(&self) -> usize {
+        let position_reports_dropped = self.position_reports_dropped.get();
+        let unreconcilable_cached_positions = self.unreconcilable_cached_positions.get();
+
+        if position_reports_dropped > 0 {
+            log::warn!(
+                "{}",
+                position_reports_dropped_warning(position_reports_dropped)
+            );
+        }
+
+        if unreconcilable_cached_positions > 0 {
+            log::warn!(
+                "{}",
+                unreconcilable_cached_positions_warning(unreconcilable_cached_positions)
+            );
+        }
+
+        position_reports_dropped
+    }
+
     fn should_skip_order_report(&self, report: &OrderStatusReport) -> bool {
         if let Some(client_order_id) = &report.client_order_id
             && self
@@ -2628,6 +2807,40 @@ impl ExecutionManager {
         let net_qty_matches = (cached_signed_qty - venue_signed_qty).abs() <= tolerance;
         let side_qty_matches = (cached_long_qty - venue_long_qty).abs() <= tolerance
             && (cached_short_qty - venue_short_qty).abs() <= tolerance;
+        let report_shape = if nonflat_count > 1 || venue_has_side_reports {
+            PositionReportShape::MultiLeg
+        } else {
+            PositionReportShape::Unambiguous
+        };
+        let retries = self
+            .position_reconciliation_states
+            .get(&key)
+            .filter(|state| state.report_shape == report_shape)
+            .map_or(0, |state| state.retries);
+
+        let mut reports_have_known_accounts = true;
+
+        for report in venue_reports {
+            reports_have_known_accounts &= self
+                .validate_position_reconciliation_account(report.account_id, report.instrument_id);
+        }
+
+        if !reports_have_known_accounts {
+            if retries < self.config.position_check_retries {
+                let new_retries = retries + 1;
+                self.set_position_reconciliation_retries(key, report_shape, new_retries);
+
+                if new_retries >= self.config.position_check_retries {
+                    log::error!(
+                        "Position discrepancy for {instrument_id} unresolved after {} attempts \
+                         (cached_qty={cached_signed_qty}, venue_qty={venue_signed_qty}); \
+                         no further reconciliation attempts will be made for the current report shape",
+                        self.config.position_check_retries,
+                    );
+                }
+            }
+            return None;
+        }
 
         if net_qty_matches && (!venue_has_side_reports || side_qty_matches) {
             self.position_reconciliation_states.shift_remove(&key);
@@ -2646,17 +2859,6 @@ impl ExecutionManager {
             );
             return None;
         }
-
-        let report_shape = if nonflat_count > 1 || venue_has_side_reports {
-            PositionReportShape::MultiLeg
-        } else {
-            PositionReportShape::Unambiguous
-        };
-        let retries = self
-            .position_reconciliation_states
-            .get(&key)
-            .filter(|state| state.report_shape == report_shape)
-            .map_or(0, |state| state.retries);
 
         if retries >= self.config.position_check_retries {
             return None;
@@ -2694,6 +2896,12 @@ impl ExecutionManager {
                     self.config.position_check_retries,
                 );
             }
+            self.record_position_reconciliation_failure(
+                instrument_id,
+                venue_report.is_some(),
+                cached_positions.len(),
+                "instrument is not in the cache",
+            );
             return None;
         };
 
@@ -2732,69 +2940,105 @@ impl ExecutionManager {
             );
 
             match reconciliation_px.or(venue_avg_px).or(cached_avg_px) {
-                Some(fill_px) => {
+                Some(fill_px) => 'difference_order: {
                     let fill_qty = qty_diff.abs();
                     let venue_position_id = venue_report.and_then(|r| r.venue_position_id);
                     let venue_ts_last = venue_report.map_or(ts_now, |r| r.ts_last);
 
-                    Quantity::from_decimal_dp(fill_qty, instrument.size_precision())
-                        .ok()
-                        .map(|order_qty| {
-                            let fill_price =
-                                Price::from_decimal_dp(fill_px, instrument.price_precision()).ok();
-                            let venue_order_id = create_position_reconciliation_venue_order_id(
-                                account_id,
-                                instrument_id,
-                                order_side,
-                                OrderType::Market,
-                                order_qty,
-                                fill_price,
-                                venue_position_id,
-                                None,
-                                venue_ts_last,
-                            );
+                    let Ok(order_qty) =
+                        Quantity::from_decimal_dp(fill_qty, instrument.size_precision())
+                    else {
+                        self.record_position_reconciliation_failure(
+                            instrument_id,
+                            venue_report.is_some(),
+                            cached_positions.len(),
+                            "difference quantity cannot be represented at instrument precision",
+                        );
+                        break 'difference_order None;
+                    };
+                    let Ok(fill_price) =
+                        Price::from_decimal_dp(fill_px, instrument.price_precision())
+                    else {
+                        self.record_position_reconciliation_failure(
+                            instrument_id,
+                            venue_report.is_some(),
+                            cached_positions.len(),
+                            "difference price cannot be represented at instrument precision",
+                        );
+                        break 'difference_order None;
+                    };
+                    let venue_order_id = create_position_reconciliation_venue_order_id(
+                        account_id,
+                        instrument_id,
+                        order_side,
+                        OrderType::Market,
+                        order_qty,
+                        Some(fill_price),
+                        venue_position_id,
+                        None,
+                        venue_ts_last,
+                    );
 
-                            OrderStatusReport::new(
-                                account_id,
-                                instrument_id,
-                                None,
-                                venue_order_id,
-                                order_side,
-                                OrderType::Market,
-                                TimeInForce::Gtc,
-                                OrderStatus::Filled,
-                                order_qty,
-                                order_qty,
-                                ts_now,
-                                ts_now,
-                                ts_now,
-                                None,
-                            )
-                            .with_avg_px(fill_px)
-                        })
-                        .map(|order_report| {
-                            log::info!(
-                                color = LogColor::Blue as u8;
-                                "Generating synthetic fill for position reconciliation {instrument_id}: side={order_side:?}, qty={}, px={fill_px}", qty_diff.abs(),
-                            );
+                    let order_report = OrderStatusReport::new(
+                        account_id,
+                        instrument_id,
+                        None,
+                        venue_order_id,
+                        order_side,
+                        OrderType::Market,
+                        TimeInForce::Gtc,
+                        OrderStatus::Filled,
+                        order_qty,
+                        order_qty,
+                        ts_now,
+                        ts_now,
+                        ts_now,
+                        None,
+                    )
+                    .with_avg_px(fill_px);
 
-                            let (events, _) = self.handle_external_order(
-                                &order_report,
-                                account_id,
-                                &instrument,
-                                &[],
-                                true,
-                                None,
-                            );
-                            events
-                        })
+                    log::info!(
+                        color = LogColor::Blue as u8;
+                        "Generating synthetic fill for position reconciliation {instrument_id}: side={order_side:?}, qty={}, px={fill_px}", qty_diff.abs(),
+                    );
+
+                    let (events, _) = self.handle_external_order(
+                        &order_report,
+                        account_id,
+                        &instrument,
+                        &[],
+                        true,
+                        None,
+                    );
+
+                    if !position_reconciliation_applied(&events) {
+                        self.record_position_reconciliation_failure(
+                            instrument_id,
+                            venue_report.is_some(),
+                            cached_positions.len(),
+                            "synthetic difference order was not applied",
+                        );
+                    }
+
+                    Some(events)
                 }
-                None => None,
+                None => {
+                    self.record_position_reconciliation_failure(
+                        instrument_id,
+                        venue_report.is_some(),
+                        cached_positions.len(),
+                        "no reconciliation price is available for the difference fill",
+                    );
+                    None
+                }
             }
         };
 
-        // Track retries when reconciliation didn't produce events
-        if result.is_none() || result.as_ref().is_some_and(|e| e.is_empty()) {
+        // Only an applied fill resolves the discrepancy and clears retry state.
+        if result
+            .as_ref()
+            .is_none_or(|events| !position_reconciliation_applied(events))
+        {
             let new_retries = retries + 1;
             self.set_position_reconciliation_retries(key, report_shape, new_retries);
             if new_retries >= self.config.position_check_retries {
@@ -2847,6 +3091,8 @@ impl ExecutionManager {
 
     /// Handles position reconciliation when position flips sign, splitting into two
     /// fills: close existing position then open new position in opposite direction.
+    ///
+    /// Drop counting on this path is per report, even when both legs fail.
     #[expect(clippy::too_many_arguments)]
     fn reconcile_cross_zero_position(
         &self,
@@ -2860,6 +3106,8 @@ impl ExecutionManager {
         ts_now: UnixNanos,
         venue_ts_last: UnixNanos,
     ) -> Option<Vec<OrderEventAny>> {
+        let position_reports_dropped_before = self.position_reports_dropped.get();
+
         log::info!(
             color = LogColor::Blue as u8;
             "Position crosses zero for {instrument_id}: cached={cached_signed_qty}, venue={venue_signed_qty}. Splitting into two fills",
@@ -2879,13 +3127,17 @@ impl ExecutionManager {
         };
 
         let Some(close_px) = cached_avg_px else {
-            log::warn!("Cannot close position for {instrument_id}: no cached average price");
+            log::debug!("Cannot close position for {instrument_id}: no cached average price");
+            self.record_position_report_drop(
+                instrument_id,
+                "cached average price is unavailable for the close leg",
+            );
             return None;
         };
 
         let open_report = match venue_avg_px {
-            Some(open_px) => Some((
-                build_cross_zero_leg_report(
+            Some(open_px) => {
+                let open_report = match build_cross_zero_leg_report(
                     instrument,
                     account_id,
                     instrument_id,
@@ -2895,13 +3147,30 @@ impl ExecutionManager {
                     "OPEN",
                     ts_now,
                     venue_ts_last,
-                )?,
-                open_px,
-            )),
+                ) {
+                    Ok(report) => report,
+                    Err(CrossZeroLegReportError::Quantity) => {
+                        self.record_position_report_drop(
+                            instrument_id,
+                            "open quantity cannot be represented at instrument precision",
+                        );
+                        return None;
+                    }
+                    Err(CrossZeroLegReportError::Price) => {
+                        self.record_position_report_drop(
+                            instrument_id,
+                            "open price cannot be represented at instrument precision",
+                        );
+                        return None;
+                    }
+                };
+
+                Some((open_report, open_px))
+            }
             None => None,
         };
 
-        let close_report = build_cross_zero_leg_report(
+        let close_report = match build_cross_zero_leg_report(
             instrument,
             account_id,
             instrument_id,
@@ -2911,7 +3180,23 @@ impl ExecutionManager {
             "CLOSE",
             ts_now,
             venue_ts_last,
-        )?;
+        ) {
+            Ok(report) => report,
+            Err(CrossZeroLegReportError::Quantity) => {
+                self.record_position_report_drop(
+                    instrument_id,
+                    "close quantity cannot be represented at instrument precision",
+                );
+                return None;
+            }
+            Err(CrossZeroLegReportError::Price) => {
+                self.record_position_report_drop(
+                    instrument_id,
+                    "close price cannot be represented at instrument precision",
+                );
+                return None;
+            }
+        };
 
         log::info!(
             color = LogColor::Blue as u8;
@@ -2920,6 +3205,14 @@ impl ExecutionManager {
 
         let (close_events, _) =
             self.handle_external_order(&close_report, account_id, instrument, &[], true, None);
+
+        if !position_reconciliation_applied(&close_events) {
+            self.record_position_report_drop(
+                instrument_id,
+                "synthetic close order was not applied",
+            );
+        }
+
         let mut all_events = close_events;
 
         if let Some((open_report, open_px)) = open_report {
@@ -2930,9 +3223,26 @@ impl ExecutionManager {
 
             let (open_events, _) =
                 self.handle_external_order(&open_report, account_id, instrument, &[], true, None);
+
+            if !position_reconciliation_applied(&open_events) {
+                self.record_position_report_drop(
+                    instrument_id,
+                    "synthetic open order was not applied",
+                );
+            }
+
             all_events.extend(open_events);
         } else {
-            log::warn!("Cannot open new position for {instrument_id}: no venue average price");
+            log::debug!("Cannot open new position for {instrument_id}: no venue average price");
+            self.record_position_report_drop(
+                instrument_id,
+                "venue average price is unavailable for the open leg",
+            );
+        }
+
+        if self.position_reports_dropped.get() > position_reports_dropped_before {
+            self.position_reports_dropped
+                .set(position_reports_dropped_before + 1);
         }
 
         Some(all_events)
@@ -2962,18 +3272,34 @@ impl ExecutionManager {
         };
 
         let qty_abs = venue_signed_qty.abs();
-        let venue_avg_px = report.avg_px_open?;
+        let Some(venue_avg_px) = report.avg_px_open else {
+            self.record_position_report_drop(instrument_id, "venue average open price is missing");
+            return None;
+        };
 
         let ts_now = self.clock.borrow().timestamp_ns();
-        let order_qty = Quantity::from_decimal_dp(qty_abs, instrument.size_precision()).ok()?;
-        let fill_price = Price::from_decimal_dp(venue_avg_px, instrument.price_precision()).ok();
+        let Ok(order_qty) = Quantity::from_decimal_dp(qty_abs, instrument.size_precision()) else {
+            self.record_position_report_drop(
+                instrument_id,
+                "venue quantity cannot be represented at instrument precision",
+            );
+            return None;
+        };
+        let Ok(fill_price) = Price::from_decimal_dp(venue_avg_px, instrument.price_precision())
+        else {
+            self.record_position_report_drop(
+                instrument_id,
+                "venue average open price cannot be represented at instrument precision",
+            );
+            return None;
+        };
         let venue_order_id = create_position_reconciliation_venue_order_id(
             account_id,
             instrument_id,
             order_side,
             OrderType::Market,
             order_qty,
-            fill_price,
+            Some(fill_price),
             report.venue_position_id,
             None,
             report.ts_last,
@@ -2997,7 +3323,7 @@ impl ExecutionManager {
         )
         .with_avg_px(venue_avg_px);
 
-        // Preserve venue_position_id for hedging mode
+        // Hedge-mode fills require the venue position identifier.
         if let Some(venue_position_id) = report.venue_position_id {
             order_report = order_report.with_venue_position_id(venue_position_id);
         }
@@ -3009,16 +3335,27 @@ impl ExecutionManager {
 
         let (events, _) =
             self.handle_external_order(&order_report, account_id, instrument, &[], true, None);
+
+        if !position_reconciliation_applied(&events) {
+            self.record_position_report_drop(
+                instrument_id,
+                "synthetic reconciliation order was not applied",
+            );
+        }
+
         Some(events)
     }
 
     fn reconcile_position_report(
         &self,
         report: &PositionStatusReport,
-        account_id: AccountId,
         instruments_with_unattributed_fills: &IndexSet<InstrumentId>,
         positions_with_fills: &IndexSet<PositionId>,
     ) -> Option<Vec<OrderEventAny>> {
+        // Position reconciliation is scoped to the account on the report, not
+        // the mass-status envelope; the two are not enforced to match.
+        let account_id = report.account_id;
+
         if report.venue_position_id.is_some() {
             self.reconcile_position_report_hedging(
                 report,
@@ -3039,12 +3376,43 @@ impl ExecutionManager {
         positions_with_fills: &IndexSet<PositionId>,
     ) -> Option<Vec<OrderEventAny>> {
         let venue_position_id = report.venue_position_id?;
+        let position = {
+            let cache = self.cache.borrow();
+            cache.position_owned(&venue_position_id)
+        };
+
+        if position
+            .as_ref()
+            .is_some_and(|position| position.account_id != account_id)
+        {
+            self.record_position_report_drop(
+                report.instrument_id,
+                "venue position ID belongs to another cached account",
+            );
+            return None;
+        }
 
         // Skip if batch already has fills for this position (will be created from fills)
         if positions_with_fills.contains(&venue_position_id) {
-            log::debug!(
-                "Skipping hedge position {venue_position_id} reconciliation: fills already in batch"
-            );
+            let cached_signed_qty = position
+                .as_ref()
+                .map_or(Decimal::ZERO, Position::signed_decimal_qty);
+            let tolerance = self.position_reconciliation_tolerance(account_id);
+
+            if (cached_signed_qty - report.signed_decimal_qty).abs() <= tolerance {
+                log::debug!(
+                    "Skipping hedge position {venue_position_id} reconciliation: fills already in batch"
+                );
+            } else {
+                self.record_position_report_drop(
+                    report.instrument_id,
+                    &format!(
+                        "fills in batch did not establish the reported hedge position quantity \
+                         (cached={cached_signed_qty}, venue={})",
+                        report.signed_decimal_qty,
+                    ),
+                );
+            }
             return None;
         }
 
@@ -3062,11 +3430,6 @@ impl ExecutionManager {
             report.instrument_id,
             venue_position_id
         );
-
-        let position = {
-            let cache = self.cache.borrow();
-            cache.position_owned(&venue_position_id)
-        };
 
         match position {
             Some(position) => {
@@ -3127,16 +3490,32 @@ impl ExecutionManager {
         position: &Position,
         cached_signed_qty: Decimal,
     ) -> Option<Vec<OrderEventAny>> {
-        let instrument = self.get_instrument(&report.instrument_id)?;
+        let Some(instrument) = self.get_instrument(&report.instrument_id) else {
+            self.record_position_report_drop(
+                report.instrument_id,
+                "instrument is not in the cache",
+            );
+            return None;
+        };
         let venue_signed_qty = report.signed_decimal_qty;
 
         let diff = (cached_signed_qty - venue_signed_qty).abs();
-        let diff_qty = Quantity::from_decimal_dp(diff, instrument.size_precision()).ok()?;
+        let Ok(diff_qty) = Quantity::from_decimal_dp(diff, instrument.size_precision()) else {
+            self.record_position_report_drop(
+                report.instrument_id,
+                "position difference cannot be represented at instrument precision",
+            );
+            return None;
+        };
 
         if diff_qty.is_zero() {
             log::debug!(
                 "Difference quantity rounds to zero for {}, skipping",
                 instrument.id()
+            );
+            self.record_position_report_drop(
+                report.instrument_id,
+                "position difference rounds to zero at instrument precision",
             );
             return None;
         }
@@ -3171,13 +3550,29 @@ impl ExecutionManager {
         report: &PositionStatusReport,
         account_id: AccountId,
     ) -> Option<Vec<OrderEventAny>> {
-        let instrument = self.get_instrument(&report.instrument_id)?;
+        let Some(instrument) = self.get_instrument(&report.instrument_id) else {
+            self.record_position_report_drop(
+                report.instrument_id,
+                "instrument is not in the cache",
+            );
+            return None;
+        };
         let venue_signed_qty = report.signed_decimal_qty;
 
         let qty = venue_signed_qty.abs();
-        let diff_qty = Quantity::from_decimal_dp(qty, instrument.size_precision()).ok()?;
+        let Ok(diff_qty) = Quantity::from_decimal_dp(qty, instrument.size_precision()) else {
+            self.record_position_report_drop(
+                report.instrument_id,
+                "venue quantity cannot be represented at instrument precision",
+            );
+            return None;
+        };
 
         if diff_qty.is_zero() {
+            self.record_position_report_drop(
+                report.instrument_id,
+                "venue quantity rounds to zero at instrument precision",
+            );
             return None;
         }
 
@@ -3208,7 +3603,25 @@ impl ExecutionManager {
 
         log::debug!("Reconciling NET position for {instrument_id}");
 
-        let instrument = self.get_instrument(&instrument_id)?;
+        let Some(instrument) = self.get_instrument(&instrument_id) else {
+            let is_flat_without_open_position = report.signed_decimal_qty == Decimal::ZERO
+                && self
+                    .cache
+                    .borrow()
+                    .positions_open(None, Some(&instrument_id), None, Some(&account_id), None)
+                    .is_empty();
+
+            if is_flat_without_open_position {
+                log::debug!(
+                    "Skipping flat venue position report for {instrument_id}: instrument is not \
+                     in the cache and no open position is cached"
+                );
+            } else {
+                self.record_position_report_drop(instrument_id, "instrument is not in the cache");
+            }
+
+            return None;
+        };
 
         let (cached_signed_qty, cached_avg_px) = {
             let cache = self.cache.borrow();
@@ -3262,11 +3675,21 @@ impl ExecutionManager {
         }
 
         let diff = (cached_signed_qty - venue_signed_qty).abs();
-        let diff_qty = Quantity::from_decimal_dp(diff, instrument.size_precision()).ok()?;
+        let Ok(diff_qty) = Quantity::from_decimal_dp(diff, instrument.size_precision()) else {
+            self.record_position_report_drop(
+                instrument_id,
+                "position difference cannot be represented at instrument precision",
+            );
+            return None;
+        };
 
         if diff_qty.is_zero() {
             log::debug!(
                 "Difference quantity rounds to zero for {instrument_id}, skipping order generation"
+            );
+            self.record_position_report_drop(
+                instrument_id,
+                "position difference rounds to zero at instrument precision",
             );
             return None;
         }
@@ -3330,19 +3753,26 @@ impl ExecutionManager {
             report.avg_px_open,
         );
 
-        let fill_px = reconciliation_px
-            .or(report.avg_px_open)
-            .or(current_avg_px)?;
+        let Some(fill_px) = reconciliation_px.or(report.avg_px_open).or(current_avg_px) else {
+            self.record_position_report_drop(instrument_id, "no reconciliation price is available");
+            return None;
+        };
 
         let ts_now = self.clock.borrow().timestamp_ns();
-        let fill_price = Price::from_decimal_dp(fill_px, instrument.price_precision()).ok();
+        let Ok(fill_price) = Price::from_decimal_dp(fill_px, instrument.price_precision()) else {
+            self.record_position_report_drop(
+                instrument_id,
+                "reconciliation price cannot be represented at instrument precision",
+            );
+            return None;
+        };
         let venue_order_id = create_position_reconciliation_venue_order_id(
             account_id,
             instrument_id,
             order_side,
             OrderType::Market,
             diff_qty,
-            fill_price,
+            Some(fill_price),
             report.venue_position_id,
             None,
             report.ts_last,
@@ -3377,6 +3807,14 @@ impl ExecutionManager {
 
         let (events, _) =
             self.handle_external_order(&order_report, account_id, instrument, &[], true, None);
+
+        if !position_reconciliation_applied(&events) {
+            self.record_position_report_drop(
+                instrument_id,
+                "synthetic reconciliation order was not applied",
+            );
+        }
+
         Some(events)
     }
 
@@ -3603,7 +4041,7 @@ impl ExecutionManager {
                         );
                     }
                     Some(existing) if is_synthetic => {
-                        log::warn!(
+                        log::debug!(
                             "Synthetic reconciliation order {client_order_id} for {} exists in \
                              cache in non-terminal state {:?}; fill not regenerated",
                             report.instrument_id,
@@ -4028,24 +4466,56 @@ fn targeted_report_matches(query: &TargetedOrderQuery, report: &OrderStatusRepor
     instrument_matches && order_matches
 }
 
+fn position_reports_dropped_warning(count: usize) -> String {
+    format!(
+        "{count} received venue position report(s) dropped during reconciliation; positions may be unreconciled"
+    )
+}
+
+fn unreconcilable_cached_positions_warning(count: usize) -> String {
+    format!(
+        "{count} cached position(s) could not be reconciled because no venue position report arrived; positions may be unreconciled"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use nautilus_common::clock::TestClock;
     use nautilus_core::datetime::NANOSECONDS_IN_SECOND;
     use nautilus_execution::reconciliation::generate_reconciliation_order_events;
     use nautilus_model::{
-        enums::{LiquiditySide, OmsType, PositionSideSpecified},
-        events::order::spec::{OrderPendingUpdateSpec, OrderUpdatedSpec},
+        accounts::{AccountAny, MarginAccount},
+        enums::{AccountType, LiquiditySide, OmsType, PositionSideSpecified},
+        events::{
+            account::state::AccountState,
+            order::spec::{OrderPendingUpdateSpec, OrderUpdatedSpec},
+        },
         instruments::{
             Instrument,
             stubs::{crypto_perpetual_ethusdt, xbtusd_bitmex},
         },
         orders::{OrderTestBuilder, stubs::TestOrderEventStubs},
-        types::Money,
+        types::{AccountBalance, Currency, Money},
     };
     use rstest::rstest;
 
     use super::*;
+
+    #[rstest]
+    fn test_position_reports_dropped_warning_message() {
+        assert_eq!(
+            position_reports_dropped_warning(2),
+            "2 received venue position report(s) dropped during reconciliation; positions may be unreconciled",
+        );
+    }
+
+    #[rstest]
+    fn test_unreconcilable_cached_positions_warning_message() {
+        assert_eq!(
+            unreconcilable_cached_positions_warning(3),
+            "3 cached position(s) could not be reconciled because no venue position report arrived; positions may be unreconciled",
+        );
+    }
 
     #[rstest]
     fn test_clear_recon_tracking_removes_targeted_query() {
@@ -4481,6 +4951,7 @@ mod tests {
             .add_instrument(instrument.clone())
             .unwrap();
         let account_id = position.account_id;
+        insert_margin_account(&cache, account_id);
         let check = manager.prepare_position_report_check(UUID4::new(), &[]);
         let report = PositionStatusReport::new(
             account_id,
@@ -4552,6 +5023,7 @@ mod tests {
         );
         cache.borrow_mut().add_instrument(instrument).unwrap();
         let account_id = position.account_id;
+        insert_margin_account(&cache, account_id);
         manager.record_position_activity(instrument_id, account_id);
         let check = manager.prepare_position_report_check(UUID4::new(), &[]);
         let report = PositionStatusReport::new(
@@ -4734,6 +5206,26 @@ mod tests {
             .add_position(&position, OmsType::Hedging)
             .unwrap();
         position
+    }
+
+    fn insert_margin_account(cache: &Rc<RefCell<Cache>>, account_id: AccountId) {
+        let state = AccountState::new(
+            account_id,
+            AccountType::Margin,
+            vec![AccountBalance::new(
+                Money::from("1000000 USDT"),
+                Money::from("0 USDT"),
+                Money::from("1000000 USDT"),
+            )],
+            vec![],
+            true,
+            UUID4::new(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            Some(Currency::USDT()),
+        );
+        let account = AccountAny::Margin(MarginAccount::new(state, true));
+        cache.borrow_mut().add_account(account).unwrap();
     }
 
     fn close_long_position(

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -385,6 +385,8 @@ impl LiveNode {
                 .await;
         }
 
+        self.drain_runner_pending();
+
         if let Some(reason) = self.startup_abort_reason() {
             self.abort_startup(reason).await?;
             return Ok(());
@@ -759,7 +761,16 @@ impl LiveNode {
                         .reconcile_execution_mass_status(mass_status, exec_engine_rc)
                         .await;
 
-                    if result.events.is_empty() {
+                    if result.position_reports_dropped > 0 {
+                        log::warn!(
+                            "{}",
+                            reconciliation_drop_warning(
+                                client_id,
+                                result.events.len(),
+                                result.position_reports_dropped,
+                            )
+                        );
+                    } else if result.events.is_empty() {
                         log_info!(
                             "Reconciliation for {} succeeded",
                             client_id,
@@ -3178,6 +3189,16 @@ fn render_client_statuses(rows: Vec<ClientStatus>) -> String {
     builder.build().with(Style::rounded()).to_string()
 }
 
+fn reconciliation_drop_warning(
+    client_id: ClientId,
+    event_count: usize,
+    position_reports_dropped: usize,
+) -> String {
+    format!(
+        "Reconciliation for {client_id} processed {event_count} events with {position_reports_dropped} venue position report(s) dropped"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -3300,6 +3321,14 @@ mod tests {
 ╰─────────┴───────────┴───────────╯";
 
         assert_eq!(output, expected);
+    }
+
+    #[rstest]
+    fn test_reconciliation_drop_warning_includes_processed_events() {
+        assert_eq!(
+            reconciliation_drop_warning(ClientId::from("BINANCE"), 3, 2),
+            "Reconciliation for BINANCE processed 3 events with 2 venue position report(s) dropped",
+        );
     }
 
     #[rstest]
@@ -5008,6 +5037,56 @@ mod tests {
         assert_eq!(handle.state(), NodeState::Stopped);
         assert!(handle.should_stop());
         assert!(!handle.is_running());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_start_drains_pending_account_event_before_reconciliation() {
+        let config = LiveNodeConfig {
+            exec_engine: crate::config::LiveExecEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            timeout_connection: Duration::ZERO,
+            timeout_reconciliation: Duration::ZERO,
+            timeout_portfolio: Duration::ZERO,
+            timeout_disconnection: Duration::ZERO,
+            delay_post_stop: Duration::ZERO,
+            timeout_shutdown: Duration::ZERO,
+            ..Default::default()
+        };
+        let mut node = LiveNode::build("StartupAccountNode".to_string(), Some(config)).unwrap();
+        let account_id = AccountId::from("STARTUP-001");
+        let account_state = AccountState::new(
+            account_id,
+            AccountType::Margin,
+            vec![AccountBalance::new(
+                Money::from("1000000 USDT"),
+                Money::from("0 USDT"),
+                Money::from("1000000 USDT"),
+            )],
+            vec![],
+            true,
+            UUID4::new(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            Some(Currency::USDT()),
+        );
+
+        node.runner.as_ref().unwrap().bind_senders();
+        get_exec_event_sender()
+            .send(ExecutionEvent::Account(account_state))
+            .unwrap();
+
+        assert!(node.kernel.cache().borrow().account(&account_id).is_none());
+
+        node.start().await.unwrap();
+
+        assert!(node.kernel.cache().borrow().account(&account_id).is_some());
+        assert_eq!(node.poll().unwrap(), 0);
+
+        node.stop().await.unwrap();
+        node.dispose();
     }
 
     #[rstest]

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -22,10 +22,12 @@ use std::{
     cell::{Cell, RefCell},
     collections::HashSet,
     rc::Rc,
+    sync::Mutex,
 };
 
 use async_trait::async_trait;
 use indexmap::IndexSet;
+use log::{Level, LevelFilter, Log, Metadata, Record};
 use nautilus_common::{
     cache::Cache,
     clients::ExecutionClient,
@@ -102,6 +104,31 @@ struct TestContext {
     cache: Rc<RefCell<Cache>>,
     manager: ExecutionManager,
     exec_engine: Rc<RefCell<ExecutionEngine>>,
+}
+
+struct MassStatusLogCapture {
+    messages: Mutex<Vec<String>>,
+}
+
+static MASS_STATUS_LOG_CAPTURE: MassStatusLogCapture = MassStatusLogCapture {
+    messages: Mutex::new(Vec::new()),
+};
+
+impl Log for MassStatusLogCapture {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.level() == Level::Info && metadata.target() == "nautilus_live::execution::manager"
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if self.enabled(record.metadata()) {
+            self.messages
+                .lock()
+                .unwrap()
+                .push(record.args().to_string());
+        }
+    }
+
+    fn flush(&self) {}
 }
 
 impl TestContext {
@@ -5499,6 +5526,22 @@ fn close_test_long_position(
     position
 }
 
+fn add_non_terminal_synthetic_order(
+    ctx: &TestContext,
+    venue_order_id: VenueOrderId,
+    instrument_id: InstrumentId,
+    side: OrderSide,
+    quantity: Quantity,
+) {
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .client_order_id(ClientOrderId::from(venue_order_id.as_str()))
+        .instrument_id(instrument_id)
+        .side(side)
+        .quantity(quantity)
+        .build();
+    ctx.add_order(order);
+}
+
 #[tokio::test]
 async fn test_reconcile_mass_status_iterates_all_position_reports() {
     // Tests that we iterate ALL position reports, not just the first one
@@ -5645,6 +5688,7 @@ async fn test_reconcile_mass_status_routes_to_netting_without_venue_position_id(
     assert!(!result.events.is_empty());
 }
 
+#[rstest]
 #[tokio::test]
 async fn test_reconcile_mass_status_skips_hedge_position_when_fills_in_batch() {
     // Tests that hedge position reconciliation is skipped when fills for the same
@@ -5656,7 +5700,17 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_fills_in_batch() {
     let venue_position_id = PositionId::from("P-HEDGE-001");
 
     ctx.add_instrument(test_instrument());
-    let order = create_limit_order("O-001", instrument_id, OrderSide::Buy, "5.0", "3000.00");
+    let order = create_accepted_order(
+        "O-001",
+        instrument_id,
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        venue_order_id,
+    );
+    ctx.exec_engine
+        .borrow_mut()
+        .register_oms_type(order.strategy_id(), OmsType::Hedging);
     ctx.add_order(order);
 
     let mut mass_status = ExecutionMassStatus::new(
@@ -5685,6 +5739,26 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_fills_in_batch() {
         None,
     );
     mass_status.add_fill_reports(vec![fill]);
+    mass_status.add_order_reports(vec![
+        OrderStatusReport::new(
+            test_account_id(),
+            instrument_id,
+            Some(client_order_id),
+            venue_order_id,
+            OrderSide::Buy,
+            OrderType::Limit,
+            TimeInForce::Gtc,
+            OrderStatus::Filled,
+            Quantity::from("5.0"),
+            Quantity::from("5.0"),
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(1_000_000),
+            None,
+        )
+        .with_avg_px(dec!(3000.00))
+        .with_venue_position_id(venue_position_id),
+    ]);
 
     // Add a hedge position report for the same venue_position_id
     let position_report = PositionStatusReport::new(
@@ -5704,10 +5778,113 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_fills_in_batch() {
         .manager
         .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
         .await;
+    let cached_positions = ctx
+        .cache
+        .borrow()
+        .positions(None, Some(&instrument_id), None, None, None)
+        .into_iter()
+        .map(|position| (position.id, position.signed_decimal_qty()))
+        .collect::<Vec<_>>();
 
     // Should only have fill event, no synthetic order from position report
     assert_eq!(result.events.len(), 1);
     assert!(matches!(result.events[0], OrderEventAny::Filled(_)));
+    assert_eq!(cached_positions, vec![(venue_position_id, dec!(5.0))]);
+    assert_eq!(result.position_reports_dropped, 0);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_reconcile_mass_status_counts_hedge_report_drop_when_batch_fill_qty_differs() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let client_order_id = ClientOrderId::from("O-HEDGE-MISMATCH");
+    let venue_order_id = VenueOrderId::from("V-HEDGE-MISMATCH");
+    let venue_position_id = PositionId::from("P-HEDGE-MISMATCH");
+
+    ctx.add_instrument(test_instrument());
+    let order = create_accepted_order(
+        client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        venue_order_id,
+    );
+    ctx.exec_engine
+        .borrow_mut()
+        .register_oms_type(order.strategy_id(), OmsType::Hedging);
+    ctx.add_order(order);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_fill_reports(vec![FillReport::new(
+        test_account_id(),
+        instrument_id,
+        venue_order_id,
+        TradeId::from("T-HEDGE-MISMATCH"),
+        OrderSide::Buy,
+        Quantity::from("1.0"),
+        Price::from("3000.00"),
+        Money::from("0.50 USDT"),
+        LiquiditySide::Maker,
+        Some(client_order_id),
+        Some(venue_position_id),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )]);
+    mass_status.add_order_reports(vec![
+        OrderStatusReport::new(
+            test_account_id(),
+            instrument_id,
+            Some(client_order_id),
+            venue_order_id,
+            OrderSide::Buy,
+            OrderType::Limit,
+            TimeInForce::Gtc,
+            OrderStatus::PartiallyFilled,
+            Quantity::from("5.0"),
+            Quantity::from("1.0"),
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(1_000_000),
+            None,
+        )
+        .with_avg_px(dec!(3000.00))
+        .with_venue_position_id(venue_position_id),
+    ]);
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        Some(venue_position_id),
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, OrderEventAny::Filled(_)))
+            .count(),
+        1,
+    );
+    assert_eq!(result.position_reports_dropped, 1);
 }
 
 #[tokio::test]
@@ -5843,6 +6020,290 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_fills_lack_positio
     // Should only have fill event, position report skipped due to instrument-level fill
     assert_eq!(result.events.len(), 1);
     assert!(matches!(result.events[0], OrderEventAny::Filled(_)));
+}
+
+#[tokio::test]
+async fn test_reconcile_mass_status_preserves_open_order_for_cross_account_position_id_collision() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_a = test_account_id();
+    let account_b = AccountId::from("BINANCE-002");
+    let venue_position_id = PositionId::from("P-SHARED-OPEN-ORDER");
+    let venue_order_id = VenueOrderId::from("V-SHARED-OPEN-ORDER");
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_margin_account(account_b);
+    ctx.add_position(&create_test_position_for_account(
+        &instrument,
+        venue_position_id,
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        account_a,
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_a,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_order_reports(vec![
+        OrderStatusReport::new(
+            account_b,
+            instrument_id,
+            None,
+            venue_order_id,
+            OrderSide::Buy,
+            OrderType::Limit,
+            TimeInForce::Gtc,
+            OrderStatus::Accepted,
+            Quantity::from("5.0"),
+            Quantity::from("0.0"),
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(1_000_000),
+            None,
+        )
+        .with_price(Price::from("3000.00"))
+        .with_venue_position_id(venue_position_id),
+    ]);
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_b,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        Some(venue_position_id),
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Accepted(_)))
+    );
+}
+
+#[rstest]
+#[case(false)]
+#[case(true)]
+#[tokio::test]
+async fn test_reconcile_mass_status_applies_external_order_under_envelope_account(
+    #[case] has_client_order_id: bool,
+) {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let envelope_account = test_account_id();
+    let report_account = AccountId::from("BINANCE-002");
+    let venue_position_id = PositionId::from("P-REPORT-ACCOUNT-FILL");
+
+    ctx.add_instrument(test_instrument());
+    ctx.add_margin_account(report_account);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        envelope_account,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_order_reports(vec![
+        OrderStatusReport::new(
+            report_account,
+            instrument_id,
+            has_client_order_id.then(|| ClientOrderId::from("O-REPORT-ACCOUNT-FILL")),
+            VenueOrderId::from("V-REPORT-ACCOUNT-FILL"),
+            OrderSide::Buy,
+            OrderType::Market,
+            TimeInForce::Gtc,
+            OrderStatus::Filled,
+            Quantity::from("3.0"),
+            Quantity::from("3.0"),
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(1_000_000),
+            UnixNanos::from(1_000_000),
+            None,
+        )
+        .with_avg_px(dec!(3100.00))
+        .with_venue_position_id(venue_position_id),
+    ]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 0);
+    assert_eq!(result.positions_created, 0);
+    assert!(result.events.iter().any(|event| {
+        matches!(
+            event,
+            OrderEventAny::Filled(fill)
+                if fill.account_id == envelope_account
+                    && fill.position_id == Some(venue_position_id)
+        )
+    }));
+    assert_eq!(
+        ctx.cache
+            .borrow()
+            .position(&venue_position_id)
+            .expect("envelope-account position should be cached")
+            .account_id,
+        envelope_account,
+    );
+}
+
+#[tokio::test]
+async fn test_reconcile_mass_status_counts_uncached_report_account_drop() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let report_account = AccountId::from("BINANCE-UNREGISTERED");
+
+    ctx.add_instrument(test_instrument());
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        report_account,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3100.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert_eq!(result.positions_created, 0);
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Filled(_)))
+    );
+}
+
+#[rstest]
+#[case(false, true)]
+#[case(true, false)]
+#[case(true, true)]
+#[tokio::test]
+async fn test_reconcile_mass_status_preserves_fill_for_cross_account_position_id_collision(
+    #[case] order_has_position_id: bool,
+    #[case] fill_has_position_id: bool,
+) {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_a = test_account_id();
+    let account_b = AccountId::from("BINANCE-002");
+    let venue_position_id = PositionId::from("P-SHARED-CROSS-ACCOUNT");
+    let venue_order_id = VenueOrderId::from("V-SHARED-CROSS-ACCOUNT");
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_margin_account(account_b);
+    ctx.add_position(&create_test_position_for_account(
+        &instrument,
+        venue_position_id,
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        account_a,
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_a,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    let mut order_report = OrderStatusReport::new(
+        account_b,
+        instrument_id,
+        None,
+        venue_order_id,
+        OrderSide::Buy,
+        OrderType::Market,
+        TimeInForce::Gtc,
+        OrderStatus::Filled,
+        Quantity::from("5.0"),
+        Quantity::from("5.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )
+    .with_avg_px(dec!(3000.00));
+
+    if order_has_position_id {
+        order_report = order_report.with_venue_position_id(venue_position_id);
+    }
+
+    mass_status.add_order_reports(vec![order_report]);
+    mass_status.add_fill_reports(vec![FillReport::new(
+        account_b,
+        instrument_id,
+        venue_order_id,
+        TradeId::from("T-SHARED-CROSS-ACCOUNT"),
+        OrderSide::Buy,
+        Quantity::from("5.0"),
+        Price::from("3000.00"),
+        Money::from("0.10 USDT"),
+        LiquiditySide::Taker,
+        None,
+        fill_has_position_id.then_some(venue_position_id),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )]);
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_b,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        Some(venue_position_id),
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert!(result.events.iter().any(|event| {
+        matches!(
+            event,
+            OrderEventAny::Filled(fill)
+                if fill.trade_id == TradeId::from("T-SHARED-CROSS-ACCOUNT")
+        )
+    }));
 }
 
 #[tokio::test]
@@ -6794,6 +7255,7 @@ async fn test_cross_zero_unbuildable_open_leg_has_no_side_effects() {
         .signed_decimal_qty();
 
     assert!(events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 1);
     assert_eq!(
         cache.orders_total_count(None, None, None, None, None),
         order_count_before,
@@ -6811,6 +7273,59 @@ async fn test_cross_zero_unbuildable_open_leg_has_no_side_effects() {
     assert!(
         event_messages.get_messages().is_empty(),
         "an unbuildable open leg must not publish any order event",
+    );
+}
+
+#[tokio::test]
+async fn test_cross_zero_unrepresentable_open_price_counts_drop_without_side_effects() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let position_id = PositionId::from("P-CROSS-ZERO-PRICE");
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        position_id,
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Short,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(Decimal::MAX),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert_eq!(result.positions_created, 0);
+    assert!(result.events.is_empty());
+    assert_eq!(
+        ctx.cache
+            .borrow()
+            .position(&position_id)
+            .expect("cached position should remain present")
+            .signed_decimal_qty(),
+        dec!(5.0),
     );
 }
 
@@ -7881,7 +8396,7 @@ async fn test_adjust_fills_filter_to_current_lifecycle_preserves_working_orders(
 }
 
 #[tokio::test]
-async fn test_cross_zero_with_missing_cached_avg_px_returns_none() {
+async fn test_cross_zero_with_missing_cached_avg_px_counts_dropped_report() {
     // When cached position has no avg_px, cross-zero cannot generate close fill
     let mut ctx = TestContext::new();
     let instrument = test_instrument();
@@ -7929,10 +8444,11 @@ async fn test_cross_zero_with_missing_cached_avg_px_returns_none() {
         result.events.len() <= 4,
         "Should not produce excessive events"
     );
+    assert_eq!(result.position_reports_dropped, 1);
 }
 
 #[tokio::test]
-async fn test_cross_zero_with_missing_venue_avg_px_closes_only() {
+async fn test_cross_zero_with_missing_venue_avg_px_counts_partial_drop() {
     // When venue position has no avg_px, cross-zero can close but not open new position
     let mut ctx = TestContext::new();
     let instrument = test_instrument();
@@ -7974,7 +8490,7 @@ async fn test_cross_zero_with_missing_venue_avg_px_closes_only() {
         .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
         .await;
 
-    // Should generate close fill only (not open fill due to missing venue avg_px)
+    // A missing venue average price permits only the cached-position close fill.
     let fill_events: Vec<_> = result
         .events
         .iter()
@@ -7995,6 +8511,733 @@ async fn test_cross_zero_with_missing_venue_avg_px_closes_only() {
     );
     assert_eq!(fill_events[0].order_side, OrderSide::Sell);
     assert_eq!(fill_events[0].last_qty, Quantity::from("5.0"));
+    assert_eq!(result.position_reports_dropped, 1);
+}
+
+#[tokio::test]
+async fn test_cross_zero_empty_close_events_count_dropped_report() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+    let close_qty = Quantity::from_decimal_dp(dec!(5.0), instrument.size_precision()).unwrap();
+    let close_price = Price::from_decimal_dp(dec!(3000.00), instrument.price_precision()).ok();
+    let close_venue_order_id = create_position_reconciliation_venue_order_id(
+        account_id,
+        instrument_id,
+        OrderSide::Sell,
+        OrderType::Market,
+        close_qty,
+        close_price,
+        None,
+        Some("CLOSE"),
+        ts_last,
+    );
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        PositionId::new("P-CLOSE-COLLISION"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    ));
+    add_non_terminal_synthetic_order(
+        &ctx,
+        close_venue_order_id,
+        instrument_id,
+        OrderSide::Sell,
+        close_qty,
+    );
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Short,
+        Quantity::from("3.0"),
+        ts_last,
+        ts_last,
+        None,
+        None,
+        Some(dec!(3100.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert!(result.events.iter().any(
+        |event| matches!(event, OrderEventAny::Filled(fill) if fill.last_qty == Quantity::from("3.0"))
+    ));
+}
+
+#[tokio::test]
+async fn test_cross_zero_empty_open_events_count_dropped_report() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+    let open_qty = Quantity::from_decimal_dp(dec!(3.0), instrument.size_precision()).unwrap();
+    let open_price = Price::from_decimal_dp(dec!(3100.00), instrument.price_precision()).ok();
+    let open_venue_order_id = create_position_reconciliation_venue_order_id(
+        account_id,
+        instrument_id,
+        OrderSide::Sell,
+        OrderType::Market,
+        open_qty,
+        open_price,
+        None,
+        Some("OPEN"),
+        ts_last,
+    );
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        PositionId::new("P-OPEN-COLLISION"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    ));
+    add_non_terminal_synthetic_order(
+        &ctx,
+        open_venue_order_id,
+        instrument_id,
+        OrderSide::Sell,
+        open_qty,
+    );
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Short,
+        Quantity::from("3.0"),
+        ts_last,
+        ts_last,
+        None,
+        None,
+        Some(dec!(3100.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert!(result.events.iter().any(
+        |event| matches!(event, OrderEventAny::Filled(fill) if fill.last_qty == Quantity::from("5.0"))
+    ));
+}
+
+#[tokio::test]
+async fn test_cross_zero_two_failed_legs_count_dropped_report_once() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+    let close_qty = Quantity::from_decimal_dp(dec!(5.0), instrument.size_precision()).unwrap();
+    let close_price = Price::from_decimal_dp(dec!(3000.00), instrument.price_precision()).ok();
+    let close_venue_order_id = create_position_reconciliation_venue_order_id(
+        account_id,
+        instrument_id,
+        OrderSide::Sell,
+        OrderType::Market,
+        close_qty,
+        close_price,
+        None,
+        Some("CLOSE"),
+        ts_last,
+    );
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        PositionId::new("P-TWO-FAILED-LEGS"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    ));
+    add_non_terminal_synthetic_order(
+        &ctx,
+        close_venue_order_id,
+        instrument_id,
+        OrderSide::Sell,
+        close_qty,
+    );
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Short,
+        Quantity::from("3.0"),
+        ts_last,
+        ts_last,
+        None,
+        None,
+        None,
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_flat_report_with_cached_open_position_emits_close_events() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = test_instrument_id();
+    ctx.add_instrument(instrument.clone());
+
+    let position = create_test_position(
+        &instrument,
+        PositionId::new("P-001"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    );
+    ctx.add_position(&position);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    let position_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Flat,
+        Quantity::from("0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    );
+    mass_status.add_position_reports(vec![position_report]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+    let fill_events: Vec<_> = result
+        .events
+        .iter()
+        .filter_map(|event| {
+            if let OrderEventAny::Filled(fill) = event {
+                Some(fill)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert_eq!(result.position_reports_dropped, 0);
+    assert_eq!(fill_events.len(), 1);
+    assert_eq!(fill_events[0].order_side, OrderSide::Sell);
+    assert_eq!(fill_events[0].last_qty, Quantity::from("5.0"));
+}
+
+#[tokio::test]
+async fn test_flat_report_with_uncached_instrument_and_cached_open_position_counts_drop() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = test_instrument_id();
+
+    let position = create_test_position(
+        &instrument,
+        PositionId::new("P-001"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    );
+    ctx.add_position(&position);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    let position_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Flat,
+        Quantity::from("0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    );
+    mass_status.add_position_reports(vec![position_report]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_flat_report_ignores_other_account_position_when_instrument_uncached() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_a = test_account_id();
+    let account_b = AccountId::from("BINANCE-002");
+
+    ctx.add_margin_account(account_b);
+    ctx.add_position(&create_test_position_for_account(
+        &instrument,
+        PositionId::new("P-OTHER-ACCOUNT"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        account_b,
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_a,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_a,
+        instrument_id,
+        PositionSideSpecified::Flat,
+        Quantity::from("0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 0);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_mass_position_synthetic_collision_counts_drop_not_created_position() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+    let order_qty = Quantity::from_decimal_dp(dec!(3.0), instrument.size_precision()).unwrap();
+    let fill_price = Price::from_decimal_dp(dec!(3000.00), instrument.price_precision()).ok();
+    let venue_order_id = create_position_reconciliation_venue_order_id(
+        account_id,
+        instrument_id,
+        OrderSide::Buy,
+        OrderType::Market,
+        order_qty,
+        fill_price,
+        None,
+        None,
+        ts_last,
+    );
+
+    ctx.add_instrument(instrument);
+    add_non_terminal_synthetic_order(
+        &ctx,
+        venue_order_id,
+        instrument_id,
+        OrderSide::Buy,
+        order_qty,
+    );
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        ts_last,
+        ts_last,
+        None,
+        None,
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert_eq!(result.positions_created, 0);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_mass_position_difference_collision_counts_drop_not_created_position() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+    let order_qty = Quantity::from_decimal_dp(dec!(2.0), instrument.size_precision()).unwrap();
+    let fill_price = Price::from_decimal_dp(dec!(3000.00), instrument.price_precision()).ok();
+    let venue_order_id = create_position_reconciliation_venue_order_id(
+        account_id,
+        instrument_id,
+        OrderSide::Sell,
+        OrderType::Market,
+        order_qty,
+        fill_price,
+        None,
+        None,
+        ts_last,
+    );
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        PositionId::from("P-DIFFERENCE-COLLISION"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    ));
+    add_non_terminal_synthetic_order(
+        &ctx,
+        venue_order_id,
+        instrument_id,
+        OrderSide::Sell,
+        order_qty,
+    );
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        ts_last,
+        ts_last,
+        None,
+        None,
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert_eq!(result.positions_created, 0);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_mass_position_created_counts_applied_synthetic_position() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+
+    ctx.add_instrument(instrument);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        ts_last,
+        ts_last,
+        None,
+        None,
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.positions_created, 1);
+    assert_eq!(result.position_reports_dropped, 0);
+    assert!(!result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_mass_unrepresentable_position_price_counts_drop_not_created_position() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+
+    ctx.add_instrument(instrument);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(Decimal::MAX),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert_eq!(result.positions_created, 0);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_netting_subprecision_difference_counts_drop() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        PositionId::from("P-SUBPRECISION"),
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("1.0004"),
+        ts_last,
+        ts_last,
+        None,
+        None,
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert_eq!(result.positions_created, 0);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_missing_hedge_subprecision_quantity_counts_drop() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+
+    ctx.add_instrument(instrument);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("0.0004"),
+        ts_last,
+        ts_last,
+        None,
+        Some(PositionId::from("P-VENUE-HEDGE")),
+        None,
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert_eq!(result.positions_created, 0);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_flat_report_counts_drop_for_report_account_open_position() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let envelope_account = test_account_id();
+    let report_account = AccountId::from("BINANCE-002");
+
+    ctx.add_margin_account(report_account);
+    ctx.add_position(&create_test_position_for_account(
+        &instrument,
+        PositionId::new("P-REPORT-ACCOUNT"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        report_account,
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        envelope_account,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        report_account,
+        instrument_id,
+        PositionSideSpecified::Flat,
+        Quantity::from("0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert!(result.events.is_empty());
+}
+
+#[tokio::test]
+async fn test_flat_report_exemption_scopes_to_report_account_not_envelope() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let envelope_account = test_account_id();
+    let report_account = AccountId::from("BINANCE-002");
+
+    ctx.add_margin_account(report_account);
+    ctx.add_position(&create_test_position_for_account(
+        &instrument,
+        PositionId::new("P-ENVELOPE-ACCOUNT"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        envelope_account,
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        envelope_account,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        report_account,
+        instrument_id,
+        PositionSideSpecified::Flat,
+        Quantity::from("0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 0);
+    assert!(result.events.is_empty());
 }
 
 #[tokio::test]
@@ -10847,6 +12090,325 @@ async fn test_position_check_preserves_retry_for_uncovered_position_opened_durin
 }
 
 #[tokio::test]
+async fn test_position_check_missing_instrument_counts_unreconcilable_cached_position() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    ctx.add_position(&create_test_position(
+        &instrument,
+        PositionId::from("P-MISSING-INSTRUMENT"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    ));
+    let mock_client = MockExecutionClient::new(vec![]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 0);
+    assert_eq!(ctx.manager.unreconcilable_cached_positions(), 1);
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, test_account_id())),
+        1,
+    );
+}
+
+#[tokio::test]
+async fn test_position_check_without_price_counts_drop_on_each_retry() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        PositionId::from("P-NO-PRICE"),
+        OrderSide::Buy,
+        "5.0",
+        "0.00",
+    ));
+    let venue_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    );
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let first_events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(first_events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 1);
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, test_account_id())),
+        1,
+    );
+
+    let second_events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(second_events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 1);
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, test_account_id())),
+        2,
+    );
+}
+
+#[tokio::test]
+async fn test_position_check_empty_synthetic_events_count_drop_and_retry() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+    let ts_last = UnixNanos::from(1_000_000);
+    let order_qty = Quantity::from_decimal_dp(dec!(3.0), instrument.size_precision()).unwrap();
+    let fill_price = Price::from_decimal_dp(dec!(3000.00), instrument.price_precision()).ok();
+    let venue_order_id = create_position_reconciliation_venue_order_id(
+        account_id,
+        instrument_id,
+        OrderSide::Buy,
+        OrderType::Market,
+        order_qty,
+        fill_price,
+        None,
+        None,
+        ts_last,
+    );
+
+    ctx.add_instrument(instrument);
+    add_non_terminal_synthetic_order(
+        &ctx,
+        venue_order_id,
+        instrument_id,
+        OrderSide::Buy,
+        order_qty,
+    );
+    let venue_report = PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        ts_last,
+        ts_last,
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 1);
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, account_id)),
+        1,
+    );
+}
+
+#[tokio::test]
+async fn test_position_check_unrepresentable_price_counts_drop_and_retry() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+
+    ctx.add_instrument(instrument);
+
+    let venue_report = PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(Decimal::MAX),
+    );
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 1);
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, account_id)),
+        1,
+    );
+}
+
+#[tokio::test]
+async fn test_position_check_unrepresentable_difference_quantity_counts_drop_and_retry() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let account_id = test_account_id();
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        PositionId::from("P-UNREPRESENTABLE-DIFFERENCE-QUANTITY"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+    ));
+
+    let mut venue_report = PositionStatusReport::new(
+        account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3100.00)),
+    );
+    venue_report.signed_decimal_qty = dec!(10000000000000000000);
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 1);
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, account_id)),
+        1,
+    );
+}
+
+#[tokio::test]
+async fn test_position_check_uncached_report_account_counts_drop_and_retry() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let report_account = AccountId::from("BINANCE-UNREGISTERED");
+
+    ctx.add_instrument(instrument);
+
+    let venue_report = PositionStatusReport::new(
+        report_account,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 1);
+    assert_eq!(
+        ctx.manager
+            .position_recon_retry_count(&(instrument_id, report_account)),
+        1,
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_position_check_unknown_account_is_counted_before_quantity_match() {
+    let config = ExecutionManagerConfig {
+        position_check_retries: 3,
+        position_check_threshold_ns: 0,
+        ..Default::default()
+    };
+    let mut ctx = TestContext::with_config(config);
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let report_account = AccountId::from("BINANCE-REMOVED");
+
+    ctx.add_instrument(instrument.clone());
+    ctx.add_margin_account(report_account);
+    ctx.add_position(&create_test_position_for_account(
+        &instrument,
+        PositionId::from("P-REMOVED-ACCOUNT"),
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        report_account,
+    ));
+    assert!(
+        ctx.cache
+            .borrow_mut()
+            .take_account(&report_account)
+            .is_some()
+    );
+
+    let venue_report = PositionStatusReport::new(
+        report_account,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    let mock_client = MockPositionExecutionClient::new(vec![], vec![venue_report]);
+    let clients: Vec<&dyn ExecutionClient> = vec![&mock_client];
+
+    let events = ctx.manager.check_positions_consistency(&clients).await;
+
+    assert!(events.is_empty());
+    assert_eq!(ctx.manager.position_reports_dropped(), 1);
+}
+
+#[tokio::test]
 async fn test_position_check_retries_stops_after_max() {
     // When instrument is not in cache, check_position_discrepancy returns None
     // (can't generate fills), so retries should increment until exhausted
@@ -13144,4 +14706,352 @@ async fn test_reconcile_mass_status_does_not_capture_synthetic_reports() {
         TradeId::from("T-SYN-RAW"),
         "captured trade_id must match the original raw input, not a synthetic `S-` id",
     );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_mass_status_unknown_report_account_cannot_adjust_envelope_account_fills() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let envelope_account_id = test_account_id();
+    let report_account_id = AccountId::from("BINANCE-UNKNOWN");
+    let client_order_id = ClientOrderId::from("O-CROSS-ACCOUNT-ADJUST");
+    let venue_order_id = VenueOrderId::from("V-CROSS-ACCOUNT-ADJUST");
+
+    ctx.add_instrument(instrument);
+    ctx.add_order(create_limit_order(
+        client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        envelope_account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_fill_reports(vec![FillReport::new(
+        envelope_account_id,
+        instrument_id,
+        venue_order_id,
+        TradeId::from("T-CROSS-ACCOUNT-ADJUST"),
+        OrderSide::Buy,
+        Quantity::from("1.0"),
+        Price::from("3000.00"),
+        Money::from("0.50 USDT"),
+        LiquiditySide::Maker,
+        Some(client_order_id),
+        None,
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )]);
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        report_account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    let applied_fills = result
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            OrderEventAny::Filled(fill) => Some(fill),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let cache = ctx.cache.borrow();
+
+    assert_eq!(result.position_reports_dropped, 1);
+    assert_eq!(
+        applied_fills.len(),
+        1,
+        "no synthetic fill should be applied"
+    );
+    assert_eq!(
+        applied_fills[0].trade_id,
+        TradeId::from("T-CROSS-ACCOUNT-ADJUST"),
+    );
+    assert_eq!(
+        cache.orders_total_count(None, None, None, None, None),
+        1,
+        "no synthetic order should be cached",
+    );
+    assert!(
+        cache
+            .positions_open(
+                None,
+                Some(&instrument_id),
+                None,
+                Some(&report_account_id),
+                None,
+            )
+            .is_empty()
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_mass_status_flat_report_for_cached_instrument_requires_known_account() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let report_account_id = AccountId::from("BINANCE-UNKNOWN-FLAT");
+
+    ctx.add_instrument(instrument);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        report_account_id,
+        instrument_id,
+        PositionSideSpecified::Flat,
+        Quantity::from("0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert!(result.events.is_empty());
+    assert_eq!(result.position_reports_dropped, 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_mass_status_completion_log_includes_position_drop_counts() {
+    log::set_logger(&MASS_STATUS_LOG_CAPTURE).expect("test logger already installed");
+    log::set_max_level(LevelFilter::Info);
+    MASS_STATUS_LOG_CAPTURE.messages.lock().unwrap().clear();
+
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let client_order_id = ClientOrderId::from("O-COMPLETION-COUNTS");
+    let venue_order_id = VenueOrderId::from("V-COMPLETION-COUNTS");
+
+    ctx.add_instrument(instrument);
+    ctx.add_order(create_limit_order(
+        client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_fill_reports(vec![FillReport::new(
+        test_account_id(),
+        instrument_id,
+        venue_order_id,
+        TradeId::from("T-COMPLETION-COUNTS"),
+        OrderSide::Buy,
+        Quantity::from("1.0"),
+        Price::from("3000.00"),
+        Money::from("0.50 USDT"),
+        LiquiditySide::Maker,
+        Some(client_order_id),
+        None,
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )]);
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        AccountId::from("BINANCE-UNKNOWN-COMPLETION"),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("1.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.events.len(), 1);
+    assert!(matches!(result.events[0], OrderEventAny::Filled(_)));
+    assert_eq!(result.position_reports_dropped, 1);
+
+    let messages = MASS_STATUS_LOG_CAPTURE.messages.lock().unwrap();
+    let completion = messages
+        .iter()
+        .find(|message| message.starts_with("Reconciliation complete for BINANCE:"))
+        .expect("mass-status reconciliation completion log was not emitted");
+    assert!(
+        completion.contains("position_reports_dropped=1"),
+        "completion line missing dropped-report count: {completion}",
+    );
+    assert!(
+        completion.contains("unreconcilable_cached_positions=0"),
+        "completion line missing cached-position anomaly count: {completion}",
+    );
+}
+
+#[tokio::test]
+async fn test_reconcile_mass_status_counts_dropped_position_reports() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+
+    let mut non_flat_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    let position_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.000"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    non_flat_status.add_position_reports(vec![position_report]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(non_flat_status, ctx.exec_engine.clone())
+        .await;
+    assert_eq!(result.position_reports_dropped, 1);
+
+    let mut flat_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    let flat_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Flat,
+        Quantity::from("0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    );
+    flat_status.add_position_reports(vec![flat_report]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(flat_status, ctx.exec_engine.clone())
+        .await;
+    assert_eq!(result.position_reports_dropped, 0);
+
+    ctx.add_instrument(test_instrument());
+
+    let mut missing_avg_px_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    let missing_avg_px_report = PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.000"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        None,
+    );
+    missing_avg_px_status.add_position_reports(vec![missing_avg_px_report]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(missing_avg_px_status, ctx.exec_engine.clone())
+        .await;
+    assert_eq!(result.position_reports_dropped, 1);
+}
+
+#[tokio::test]
+async fn test_reconcile_mass_status_aggregates_two_dropped_position_reports() {
+    let mut ctx = TestContext::new();
+    let first_instrument_id = test_instrument_id();
+    let second_instrument_id = InstrumentId::from("UNKNOWN-PERP.BINANCE");
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    let first_report = PositionStatusReport::new(
+        test_account_id(),
+        first_instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.000"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    );
+    let second_report = PositionStatusReport::new(
+        test_account_id(),
+        second_instrument_id,
+        PositionSideSpecified::Short,
+        Quantity::from("2.000"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(2000.00)),
+    );
+    mass_status.add_position_reports(vec![first_report, second_report]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(result.position_reports_dropped, 2);
 }


### PR DESCRIPTION
## Summary

The live execution manager dropped a venue position report whose instrument was absent from its cache with no else branch, no counter and no log, so a mass status the adapter built completely could still lose positions inside the engine. The same silence covered sub-lot quantities, cross-zero legs, unrepresentable values, and periodic discrepancy handling.

This PR makes every such drop visible and closes the silent-acceptance paths:

- Every drop or skip of a venue position report is counted exactly once per reconciliation pass and surfaced as one aggregated warning naming the count; per-site detail logs at debug (no per-report error spam).
- Position reconciliation is scoped to each report's `account_id`, with a fail-closed cache-account gate for received reports (previously reports were reconciled under the mass-status envelope account regardless of their own account). The gate runs before any early return: mass-status position reports are gated up front, and the periodic path validates every venue report's account before quantity matching.
- A hedge position report whose batch fills establish a different quantity than reported is counted as a drop (no corrective order is generated; reconciliation outcomes are unchanged).
- Flat reports remain exempt only when the instrument is uncached and no same-account open position is cached; a flat report for a cached instrument from an unknown account is dropped and counted.
- A cached position that cannot be reconciled because no venue report arrived is counted separately (`unreconcilable_cached_positions`), so the pass message never claims a report was dropped when nothing was received; cross-zero leg failures count their report once.
- The reconciliation completion line now carries both the applied-event count and the dropped-report count on every path (previously the direct mass-reconciliation line omitted drops).
- `LiveNode::start()` now drains pending runner events (including account state) before startup reconciliation, matching the `run()` path, so the account gate's precondition holds on both startup paths.

## Behavior changes (deliberate, fail-closed)

- Venue reports whose price or quantity cannot be represented at instrument precision are now dropped and counted, instead of generating a synthetic reconciliation order with a missing or downstream-clamped price (four sites: periodic difference, cross-zero open/close legs, position creation).
- Position reports for accounts absent from the cache are dropped and counted instead of being reconciled under the envelope account. The gating happens before mass-status fill adjustment, so an unknown-account report can no longer steer synthetic fills on the envelope account.

## Known limitations (pre-existing)

- After `position_check_retries` is exhausted, later periodic passes discard recurring reports without counting (the retry ladder's existing terminal behavior).
- A cached open position whose account was removed from the cache, with no venue report arriving, follows the pre-existing periodic path semantics.

## Test plan

- `cargo nextest run -p nautilus-live`: 555 passed, 2 skipped (new: per-site drop counting, flat exemption both directions, account gating before fill adjustment and before periodic early returns, hedge batch-fill quantity mismatch, startup event draining, completion-line counts).
- `cargo clippy -p nautilus-live --all-targets -- -D warnings`: clean. `prek run --all-files`: all hooks pass.
- Negative controls: each new test was confirmed to fail with its production change reverted, then restored.
