### PR TITLE
Apply contract multiplier in FixedRiskSizer

### DIFF
--- a/crates/risk/src/sizing.rs
+++ b/crates/risk/src/sizing.rs
@@ -82,6 +82,7 @@ pub fn calculate_fixed_risk_position_size(
         .checked_div(exchange_rate)
         .and_then(|value| value.checked_div(risk_points))
         .and_then(|value| value.checked_div(instrument.price_increment().as_decimal()))
+        .and_then(|value| value.checked_div(instrument.multiplier().as_decimal()))
         .ok_or_else(position_size_overflow)?;
 
     if let Some(hard_limit) = hard_limit {
@@ -159,7 +160,9 @@ fn position_size_overflow() -> CorrectnessError {
 #[cfg(test)]
 mod tests {
     use nautilus_model::{
-        identifiers::Symbol, instruments::stubs::default_fx_ccy, types::Currency,
+        identifiers::Symbol,
+        instruments::stubs::{default_fx_ccy, futures_contract_es},
+        types::Currency,
     };
     use rstest::*;
     use rust_decimal_macros::dec;
@@ -171,6 +174,15 @@ mod tests {
     #[fixture]
     fn instrument_gbpusd() -> InstrumentAny {
         InstrumentAny::CurrencyPair(default_fx_ccy(Symbol::from_str_unchecked("GBP/USD"), None))
+    }
+
+    #[fixture]
+    fn instrument_futures_with_multiplier() -> InstrumentAny {
+        // A futures contract whose multiplier scales the per-unit dollar risk,
+        // as it does for position P&L (e.g. ES, CL, NG).
+        let mut instrument = futures_contract_es(None, None);
+        instrument.multiplier = Quantity::from(1000);
+        InstrumentAny::FuturesContract(instrument)
     }
 
     #[fixture]
@@ -269,6 +281,33 @@ mod tests {
         .unwrap();
 
         assert_eq!(result, Quantity::from("1000000.0"));
+    }
+
+    #[rstest]
+    fn test_calculate_accounts_for_instrument_multiplier(
+        instrument_futures_with_multiplier: InstrumentAny,
+    ) {
+        // Multiplier = 1000: a $1.00 stop risks $1,000/contract, so $10,000 of
+        // risk targets 10 contracts.
+        let equity = Money::new(1_000_000.0, Currency::USD());
+        let entry = Price::new(100.00, instrument_futures_with_multiplier.price_precision());
+        let stop_loss = Price::new(99.00, instrument_futures_with_multiplier.price_precision());
+
+        let result = calculate_fixed_risk_position_size(
+            &instrument_futures_with_multiplier,
+            entry,
+            stop_loss,
+            equity,
+            Decimal::new(1, 2), // 1%
+            Decimal::ZERO,
+            EXCHANGE_RATE,
+            None,
+            Decimal::from(1),
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(result.as_decimal(), dec!(10));
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

`FixedRiskSizer` computed position size as `risk_money / |entry - stop|`, omitting the instrument's contract multiplier.

The position P&L engine charges risk as `qty * multiplier * points`, so for any instrument with multiplier > 1 (futures, options) the sizer's quantity overshot the intended dollar risk by the multiplier factor.

Divide by `instrument.multiplier()` so the size matches the P&L path. No-op for multiplier = 1 instruments (FX, equities, spot), so existing behavior is unchanged.

## Related issues/PRs

Resolves #4696

## Type of change

- [x] Bug fix (non-breaking)

## Documentation

No documentation or PyO3 binding signatures changed (the fix is internal to the sizing calculation; no `.pyi` drift).

## Testing

- [x] I added/updated tests to cover new or changed logic

Added `test_calculate_accounts_for_instrument_multiplier`: a futures contract with multiplier 1000, $1M equity, 1% risk, $1.00 stop targets $10,000 of risk → asserts 10 contracts (the correct size), where the pre-fix formula returned 10,000. All existing `GBP/USD` (multiplier = 1) sizing cases remain unchanged.

Exact commands and results:

- `make format` — clean; nightly `cargo fmt` made no changes, ruff left 776 files unchanged.
- `prek run --files crates/risk/src/sizing.rs` — all applicable hooks Passed (cargo fmt, cargo clippy, cargo doc, cargo machete, typos, codespell, gitleaks, and the project convention checks). `make pre-commit` runs `prek run --all-files`, which timed out here on the first-run install of hook environments; the scoped run covers every hook applicable to this Rust-only change, and the remaining hooks report "no files to check".
- `cargo nextest run -p nautilus-risk` — 137 passed, 6 skipped.

---

# Pull Request

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

> External contributions must not modify files under `.github/workflows` or `.github/actions`;
> workflow changes are maintainer‑only.

<!-- PR title: use a capitalized, imperative subject naming the affected surface, for example
     "Fix Bybit post-only rejection flag". Do NOT use Conventional Commits (`feat:`, `fix:`) syntax.
     A squash merge turns this title into the commit subject. -->

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self‑contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally and listed the exact commands and results below, or no tests
  apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`FixedRiskSizer` computed position size as `risk_money / |entry - stop|`, omitting the instrument's contract multiplier.

The position P&L engine charges risk as `qty * multiplier * points`, so for any instrument with multiplier > 1 (futures, options) the sizer's quantity overshot the intended dollar risk by the multiplier factor.

Divide by `instrument.multiplier()` so the size matches the P&L path. No-op for multiplier = 1 instruments (FX, equities, spot), so existing behavior is unchanged.

## Related issues/PRs

Resolves #4696

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

N/A. Position sizes are unchanged for instruments with multiplier = 1 (the only instruments covered by the existing tests and the common FX/equity/spot cases). For multiplier > 1 instruments the previous size was incorrect by the multiplier factor, so this corrects rather than breaks behavior.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

**New or changed logic must be covered by tests.** Select all that apply:

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Added `test_calculate_accounts_for_instrument_multiplier`: a futures contract with multiplier 1000, $1M equity, 1% risk, $1.00 stop targets $10,000 of risk → asserts 10 contracts (the correct size), where the pre-fix formula returned 10,000. All existing `GBP/USD` (multiplier = 1) sizing cases remain unchanged.

Exact commands and results:

- `make format` — clean; nightly `cargo fmt` made no changes, ruff left 776 files unchanged.
- `prek run --files crates/risk/src/sizing.rs` — all applicable hooks Passed (cargo fmt, cargo clippy, cargo doc, cargo machete, typos, codespell, gitleaks, and the project convention checks). `make pre-commit` runs `prek run --all-files`, which timed out here on the first-run install of hook environments; the scoped run covers every hook applicable to this Rust-only change, and the remaining hooks report "no files to check".
- `cargo nextest run -p nautilus-risk` — 137 passed, 6 skipped.
