### PR TITLE
Capture Polymarket market closure state

### DIFF
--- a/crates/adapters/polymarket/src/http/parse.rs
+++ b/crates/adapters/polymarket/src/http/parse.rs
@@ -72,6 +72,9 @@ pub struct PolymarketInstrumentDef {
     pub end_date: Option<String>,
     /// Whether the market is active and accepting orders.
     pub active: bool,
+    /// Whether Gamma reports the market closed.
+    #[serde(default)]
+    pub closed: bool,
     /// URL slug for the market.
     pub market_slug: Option<String>,
     /// Whether the market uses the neg-risk CTF exchange contract.
@@ -166,6 +169,7 @@ pub fn parse_gamma_market(market: &GammaMarket) -> anyhow::Result<Vec<Polymarket
             start_date: market.start_date.clone(),
             end_date: market.end_date.clone(),
             active,
+            closed: market.closed.unwrap_or(false),
             market_slug: market.market_slug.clone(),
             neg_risk,
             fee_schedule: market.fee_schedule.clone(),
@@ -354,6 +358,7 @@ fn build_info_json(def: &PolymarketInstrumentDef) -> serde_json::Value {
         "neg_risk".to_string(),
         serde_json::Value::Bool(def.neg_risk),
     );
+    map.insert("closed".to_string(), serde_json::Value::Bool(def.closed));
 
     if let Some(fee_schedule) = &def.fee_schedule
         && let Ok(value) = serde_json::to_value(fee_schedule)
@@ -634,6 +639,27 @@ mod tests {
         );
         assert_eq!(info.get_u64("game_id"), None);
         assert_eq!(info.get("fee_schedule"), None);
+    }
+
+    #[rstest]
+    fn test_past_end_market_preserves_open_market_state() {
+        let mut market = load_gamma_market("gamma_market_past_end_date_open.json");
+        let defs = parse_gamma_market(&market).unwrap();
+
+        assert!(!defs[0].closed);
+
+        let instrument =
+            create_instrument_from_def(&defs[0], UnixNanos::from(1_000_000_000u64)).unwrap();
+        let binary = match &instrument {
+            InstrumentAny::BinaryOption(binary) => binary,
+            other => panic!("Expected BinaryOption, was {other:?}"),
+        };
+        let info = binary.info.as_ref().expect("info should be present");
+        assert_eq!(info.get_bool("closed"), Some(false));
+
+        market.closed = Some(true);
+        let closed = parse_gamma_market(&market).unwrap();
+        assert!(closed[0].closed);
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/test_data/gamma_market_past_end_date_open.json
+++ b/crates/adapters/polymarket/test_data/gamma_market_past_end_date_open.json
@@ -1,0 +1,21 @@
+{
+  "id": "2063130",
+  "conditionId": "0x72af7d77091bd2209f78a45a13876beefc734768177dbc0c8171f515ba1a52a7",
+  "questionID": "0x55ab76d092f682bf5cbb7e14f13ee12f8410ce7cc1b7906f23b8fb56c11f6502",
+  "question": "Will Berhanu Nega be the next Prime Minister of Ethiopia?",
+  "description": "General elections are scheduled to be held in Ethiopia on June 1, 2026.\n\nThis market will resolve to the next individual who officially assumes the office of Prime Minister of Ethiopia following the 2026 General elections.\n\nTo count for resolution, the individual must be officially appointed and sworn in as Prime Minister of Ethiopia. Any interim or caretaker Prime Minister will not count toward the resolution of this market.\n\nIf no such Prime Minister takes office by December 31, 2028, 11:59 PM ET, this market will resolve to \u201cOther\u201d.\n\nThe primary resolution source for this market will be official information from the Government of Ethiopia; however, a consensus of credible reporting may also be used.",
+  "slug": "will-berhanu-nega-be-the-next-prime-minister-of-ethiopia",
+  "startDate": "2026-04-27T21:54:45.451Z",
+  "endDate": "2026-06-01T00:00:00Z",
+  "active": true,
+  "closed": false,
+  "acceptingOrders": true,
+  "enableOrderBook": true,
+  "clobTokenIds": "[\"9700525976462326306802795530553376348116310383328382626789994562350229436531\", \"9684129004308889646536044141330168144866101175836994432446145127310478131443\"]",
+  "outcomes": "[\"Yes\", \"No\"]",
+  "orderPriceMinTickSize": 0.001,
+  "orderMinSize": 5,
+  "negRisk": true,
+  "negRiskMarketID": "0x55ab76d092f682bf5cbb7e14f13ee12f8410ce7cc1b7906f23b8fb56c11f6500",
+  "umaResolutionStatuses": "[]"
+}


### PR DESCRIPTION
## Checklist

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed `CONTRIBUTING.md` and `AI_POLICY.md`
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [x] I ran the local validation described below
- [x] I have not modified `RELEASES.md`

## Summary

Observed: the captured Gamma payload for a market past `endDate` contains `closed: false` and `acceptingOrders: true`.

From code inspection: the parser did not retain `closed`. This change carries it through `PolymarketInstrumentDef` and stores it in `BinaryOption.info`. It does not change cleanup or admission decisions by itself. The next incremental change consumes this value.

## Related issues/PRs

Related to #4689

Replaces the first slice of #4690.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details

None.

## Documentation

No documentation behavior changes are included in this slice.

## Testing

- [x] I added tests for missing, open, and closed market state.

Commands and observed results:

- `cargo test -p nautilus-polymarket`: passed.
- `cargo clippy -p nautilus-polymarket --all-targets -- -D warnings`: passed.
- `cargo +nightly fmt -p nautilus-polymarket -- --check`: passed.
- `make pre-commit` on the cumulative series tip: every hook passed except `test wheel publishing`. That hook failed with `Failed orphan deletion left a stale index link`, the same observed failure on pristine `upstream/develop`.