### PR TITLE
Isolate indicator failures from sibling indicators and actor handlers

### DIFF
--- a/crates/common/src/actor/data_actor.rs
+++ b/crates/common/src/actor/data_actor.rs
@@ -900,7 +900,6 @@ pub trait DataActor: Component {
 
         if let Err(e) = self.core().handle_indicators_for_quote(quote) {
             log_error(&e);
-            return;
         }
 
         if self.not_running() {
@@ -922,7 +921,6 @@ pub trait DataActor: Component {
 
         if let Err(e) = self.core().handle_indicators_for_trade(trade) {
             log_error(&e);
-            return;
         }
 
         if self.not_running() {
@@ -944,7 +942,6 @@ pub trait DataActor: Component {
 
         if let Err(e) = self.core().handle_indicators_for_bar(bar) {
             log_error(&e);
-            return;
         }
 
         if self.not_running() {
@@ -1228,7 +1225,6 @@ pub trait DataActor: Component {
 
         if let Err(e) = self.core().handle_indicators_for_quotes(&resp.data) {
             log_error(&e);
-            return;
         }
 
         if let Err(e) = self.on_historical_quotes(&resp.data) {
@@ -1246,7 +1242,6 @@ pub trait DataActor: Component {
 
         if let Err(e) = self.core().handle_indicators_for_trades(&resp.data) {
             log_error(&e);
-            return;
         }
 
         if let Err(e) = self.on_historical_trades(&resp.data) {
@@ -1264,7 +1259,6 @@ pub trait DataActor: Component {
 
         if let Err(e) = self.core().handle_indicators_for_bars(&resp.data) {
             log_error(&e);
-            return;
         }
 
         if let Err(e) = self.on_historical_bars(&resp.data) {

--- a/crates/common/src/actor/indicators.rs
+++ b/crates/common/src/actor/indicators.rs
@@ -15,7 +15,12 @@
 
 #[cfg(feature = "indicators")]
 use std::cell::RefCell;
-use std::{any::Any, fmt::Debug, rc::Rc};
+use std::{
+    any::Any,
+    error::Error,
+    fmt::{Debug, Display},
+    rc::Rc,
+};
 
 use ahash::AHashMap;
 #[cfg(feature = "indicators")]
@@ -183,13 +188,9 @@ impl Indicators {
     ///
     /// Returns an error if a registered indicator cannot handle the quote tick.
     pub fn handle_quote(&self, quote: &QuoteTick) -> anyhow::Result<()> {
-        if let Some(indicators) = self.indicators_for_quotes.get(&quote.instrument_id) {
-            for indicator in indicators {
-                indicator.handle_quote(quote)?;
-            }
-        }
-
-        Ok(())
+        let mut failures = IndicatorFailures::default();
+        self.collect_quote_failures(quote, &mut failures);
+        failures.into_result()
     }
 
     /// Handles quote ticks with registered indicators.
@@ -198,11 +199,13 @@ impl Indicators {
     ///
     /// Returns an error if a registered indicator cannot handle a quote tick.
     pub fn handle_quotes(&self, quotes: &[QuoteTick]) -> anyhow::Result<()> {
+        let mut failures = IndicatorFailures::default();
+
         for quote in quotes {
-            self.handle_quote(quote)?;
+            self.collect_quote_failures(quote, &mut failures);
         }
 
-        Ok(())
+        failures.into_result()
     }
 
     /// Handles a trade tick with registered indicators.
@@ -211,13 +214,9 @@ impl Indicators {
     ///
     /// Returns an error if a registered indicator cannot handle the trade tick.
     pub fn handle_trade(&self, trade: &TradeTick) -> anyhow::Result<()> {
-        if let Some(indicators) = self.indicators_for_trades.get(&trade.instrument_id) {
-            for indicator in indicators {
-                indicator.handle_trade(trade)?;
-            }
-        }
-
-        Ok(())
+        let mut failures = IndicatorFailures::default();
+        self.collect_trade_failures(trade, &mut failures);
+        failures.into_result()
     }
 
     /// Handles trade ticks with registered indicators.
@@ -226,11 +225,13 @@ impl Indicators {
     ///
     /// Returns an error if a registered indicator cannot handle a trade tick.
     pub fn handle_trades(&self, trades: &[TradeTick]) -> anyhow::Result<()> {
+        let mut failures = IndicatorFailures::default();
+
         for trade in trades {
-            self.handle_trade(trade)?;
+            self.collect_trade_failures(trade, &mut failures);
         }
 
-        Ok(())
+        failures.into_result()
     }
 
     /// Handles a bar with registered indicators.
@@ -239,13 +240,9 @@ impl Indicators {
     ///
     /// Returns an error if a registered indicator cannot handle the bar.
     pub fn handle_bar(&self, bar: &Bar) -> anyhow::Result<()> {
-        if let Some(indicators) = self.indicators_for_bars.get(&bar.bar_type.id_spec_key()) {
-            for indicator in indicators {
-                indicator.handle_bar(bar)?;
-            }
-        }
-
-        Ok(())
+        let mut failures = IndicatorFailures::default();
+        self.collect_bar_failures(bar, &mut failures);
+        failures.into_result()
     }
 
     /// Handles bars with registered indicators.
@@ -254,11 +251,43 @@ impl Indicators {
     ///
     /// Returns an error if a registered indicator cannot handle a bar.
     pub fn handle_bars(&self, bars: &[Bar]) -> anyhow::Result<()> {
+        let mut failures = IndicatorFailures::default();
+
         for bar in bars {
-            self.handle_bar(bar)?;
+            self.collect_bar_failures(bar, &mut failures);
         }
 
-        Ok(())
+        failures.into_result()
+    }
+
+    fn collect_quote_failures(&self, quote: &QuoteTick, failures: &mut IndicatorFailures) {
+        if let Some(indicators) = self.indicators_for_quotes.get(&quote.instrument_id) {
+            for indicator in indicators {
+                if let Err(e) = indicator.handle_quote(quote) {
+                    failures.push(&e);
+                }
+            }
+        }
+    }
+
+    fn collect_trade_failures(&self, trade: &TradeTick, failures: &mut IndicatorFailures) {
+        if let Some(indicators) = self.indicators_for_trades.get(&trade.instrument_id) {
+            for indicator in indicators {
+                if let Err(e) = indicator.handle_trade(trade) {
+                    failures.push(&e);
+                }
+            }
+        }
+    }
+
+    fn collect_bar_failures(&self, bar: &Bar, failures: &mut IndicatorFailures) {
+        if let Some(indicators) = self.indicators_for_bars.get(&bar.bar_type.id_spec_key()) {
+            for indicator in indicators {
+                if let Err(e) = indicator.handle_bar(bar) {
+                    failures.push(&e);
+                }
+            }
+        }
     }
 
     fn register_indicator(&mut self, indicator: SharedActorIndicator) {
@@ -295,6 +324,57 @@ impl Indicators {
         }
     }
 }
+
+const MAX_FAILURE_DETAILS: usize = 3;
+
+#[derive(Debug, Default)]
+struct IndicatorFailures {
+    total: usize,
+    details: Vec<String>,
+}
+
+impl IndicatorFailures {
+    fn push(&mut self, e: &anyhow::Error) {
+        self.total += 1;
+
+        // Retain distinct messages only: one indicator failing on every item of a
+        // batch would otherwise fill every slot and hide a different failure.
+        let detail = e.to_string();
+
+        if self.details.len() < MAX_FAILURE_DETAILS && !self.details.contains(&detail) {
+            self.details.push(detail);
+        }
+    }
+
+    fn into_result(self) -> anyhow::Result<()> {
+        if self.total == 0 {
+            Ok(())
+        } else {
+            Err(anyhow::Error::new(self))
+        }
+    }
+}
+
+impl Display for IndicatorFailures {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = if self.total == 1 {
+            "indicator failure"
+        } else {
+            "indicator failures"
+        };
+        write!(f, "{} {label}: {}", self.total, self.details.join("; "))?;
+
+        if self.total > self.details.len() {
+            let omitted = self.total - self.details.len();
+            let noun = if omitted == 1 { "failure" } else { "failures" };
+            write!(f, "; {omitted} additional {noun} omitted")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Error for IndicatorFailures {}
 
 #[derive(Clone, Copy)]
 enum IndicatorKind {
@@ -386,12 +466,18 @@ mod tests {
     #[derive(Debug)]
     struct ErrorIndicator {
         key: usize,
+        message: String,
     }
 
     impl ErrorIndicator {
         fn new() -> Self {
+            Self::with_message("indicator failed")
+        }
+
+        fn with_message(message: &str) -> Self {
             Self {
                 key: NEXT_KEY.fetch_add(1, Ordering::Relaxed),
+                message: message.to_string(),
             }
         }
     }
@@ -410,15 +496,15 @@ mod tests {
         }
 
         fn handle_quote(&self, _quote: &QuoteTick) -> anyhow::Result<()> {
-            anyhow::bail!("indicator failed");
+            anyhow::bail!("{}", self.message);
         }
 
         fn handle_trade(&self, _trade: &TradeTick) -> anyhow::Result<()> {
-            Ok(())
+            anyhow::bail!("{}", self.message);
         }
 
         fn handle_bar(&self, _bar: &Bar) -> anyhow::Result<()> {
-            Ok(())
+            anyhow::bail!("{}", self.message);
         }
     }
 
@@ -482,6 +568,157 @@ mod tests {
 
         let err = indicators.handle_quote(&quote).unwrap_err();
 
-        assert_eq!(err.to_string(), "indicator failed");
+        assert!(err.to_string().contains("indicator failed"));
+    }
+
+    #[rstest]
+    fn test_handle_quote_continues_after_indicator_error() {
+        let mut indicators = Indicators::default();
+        let before = Rc::new(TrackingIndicator::new());
+        let failing = Rc::new(ErrorIndicator::new());
+        let after = Rc::new(TrackingIndicator::new());
+        let quote = QuoteTick::default();
+
+        indicators.register_indicator_for_quote_ticks(quote.instrument_id, before.clone());
+        indicators.register_indicator_for_quote_ticks(quote.instrument_id, failing);
+        indicators.register_indicator_for_quote_ticks(quote.instrument_id, after.clone());
+
+        assert!(indicators.handle_quote(&quote).is_err());
+        assert_eq!(before.quotes.get(), 1);
+        assert_eq!(after.quotes.get(), 1);
+    }
+
+    #[rstest]
+    fn test_handle_trade_continues_after_indicator_error() {
+        let mut indicators = Indicators::default();
+        let before = Rc::new(TrackingIndicator::new());
+        let failing = Rc::new(ErrorIndicator::new());
+        let after = Rc::new(TrackingIndicator::new());
+        let trade = TradeTick::default();
+
+        indicators.register_indicator_for_trade_ticks(trade.instrument_id, before.clone());
+        indicators.register_indicator_for_trade_ticks(trade.instrument_id, failing);
+        indicators.register_indicator_for_trade_ticks(trade.instrument_id, after.clone());
+
+        assert!(indicators.handle_trade(&trade).is_err());
+        assert_eq!(before.trades.get(), 1);
+        assert_eq!(after.trades.get(), 1);
+    }
+
+    #[rstest]
+    fn test_handle_bar_continues_after_indicator_error() {
+        let mut indicators = Indicators::default();
+        let before = Rc::new(TrackingIndicator::new());
+        let failing = Rc::new(ErrorIndicator::new());
+        let after = Rc::new(TrackingIndicator::new());
+        let bar = Bar::default();
+
+        indicators.register_indicator_for_bars(bar.bar_type, before.clone());
+        indicators.register_indicator_for_bars(bar.bar_type, failing);
+        indicators.register_indicator_for_bars(bar.bar_type, after.clone());
+
+        assert!(indicators.handle_bar(&bar).is_err());
+        assert_eq!(before.bars.get(), 1);
+        assert_eq!(after.bars.get(), 1);
+    }
+
+    #[rstest]
+    fn test_handle_quotes_continues_after_indicator_error() {
+        let mut indicators = Indicators::default();
+        let before = Rc::new(TrackingIndicator::new());
+        let failing = Rc::new(ErrorIndicator::new());
+        let after = Rc::new(TrackingIndicator::new());
+        let quotes = [QuoteTick::default(), QuoteTick::default()];
+
+        indicators.register_indicator_for_quote_ticks(quotes[0].instrument_id, before.clone());
+        indicators.register_indicator_for_quote_ticks(quotes[0].instrument_id, failing);
+        indicators.register_indicator_for_quote_ticks(quotes[0].instrument_id, after.clone());
+
+        assert!(indicators.handle_quotes(&quotes).is_err());
+        assert_eq!(before.quotes.get(), 2);
+        assert_eq!(after.quotes.get(), 2);
+    }
+
+    #[rstest]
+    fn test_handle_trades_continues_after_indicator_error() {
+        let mut indicators = Indicators::default();
+        let before = Rc::new(TrackingIndicator::new());
+        let failing = Rc::new(ErrorIndicator::new());
+        let after = Rc::new(TrackingIndicator::new());
+        let trades = [TradeTick::default(), TradeTick::default()];
+
+        indicators.register_indicator_for_trade_ticks(trades[0].instrument_id, before.clone());
+        indicators.register_indicator_for_trade_ticks(trades[0].instrument_id, failing);
+        indicators.register_indicator_for_trade_ticks(trades[0].instrument_id, after.clone());
+
+        assert!(indicators.handle_trades(&trades).is_err());
+        assert_eq!(before.trades.get(), 2);
+        assert_eq!(after.trades.get(), 2);
+    }
+
+    #[rstest]
+    fn test_handle_bars_continues_after_indicator_error() {
+        let mut indicators = Indicators::default();
+        let before = Rc::new(TrackingIndicator::new());
+        let failing = Rc::new(ErrorIndicator::new());
+        let after = Rc::new(TrackingIndicator::new());
+        let bars = [Bar::default(), Bar::default()];
+
+        indicators.register_indicator_for_bars(bars[0].bar_type, before.clone());
+        indicators.register_indicator_for_bars(bars[0].bar_type, failing);
+        indicators.register_indicator_for_bars(bars[0].bar_type, after.clone());
+
+        assert!(indicators.handle_bars(&bars).is_err());
+        assert_eq!(before.bars.get(), 2);
+        assert_eq!(after.bars.get(), 2);
+    }
+
+    #[rstest]
+    fn test_handle_quote_error_collapses_identical_details_and_counts_all() {
+        let mut indicators = Indicators::default();
+        let first = Rc::new(ErrorIndicator::new());
+        let second = Rc::new(ErrorIndicator::new());
+        let third = Rc::new(ErrorIndicator::new());
+        let fourth = Rc::new(ErrorIndicator::new());
+        let quote = QuoteTick::default();
+
+        indicators.register_indicator_for_quote_ticks(quote.instrument_id, first);
+        indicators.register_indicator_for_quote_ticks(quote.instrument_id, second);
+        indicators.register_indicator_for_quote_ticks(quote.instrument_id, third);
+        indicators.register_indicator_for_quote_ticks(quote.instrument_id, fourth);
+
+        let err = indicators.handle_quote(&quote).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("4 indicator failures"));
+        assert!(message.contains("3 additional failures omitted"));
+    }
+
+    #[rstest]
+    fn test_handle_quote_error_retains_distinct_details_up_to_the_bound() {
+        let mut indicators = Indicators::default();
+        let quote = QuoteTick::default();
+
+        for message in [
+            "first failure",
+            "second failure",
+            "third failure",
+            "fourth failure",
+        ] {
+            indicators.register_indicator_for_quote_ticks(
+                quote.instrument_id,
+                Rc::new(ErrorIndicator::with_message(message)),
+            );
+        }
+
+        let err = indicators.handle_quote(&quote).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("4 indicator failures"));
+        assert!(message.contains("first failure"));
+        assert!(message.contains("second failure"));
+        assert!(message.contains("third failure"));
+        assert!(!message.contains("fourth failure"));
+        assert!(message.contains("1 additional failure omitted"));
     }
 }

--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -19,7 +19,10 @@ use std::{
     num::NonZeroUsize,
     rc::Rc,
     str::FromStr,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -68,7 +71,10 @@ use {
     },
 };
 
-use super::{Actor, DataActor, DataActorCore, DataActorNative, data_actor::DataActorConfig};
+use super::{
+    Actor, DataActor, DataActorCore, DataActorNative, data_actor::DataActorConfig,
+    indicators::ActorIndicator,
+};
 #[cfg(feature = "defi")]
 use crate::defi::switchboard::{
     get_defi_blocks_topic, get_defi_pool_swaps_topic, get_defi_pool_topic,
@@ -180,6 +186,47 @@ struct TestDataActor {
     pub received_pool_swaps: Vec<PoolSwap>,
     #[cfg(feature = "defi")]
     pub received_pool_liquidity_updates: Vec<PoolLiquidityUpdate>,
+}
+
+#[derive(Debug)]
+struct FailingIndicator {
+    key: usize,
+}
+
+impl FailingIndicator {
+    fn new() -> Self {
+        static NEXT_KEY: AtomicUsize = AtomicUsize::new(1);
+
+        Self {
+            key: NEXT_KEY.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+}
+
+impl ActorIndicator for FailingIndicator {
+    fn key(&self) -> usize {
+        self.key
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn initialized(&self) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+
+    fn handle_quote(&self, _quote: &QuoteTick) -> anyhow::Result<()> {
+        anyhow::bail!("indicator failed");
+    }
+
+    fn handle_trade(&self, _trade: &TradeTick) -> anyhow::Result<()> {
+        anyhow::bail!("indicator failed");
+    }
+
+    fn handle_bar(&self, _bar: &Bar) -> anyhow::Result<()> {
+        anyhow::bail!("indicator failed");
+    }
 }
 
 #[derive(Debug)]
@@ -505,6 +552,134 @@ fn register_data_actor(
 
     register_actor(actor);
     actor_id.inner()
+}
+
+#[rstest]
+fn test_quote_handler_runs_after_indicator_error(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+) {
+    let mut actor = TestDataActor::new(DataActorConfig::default());
+    let quote = QuoteTick::default();
+    actor.register(trader_id, clock, cache).unwrap();
+    actor.start().unwrap();
+    actor
+        .core_mut()
+        .register_indicator_for_quote_ticks(quote.instrument_id, Rc::new(FailingIndicator::new()));
+
+    DataActor::handle_quote(&mut actor, &quote);
+
+    assert_eq!(actor.received_quotes, vec![quote]);
+}
+
+#[rstest]
+fn test_trade_handler_runs_after_indicator_error(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+) {
+    let mut actor = TestDataActor::new(DataActorConfig::default());
+    let trade = TradeTick::default();
+    actor.register(trader_id, clock, cache).unwrap();
+    actor.start().unwrap();
+    actor
+        .core_mut()
+        .register_indicator_for_trade_ticks(trade.instrument_id, Rc::new(FailingIndicator::new()));
+
+    DataActor::handle_trade(&mut actor, &trade);
+
+    assert_eq!(actor.received_trades, vec![trade]);
+}
+
+#[rstest]
+fn test_bar_handler_runs_after_indicator_error(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+) {
+    let mut actor = TestDataActor::new(DataActorConfig::default());
+    let bar = Bar::default();
+    actor.register(trader_id, clock, cache).unwrap();
+    actor.start().unwrap();
+    actor
+        .core_mut()
+        .register_indicator_for_bars(bar.bar_type, Rc::new(FailingIndicator::new()));
+
+    DataActor::handle_bar(&mut actor, &bar);
+
+    assert_eq!(actor.received_bars, vec![bar]);
+}
+
+#[rstest]
+fn test_historical_quotes_handler_receives_complete_response_after_indicator_error() {
+    let mut actor = TestDataActor::new(DataActorConfig::default());
+    let quotes = vec![QuoteTick::default(), QuoteTick::default()];
+    actor.core_mut().register_indicator_for_quote_ticks(
+        quotes[0].instrument_id,
+        Rc::new(FailingIndicator::new()),
+    );
+    let response = QuotesResponse::new(
+        UUID4::new(),
+        ClientId::from("TEST-CLIENT"),
+        quotes[0].instrument_id,
+        quotes.clone(),
+        None,
+        None,
+        UnixNanos::default(),
+        None,
+    );
+
+    DataActor::handle_quotes_response(&mut actor, &response);
+
+    assert_eq!(actor.received_quotes, quotes);
+}
+
+#[rstest]
+fn test_historical_trades_handler_receives_complete_response_after_indicator_error() {
+    let mut actor = TestDataActor::new(DataActorConfig::default());
+    let trades = vec![TradeTick::default(), TradeTick::default()];
+    actor.core_mut().register_indicator_for_trade_ticks(
+        trades[0].instrument_id,
+        Rc::new(FailingIndicator::new()),
+    );
+    let response = TradesResponse::new(
+        UUID4::new(),
+        ClientId::from("TEST-CLIENT"),
+        trades[0].instrument_id,
+        trades.clone(),
+        None,
+        None,
+        UnixNanos::default(),
+        None,
+    );
+
+    DataActor::handle_trades_response(&mut actor, &response);
+
+    assert_eq!(actor.received_trades, trades);
+}
+
+#[rstest]
+fn test_historical_bars_handler_receives_complete_response_after_indicator_error() {
+    let mut actor = TestDataActor::new(DataActorConfig::default());
+    let bars = vec![Bar::default(), Bar::default()];
+    actor
+        .core_mut()
+        .register_indicator_for_bars(bars[0].bar_type, Rc::new(FailingIndicator::new()));
+    let response = BarsResponse::new(
+        UUID4::new(),
+        ClientId::from("TEST-CLIENT"),
+        bars[0].bar_type,
+        bars.clone(),
+        None,
+        None,
+        UnixNanos::default(),
+        None,
+    );
+
+    DataActor::handle_bars_response(&mut actor, &response);
+
+    assert_eq!(actor.received_bars, bars);
 }
 
 #[rstest]

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -4386,7 +4386,7 @@ class IndicatorEventActor:
     }
 
     #[rstest]
-    fn test_indicator_error_prevents_actor_callback(
+    fn test_indicator_error_does_not_prevent_actor_callback(
         clock: Rc<RefCell<TestClock>>,
         cache: Rc<RefCell<Cache>>,
         trader_id: TraderId,
@@ -4410,7 +4410,9 @@ class IndicatorEventActor:
             DataActor::handle_quote(rust_actor.inner_mut(), &quote);
             let events = events.extract::<Vec<String>>().unwrap();
 
-            assert!(events.is_empty());
+            // A failing indicator no longer suppresses delivery of the quote the
+            // actor subscribed to; the error is logged and `on_quote` still runs.
+            assert_eq!(events, vec!["actor:quote".to_string()]);
         });
     }
 


### PR DESCRIPTION
A single registered indicator returning `Err` currently suppresses both its sibling indicators and the actor's own data handler for that data point.

## Registry fan-out aborts at the first failure

`Indicators::handle_quote` drove the per-instrument indicator list with `?` inside the loop, so the first `Err` returned and every indicator registered after the failing one was skipped for that quote; `handle_trade` and `handle_bar` have the same shape. The bulk forms propagate per element, so one failing element also abandoned the remainder of a historical batch. The registry now completes the whole fan-out - across the remaining indicators for a failed item, and across the remaining items of a batch - and returns one aggregate error carrying the first three distinct messages plus the total failure count.

## Actor handlers treated the failure as fatal for the data point

`DataActor::handle_quote` logged the registry error and returned before `on_quote`, so the subscribed handler never ran. Same at `handle_trade`, `handle_bar`, and the three `handle_*_response` paths, each returning before its `on_historical_*` call. The `return` is dropped at all six sites: the error is logged and delivery continues.

## Behaviour change

Handlers now run after an indicator update fails, so a handler reading the failed indicator can observe stale or partially updated state where previously it did not run at all. The failure is logged before the callback. With shutdown-on-error armed, the trigger is recorded synchronously but drained asynchronously, so a handler can still act on the datum that produced the error.

## Testing

Registry: `test_handle_{quote,trade,bar}_continues_after_indicator_error` register tracking/failing/tracking in that order and assert both trackers received the item while the call still reports an error. The bulk equivalents use two items with the failure on the first, asserting both trackers received both. `test_handle_quote_error_retains_distinct_details_up_to_the_bound` asserts the first three distinct messages appear and the fourth is accounted for by the count; `test_handle_quote_error_collapses_identical_details_and_counts_all` asserts four identical failures collapse to one detail with all four counted.

Actor: `test_{quote,trade,bar}_handler_runs_after_indicator_error` register one failing indicator on a running actor and assert the handler ran once with that item. `test_historical_{quotes,trades,bars}_handler_receives_complete_response_after_indicator_error` assert the historical handler ran and received the complete slice rather than a prefix.

Both halves were checked against the unfixed code independently: restoring the actor-side returns fails all six actor tests, and making the registry stop at the first failure fails all six continuation tests on the count of the indicator registered after the failing one.

PS: this stops at not losing data. A repeatedly failing indicator keeps being called and keeps failing, and the actor carries on. Automatic deregistration, or degrading the actor after a number of failures, is a policy decision rather than part of this defect, so I left it alone - if you have a view on what the behaviour should be there, I am happy to do it as a follow-up.
