### PR TITLE
Make Polymarket reconciliation authoritative

### DIFF
--- a/crates/adapters/polymarket/benches/data.rs
+++ b/crates/adapters/polymarket/benches/data.rs
@@ -197,7 +197,8 @@ fn bench_order_event(c: &mut Criterion) {
                 px_prec,
                 sz_prec,
                 ts_init,
-            );
+            )
+            .expect("benchmark fixture order should be valid");
             black_box(report);
         });
     });
@@ -232,7 +233,8 @@ fn bench_order_fill(c: &mut Criterion) {
                 taker_fee,
                 fee_exponent,
                 ts_init,
-            );
+            )
+            .expect("benchmark fixture fill should be valid");
             black_box(report);
         });
     });
@@ -271,6 +273,7 @@ fn bench_order_fill_maker(c: &mut Criterion) {
                         ts_init,
                         ts_init,
                     )
+                    .expect("benchmark fixture maker fill should be valid")
                 })
                 .collect();
             black_box(reports);

--- a/crates/adapters/polymarket/src/execution/parse.rs
+++ b/crates/adapters/polymarket/src/execution/parse.rs
@@ -28,6 +28,7 @@ use nautilus_model::{
     types::{AccountBalance, Currency, Money, Price, Quantity},
 };
 use rust_decimal::Decimal;
+use thiserror::Error;
 
 use crate::{
     common::{
@@ -40,6 +41,19 @@ use crate::{
     },
     http::models::{ClobBookLevel, PolymarketOpenOrder, PolymarketTradeReport},
 };
+
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ReportParseError {
+    #[error("quantity is not representable or positive")]
+    Quantity,
+    #[error("filled quantity is not representable or valid for the order status")]
+    FilledQuantity,
+    #[error("price is not representable within the open unit interval")]
+    Price,
+    #[error("timestamp is not representable")]
+    Timestamp,
+}
 
 /// Converts a [`PolymarketLiquiditySide`] to a Nautilus [`LiquiditySide`].
 pub const fn parse_liquidity_side(side: PolymarketLiquiditySide) -> LiquiditySide {
@@ -125,7 +139,7 @@ pub fn parse_order_status_report(
     price_precision: u8,
     size_precision: u8,
     ts_init: UnixNanos,
-) -> OrderStatusReport {
+) -> Result<OrderStatusReport, ReportParseError> {
     let venue_order_id = VenueOrderId::from(order.id.as_str());
     let order_side = OrderSide::from(order.side);
     let time_in_force = TimeInForce::from(order.order_type);
@@ -137,15 +151,21 @@ pub fn parse_order_status_report(
     } else {
         OrderStatus::from(order.status)
     };
-    let quantity = Quantity::from_decimal_dp(order.original_size, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
+    let quantity = parse_positive_quantity(order.original_size, size_precision)?;
     let raw_filled_qty = Quantity::from_decimal_dp(order.size_matched, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
+        .map_err(|_| ReportParseError::FilledQuantity)?;
+    if order_status == OrderStatus::Filled && raw_filled_qty.is_zero() {
+        return Err(ReportParseError::FilledQuantity);
+    }
     let filled_qty = snap_filled_qty_to_quantity(quantity, raw_filled_qty, order_status);
-    let price = Price::from_decimal_dp(order.price, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
+    let price = parse_probability_price(order.price, price_precision)?;
 
-    let ts_accepted = UnixNanos::from(order.created_at * NANOSECONDS_IN_SECOND);
+    let ts_accepted = UnixNanos::from(
+        order
+            .created_at
+            .checked_mul(NANOSECONDS_IN_SECOND)
+            .ok_or(ReportParseError::Timestamp)?,
+    );
 
     let mut report = OrderStatusReport::new(
         account_id,
@@ -168,7 +188,7 @@ pub fn parse_order_status_report(
     if let Some(nanos) = order.expiration.as_deref().and_then(parse_expiration_nanos) {
         report.expire_time = Some(UnixNanos::from(nanos));
     }
-    report
+    Ok(report)
 }
 
 /// Parses a CLOB V2 `expiration` string into a Unix-nanos value. Returns
@@ -200,14 +220,12 @@ pub fn parse_fill_report(
     taker_fee_rate: Decimal,
     fee_exponent: f64,
     ts_init: UnixNanos,
-) -> FillReport {
+) -> Result<FillReport, ReportParseError> {
     let venue_order_id = VenueOrderId::from(trade.taker_order_id.as_str());
     let trade_id = TradeId::from(trade.id.as_str());
     let order_side = OrderSide::from(trade.side);
-    let last_qty = Quantity::from_decimal_dp(trade.size, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
-    let last_px = Price::from_decimal_dp(trade.price, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
+    let (last_qty, last_px) =
+        parse_fill_values(trade.size, trade.price, size_precision, price_precision)?;
     let liquidity_side = parse_liquidity_side(trade.trader_side);
 
     let commission_value = compute_commission(
@@ -219,9 +237,9 @@ pub fn parse_fill_report(
     );
     let commission = Money::new(commission_value, currency);
 
-    let ts_event = parse_timestamp(&trade.match_time).unwrap_or(ts_init);
+    let ts_event = parse_timestamp(&trade.match_time).ok_or(ReportParseError::Timestamp)?;
 
-    FillReport {
+    Ok(FillReport {
         account_id,
         instrument_id,
         venue_order_id,
@@ -237,7 +255,7 @@ pub fn parse_fill_report(
         ts_init,
         client_order_id,
         venue_position_id: None,
-    }
+    })
 }
 
 /// Builds a [`FillReport`] from a [`PolymarketMakerOrder`] and trade-level context.
@@ -260,7 +278,7 @@ pub fn build_maker_fill_report(
     liquidity_side: LiquiditySide,
     ts_event: UnixNanos,
     ts_init: UnixNanos,
-) -> FillReport {
+) -> Result<FillReport, ReportParseError> {
     let venue_order_id = VenueOrderId::from(mo.order_id.as_str());
     let fill_trade_id = make_composite_trade_id(trade_id, &mo.order_id);
     let order_side = determine_order_side(
@@ -269,10 +287,8 @@ pub fn build_maker_fill_report(
         taker_asset_id,
         mo.asset_id.as_str(),
     );
-    let last_qty = Quantity::from_decimal_dp(mo.matched_amount, size_precision)
-        .unwrap_or_else(|_| Quantity::zero(size_precision));
-    let last_px = Price::from_decimal_dp(mo.price, price_precision)
-        .unwrap_or_else(|_| Price::zero(price_precision));
+    let (last_qty, last_px) =
+        parse_fill_values(mo.matched_amount, mo.price, size_precision, price_precision)?;
     let commission_value = compute_commission(
         Decimal::ZERO,
         1.0,
@@ -281,7 +297,7 @@ pub fn build_maker_fill_report(
         liquidity_side,
     );
 
-    FillReport {
+    Ok(FillReport {
         account_id,
         instrument_id,
         venue_order_id,
@@ -297,7 +313,39 @@ pub fn build_maker_fill_report(
         ts_init,
         client_order_id: None,
         venue_position_id: None,
+    })
+}
+
+fn parse_positive_quantity(value: Decimal, precision: u8) -> Result<Quantity, ReportParseError> {
+    let quantity =
+        Quantity::from_decimal_dp(value, precision).map_err(|_| ReportParseError::Quantity)?;
+    if quantity.is_zero() {
+        Err(ReportParseError::Quantity)
+    } else {
+        Ok(quantity)
     }
+}
+
+fn parse_probability_price(value: Decimal, precision: u8) -> Result<Price, ReportParseError> {
+    let price = Price::from_decimal_dp(value, precision).map_err(|_| ReportParseError::Price)?;
+    let value = price.as_decimal();
+    if value > Decimal::ZERO && value < Decimal::ONE {
+        Ok(price)
+    } else {
+        Err(ReportParseError::Price)
+    }
+}
+
+fn parse_fill_values(
+    quantity: Decimal,
+    price: Decimal,
+    quantity_precision: u8,
+    price_precision: u8,
+) -> Result<(Quantity, Price), ReportParseError> {
+    Ok((
+        parse_positive_quantity(quantity, quantity_precision)?,
+        parse_probability_price(price, price_precision)?,
+    ))
 }
 
 /// Returns the effective taker fee rate for a Polymarket instrument.
@@ -1263,7 +1311,8 @@ mod tests {
             4,
             6,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("fixture order should be valid");
 
         assert_eq!(report.account_id, account_id);
         assert_eq!(report.instrument_id, instrument_id);
@@ -1283,6 +1332,28 @@ mod tests {
         assert_eq!(report.ts_init, UnixNanos::from(1_000_000_000u64));
         // Fixture has expiration=null which must surface as no expire_time.
         assert_eq!(report.expire_time, None);
+    }
+
+    #[rstest]
+    fn test_parse_order_status_report_rejects_filled_order_without_filled_quantity() {
+        let path = "test_data/http_open_order.json";
+        let content = std::fs::read_to_string(path).expect("Failed to read test data");
+        let mut order: PolymarketOpenOrder =
+            serde_json::from_str(&content).expect("Failed to parse test data");
+        order.status = PolymarketOrderStatus::Matched;
+        order.size_matched = Decimal::ZERO;
+
+        let result = parse_order_status_report(
+            &order,
+            InstrumentId::from("TEST-TOKEN.POLYMARKET"),
+            AccountId::from("POLYMARKET-001"),
+            None,
+            4,
+            6,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert_eq!(result, Err(ReportParseError::FilledQuantity));
     }
 
     // Verifies parse_order_status_report wires `snap_filled_qty_to_quantity`
@@ -1328,7 +1399,8 @@ mod tests {
             3,
             6,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("order should be valid");
 
         assert_eq!(report.filled_qty, Quantity::new(expected_filled, 6));
         assert_eq!(
@@ -1365,7 +1437,8 @@ mod tests {
             3,
             6,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("partial FAK order should be valid");
 
         assert_eq!(report.order_status, OrderStatus::Canceled);
         assert_eq!(report.time_in_force, TimeInForce::Ioc);
@@ -1412,7 +1485,8 @@ mod tests {
             4,
             6,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("expiration fixture should be valid");
 
         assert_eq!(report.expire_time, expected);
     }
@@ -1439,13 +1513,46 @@ mod tests {
             Decimal::ZERO,
             1.0,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("fixture fill should be valid");
 
         assert_eq!(report.account_id, account_id);
         assert_eq!(report.instrument_id, instrument_id);
         assert_eq!(report.order_side, OrderSide::Buy);
         assert_eq!(report.liquidity_side, LiquiditySide::Taker);
         assert_eq!(report.commission.as_f64(), 0.0);
+    }
+
+    #[rstest]
+    #[case::quantity_rounds_to_zero(dec!(0.0000004), dec!(0.5), ReportParseError::Quantity)]
+    #[case::zero_price(dec!(1), Decimal::ZERO, ReportParseError::Price)]
+    #[case::unit_price(dec!(1), Decimal::ONE, ReportParseError::Price)]
+    fn test_parse_fill_report_rejects_degenerate_values(
+        #[case] quantity: Decimal,
+        #[case] price: Decimal,
+        #[case] expected: ReportParseError,
+    ) {
+        let path = "test_data/http_trade_report.json";
+        let content = std::fs::read_to_string(path).expect("Failed to read test data");
+        let mut trade: PolymarketTradeReport =
+            serde_json::from_str(&content).expect("Failed to parse test data");
+        trade.size = quantity;
+        trade.price = price;
+
+        let result = parse_fill_report(
+            &trade,
+            InstrumentId::from("TEST-TOKEN.POLYMARKET"),
+            AccountId::from("POLYMARKET-001"),
+            None,
+            4,
+            6,
+            Currency::pUSD(),
+            Decimal::ZERO,
+            1.0,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert_eq!(result, Err(expected));
     }
 
     #[rstest]
@@ -1471,7 +1578,8 @@ mod tests {
             dec!(0.03),
             2.0,
             UnixNanos::from(1_000_000_000u64),
-        );
+        )
+        .expect("fixture fill should be valid");
 
         assert_eq!(report.liquidity_side, LiquiditySide::Taker);
         assert_eq!(report.commission.as_f64(), 0.04688);

--- a/crates/adapters/polymarket/src/execution/reconciliation.rs
+++ b/crates/adapters/polymarket/src/execution/reconciliation.rs
@@ -15,8 +15,11 @@
 
 //! Reconciliation report generation for the Polymarket execution client.
 
+use std::fmt::Display;
+
 use ahash::AHashMap;
 use anyhow::Context;
+use indexmap::IndexMap;
 use nautilus_core::{UnixNanos, collections::AtomicMap, time::AtomicTime};
 use nautilus_model::{
     enums::{LiquiditySide, OrderStatus, PositionSideSpecified},
@@ -31,8 +34,8 @@ use ustr::Ustr;
 use super::{
     order_fill_tracker::OrderFillTrackerMap,
     parse::{
-        build_maker_fill_report, instrument_fee_exponent, instrument_taker_fee, parse_fill_report,
-        parse_order_status_report, parse_timestamp,
+        ReportParseError, build_maker_fill_report, instrument_fee_exponent, instrument_taker_fee,
+        parse_fill_report, parse_order_status_report, parse_timestamp,
     },
 };
 use crate::{
@@ -57,14 +60,136 @@ pub(crate) struct FillContext<'a> {
     pub clock: &'static AtomicTime,
 }
 
-/// Counts of confirmed trade evidence dropped while building fill reports.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) struct FillBuildDiscards {
-    /// Fill entries dropped because their instrument is not loaded.
-    pub unmapped_instruments: usize,
-    /// Confirmed maker trades dropped because no maker order in the match is
-    /// owned by the account.
-    pub unowned_maker_trades: usize,
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum PositionOmission {
+    Dust,
+    Zero,
+    InvalidSize,
+    InvalidAveragePrice,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum ReconciliationOmission {
+    PendingTrade,
+    FailedTrade,
+    UnmappedOrder,
+    InvalidOrder(ReportParseError),
+    UnmappedFill,
+    InvalidFill(ReportParseError),
+    UnownedMakerTrade,
+    Position(PositionOmission),
+    LookbackOrder,
+    LookbackFill,
+}
+
+impl ReconciliationOmission {
+    const fn invalidates_snapshot(self) -> bool {
+        match self {
+            Self::PendingTrade
+            | Self::UnmappedOrder
+            | Self::InvalidOrder(_)
+            | Self::UnmappedFill
+            | Self::InvalidFill(_)
+            | Self::UnownedMakerTrade
+            | Self::Position(
+                PositionOmission::InvalidSize | PositionOmission::InvalidAveragePrice,
+            ) => true,
+            Self::FailedTrade
+            | Self::Position(PositionOmission::Dust | PositionOmission::Zero)
+            | Self::LookbackOrder
+            | Self::LookbackFill => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ReconciliationOmissions {
+    counts: IndexMap<ReconciliationOmission, usize>,
+}
+
+impl ReconciliationOmissions {
+    pub(crate) fn record(&mut self, reason: ReconciliationOmission) {
+        self.record_n(reason, 1);
+    }
+
+    pub(crate) fn record_n(&mut self, reason: ReconciliationOmission, count: usize) {
+        if count > 0 {
+            *self.counts.entry(reason).or_default() += count;
+        }
+    }
+
+    #[must_use]
+    #[cfg(test)]
+    pub(crate) fn count(&self, reason: ReconciliationOmission) -> usize {
+        self.counts.get(&reason).copied().unwrap_or_default()
+    }
+
+    #[must_use]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        for (reason, count) in other.counts {
+            self.record_n(reason, count);
+        }
+    }
+
+    fn ensure_authoritative(&self) -> anyhow::Result<()> {
+        let invalidating = self
+            .counts
+            .iter()
+            .filter(|(reason, _)| reason.invalidates_snapshot())
+            .map(|(reason, count)| format!("{reason:?}={count}"))
+            .collect::<Vec<_>>();
+        anyhow::ensure!(
+            invalidating.is_empty(),
+            "Mass status is not authoritative: {}",
+            invalidating.join(", "),
+        );
+        Ok(())
+    }
+}
+
+impl Display for ReconciliationOmissions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut separator = "";
+        for (reason, count) in &self.counts {
+            write!(f, "{separator}{reason:?}={count}")?;
+            separator = ", ";
+        }
+
+        if separator.is_empty() {
+            f.write_str("none")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ReportSet<T> {
+    pub reports: Vec<T>,
+    pub omissions: ReconciliationOmissions,
+}
+
+impl<T> ReportSet<T> {
+    fn new() -> Self {
+        Self {
+            reports: Vec::new(),
+            omissions: ReconciliationOmissions::default(),
+        }
+    }
+
+    fn omit(&mut self, reason: ReconciliationOmission) {
+        self.omissions.record(reason);
+    }
+}
+
+#[derive(Debug)]
+struct ReconciliationSnapshot {
+    orders: Vec<OrderStatusReport>,
+    fills: Vec<FillReport>,
+    positions: Vec<PositionStatusReport>,
 }
 
 /// Converts trade reports into fill reports: single implementation of maker/taker
@@ -75,13 +200,22 @@ pub(crate) fn build_fill_reports_from_trades(
     instruments: &AtomicMap<Ustr, InstrumentAny>,
     instrument_filter: Option<InstrumentId>,
     ts_init: UnixNanos,
-) -> (Vec<FillReport>, FillBuildDiscards) {
-    let mut reports = Vec::new();
-    let mut discards = FillBuildDiscards::default();
+) -> ReportSet<FillReport> {
+    let mut output = ReportSet::new();
 
     for trade in trades {
-        if trade.status != PolymarketTradeStatus::Confirmed {
-            continue;
+        match trade.status {
+            PolymarketTradeStatus::Confirmed => {}
+            PolymarketTradeStatus::Failed => {
+                output.omit(ReconciliationOmission::FailedTrade);
+                continue;
+            }
+            PolymarketTradeStatus::Matched
+            | PolymarketTradeStatus::Mined
+            | PolymarketTradeStatus::Retrying => {
+                output.omit(ReconciliationOmission::PendingTrade);
+                continue;
+            }
         }
 
         let is_maker = trade.trader_side == PolymarketLiquiditySide::Maker;
@@ -92,7 +226,7 @@ pub(crate) fn build_fill_reports_from_trades(
                 .iter()
                 .any(|mo| mo.is_owned_by(ctx.user_address, ctx.api_key))
             {
-                discards.unowned_maker_trades += 1;
+                output.omit(ReconciliationOmission::UnownedMakerTrade);
                 log::debug!(
                     "Confirmed maker trade {} holds no maker order owned by the account",
                     trade.id,
@@ -109,7 +243,7 @@ pub(crate) fn build_fill_reports_from_trades(
                 let (instrument_id, price_prec, size_prec) = match instrument {
                     Some(i) => (i.id(), i.price_precision(), i.size_precision()),
                     None => {
-                        discards.unmapped_instruments += 1;
+                        output.omit(ReconciliationOmission::UnmappedFill);
                         continue;
                     }
                 };
@@ -120,9 +254,13 @@ pub(crate) fn build_fill_reports_from_trades(
                     continue;
                 }
 
-                let ts_event =
-                    parse_timestamp(&trade.match_time).unwrap_or(ctx.clock.get_time_ns());
-                let report = build_maker_fill_report(
+                let Some(ts_event) = parse_timestamp(&trade.match_time) else {
+                    output.omit(ReconciliationOmission::InvalidFill(
+                        ReportParseError::Timestamp,
+                    ));
+                    continue;
+                };
+                let report = match build_maker_fill_report(
                     mo,
                     &trade.id,
                     trade.trader_side,
@@ -136,8 +274,14 @@ pub(crate) fn build_fill_reports_from_trades(
                     LiquiditySide::Maker,
                     ts_event,
                     ts_init,
-                );
-                reports.push(report);
+                ) {
+                    Ok(report) => report,
+                    Err(e) => {
+                        output.omit(ReconciliationOmission::InvalidFill(e));
+                        continue;
+                    }
+                };
+                output.reports.push(report);
             }
         } else {
             let token_id = Ustr::from(trade.asset_id.as_str());
@@ -152,7 +296,7 @@ pub(crate) fn build_fill_reports_from_trades(
                         instrument_fee_exponent(&i),
                     ),
                     None => {
-                        discards.unmapped_instruments += 1;
+                        output.omit(ReconciliationOmission::UnmappedFill);
                         continue;
                     }
                 };
@@ -163,7 +307,7 @@ pub(crate) fn build_fill_reports_from_trades(
                 continue;
             }
 
-            let report = parse_fill_report(
+            let report = match parse_fill_report(
                 trade,
                 instrument_id,
                 ctx.account_id,
@@ -174,12 +318,18 @@ pub(crate) fn build_fill_reports_from_trades(
                 taker_fee_rate,
                 fee_exponent,
                 ts_init,
-            );
-            reports.push(report);
+            ) {
+                Ok(report) => report,
+                Err(e) => {
+                    output.omit(ReconciliationOmission::InvalidFill(e));
+                    continue;
+                }
+            };
+            output.reports.push(report);
         }
     }
 
-    (reports, discards)
+    output
 }
 
 /// Converts open orders into order status reports.
@@ -189,9 +339,8 @@ pub(crate) fn build_order_reports_from_orders(
     account_id: AccountId,
     instrument_filter: Option<InstrumentId>,
     ts_init: UnixNanos,
-) -> (Vec<OrderStatusReport>, usize) {
-    let mut reports = Vec::new();
-    let mut filtered = 0usize;
+) -> ReportSet<OrderStatusReport> {
+    let mut output = ReportSet::new();
 
     for order in orders {
         let token_id = Ustr::from(order.asset_id.as_str());
@@ -199,7 +348,7 @@ pub(crate) fn build_order_reports_from_orders(
         let (instrument_id, price_prec, size_prec) = match instrument {
             Some(i) => (i.id(), i.price_precision(), i.size_precision()),
             None => {
-                filtered += 1;
+                output.omit(ReconciliationOmission::UnmappedOrder);
                 continue;
             }
         };
@@ -210,7 +359,7 @@ pub(crate) fn build_order_reports_from_orders(
             continue;
         }
 
-        let report = parse_order_status_report(
+        let report = match parse_order_status_report(
             order,
             instrument_id,
             account_id,
@@ -218,11 +367,17 @@ pub(crate) fn build_order_reports_from_orders(
             price_prec,
             size_prec,
             ts_init,
-        );
-        reports.push(report);
+        ) {
+            Ok(report) => report,
+            Err(e) => {
+                output.omit(ReconciliationOmission::InvalidOrder(e));
+                continue;
+            }
+        };
+        output.reports.push(report);
     }
 
-    (reports, filtered)
+    output
 }
 
 /// Applies venue_order_id and time-range filters to fill reports.
@@ -251,48 +406,55 @@ pub(crate) fn build_position_reports(
     positions: &[DataApiPosition],
     account_id: AccountId,
     ts: UnixNanos,
-) -> Vec<PositionStatusReport> {
-    positions
-        .iter()
-        .filter(|p| {
-            if p.size > Decimal::ZERO && p.size < DUST_POSITION_THRESHOLD {
-                log::debug!(
-                    "Filtering dust position: {}-{}, size={}",
-                    p.condition_id,
-                    p.asset,
-                    p.size
-                );
+) -> ReportSet<PositionStatusReport> {
+    let mut output = ReportSet::new();
+
+    for position in positions {
+        if position.size == Decimal::ZERO {
+            output.omit(ReconciliationOmission::Position(PositionOmission::Zero));
+            continue;
+        }
+
+        if position.size > Decimal::ZERO && position.size < DUST_POSITION_THRESHOLD {
+            output.omit(ReconciliationOmission::Position(PositionOmission::Dust));
+            continue;
+        }
+
+        let quantity = match Quantity::from_decimal_dp(position.size, USDC_DECIMALS as u8) {
+            Ok(quantity) => quantity,
+            Err(_) => {
+                output.omit(ReconciliationOmission::Position(
+                    PositionOmission::InvalidSize,
+                ));
+                continue;
             }
-            p.size >= DUST_POSITION_THRESHOLD
-        })
-        .filter_map(|p| {
-            let instrument_id =
-                InstrumentId::from(format!("{}-{}.POLYMARKET", p.condition_id, p.asset).as_str());
-            let quantity = match Quantity::from_decimal_dp(p.size, USDC_DECIMALS as u8) {
-                Ok(quantity) => quantity,
-                Err(e) => {
-                    log::warn!(
-                        "Skipping invalid Data API position {}-{} size {}: {e}",
-                        p.condition_id,
-                        p.asset,
-                        p.size,
-                    );
-                    return None;
-                }
-            };
-            Some(PositionStatusReport::new(
-                account_id,
-                instrument_id,
-                PositionSideSpecified::Long,
-                quantity,
-                ts,
-                ts,
-                None,
-                None,
-                p.avg_price,
-            ))
-        })
-        .collect()
+        };
+        let Some(avg_price) = position
+            .avg_price
+            .filter(|price| *price > Decimal::ZERO && *price < Decimal::ONE)
+        else {
+            output.omit(ReconciliationOmission::Position(
+                PositionOmission::InvalidAveragePrice,
+            ));
+            continue;
+        };
+        let instrument_id = InstrumentId::from(
+            format!("{}-{}.POLYMARKET", position.condition_id, position.asset).as_str(),
+        );
+        output.reports.push(PositionStatusReport::new(
+            account_id,
+            instrument_id,
+            PositionSideSpecified::Long,
+            quantity,
+            ts,
+            ts,
+            None,
+            None,
+            Some(avg_price),
+        ));
+    }
+
+    output
 }
 
 /// Full reconciliation mass status generation.
@@ -308,107 +470,134 @@ pub(crate) async fn generate_mass_status(
     lookback_mins: Option<u64>,
 ) -> anyhow::Result<Option<ExecutionMassStatus>> {
     let ts_init = ctx.clock.get_time_ns();
-
-    // Fetch orders
     let orders = http_client
         .get_orders(GetOrdersParams::default())
         .await
         .context("failed to fetch orders for mass status")?;
-
-    let (mut order_reports, orders_filtered) =
-        build_order_reports_from_orders(&orders, instruments, ctx.account_id, None, ts_init);
-
-    // Fetch and parse fill reports
     let trades = http_client
         .get_trades(GetTradesParams::default())
         .await
         .context("failed to fetch trades for mass status")?;
-
-    let (mut fill_reports, fill_discards) =
-        build_fill_reports_from_trades(&trades, ctx, instruments, None, ts_init);
-
-    if fill_discards.unowned_maker_trades > 0 {
-        log::error!(
-            "Mass status is missing {} confirmed maker trade(s) holding no maker order owned by \
-             the account; executed quantity may be understated",
-            fill_discards.unowned_maker_trades,
-        );
-    }
-
-    // Snap dust drift on REST fills the same way the WS path does.
-    // Commission stays as venue-reported.
-    fill_tracker.snap_fill_reports(&mut fill_reports);
-
-    // Position reports from Data API
     let positions = data_api_client
         .get_positions(ctx.user_address)
         .await
         .context("failed to fetch positions for mass status")?;
-
-    let position_reports = build_position_reports(&positions, ctx.account_id, ts_init);
-
-    // Apply lookback filter
-    if let Some(mins) = lookback_mins {
-        let now_ns = ctx.clock.get_time_ns();
-        let cutoff_ns = now_ns.as_u64().saturating_sub(mins * 60 * 1_000_000_000);
-        let cutoff = UnixNanos::from(cutoff_ns);
-
-        let orders_before = order_reports.len();
-        order_reports.retain(|r| r.ts_last >= cutoff);
-        let orders_removed = orders_before - order_reports.len();
-
-        let fills_before = fill_reports.len();
-        fill_reports.retain(|r| r.ts_event >= cutoff);
-        let fills_removed = fills_before - fill_reports.len();
-
-        log::debug!(
-            "Lookback filter ({}min): orders {}->{} (removed {}), fills {}->{} (removed {})",
-            mins,
-            orders_before,
-            order_reports.len(),
-            orders_removed,
-            fills_before,
-            fill_reports.len(),
-            fills_removed,
-        );
-    } else {
-        log::debug!(
-            "Generated mass status: {} orders ({} filtered), {} fills ({} instrument-filtered, \
-             {} unowned maker trades), {} positions",
-            order_reports.len(),
-            orders_filtered,
-            fill_reports.len(),
-            fill_discards.unmapped_instruments,
-            fill_discards.unowned_maker_trades,
-            position_reports.len(),
-        );
-    }
-
-    cap_order_reports_to_confirmed_fills(&mut order_reports, &fill_reports);
+    let snapshot = build_reconciliation_snapshot(
+        &orders,
+        &trades,
+        &positions,
+        instruments,
+        fill_tracker,
+        ctx,
+        lookback_mins,
+        ts_init,
+    )?;
 
     let mut mass_status = ExecutionMassStatus::new(client_id, ctx.account_id, venue, ts_init, None);
-
-    mass_status.add_order_reports(order_reports);
-    mass_status.add_position_reports(position_reports);
-    mass_status.add_fill_reports(fill_reports);
+    mass_status.add_order_reports(snapshot.orders);
+    mass_status.add_position_reports(snapshot.positions);
+    mass_status.add_fill_reports(snapshot.fills);
 
     Ok(Some(mass_status))
 }
 
-fn cap_order_reports_to_confirmed_fills(
-    order_reports: &mut [OrderStatusReport],
-    fill_reports: &[FillReport],
-) {
-    let confirmed_by_order = confirmed_filled_quantities(fill_reports);
+#[expect(clippy::too_many_arguments)]
+fn build_reconciliation_snapshot(
+    orders: &[PolymarketOpenOrder],
+    trades: &[PolymarketTradeReport],
+    positions: &[DataApiPosition],
+    instruments: &AtomicMap<Ustr, InstrumentAny>,
+    fill_tracker: &OrderFillTrackerMap,
+    ctx: &FillContext<'_>,
+    lookback_mins: Option<u64>,
+    ts_init: UnixNanos,
+) -> anyhow::Result<ReconciliationSnapshot> {
+    let mut order_set =
+        build_order_reports_from_orders(orders, instruments, ctx.account_id, None, ts_init);
+    let mut fill_set = build_fill_reports_from_trades(trades, ctx, instruments, None, ts_init);
+    let position_set = build_position_reports(positions, ctx.account_id, ts_init);
 
-    for report in order_reports {
+    fill_tracker.snap_fill_reports(&mut fill_set.reports);
+
+    if let Some(mins) = lookback_mins {
+        let lookback_ns = mins.saturating_mul(60).saturating_mul(1_000_000_000);
+        let cutoff = UnixNanos::from(ts_init.as_u64().saturating_sub(lookback_ns));
+        let order_count = order_set.reports.len();
+        let fill_count = fill_set.reports.len();
+        order_set.reports.retain(|report| report.ts_last >= cutoff);
+        fill_set.reports.retain(|report| report.ts_event >= cutoff);
+        order_set.omissions.record_n(
+            ReconciliationOmission::LookbackOrder,
+            order_count - order_set.reports.len(),
+        );
+        fill_set.omissions.record_n(
+            ReconciliationOmission::LookbackFill,
+            fill_count - fill_set.reports.len(),
+        );
+    }
+
+    let invalid_orders =
+        cap_order_reports_to_confirmed_fills(&mut order_set.reports, &fill_set.reports);
+    order_set.omissions.record_n(
+        ReconciliationOmission::InvalidOrder(ReportParseError::FilledQuantity),
+        invalid_orders,
+    );
+
+    let mut omissions = order_set.omissions;
+    omissions.merge(fill_set.omissions);
+    omissions.merge(position_set.omissions);
+    log_reconciliation_summary(
+        "mass status",
+        order_set.reports.len(),
+        fill_set.reports.len(),
+        position_set.reports.len(),
+        &omissions,
+    );
+    omissions.ensure_authoritative()?;
+
+    Ok(ReconciliationSnapshot {
+        orders: order_set.reports,
+        fills: fill_set.reports,
+        positions: position_set.reports,
+    })
+}
+
+pub(crate) fn log_reconciliation_summary(
+    route: &str,
+    order_reports: usize,
+    fill_reports: usize,
+    position_reports: usize,
+    omissions: &ReconciliationOmissions,
+) {
+    let message = format!(
+        "Polymarket {route}: reports(order={order_reports}, fill={fill_reports}, position={position_reports}); omissions={omissions}"
+    );
+
+    if omissions.is_empty() {
+        log::debug!("{message}");
+    } else {
+        log::warn!("{message}");
+    }
+}
+
+fn cap_order_reports_to_confirmed_fills(
+    order_reports: &mut Vec<OrderStatusReport>,
+    fill_reports: &[FillReport],
+) -> usize {
+    let confirmed_by_order = confirmed_filled_quantities(fill_reports);
+    let before = order_reports.len();
+
+    order_reports.retain_mut(|report| {
         let local_filled = Quantity::zero(report.quantity.precision);
         cap_order_report_filled_qty(
             report,
             local_filled,
             confirmed_by_order.get(&report.venue_order_id).copied(),
-        );
-    }
+        )
+        .is_ok()
+    });
+
+    before - order_reports.len()
 }
 
 pub(crate) fn confirmed_filled_quantities(
@@ -426,13 +615,18 @@ pub(crate) fn cap_order_report_filled_qty(
     report: &mut OrderStatusReport,
     local_filled: Quantity,
     confirmed_filled: Option<Decimal>,
-) {
+) -> Result<(), ReportParseError> {
     let confirmed_filled = confirmed_filled
         .and_then(|qty| Quantity::from_decimal_dp(qty, report.quantity.precision).ok())
         .unwrap_or_else(|| Quantity::zero(report.quantity.precision));
     let capped = report.filled_qty.min(local_filled.max(confirmed_filled));
     report.filled_qty = capped;
+    if report.order_status == OrderStatus::Filled && report.filled_qty.is_zero() {
+        return Err(ReportParseError::FilledQuantity);
+    }
+
     normalize_terminal_order_report_quantity(report);
+    Ok(())
 }
 
 pub(crate) fn normalize_terminal_order_report_quantity(report: &mut OrderStatusReport) {
@@ -465,6 +659,144 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::{
+        common::enums::PolymarketTradeStatus,
+        http::{
+            models::GammaMarket,
+            parse::{create_instrument_from_def, parse_gamma_market},
+        },
+    };
+
+    fn load<T: serde::de::DeserializeOwned>(filename: &str) -> T {
+        let path = format!("test_data/{filename}");
+        let content = std::fs::read_to_string(path).expect("failed to read test data");
+        serde_json::from_str(&content).expect("failed to parse test data")
+    }
+
+    fn test_instrument() -> InstrumentAny {
+        let market: GammaMarket = load("gamma_market.json");
+        let defs = parse_gamma_market(&market).expect("market should parse");
+        create_instrument_from_def(&defs[0], UnixNanos::from(1_000_000_000u64))
+            .expect("instrument should parse")
+    }
+
+    fn test_fill_context() -> FillContext<'static> {
+        FillContext {
+            account_id: AccountId::from("POLY-001"),
+            user_address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+            api_key: "00000000-0000-0000-0000-000000000001",
+            pusd: Currency::pUSD(),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+        }
+    }
+
+    #[rstest]
+    fn reconciliation_snapshot_rejects_pending_settlement() {
+        let instrument = test_instrument();
+        let mut trade: PolymarketTradeReport = load("http_trade_report.json");
+        trade.status = PolymarketTradeStatus::Matched;
+        let position = DataApiPosition {
+            asset: trade.asset_id.to_string(),
+            condition_id: "0xabc".to_string(),
+            size: Decimal::ZERO,
+            avg_price: None,
+        };
+
+        let instruments = AtomicMap::new();
+        instruments.insert(trade.asset_id, instrument);
+        let error = build_reconciliation_snapshot(
+            &[],
+            &[trade],
+            &[position],
+            &instruments,
+            &OrderFillTrackerMap::new(),
+            &test_fill_context(),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("pending settlement must make the snapshot non-authoritative");
+
+        assert_eq!(
+            error.to_string(),
+            "Mass status is not authoritative: PendingTrade=1",
+        );
+    }
+
+    #[rstest]
+    fn reconciliation_snapshot_omits_zero_position_evidence() {
+        let position = DataApiPosition {
+            asset: "123".to_string(),
+            condition_id: "0xabc".to_string(),
+            size: Decimal::ZERO,
+            avg_price: Some(Decimal::new(5, 1)),
+        };
+        let snapshot = build_reconciliation_snapshot(
+            &[],
+            &[],
+            &[position],
+            &AtomicMap::new(),
+            &OrderFillTrackerMap::new(),
+            &test_fill_context(),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect("zero rows should not be treated as position-close evidence");
+
+        assert!(snapshot.positions.is_empty());
+    }
+
+    #[rstest]
+    fn reconciliation_snapshot_rejects_invalid_open_position() {
+        let position = DataApiPosition {
+            asset: "123".to_string(),
+            condition_id: "0xabc".to_string(),
+            size: Decimal::TEN,
+            avg_price: None,
+        };
+        let error = build_reconciliation_snapshot(
+            &[],
+            &[],
+            &[position],
+            &AtomicMap::new(),
+            &OrderFillTrackerMap::new(),
+            &test_fill_context(),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("invalid open position must make the snapshot non-authoritative");
+
+        assert_eq!(
+            error.to_string(),
+            "Mass status is not authoritative: Position(InvalidAveragePrice)=1",
+        );
+    }
+
+    #[rstest]
+    fn reconciliation_snapshot_rejects_filled_order_without_confirmed_fill() {
+        let instrument = test_instrument();
+        let mut order: PolymarketOpenOrder = load("http_open_order.json");
+        order.status = crate::common::enums::PolymarketOrderStatus::Matched;
+        order.size_matched = order.original_size;
+
+        let instruments = AtomicMap::new();
+        instruments.insert(order.asset_id, instrument);
+        let error = build_reconciliation_snapshot(
+            &[order],
+            &[],
+            &[],
+            &instruments,
+            &OrderFillTrackerMap::new(),
+            &test_fill_context(),
+            None,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect_err("filled order without confirmed fill must not emit malformed state");
+
+        assert_eq!(
+            error.to_string(),
+            "Mass status is not authoritative: InvalidOrder(FilledQuantity)=1",
+        );
+    }
 
     #[rstest]
     fn caps_order_report_to_confirmed_companion_fills() {

--- a/crates/adapters/polymarket/src/execution/reports.rs
+++ b/crates/adapters/polymarket/src/execution/reports.rs
@@ -38,9 +38,9 @@ use super::{
         weighted_average_price,
     },
     reconciliation::{
-        FillContext, apply_fill_filters, build_fill_reports_from_trades, build_position_reports,
-        cap_order_report_filled_qty, confirmed_filled_quantities,
-        normalize_terminal_order_report_quantity,
+        FillContext, ReconciliationOmission, apply_fill_filters, build_fill_reports_from_trades,
+        build_position_reports, cap_order_report_filled_qty, confirmed_filled_quantities,
+        log_reconciliation_summary, normalize_terminal_order_report_quantity,
     },
 };
 use crate::{
@@ -139,13 +139,14 @@ impl PolymarketExecutionClient {
             return Ok(Some(report));
         }
 
-        let (mut order_fills, _) = build_fill_reports_from_trades(
+        let output = build_fill_reports_from_trades(
             &trades,
             &ctx,
             &self.shared_token_instruments,
             Some(instrument_id),
             ts_init,
         );
+        let mut order_fills = output.reports;
         order_fills.retain(|f| f.venue_order_id == venue_order_id);
         self.fill_tracker.snap_fill_reports(&mut order_fills);
 
@@ -284,7 +285,7 @@ impl PolymarketExecutionClient {
         self.spawn_task("query_order", async move {
             match http_client.get_order_optional(&venue_order_id).await {
                 Ok(Some(order)) => {
-                    let mut report = parse_order_status_report(
+                    let mut report = match parse_order_status_report(
                         &order,
                         instrument_id,
                         account_id,
@@ -292,7 +293,13 @@ impl PolymarketExecutionClient {
                         price_prec,
                         size_prec,
                         clock.get_time_ns(),
-                    );
+                    ) {
+                        Ok(report) => report,
+                        Err(e) => {
+                            log::warn!("Skipping invalid order report {venue_order_id}: {e}");
+                            return Ok(());
+                        }
+                    };
                     let venue_order_id = VenueOrderId::from(venue_order_id.as_str());
                     let tracked_filled = fill_tracker
                         .get_cumulative_filled(&venue_order_id)
@@ -330,11 +337,15 @@ impl PolymarketExecutionClient {
                     } else {
                         None
                     };
-                    cap_order_report_filled_qty(
+
+                    if let Err(e) = cap_order_report_filled_qty(
                         &mut report,
                         local_filled,
                         confirmed_filled,
-                    );
+                    ) {
+                        log::warn!("Skipping invalid order report {venue_order_id}: {e}");
+                        return Ok(());
+                    }
                     emitter.send_order_status_report(report);
                 }
                 Ok(None) => {
@@ -381,7 +392,7 @@ impl PolymarketExecutionClient {
         };
 
         if let Some(order) = order {
-            let mut report = parse_order_status_report(
+            let mut report = match parse_order_status_report(
                 &order,
                 instrument_id,
                 self.core.account_id,
@@ -389,7 +400,13 @@ impl PolymarketExecutionClient {
                 price_prec,
                 size_prec,
                 self.clock.get_time_ns(),
-            );
+            ) {
+                Ok(report) => report,
+                Err(e) => {
+                    log::warn!("Skipping invalid order report {venue_order_id}: {e}");
+                    return Ok(None);
+                }
+            };
             let cached_filled = cmd
                 .client_order_id
                 .and_then(|id| self.core.cache().order(&id).map(|order| order.filled_qty()))
@@ -429,7 +446,12 @@ impl PolymarketExecutionClient {
             } else {
                 None
             };
-            cap_order_report_filled_qty(&mut report, local_filled, confirmed_filled);
+
+            if let Err(e) = cap_order_report_filled_qty(&mut report, local_filled, confirmed_filled)
+            {
+                log::warn!("Skipping invalid order report {venue_order_id}: {e}");
+                return Ok(None);
+            }
             return Ok(Some(report));
         }
 
@@ -453,7 +475,7 @@ impl PolymarketExecutionClient {
             .await
             .context("failed to fetch orders")?;
 
-        let (mut reports, _) = super::reconciliation::build_order_reports_from_orders(
+        let mut output = super::reconciliation::build_order_reports_from_orders(
             &orders,
             &self.shared_token_instruments,
             self.core.account_id,
@@ -461,7 +483,7 @@ impl PolymarketExecutionClient {
             self.clock.get_time_ns(),
         );
 
-        let needs_confirmed_fills = reports.iter().any(|report| {
+        let needs_confirmed_fills = output.reports.iter().any(|report| {
             let cached_filled = report
                 .client_order_id
                 .and_then(|id| self.core.cache().order(&id).map(|order| order.filled_qty()))
@@ -489,7 +511,8 @@ impl PolymarketExecutionClient {
             Default::default()
         };
 
-        for report in &mut reports {
+        let before_normalization = output.reports.len();
+        output.reports.retain_mut(|report| {
             let cached_filled = report
                 .client_order_id
                 .and_then(|id| self.core.cache().order(&id).map(|order| order.filled_qty()))
@@ -508,19 +531,25 @@ impl PolymarketExecutionClient {
                 report,
                 cached_filled.max(tracked_filled),
                 confirmed_fills.get(&report.venue_order_id).copied(),
-            );
-        }
+            )
+            .is_ok()
+        });
+        output.omissions.record_n(
+            ReconciliationOmission::InvalidOrder(super::parse::ReportParseError::FilledQuantity),
+            before_normalization - output.reports.len(),
+        );
 
         let reports = if cmd.open_only {
-            reports
+            output
+                .reports
                 .into_iter()
                 .filter(|r| r.order_status.is_open())
                 .collect()
         } else {
-            reports
+            output.reports
         };
 
-        log::debug!("Generated {} order status reports", reports.len());
+        log_reconciliation_summary("order reports", reports.len(), 0, 0, &output.omissions);
         Ok(reports)
     }
 
@@ -535,7 +564,7 @@ impl PolymarketExecutionClient {
             .context("failed to fetch trades")?;
 
         let ctx = self.fill_context();
-        let (mut reports, _) = build_fill_reports_from_trades(
+        let mut output = build_fill_reports_from_trades(
             &trades,
             &ctx,
             &self.shared_token_instruments,
@@ -543,11 +572,11 @@ impl PolymarketExecutionClient {
             self.clock.get_time_ns(),
         );
 
-        self.fill_tracker.snap_fill_reports(&mut reports);
+        self.fill_tracker.snap_fill_reports(&mut output.reports);
 
-        let reports = apply_fill_filters(reports, cmd.venue_order_id, cmd.start, cmd.end);
+        let reports = apply_fill_filters(output.reports, cmd.venue_order_id, cmd.start, cmd.end);
 
-        log::debug!("Generated {} fill reports", reports.len());
+        log_reconciliation_summary("fill reports", 0, reports.len(), 0, &output.omissions);
         Ok(reports)
     }
 
@@ -563,14 +592,22 @@ impl PolymarketExecutionClient {
             .context("failed to fetch positions from Data API")?;
 
         let ts_now = self.clock.get_time_ns();
-        let mut reports = build_position_reports(&positions, self.core.account_id, ts_now);
+        let mut output = build_position_reports(&positions, self.core.account_id, ts_now);
 
         if let Some(ref filter_id) = cmd.instrument_id {
-            reports.retain(|r| &r.instrument_id == filter_id);
+            output
+                .reports
+                .retain(|report| &report.instrument_id == filter_id);
         }
 
-        log::debug!("Generated {} position status reports", reports.len());
-        Ok(reports)
+        log_reconciliation_summary(
+            "position reports",
+            0,
+            0,
+            output.reports.len(),
+            &output.omissions,
+        );
+        Ok(output.reports)
     }
 
     pub(super) async fn generate_mass_status_impl(
@@ -621,9 +658,10 @@ async fn fetch_confirmed_fill_reports(
         .get_trades(params)
         .await
         .context("failed to fetch confirmed trades")?;
-    let (reports, _) =
-        build_fill_reports_from_trades(&trades, ctx, token_instruments, instrument_id, ts_init);
-    Ok(reports)
+    Ok(
+        build_fill_reports_from_trades(&trades, ctx, token_instruments, instrument_id, ts_init)
+            .reports,
+    )
 }
 
 pub(crate) fn get_pusd_currency() -> Currency {

--- a/crates/adapters/polymarket/src/execution/responses.rs
+++ b/crates/adapters/polymarket/src/execution/responses.rs
@@ -19,12 +19,12 @@ use nautilus_common::live::{get_runtime, task::TaskHandles};
 use nautilus_core::{UUID4, time::AtomicTime};
 use nautilus_live::ExecutionEventEmitter;
 use nautilus_model::{
-    enums::{OrderSide, OrderStatus, OrderType, TimeInForce},
+    enums::{OrderSide, OrderStatus, TimeInForce},
     events::{OrderEventAny, OrderFilled, OrderUpdated},
     identifiers::{AccountId, VenueOrderId},
     orders::{Order, OrderAny},
     reports::{FillReport, OrderStatusReport},
-    types::{Price, Quantity},
+    types::Quantity,
 };
 use rust_decimal::Decimal;
 
@@ -32,6 +32,7 @@ use super::{
     cancellations::execute_deferred_cancel,
     identity::{OrderIdentity, OrderIdentityRegistry},
     order_fill_tracker::{BufferedFill, FillCorrectionMetadata, OrderFillTrackerMap},
+    parse::parse_order_status_report,
     pending::{PendingCancelTracker, PendingSubmitTracker},
     reconciliation::cap_order_report_filled_qty,
     reports::get_pusd_currency,
@@ -782,34 +783,29 @@ pub(super) async fn check_fok_status(
             emitter.emit_order_expired(order, Some(venue_order_id), ts_now);
         }
         OrderStatus::Filled => {
-            let quantity = Quantity::from_decimal_dp(venue_order.original_size, size_precision)
-                .unwrap_or_else(|_| Quantity::zero(size_precision));
-            let filled_qty = Quantity::from_decimal_dp(venue_order.size_matched, size_precision)
-                .unwrap_or_else(|_| Quantity::zero(size_precision));
             let confirmed_filled = fill_tracker
                 .get_cumulative_filled(&venue_order_id)
                 .unwrap_or_else(|| Quantity::zero(size_precision));
-            let price = Price::from_decimal_dp(venue_order.price, price_precision)
-                .unwrap_or_else(|_| Price::zero(price_precision));
-
-            let mut report = OrderStatusReport::new(
-                account_id,
+            let mut report = match parse_order_status_report(
+                &venue_order,
                 order.instrument_id(),
+                account_id,
                 Some(order.client_order_id()),
-                venue_order_id,
-                order.order_side(),
-                OrderType::Limit,
-                TimeInForce::Fok,
-                order_status,
-                quantity,
-                filled_qty,
+                price_precision,
+                size_precision,
                 ts_now,
-                ts_now,
-                ts_now,
-                None,
-            );
-            report.price = Some(price);
-            cap_order_report_filled_qty(&mut report, confirmed_filled, None);
+            ) {
+                Ok(report) => report,
+                Err(e) => {
+                    log::warn!("Skipping invalid FOK order report {order_id}: {e}");
+                    return;
+                }
+            };
+
+            if let Err(e) = cap_order_report_filled_qty(&mut report, confirmed_filled, None) {
+                log::warn!("Skipping invalid FOK order report {order_id}: {e}");
+                return;
+            }
 
             log::debug!(
                 "FOK order {order_id} resolved via REST as Filled; deferring fill quantity until confirmation"
@@ -825,11 +821,11 @@ mod tests {
     use nautilus_common::messages::ExecutionEvent;
     use nautilus_core::{UnixNanos, collections::AtomicMap};
     use nautilus_model::{
-        enums::{AccountType, LiquiditySide},
+        enums::{AccountType, LiquiditySide, OrderType},
         identifiers::{ClientOrderId, InstrumentId, StrategyId, TradeId, TraderId},
         instruments::{Instrument, InstrumentAny},
         orders::{LimitOrder, MarketOrder, Order, stubs::TestOrderEventStubs},
-        types::{Currency, Money},
+        types::{Currency, Money, Price},
     };
     use rstest::rstest;
     use ustr::Ustr;
@@ -1061,7 +1057,7 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, _) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
@@ -1069,7 +1065,13 @@ mod tests {
             UnixNanos::from(1_000_000_000u64),
         );
 
-        assert!(reports.is_empty());
+        assert!(output.reports.is_empty());
+        let expected = if status.is_pending_settlement() {
+            crate::execution::reconciliation::ReconciliationOmission::PendingTrade
+        } else {
+            crate::execution::reconciliation::ReconciliationOmission::FailedTrade
+        };
+        assert_eq!(output.omissions.count(expected), 1);
     }
 
     #[rstest]
@@ -1104,7 +1106,7 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, discards) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
@@ -1113,16 +1115,24 @@ mod tests {
         );
 
         assert_eq!(
-            reports.len(),
+            output.reports.len(),
             1,
             "the account's own confirmed maker fill must be reported",
         );
-        assert_eq!(reports[0].venue_order_id, expected_venue_order_id);
+        assert_eq!(output.reports[0].venue_order_id, expected_venue_order_id);
         assert_eq!(
-            discards.unowned_maker_trades, 0,
+            output
+                .omissions
+                .count(crate::execution::reconciliation::ReconciliationOmission::UnownedMakerTrade),
+            0,
             "entry-level skips of foreign entries in an owned trade are not trade drops",
         );
-        assert_eq!(discards.unmapped_instruments, 0);
+        assert_eq!(
+            output
+                .omissions
+                .count(crate::execution::reconciliation::ReconciliationOmission::UnmappedFill),
+            0,
+        );
     }
 
     #[rstest]
@@ -1142,7 +1152,7 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, discards) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
@@ -1150,13 +1160,12 @@ mod tests {
             UnixNanos::from(1_000_000_000u64),
         );
 
-        assert_eq!(reports.len(), 0);
+        assert_eq!(output.reports.len(), 0,);
         assert_eq!(
-            discards,
-            crate::execution::reconciliation::FillBuildDiscards {
-                unmapped_instruments: 1,
-                unowned_maker_trades: 0,
-            },
+            output
+                .omissions
+                .count(crate::execution::reconciliation::ReconciliationOmission::UnmappedFill),
+            1,
         );
     }
 
@@ -1178,7 +1187,7 @@ mod tests {
             clock: nautilus_core::time::get_atomic_clock_realtime(),
         };
 
-        let (reports, discards) = crate::execution::reconciliation::build_fill_reports_from_trades(
+        let output = crate::execution::reconciliation::build_fill_reports_from_trades(
             &[trade],
             &ctx,
             &instruments,
@@ -1186,12 +1195,20 @@ mod tests {
             UnixNanos::from(1_000_000_000u64),
         );
 
-        assert!(reports.is_empty());
+        assert!(output.reports.is_empty());
         assert_eq!(
-            discards.unowned_maker_trades, 1,
+            output
+                .omissions
+                .count(crate::execution::reconciliation::ReconciliationOmission::UnownedMakerTrade),
+            1,
             "a confirmed maker trade dropped whole must be counted, not silent",
         );
-        assert_eq!(discards.unmapped_instruments, 0);
+        assert_eq!(
+            output
+                .omissions
+                .count(crate::execution::reconciliation::ReconciliationOmission::UnmappedFill),
+            0,
+        );
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -469,13 +469,29 @@ mod tests {
         let account_id = AccountId::from("POLYMARKET-001");
         let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let output = build_position_reports(&positions, account_id, ts_now);
 
         // 4 positions: 150.5, 0.0, 42.0, 0.005 (dust)
         // Only 150.5 and 42.0 pass the DUST_POSITION_THRESHOLD (0.01)
-        assert_eq!(reports.len(), 2);
-        assert!(reports[0].is_long());
-        assert!(reports[1].is_long());
+        assert_eq!(output.reports.len(), 2);
+        assert!(output.reports[0].is_long());
+        assert!(output.reports[1].is_long());
+        assert_eq!(
+            output.omissions.count(
+                crate::execution::reconciliation::ReconciliationOmission::Position(
+                    crate::execution::reconciliation::PositionOmission::Zero,
+                ),
+            ),
+            1,
+        );
+        assert_eq!(
+            output.omissions.count(
+                crate::execution::reconciliation::ReconciliationOmission::Position(
+                    crate::execution::reconciliation::PositionOmission::Dust,
+                ),
+            ),
+            1,
+        );
     }
 
     #[rstest]
@@ -484,7 +500,7 @@ mod tests {
         let account_id = AccountId::from("POLYMARKET-001");
         let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let reports = build_position_reports(&positions, account_id, ts_now).reports;
 
         assert_eq!(reports.len(), 2);
         assert_eq!(reports[0].avg_px_open, Some(dec!(0.55)));
@@ -497,7 +513,7 @@ mod tests {
         let account_id = AccountId::from("POLYMARKET-001");
         let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let reports = build_position_reports(&positions, account_id, ts_now).reports;
 
         assert_eq!(reports.len(), 2);
         assert_eq!(reports[0].quantity.precision, USDC_DECIMALS as u8);
@@ -515,10 +531,17 @@ mod tests {
         let account_id = AccountId::from("POLYMARKET-001");
         let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
 
-        let reports = build_position_reports(&positions, account_id, ts_now);
+        let output = build_position_reports(&positions, account_id, ts_now);
 
-        assert_eq!(reports.len(), 1);
-        assert_eq!(reports[0].avg_px_open, None);
+        assert!(output.reports.is_empty());
+        assert_eq!(
+            output.omissions.count(
+                crate::execution::reconciliation::ReconciliationOmission::Position(
+                    crate::execution::reconciliation::PositionOmission::InvalidAveragePrice,
+                ),
+            ),
+            1,
+        );
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/websocket/dispatch.rs
+++ b/crates/adapters/polymarket/src/websocket/dispatch.rs
@@ -385,7 +385,9 @@ fn dispatch_trade_update(
     }
 
     let is_confirmed = trade.status == PolymarketTradeStatus::Confirmed;
-    dispatch_trade_fills(trade, &dedup_key, is_confirmed, ctx, state);
+    if !dispatch_trade_fills(trade, &dedup_key, is_confirmed, ctx, state) {
+        return None;
+    }
 
     if !is_confirmed {
         return None;
@@ -442,22 +444,26 @@ fn dispatch_trade_fills(
     is_confirmed: bool,
     ctx: &WsDispatchContext<'_>,
     state: &mut WsDispatchState,
-) {
+) -> bool {
     if state.processed_fills.contains(dedup_key) {
         log::debug!("Duplicate fill skipped: {dedup_key}");
-        return;
+        return true;
     }
 
-    state.processed_fills.add(dedup_key.clone());
     let fills = if trade.trader_side == PolymarketLiquiditySide::Maker {
-        dispatch_maker_fills(trade, dedup_key, is_confirmed, ctx, state)
+        let Some(fills) = dispatch_maker_fills(trade, dedup_key, is_confirmed, ctx, state) else {
+            return false;
+        };
+        fills
     } else {
         dispatch_taker_fill(trade, dedup_key, is_confirmed, ctx, state)
     };
+    state.processed_fills.add(dedup_key.clone());
 
     if !fills.is_empty() {
         state.matched_fills.insert(dedup_key.clone(), fills);
     }
+    true
 }
 
 fn confirm_trade(
@@ -497,7 +503,7 @@ fn dispatch_maker_fills(
     is_confirmed: bool,
     ctx: &WsDispatchContext<'_>,
     state: &WsDispatchState,
-) -> Vec<OrderFilled> {
+) -> Option<Vec<OrderFilled>> {
     let user_orders: Vec<_> = trade
         .maker_orders
         .iter()
@@ -506,7 +512,7 @@ fn dispatch_maker_fills(
 
     if user_orders.is_empty() {
         log::warn!("No matching maker orders for user in trade: {}", trade.id);
-        return Vec::new();
+        return None;
     }
 
     let instruments = ctx.token_instruments.load();
@@ -514,7 +520,7 @@ fn dispatch_maker_fills(
     let liquidity_side = parse_liquidity_side(trade.trader_side);
     let ts_event = parse_timestamp_ms(&trade.timestamp).unwrap_or_else(|_| ctx.clock.get_time_ns());
     let ts_init = ctx.clock.get_time_ns();
-    let mut fills = Vec::new();
+    let mut reports = Vec::with_capacity(user_orders.len());
 
     for mo in user_orders {
         let asset_id = Ustr::from(mo.asset_id.as_str());
@@ -522,10 +528,10 @@ fn dispatch_maker_fills(
             Some(i) => i,
             None => {
                 log::warn!("Unknown asset_id in maker order: {asset_id}");
-                continue;
+                return None;
             }
         };
-        let mut report = build_maker_fill_report(
+        let report = match build_maker_fill_report(
             mo,
             &trade.id,
             trade.trader_side,
@@ -539,7 +545,22 @@ fn dispatch_maker_fills(
             liquidity_side,
             ts_event,
             ts_init,
-        );
+        ) {
+            Ok(report) => report,
+            Err(e) => {
+                log::warn!(
+                    "Skipping invalid live maker fill for trade {}: {e}",
+                    trade.id
+                );
+                return None;
+            }
+        };
+        reports.push(report);
+    }
+
+    let mut fills = Vec::new();
+
+    for mut report in reports {
         let maker_venue_order_id = report.venue_order_id;
         report.client_order_id = ctx.pending_submits.client_order_id(&maker_venue_order_id);
         report.last_qty = ctx
@@ -569,7 +590,7 @@ fn dispatch_maker_fills(
             reemit_terminal_cancel(maker_venue_order_id, state, ctx);
         }
     }
-    fills
+    Some(fills)
 }
 
 fn is_user_maker_order(order: &PolymarketMakerOrder, ctx: &WsDispatchContext<'_>) -> bool {
@@ -1593,6 +1614,52 @@ mod tests {
         let fills = fill_tracker.pending_fills_for(&venue_order_id);
         assert_eq!(fills.len(), 1);
         assert_eq!(fills[0].venue_order_id, venue_order_id);
+    }
+
+    #[rstest]
+    fn test_invalid_maker_trade_remains_retryable_without_partial_application() {
+        let mut trade: PolymarketUserTrade = load("ws_user_trade.json");
+        trade.trader_side = PolymarketLiquiditySide::Maker;
+        trade.status = PolymarketTradeStatus::Confirmed;
+        let mut invalid_order = trade.maker_orders[0].clone();
+        invalid_order.order_id = "invalid-maker-order".to_string();
+        invalid_order.matched_amount = dec!(0.0000004);
+        trade.maker_orders.push(invalid_order);
+
+        let venue_order_id = VenueOrderId::from(trade.maker_orders[0].order_id.as_str());
+        let invalid_venue_order_id = VenueOrderId::from(trade.maker_orders[1].order_id.as_str());
+        let dedup_key = format!("{}-{}", trade.id, trade.taker_order_id);
+        let user_address = trade.maker_orders[0].maker_address.clone();
+        let token_instruments = AtomicMap::new();
+        token_instruments.insert(trade.maker_orders[0].asset_id, test_instrument());
+        let fill_tracker = OrderFillTrackerMap::new();
+        let pending_submits = PendingSubmitTracker::default();
+        let order_identities = OrderIdentityRegistry::default();
+        let emitter = test_emitter();
+        let ctx = WsDispatchContext {
+            token_instruments: &token_instruments,
+            fill_tracker: &fill_tracker,
+            pending_submits: &pending_submits,
+            order_identities: &order_identities,
+            emitter: &emitter,
+            account_id: AccountId::from("POLY-001"),
+            clock: nautilus_core::time::get_atomic_clock_realtime(),
+            user_address: &user_address,
+            user_api_key: "test-key",
+        };
+        let mut state = WsDispatchState::default();
+
+        let result = dispatch_user_message(&UserWsMessage::Trade(trade.clone()), &ctx, &mut state);
+
+        assert!(result.is_none());
+        assert!(fill_tracker.pending_fills_for(&venue_order_id).is_empty());
+        assert!(
+            fill_tracker
+                .pending_fills_for(&invalid_venue_order_id)
+                .is_empty()
+        );
+        assert!(!state.processed_fills.contains(&dedup_key));
+        assert!(!state.confirmed_trades.contains(&trade.id));
     }
 
     #[rstest]

--- a/docs/integrations/polymarket.md
+++ b/docs/integrations/polymarket.md
@@ -589,6 +589,17 @@ create an inferred fill. Runtime order checks fetch confirmed trade history when
 more matched quantity than the local order and WebSocket fill tracker contain. Unpaired fill reports
 retain the normal fill-only path.
 
+The REST mass status is emitted only when its evidence is authoritative. `MATCHED`, `MINED`, and
+`RETRYING` trades make the complete snapshot unavailable until settlement finishes; the user
+WebSocket remains the sole source of provisional fills and their `FAILED` corrections. A report row
+that cannot be mapped or represented also rejects the snapshot instead of producing partial state.
+Startup reconciliation propagates that error and stops.
+
+Data API rows with zero size are not position-close evidence and do not produce `Flat` reports.
+Position reductions and closes come from venue `CONFIRMED` fills, while positive Data API positions
+require a representable size and an average price strictly between zero and one. Collection report
+routes emit one summary containing the reports produced and each reason an input row was omitted.
+
 ### Single-order recovery from trades
 
 `/data/order/{id}` can return live or terminal orders. When it returns no order for a known ID,


### PR DESCRIPTION
## Summary

Polymarket REST reconciliation currently builds a mass status from independently indexed order, trade, and position rows even when some venue evidence cannot be represented. This change makes that construction an atomic authority boundary:

- A typed omission ledger accompanies every report collection. Material omissions reject the complete mass status instead of emitting partial state; policy omissions remain visible in one collection summary.
- One fallible parser contract rejects unrepresentable or degenerate order and fill values. The same contract is used by mass, polling, FOK recovery, and maker WebSocket paths.
- Settlement-pending trades make the REST snapshot unavailable. The existing user WebSocket remains the sole provisional fill and FAILED-correction lifecycle.
- Explicit zero Data API rows remain visible as omitted evidence but cannot synthesize Flat closes, because the independently indexed row has no freshness/version proof.
- Maker WebSocket trade validation is atomic: every owned leg is valid before any leg mutates fill state, and rejected trades remain retryable.

## Supersession

This replaces the per-instrument Flat guard proposed in #4691 with a snapshot-level authority contract. It intentionally does not adopt #4692’s second pending-fill lifecycle, replay heuristics, compatibility keys, or additional eviction state; those mechanisms are unnecessary when provisional ownership remains singular.

## Verification

Exact-head evidence is posted separately so this body remains stable as the branch evolves.