### PR TITLE
Restrict portfolio greeks to open positions

### DIFF
--- a/crates/common/src/greeks.rs
+++ b/crates/common/src/greeks.rs
@@ -974,7 +974,7 @@ impl GreeksCalculator {
         let side = side.unwrap_or(PositionSide::NoPositionSide);
 
         let cache = self.cache.borrow();
-        let open_positions = cache.positions(
+        let open_positions = cache.positions_open(
             venue.as_ref(),
             instrument_id.as_ref(),
             strategy_id.as_ref(),
@@ -1259,8 +1259,11 @@ mod tests {
     use jiff::{Timestamp, civil::Date, tz::Offset};
     use nautilus_model::{
         data::{IndexPriceUpdate, QuoteTick},
-        enums::{AssetClass, OptionKind, PositionSide},
-        identifiers::{InstrumentId, StrategyId, Symbol, Venue},
+        enums::{AssetClass, OmsType, OptionKind, OrderSide, PositionSide},
+        events::order::spec::OrderFilledSpec,
+        identifiers::{
+            ClientOrderId, InstrumentId, PositionId, StrategyId, Symbol, TradeId, Venue,
+        },
         instruments::{Equity, FuturesContract, OptionContract, any::InstrumentAny},
         types::{Currency, Price, Quantity},
     };
@@ -1923,6 +1926,283 @@ mod tests {
         cache.borrow_mut().add_quote(option_quote).unwrap();
         cache.borrow_mut().add_quote(underlying_quote).unwrap();
         cache
+    }
+
+    fn position_from_fill(
+        instrument: &InstrumentAny,
+        position_id: &str,
+        client_order_id: &str,
+        trade_id: &str,
+        side: OrderSide,
+        quantity: u64,
+        price: &str,
+    ) -> Position {
+        let fill = OrderFilledSpec::builder()
+            .instrument_id(instrument.id())
+            .client_order_id(ClientOrderId::from(client_order_id))
+            .trade_id(TradeId::from(trade_id))
+            .order_side(side)
+            .last_qty(Quantity::from(quantity))
+            .last_px(Price::from(price))
+            .currency(Currency::USD())
+            .position_id(PositionId::from(position_id))
+            .build();
+        Position::new(instrument, fill)
+    }
+
+    fn calculate_portfolio_greeks(
+        calculator: &GreeksCalculator,
+        side: Option<PositionSide>,
+    ) -> anyhow::Result<PortfolioGreeks> {
+        calculator.portfolio_greeks(
+            None, None, None, None, side, None, None, None, None, None, None, None, None, None,
+            None, None, None, None, None, None, None,
+        )
+    }
+
+    fn assert_portfolio_greeks_eq(actual: &PortfolioGreeks, expected: &PortfolioGreeks) {
+        assert_eq!(actual.ts_init, expected.ts_init);
+        assert_eq!(actual.ts_event, expected.ts_event);
+        assert_eq!(actual.pnl, expected.pnl);
+        assert_eq!(actual.price, expected.price);
+        assert_eq!(actual.delta, expected.delta);
+        assert_eq!(actual.gamma, expected.gamma);
+        assert_eq!(actual.vega, expected.vega);
+        assert_eq!(actual.theta, expected.theta);
+        assert_eq!(actual.rho, expected.rho);
+    }
+
+    #[rstest]
+    fn test_portfolio_greeks_ignores_closed_position_with_missing_price() {
+        let now = utc_timestamp(2025, 3, 8, 12, 0, 0);
+        let expiry = now + jiff::SignedDuration::from_hours(24 * 30);
+        let now_ns = UnixNanos::from(now);
+        let expiry_ns = UnixNanos::from(expiry);
+        let open_option = option_with_expiration("AAPL250417C00150000.OPRA", expiry_ns);
+        let open_option_id = open_option.id();
+        let underlying_id = InstrumentId::from("AAPL.OPRA");
+        let cache = setup_cache_with_option_and_quotes(open_option.clone(), underlying_id, now_ns);
+        let closed_future = future_with_expiration("CLOSED.GLBX", "CLOSED", expiry_ns);
+        let closed_future_id = closed_future.id();
+        let open_instrument = InstrumentAny::OptionContract(open_option);
+        let closed_instrument = InstrumentAny::FuturesContract(closed_future);
+
+        let open_position = position_from_fill(
+            &open_instrument,
+            "P-OPEN",
+            "O-OPEN",
+            "T-OPEN",
+            OrderSide::Buy,
+            2,
+            "10.50",
+        );
+        let mut closed_position = position_from_fill(
+            &closed_instrument,
+            "P-CLOSED",
+            "O-CLOSED-OPEN",
+            "T-CLOSED-OPEN",
+            OrderSide::Buy,
+            1,
+            "100.00",
+        );
+        cache
+            .borrow_mut()
+            .add_instrument(closed_instrument)
+            .unwrap();
+        cache
+            .borrow_mut()
+            .add_position(&open_position, OmsType::Hedging)
+            .unwrap();
+        cache
+            .borrow_mut()
+            .add_position(&closed_position, OmsType::Hedging)
+            .unwrap();
+        let closing_fill = OrderFilledSpec::builder()
+            .instrument_id(closed_future_id)
+            .client_order_id(ClientOrderId::from("O-CLOSED-CLOSE"))
+            .trade_id(TradeId::from("T-CLOSED-CLOSE"))
+            .order_side(OrderSide::Sell)
+            .last_qty(Quantity::from(1))
+            .last_px(Price::from("101.00"))
+            .currency(Currency::USD())
+            .position_id(PositionId::from("P-CLOSED"))
+            .build();
+        closed_position.apply(&closing_fill);
+        cache
+            .borrow_mut()
+            .update_position(&closed_position)
+            .unwrap();
+
+        // Pin the fixture itself: the closed position must have left the open index,
+        // or this would exercise `add_position`'s open-index insertion rather than
+        // the query scope under test.
+        assert!(closed_position.is_closed());
+        assert_eq!(
+            cache
+                .borrow()
+                .positions_open(None, None, None, None, None)
+                .len(),
+            1
+        );
+
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        clock.borrow_mut().set_time(now_ns);
+        let calculator = GreeksCalculator::new(cache, clock);
+        let expected = calculator
+            .instrument_greeks(
+                open_option_id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(now_ns),
+                Some(open_position.clone()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let expected = PortfolioGreeks::from(open_position.signed_qty * &expected);
+
+        assert_ne!(expected.delta, 0.0);
+        assert_portfolio_greeks_eq(
+            &calculate_portfolio_greeks(&calculator, None).unwrap(),
+            &expected,
+        );
+    }
+
+    #[rstest]
+    fn test_portfolio_greeks_preserves_open_position_aggregate_and_side_filters() {
+        let now = utc_timestamp(2025, 3, 8, 12, 0, 0);
+        let expiry = now + jiff::SignedDuration::from_hours(24 * 30);
+        let now_ns = UnixNanos::from(now);
+        let expiry_ns = UnixNanos::from(expiry);
+        let long_option = option_with_expiration("AAPL250417C00145000.OPRA", expiry_ns);
+        let short_option = option_with_expiration("AAPL250417C00155000.OPRA", expiry_ns);
+        let long_instrument = InstrumentAny::OptionContract(long_option.clone());
+        let short_instrument = InstrumentAny::OptionContract(short_option.clone());
+        let underlying_id = InstrumentId::from("AAPL.OPRA");
+        let cache = setup_cache_with_option_and_quotes(long_option, underlying_id, now_ns);
+        cache
+            .borrow_mut()
+            .add_instrument(short_instrument.clone())
+            .unwrap();
+        cache
+            .borrow_mut()
+            .add_quote(QuoteTick::new(
+                short_option.id(),
+                Price::from("3.50"),
+                Price::from("3.60"),
+                Quantity::from(100),
+                Quantity::from(100),
+                now_ns,
+                now_ns,
+            ))
+            .unwrap();
+        let long_position = position_from_fill(
+            &long_instrument,
+            "P-LONG",
+            "O-LONG",
+            "T-LONG",
+            OrderSide::Buy,
+            3,
+            "10.50",
+        );
+        let short_position = position_from_fill(
+            &short_instrument,
+            "P-SHORT",
+            "O-SHORT",
+            "T-SHORT",
+            OrderSide::Sell,
+            2,
+            "3.50",
+        );
+        cache
+            .borrow_mut()
+            .add_position(&long_position, OmsType::Hedging)
+            .unwrap();
+        cache
+            .borrow_mut()
+            .add_position(&short_position, OmsType::Hedging)
+            .unwrap();
+
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        clock.borrow_mut().set_time(now_ns);
+        let calculator = GreeksCalculator::new(cache, clock);
+        let long_greeks = calculator
+            .instrument_greeks(
+                long_instrument.id(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(now_ns),
+                Some(long_position.clone()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let short_greeks = calculator
+            .instrument_greeks(
+                short_instrument.id(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(now_ns),
+                Some(short_position.clone()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        let expected_long = PortfolioGreeks::from(long_position.signed_qty * &long_greeks);
+        let expected_short = PortfolioGreeks::from(short_position.signed_qty * &short_greeks);
+        let expected = expected_long + expected_short;
+
+        assert_ne!(expected.pnl, 0.0);
+        assert_ne!(expected.price, 0.0);
+        assert_ne!(expected.delta, 0.0);
+        assert_ne!(expected.gamma, 0.0);
+        assert_ne!(expected.vega, 0.0);
+        assert_ne!(expected.theta, 0.0);
+        assert_portfolio_greeks_eq(
+            &calculate_portfolio_greeks(&calculator, None).unwrap(),
+            &expected,
+        );
+        assert_portfolio_greeks_eq(
+            &calculate_portfolio_greeks(&calculator, Some(PositionSide::Long)).unwrap(),
+            &PortfolioGreeks::from(long_position.signed_qty * &long_greeks),
+        );
+        assert_portfolio_greeks_eq(
+            &calculate_portfolio_greeks(&calculator, Some(PositionSide::Short)).unwrap(),
+            &PortfolioGreeks::from(short_position.signed_qty * &short_greeks),
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
`GreeksCalculator::portfolio_greeks` documents itself as aggregating open positions but queries the full position index.

## A closed position can abort the whole call

`portfolio_greeks` binds `cache.positions(...)` to a local named `open_positions`. `Cache::positions` returns every position, open and closed, while `Cache::positions_open` sits directly beside it. A closed position has `signed_qty == 0.0`, so `quantity * &instrument_greeks` contributes exactly nothing to the total - but `instrument_greeks` is still called for it and its error propagates, so a position the portfolio no longer holds can fail an entire portfolio snapshot once its price data is gone or its contract has expired. The query now uses `positions_open` with the same filter arguments, which also stops greeks being computed for closed positions and multiplied by zero.

Error propagation for positions actually held is unchanged.

## Behaviour change with side = Flat

`portfolio_greeks(side = PositionSide::Flat)` previously selected closed positions, computed their greeks and returned zero or an error. It now selects nothing and returns zero. An open position cannot be flat under the `Position` invariants, so this removes behaviour that contradicted the method's own contract. `NoPositionSide`, `Long` and `Short` are unaffected.

## Testing

`test_portfolio_greeks_ignores_closed_position_with_missing_price` holds one open option position and one closed futures position whose instrument is registered without a price. The closed position is built the way the engine builds one - opened, offsetting fill applied, then `cache.update_position` - and the test asserts it satisfies `is_closed()` and has left the open index before calling. Against the unfixed query it fails with `No price available for CLOSED.GLBX`; with the fix it returns the open position's aggregate.

`test_portfolio_greeks_preserves_open_position_aggregate_and_side_filters` characterizes the success path over a long and a short position with non-unit quantities, comparing every `PortfolioGreeks` field against an independently computed `signed_qty * greeks` sum, asserting those expectations are non-zero first, then repeating for the `Long` and `Short` filters. It passes against the unfixed code by design - a closed position already contributed zero, so the open-book aggregate is unchanged - and the missing-price test is the one that fails without the fix.
