### PR TITLE
Retain open Polymarket markets past endDate

### DIFF
--- a/crates/adapters/polymarket/src/data/dispatch.rs
+++ b/crates/adapters/polymarket/src/data/dispatch.rs
@@ -486,6 +486,8 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                 return;
             }
 
+            drop(instruments);
+
             log::debug!(
                 "Tick size changed for {}: {} -> {}",
                 change.asset_id,
@@ -501,25 +503,42 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                 },
             );
 
-            if let Some(existing) = existing {
-                let ts_init = ctx.clock.get_time_ns();
+            let ts_init = ctx.clock.get_time_ns();
+            let mut rebuilt = None;
+            let mut rebuild_error = None;
+
+            // Rebuild from the value the map holds now, so a concurrent market closure update is
+            // carried forward rather than reverted by an older snapshot. Resolving presence here
+            // rather than from the snapshot above also covers an instrument cached after it, whose
+            // `token_meta` precision was already advanced.
+            ctx.instruments.rcu(|map| {
+                rebuilt = None;
+                rebuild_error = None;
+
+                let Some(current) = map.get(&meta.instrument_id).cloned() else {
+                    return;
+                };
 
                 match rebuild_instrument_with_tick_size(
-                    existing,
+                    &current,
                     &change.new_tick_size,
                     ts_init,
                     ts_init,
                 ) {
-                    Ok(rebuilt) => {
-                        ctx.instruments.insert(rebuilt.id(), rebuilt.clone());
-                        if let Err(e) = ctx.data_sender.send(DataEvent::Instrument(rebuilt)) {
-                            log::error!("Failed to emit rebuilt instrument: {e}");
-                        }
+                    Ok(instrument) => {
+                        map.insert(instrument.id(), instrument.clone());
+                        rebuilt = Some(instrument);
                     }
-                    Err(e) => {
-                        log::error!("Failed to rebuild instrument for tick size change: {e}");
-                    }
+                    Err(e) => rebuild_error = Some(e.to_string()),
                 }
+            });
+
+            if let Some(e) = rebuild_error {
+                log::error!("Failed to rebuild instrument for tick size change: {e}");
+            } else if let Some(rebuilt) = rebuilt
+                && let Err(e) = ctx.data_sender.send(DataEvent::Instrument(rebuilt))
+            {
+                log::error!("Failed to emit rebuilt instrument: {e}");
             }
 
             // Book epoch transition; see module docs.
@@ -1054,6 +1073,7 @@ mod tests {
         market_id: Option<&'a str>,
         condition_id: Option<&'a str>,
         expiration_ns: Option<UnixNanos>,
+        market_closed: Option<bool>,
     }
 
     fn seed_instrument_with_context(
@@ -1096,6 +1116,9 @@ mod tests {
                 );
             }
 
+            if let Some(closed) = seed_ctx.market_closed {
+                info.insert("closed".to_string(), closed.into());
+            }
             binary.info = Some(info);
         }
 
@@ -2182,6 +2205,7 @@ mod tests {
                 market_id: Some("1778973900"),
                 condition_id: Some("0xCOND-BTC"),
                 expiration_ns: Some(expiration_ns),
+                market_closed: None,
             },
         );
         let no = seed_instrument_with_context(
@@ -2194,6 +2218,7 @@ mod tests {
                 market_id: Some("1778973900"),
                 condition_id: Some("0xCOND-BTC"),
                 expiration_ns: Some(expiration_ns),
+                market_closed: None,
             },
         );
 
@@ -2294,6 +2319,7 @@ mod tests {
                 market_id: Some("1778973900"),
                 condition_id: Some("0xCOND-BTC"),
                 expiration_ns: Some(expiration_ns),
+                market_closed: None,
             },
         );
         let no = seed_instrument_with_context(
@@ -2306,6 +2332,7 @@ mod tests {
                 market_id: Some("1778973900"),
                 condition_id: Some("0xCOND-BTC"),
                 expiration_ns: Some(expiration_ns),
+                market_closed: None,
             },
         );
 
@@ -2995,12 +3022,12 @@ mod tests {
             make_gamma_market_value_with_outcome_prices(
                 "0xCOND-POLL",
                 "[\"0xTOKEN_YES\",\"0xTOKEN_NO\"]",
-                Some("[\"1\",\"0\"]"),
-                Some(true),
+                None,
+                Some(false),
                 Some(false),
             )
         ]));
-        let addr = start_mock_server(state).await;
+        let addr = start_mock_server(state.clone()).await;
         let (mut client, mut data_rx) = create_test_client(addr);
         client.config.resolve_poll_enabled = true;
         client.config.resolve_poll_interval_secs = 1;
@@ -3017,23 +3044,25 @@ mod tests {
         );
         let inst_yes = seed_instrument_with_context(
             &ws_ctx,
-            "0xTOKEN_YES",
+            "0xCOND-POLL-YES",
             Price::from("0.001"),
             Quantity::from("0.01"),
             SeedInstrumentContext {
                 condition_id: Some("0xCOND-POLL"),
                 expiration_ns: Some(expiration_ns),
+                market_closed: Some(false),
                 ..SeedInstrumentContext::default()
             },
         );
         let inst_no = seed_instrument_with_context(
             &ws_ctx,
-            "0xTOKEN_NO",
+            "0xCOND-POLL-NO",
             Price::from("0.001"),
             Quantity::from("0.01"),
             SeedInstrumentContext {
                 condition_id: Some("0xCOND-POLL"),
                 expiration_ns: Some(expiration_ns),
+                market_closed: Some(false),
                 ..SeedInstrumentContext::default()
             },
         );
@@ -3049,6 +3078,22 @@ mod tests {
         );
 
         client.spawn_resolve_poll_task();
+        tokio::time::sleep(StdDuration::from_millis(200)).await;
+        state.gamma_response.lock().await.as_mut().unwrap()[0]["closed"] = true.into();
+
+        wait_until_async(
+            || async {
+                let loaded = client.instruments.load();
+                let closed = loaded
+                    .get(&inst_yes.id())
+                    .map(crate::filters::market_closed);
+                closed == Some(Some(true))
+            },
+            StdDuration::from_secs(5),
+        )
+        .await;
+        state.gamma_response.lock().await.as_mut().unwrap()[0]["outcomePrices"] =
+            serde_json::json!("[1,0]");
 
         wait_until_async(
             || async {
@@ -3229,10 +3274,11 @@ mod tests {
     #[rstest]
     #[case::quotes(ExpiredPath::Quotes, "0xTOKEN_EXPIRED")]
     #[case::book(ExpiredPath::BookSnapshot, "0xTOKEN_EXPIRED_BOOK")]
-    #[case::trades(ExpiredPath::Trades, "0xTOKEN_EXPIRED_TRADES")]
-    fn cached_expired_instrument_live_paths_are_rejected(
+    #[case::trades(ExpiredPath::Trades, "0xCOND-EXPIRED-TRADES")]
+    fn cached_expired_instrument_live_paths_honor_market_closure(
         #[case] path: ExpiredPath,
         #[case] raw_symbol: &str,
+        #[values(None, Some(true), Some(false))] market_closed: Option<bool>,
     ) {
         let mut client = make_local_test_client();
         let expired = seed_instrument_with_context(
@@ -3243,6 +3289,7 @@ mod tests {
             SeedInstrumentContext {
                 condition_id: Some("0xCOND-EXPIRED"),
                 expiration_ns: Some(UnixNanos::from(1)),
+                market_closed,
                 ..SeedInstrumentContext::default()
             },
         );
@@ -3277,9 +3324,13 @@ mod tests {
             )),
         };
 
-        assert!(result.is_err());
+        // Only a positive `closed=false` retains an expired market; unknown state retires it.
+        let retained = market_closed == Some(false);
+
+        assert_eq!(result.is_ok(), retained);
+
         if matches!(path, ExpiredPath::Quotes) {
-            assert!(!client.active_quote_subs.contains(&expired.id()));
+            assert_eq!(client.active_quote_subs.contains(&expired.id()), retained);
         }
     }
 
@@ -3541,6 +3592,42 @@ mod tests {
             events.iter().any(|e| matches!(e, DataEvent::Instrument(_))),
             "expected rebuilt instrument event, found: {events:?}",
         );
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn tick_size_change_preserves_market_closure_state(#[case] closed: bool) {
+        let asset_id_str = "0xTOKEN_CLOSURE";
+        let market = "0xMARKET";
+
+        let (ctx, _data_rx) = make_ws_ctx();
+        let inst = seed_instrument_with_context(
+            &ctx,
+            asset_id_str,
+            Price::from("0.001"),
+            Quantity::from("0.01"),
+            SeedInstrumentContext {
+                market_closed: Some(closed),
+                ..SeedInstrumentContext::default()
+            },
+        );
+        let instrument_id = inst.id();
+
+        handle_market_message(
+            make_tick_change(market, asset_id_str, "0.001", "0.01"),
+            &ctx,
+        );
+
+        let rebuilt = ctx
+            .instruments
+            .load()
+            .get(&instrument_id)
+            .cloned()
+            .expect("rebuilt instrument");
+
+        assert_eq!(rebuilt.price_increment(), Price::from("0.01"));
+        assert_eq!(crate::filters::market_closed(&rebuilt), Some(closed));
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/data/instruments.rs
+++ b/crates/adapters/polymarket/src/data/instruments.rs
@@ -15,6 +15,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use ahash::{AHashMap, AHashSet};
 use dashmap::DashMap;
 use nautilus_common::{live::get_runtime, messages::DataEvent, providers::InstrumentProvider};
 use nautilus_core::{AtomicMap, UnixNanos, time::AtomicTime};
@@ -25,7 +26,14 @@ use nautilus_model::{
 use ustr::Ustr;
 
 use super::{PolymarketDataClient, runtime::is_instrument_expired};
-use crate::{filters::InstrumentFilter, http::gamma::PolymarketGammaHttpClient};
+use crate::{
+    common::consts::GAMMA_CONDITION_IDS_BATCH_SIZE,
+    filters::{
+        InstrumentFilter, binary_market_closed, is_expired, market_closed, set_market_closed,
+    },
+    http::{gamma::PolymarketGammaHttpClient, query::GetGammaMarketsParams},
+    providers::extract_condition_id,
+};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct TokenMeta {
@@ -123,6 +131,137 @@ pub(super) async fn refresh_scoped_instruments(
     ))
 }
 
+// Returns the condition IDs Gamma positively reports as `closed=true`.
+//
+// Condition IDs the unfiltered lookup does not return are re-queried with `closed=true`, so a
+// market that lookup leaves out is still checked. A condition ID absent from both lookups is left
+// out: closure was not observed.
+async fn probe_closed_condition_ids(
+    http: &PolymarketGammaHttpClient,
+    condition_ids: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let open = http
+        .request_markets_by_params(GetGammaMarketsParams {
+            condition_ids: Some(condition_ids.to_vec()),
+            ..Default::default()
+        })
+        .await?;
+    let returned = open
+        .iter()
+        .map(|market| market.condition_id.as_str())
+        .collect::<AHashSet<_>>();
+    let mut closed_ids = open
+        .iter()
+        .filter(|market| market.closed == Some(true))
+        .map(|market| market.condition_id.clone())
+        .collect::<Vec<_>>();
+    let missing = condition_ids
+        .iter()
+        .filter(|condition_id| !returned.contains(condition_id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if missing.is_empty() {
+        return Ok(closed_ids);
+    }
+
+    let closed = http
+        .request_markets_by_params(GetGammaMarketsParams {
+            condition_ids: Some(missing),
+            closed: Some(true),
+            ..Default::default()
+        })
+        .await?;
+    closed_ids.extend(
+        closed
+            .into_iter()
+            .filter(|market| market.closed == Some(true))
+            .map(|market| market.condition_id),
+    );
+
+    Ok(closed_ids)
+}
+
+pub(super) async fn refresh_expired_market_closure(
+    http: &PolymarketGammaHttpClient,
+    cache: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+    sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
+    now_ns: UnixNanos,
+) -> anyhow::Result<usize> {
+    let mut carried: AHashMap<String, Vec<InstrumentId>> = AHashMap::new();
+
+    for (id, instrument) in cache.load().iter() {
+        if is_expired(instrument, now_ns)
+            && market_closed(instrument) == Some(false)
+            && let Ok(condition_id) = extract_condition_id(id)
+        {
+            carried.entry(condition_id).or_default().push(*id);
+        }
+    }
+
+    let condition_ids = carried.keys().cloned().collect::<Vec<_>>();
+    let chunks = condition_ids.chunks(GAMMA_CONDITION_IDS_BATCH_SIZE);
+    let total_chunks = chunks.len();
+    let mut closed_ids = AHashSet::new();
+    let mut failed_chunks = 0;
+
+    // A failed chunk must not discard closures the other chunks already confirmed.
+    for chunk in chunks {
+        match probe_closed_condition_ids(http, chunk).await {
+            Ok(chunk_closed_ids) => closed_ids.extend(chunk_closed_ids),
+            Err(e) => {
+                failed_chunks += 1;
+                log::warn!(
+                    "Failed to probe market closure for {} condition ID(s): {e}",
+                    chunk.len()
+                );
+            }
+        }
+    }
+
+    let closing_ids = closed_ids
+        .iter()
+        .filter_map(|condition_id| carried.get(condition_id))
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    let mut updated = Vec::new();
+
+    // Compose against the latest cached value, so a concurrent tick size change is not discarded.
+    // Guarded because `rcu` clones the whole cache, and most ticks have nothing to close.
+    if !closing_ids.is_empty() {
+        cache.rcu(|map| {
+            updated.clear();
+
+            for instrument_id in &closing_ids {
+                if let Some(InstrumentAny::BinaryOption(binary)) = map.get_mut(instrument_id)
+                    && binary_market_closed(binary) != Some(true)
+                {
+                    set_market_closed(binary, true);
+                    updated.push(InstrumentAny::BinaryOption(binary.clone()));
+                }
+            }
+        });
+    }
+
+    for instrument in &updated {
+        if let Err(e) = sender.send(DataEvent::Instrument(instrument.clone())) {
+            log::warn!(
+                "Failed to publish market closure update for {}: {e}",
+                instrument.id()
+            );
+        }
+    }
+
+    if failed_chunks > 0 {
+        anyhow::bail!(
+            "Failed to probe market closure for {failed_chunks} of {total_chunks} condition ID chunk(s)"
+        );
+    }
+
+    Ok(updated.len())
+}
+
 impl PolymarketDataClient {
     pub(super) async fn bootstrap_instruments(&mut self) -> anyhow::Result<()> {
         self.provider.initialize(false).await?;
@@ -213,6 +352,18 @@ impl PolymarketDataClient {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        net::SocketAddr,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use axum::{
+        Json, Router,
+        extract::{RawQuery, State},
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        routing::get,
+    };
     use nautilus_common::live::runner::replace_data_event_sender;
     use nautilus_core::UnixNanos;
     use nautilus_model::{
@@ -428,5 +579,171 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing token_meta for {token_id}"));
             assert_eq!(meta.instrument_id, inst.id());
         }
+    }
+
+    fn past_end_open_market() -> serde_json::Value {
+        serde_json::from_str(include_str!(
+            "../../test_data/gamma_market_past_end_date_open.json"
+        ))
+        .unwrap()
+    }
+
+    // Mirrors the live Gamma funnel, which records closure state the historical loader must not
+    // carry. See `parse_markets_with_transient`.
+    fn past_end_open_instrument() -> BinaryOption {
+        let market = serde_json::from_value(past_end_open_market()).unwrap();
+        let definitions = crate::http::parse::parse_gamma_market(&market).unwrap();
+        let instrument =
+            crate::http::parse::create_instrument_from_def(&definitions[0], UnixNanos::default())
+                .unwrap();
+        let InstrumentAny::BinaryOption(mut binary) = instrument else {
+            panic!("Expected BinaryOption, was {instrument:?}");
+        };
+        set_market_closed(&mut binary, false);
+        binary
+    }
+
+    fn requested_condition_ids(query: Option<&str>) -> Vec<String> {
+        query
+            .unwrap_or_default()
+            .split('&')
+            .filter_map(|pair| pair.strip_prefix("condition_ids="))
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    async fn market_closure_response(
+        State((closed, fail)): State<(bool, bool)>,
+        RawQuery(query): RawQuery,
+    ) -> Response {
+        if fail {
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+        let wants_closed = query.unwrap_or_default().contains("closed=true");
+        let mut market = past_end_open_market();
+        market["closed"] = wants_closed.into();
+        market["orderPriceMinTickSize"] = serde_json::json!(0.01);
+        let markets = (wants_closed == closed)
+            .then_some(market)
+            .into_iter()
+            .collect::<Vec<_>>();
+        Json(serde_json::json!({"markets": markets, "next_cursor": null})).into_response()
+    }
+
+    async fn market_closure_server(closed: bool, fail: bool) -> SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/markets/keyset", get(market_closure_response))
+            .with_state((closed, fail));
+
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        addr
+    }
+
+    #[rstest]
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(false, true)]
+    #[tokio::test]
+    async fn market_closure_refresh_uses_positive_signal_without_replacing_definition(
+        #[case] closed: bool,
+        #[case] fail: bool,
+    ) {
+        let instrument = InstrumentAny::BinaryOption(past_end_open_instrument());
+        let instruments = Arc::new(AtomicMap::new());
+        instruments.insert(instrument.id(), instrument.clone());
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let addr = market_closure_server(closed, fail).await;
+        let client = PolymarketGammaHttpClient::new(
+            Some(format!("http://{addr}")),
+            1,
+            RetryConfig::default(),
+        )
+        .unwrap();
+
+        let result =
+            refresh_expired_market_closure(&client, &instruments, &tx, UnixNanos::from(u64::MAX))
+                .await;
+
+        if fail {
+            assert!(result.is_err());
+            return;
+        }
+
+        assert_eq!(result.unwrap(), usize::from(closed));
+        let cached = instruments.load();
+        let cached = cached.get(&instrument.id()).unwrap();
+        assert_eq!(market_closed(cached), Some(closed));
+        // Gamma reports a 0.01 tick size; the cached definition keeps its own 0.001.
+        assert_eq!(cached.price_increment(), Price::from("0.001"));
+    }
+
+    // Serves the first request only, echoing every requested condition ID back as closed.
+    async fn first_chunk_only_response(
+        State(requests): State<Arc<AtomicUsize>>,
+        RawQuery(query): RawQuery,
+    ) -> Response {
+        if requests.fetch_add(1, Ordering::SeqCst) > 0 {
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+
+        let markets = requested_condition_ids(query.as_deref())
+            .into_iter()
+            .map(|condition_id| {
+                let mut market = past_end_open_market();
+                market["conditionId"] = condition_id.into();
+                market["closed"] = true.into();
+                market
+            })
+            .collect::<Vec<_>>();
+
+        Json(serde_json::json!({"markets": markets, "next_cursor": null})).into_response()
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn market_closure_refresh_keeps_earlier_chunk_results_when_a_later_chunk_fails() {
+        let base = past_end_open_instrument();
+        let instruments = Arc::new(AtomicMap::new());
+
+        // One more candidate than a single Gamma request accepts, so the probe spans two chunks.
+        for i in 0..=GAMMA_CONDITION_IDS_BATCH_SIZE {
+            let mut binary = base.clone();
+            binary.raw_symbol = Symbol::new(format!("0xCOND{i:04}-Yes"));
+            binary.id = InstrumentId::new(binary.raw_symbol, base.id.venue);
+            instruments.insert(binary.id, InstrumentAny::BinaryOption(binary));
+        }
+
+        let requests = Arc::new(AtomicUsize::new(0));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/markets/keyset", get(first_chunk_only_response))
+            .with_state(requests);
+
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let client = PolymarketGammaHttpClient::new(
+            Some(format!("http://{addr}")),
+            1,
+            RetryConfig::default(),
+        )
+        .unwrap();
+
+        let result =
+            refresh_expired_market_closure(&client, &instruments, &tx, UnixNanos::from(u64::MAX))
+                .await;
+
+        assert!(result.is_err());
+
+        let closed = instruments
+            .load()
+            .values()
+            .filter(|instrument| market_closed(instrument) == Some(true))
+            .count();
+
+        assert_eq!(closed, GAMMA_CONDITION_IDS_BATCH_SIZE);
     }
 }

--- a/crates/adapters/polymarket/src/data/lifecycle.rs
+++ b/crates/adapters/polymarket/src/data/lifecycle.rs
@@ -27,6 +27,7 @@ use nautilus_model::events::PositionEvent;
 use super::{
     PolymarketDataClient,
     dispatch::{WsMessageContext, handle_ws_message},
+    instruments::refresh_expired_market_closure,
     runtime::{retire_expired_local_instruments, seed_token_meta_from_live_instruments},
 };
 use crate::{
@@ -147,6 +148,8 @@ impl PolymarketDataClient {
         let ws_open_tokens = self.ws_open_tokens.clone();
         let ws_sub_mutex = self.ws_sub_mutex.clone();
         let ws = self.ws_client.handle();
+        let closure_client = gamma_client.clone();
+        let closure_sender = self.data_sender.clone();
 
         let ctx = WsMessageContext {
             clock: self.clock,
@@ -193,6 +196,15 @@ impl PolymarketDataClient {
                     () = cancellation.cancelled() => break,
                     _ = interval.tick() => {
                         let now_ns = clock.get_time_ns();
+
+                        // Runs on every tick so retirement never trails closure by more than one
+                        // cycle. Without an expired instrument reported open, no request is sent.
+                        if let Err(e) = refresh_expired_market_closure(
+                            &closure_client, &instruments, &closure_sender, now_ns,
+                        ).await {
+                            log::warn!("Failed to refresh Polymarket market closure state: {e}");
+                        }
+
                         retire_expired_local_instruments(
                             now_ns,
                             &instruments,

--- a/crates/adapters/polymarket/src/data/mod.rs
+++ b/crates/adapters/polymarket/src/data/mod.rs
@@ -73,7 +73,7 @@ use self::{
         request_book_snapshot, request_data, request_instrument, request_instruments,
         request_trades,
     },
-    runtime::is_instrument_expired,
+    runtime::is_instrument_expired_and_not_reported_open,
     subscriptions::{resolve_token_id_from, sync_ws_subscription_async},
 };
 use crate::{
@@ -295,7 +295,7 @@ impl PolymarketDataClient {
             return Ok(());
         };
 
-        if is_instrument_expired(instrument, now_ns) {
+        if is_instrument_expired_and_not_reported_open(instrument, now_ns) {
             anyhow::bail!(
                 "Instrument {instrument_id} is expired and no longer available for live subscription"
             );
@@ -314,7 +314,7 @@ impl PolymarketDataClient {
             .ok_or_else(|| InstrumentLookupError::not_found(instrument_id))?
             .clone();
 
-        if is_instrument_expired(&instrument, self.clock.get_time_ns()) {
+        if is_instrument_expired_and_not_reported_open(&instrument, self.clock.get_time_ns()) {
             anyhow::bail!(
                 "Instrument {instrument_id} is expired and no longer available for market data requests"
             );

--- a/crates/adapters/polymarket/src/data/runtime.rs
+++ b/crates/adapters/polymarket/src/data/runtime.rs
@@ -38,6 +38,13 @@ pub(crate) fn is_instrument_expired(instrument: &InstrumentAny, now_ns: UnixNano
     crate::filters::is_expired(instrument, now_ns)
 }
 
+pub(crate) fn is_instrument_expired_and_not_reported_open(
+    instrument: &InstrumentAny,
+    now_ns: UnixNanos,
+) -> bool {
+    crate::filters::is_expired_and_not_reported_open(instrument, now_ns)
+}
+
 pub(crate) fn seed_token_meta_from_live_instruments(
     now_ns: UnixNanos,
     instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
@@ -46,7 +53,7 @@ pub(crate) fn seed_token_meta_from_live_instruments(
     let loaded = instruments.load();
 
     for instrument in loaded.values() {
-        if is_instrument_expired(instrument, now_ns) {
+        if is_instrument_expired_and_not_reported_open(instrument, now_ns) {
             continue;
         }
 
@@ -202,7 +209,7 @@ pub(crate) async fn retire_expired_local_instruments(
         loaded
             .iter()
             .filter_map(|(instrument_id, instrument)| {
-                is_instrument_expired(instrument, now_ns)
+                is_instrument_expired_and_not_reported_open(instrument, now_ns)
                     .then_some((*instrument_id, instrument.raw_symbol().as_str().to_string()))
             })
             .collect()
@@ -231,6 +238,13 @@ pub(crate) async fn retire_expired_local_instruments(
         }
 
         expired_ids.push(instrument_id);
+    }
+
+    if !expired_ids.is_empty() {
+        log::info!(
+            "Removing live state for {} closed Polymarket instrument(s)",
+            expired_ids.len()
+        );
     }
 
     for instrument_id in expired_ids {

--- a/crates/adapters/polymarket/src/filters.rs
+++ b/crates/adapters/polymarket/src/filters.rs
@@ -18,7 +18,7 @@
 use std::fmt::Debug;
 
 use nautilus_core::UnixNanos;
-use nautilus_model::instruments::{Instrument, InstrumentAny};
+use nautilus_model::instruments::{BinaryOption, Instrument, InstrumentAny};
 
 use crate::{
     http::query::{GetGammaEventsParams, GetGammaMarketsParams, GetSearchParams},
@@ -263,6 +263,40 @@ pub(crate) fn is_expired(instrument: &InstrumentAny, now_ns: UnixNanos) -> bool 
         .is_some_and(|expiration_ns| expiration_ns.as_u64() != 0 && expiration_ns <= now_ns)
 }
 
+pub(crate) const MARKET_CLOSED_KEY: &str = "closed";
+
+pub(crate) fn market_closed(instrument: &InstrumentAny) -> Option<bool> {
+    match instrument {
+        InstrumentAny::BinaryOption(binary) => binary_market_closed(binary),
+        _ => None,
+    }
+}
+
+pub(crate) fn binary_market_closed(instrument: &BinaryOption) -> Option<bool> {
+    instrument
+        .info
+        .as_ref()
+        .and_then(|info| info.get_bool(MARKET_CLOSED_KEY))
+}
+
+pub(crate) fn set_market_closed(instrument: &mut BinaryOption, closed: bool) {
+    let mut info = instrument.info.clone().unwrap_or_default();
+    info.insert(MARKET_CLOSED_KEY.to_string(), closed.into());
+    instrument.info = Some(info);
+}
+
+/// Returns whether `instrument` is past its expiration without Gamma reporting it still open.
+///
+/// Gamma `endDate` is a scheduled end, not proof that trading stopped, so an expired instrument is
+/// retained while Gamma reports `closed=false`. A missing `closed` key means the instrument did not
+/// come from the live Gamma path, which keeps the time-only retirement behavior.
+pub(crate) fn is_expired_and_not_reported_open(
+    instrument: &InstrumentAny,
+    now_ns: UnixNanos,
+) -> bool {
+    is_expired(instrument, now_ns) && market_closed(instrument) != Some(false)
+}
+
 impl Debug for PredicateFilter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct(stringify!(PredicateFilter))
@@ -493,6 +527,28 @@ mod tests {
         let instrument = stub_binary_option_with_expiration(Some("Yes"), UnixNanos::from(0u64));
         let filter = PredicateFilter::not_expired(now);
         assert!(filter.accept(&instrument));
+    }
+
+    #[rstest]
+    #[case(2_000_000, Some(false), false)]
+    #[case(2_000_000, Some(true), true)]
+    #[case(2_000_000, None, true)]
+    #[case(500_000, Some(true), false)]
+    fn test_expired_and_not_reported_open_requires_expiration_and_no_open_market_state(
+        #[case] now: u64,
+        #[case] closed: Option<bool>,
+        #[case] expected: bool,
+    ) {
+        let mut instrument =
+            stub_binary_option_with_expiration(Some("Yes"), UnixNanos::from(1_000_000));
+        if let (Some(closed), InstrumentAny::BinaryOption(binary)) = (closed, &mut instrument) {
+            set_market_closed(binary, closed);
+        }
+
+        assert_eq!(
+            is_expired_and_not_reported_open(&instrument, UnixNanos::from(now)),
+            expected
+        );
     }
 
     #[fixture]

--- a/crates/adapters/polymarket/src/http/gamma.rs
+++ b/crates/adapters/polymarket/src/http/gamma.rs
@@ -44,6 +44,7 @@ use serde_json::Value;
 
 use crate::{
     common::urls::gamma_api_url,
+    filters::set_market_closed,
     http::{
         error::{Error, Result},
         models::{GammaEvent, GammaMarket, GammaTag, SearchResponse},
@@ -369,6 +370,11 @@ fn parse_markets_to_instruments(markets: &[GammaMarket], ts_init: UnixNanos) -> 
 // Returns parsed instruments alongside condition IDs of markets still in the
 // CLOB hydration window (empty or empty-entry `clob_token_ids`), so callers
 // can retry rather than treating them as terminal.
+//
+// This is the single funnel through which live instruments reach the client caches, so Gamma's
+// `closed` state is recorded here rather than in `create_instrument_from_def`. Historical loader
+// instruments share that constructor and must not carry terminal state in `info`; they expose it
+// through `resolution_metadata` instead.
 fn parse_markets_with_transient(
     markets: &[GammaMarket],
     ts_init: UnixNanos,
@@ -386,7 +392,11 @@ fn parse_markets_with_transient(
             Ok(defs) => {
                 for def in defs {
                     match create_instrument_from_def(&def, ts_init) {
-                        Ok(instrument) => instruments.push(instrument),
+                        Ok(InstrumentAny::BinaryOption(mut binary)) => {
+                            set_market_closed(&mut binary, def.closed);
+                            instruments.push(InstrumentAny::BinaryOption(binary));
+                        }
+                        Ok(other) => instruments.push(other),
                         Err(e) => log::warn!("Failed to create instrument: {e}"),
                     }
                 }

--- a/crates/adapters/polymarket/src/http/parse.rs
+++ b/crates/adapters/polymarket/src/http/parse.rs
@@ -72,6 +72,9 @@ pub struct PolymarketInstrumentDef {
     pub end_date: Option<String>,
     /// Whether the market is active and accepting orders.
     pub active: bool,
+    /// Whether Gamma reports the market closed.
+    #[serde(default)]
+    pub closed: bool,
     /// URL slug for the market.
     pub market_slug: Option<String>,
     /// Whether the market uses the neg-risk CTF exchange contract.
@@ -166,6 +169,7 @@ pub fn parse_gamma_market(market: &GammaMarket) -> anyhow::Result<Vec<Polymarket
             start_date: market.start_date.clone(),
             end_date: market.end_date.clone(),
             active,
+            closed: market.closed.unwrap_or(false),
             market_slug: market.market_slug.clone(),
             neg_risk,
             fee_schedule: market.fee_schedule.clone(),
@@ -634,6 +638,33 @@ mod tests {
         );
         assert_eq!(info.get_u64("game_id"), None);
         assert_eq!(info.get("fee_schedule"), None);
+    }
+
+    #[rstest]
+    fn test_past_end_market_carries_closure_state_on_the_definition_only() {
+        let mut market = load_gamma_market("gamma_market_past_end_date_open.json");
+        let defs = parse_gamma_market(&market).unwrap();
+
+        assert!(!defs[0].closed);
+
+        market.closed = Some(true);
+        let closed_defs = parse_gamma_market(&market).unwrap();
+
+        assert!(closed_defs[0].closed);
+
+        // `create_instrument_from_def` is shared with the historical loader, which keeps terminal
+        // state in `resolution_metadata`. Closure is stamped on the live Gamma path instead.
+        for def in [&defs[0], &closed_defs[0]] {
+            let instrument =
+                create_instrument_from_def(def, UnixNanos::from(1_000_000_000u64)).unwrap();
+            let binary = match &instrument {
+                InstrumentAny::BinaryOption(binary) => binary,
+                other => panic!("Expected BinaryOption, was {other:?}"),
+            };
+            let info = binary.info.as_ref().expect("info should be present");
+
+            assert_eq!(info.get_bool("closed"), None);
+        }
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/test_data/gamma_market_past_end_date_open.json
+++ b/crates/adapters/polymarket/test_data/gamma_market_past_end_date_open.json
@@ -1,0 +1,21 @@
+{
+  "id": "2063130",
+  "conditionId": "0x72af7d77091bd2209f78a45a13876beefc734768177dbc0c8171f515ba1a52a7",
+  "questionID": "0x55ab76d092f682bf5cbb7e14f13ee12f8410ce7cc1b7906f23b8fb56c11f6502",
+  "question": "Will Berhanu Nega be the next Prime Minister of Ethiopia?",
+  "description": "General elections are scheduled to be held in Ethiopia on June 1, 2026.\n\nThis market will resolve to the next individual who officially assumes the office of Prime Minister of Ethiopia following the 2026 General elections.\n\nTo count for resolution, the individual must be officially appointed and sworn in as Prime Minister of Ethiopia. Any interim or caretaker Prime Minister will not count toward the resolution of this market.\n\nIf no such Prime Minister takes office by December 31, 2028, 11:59 PM ET, this market will resolve to \u201cOther\u201d.\n\nThe primary resolution source for this market will be official information from the Government of Ethiopia; however, a consensus of credible reporting may also be used.",
+  "slug": "will-berhanu-nega-be-the-next-prime-minister-of-ethiopia",
+  "startDate": "2026-04-27T21:54:45.451Z",
+  "endDate": "2026-06-01T00:00:00Z",
+  "active": true,
+  "closed": false,
+  "acceptingOrders": true,
+  "enableOrderBook": true,
+  "clobTokenIds": "[\"9700525976462326306802795530553376348116310383328382626789994562350229436531\", \"9684129004308889646536044141330168144866101175836994432446145127310478131443\"]",
+  "outcomes": "[\"Yes\", \"No\"]",
+  "orderPriceMinTickSize": 0.001,
+  "orderMinSize": 5,
+  "negRisk": true,
+  "negRiskMarketID": "0x55ab76d092f682bf5cbb7e14f13ee12f8410ce7cc1b7906f23b8fb56c11f6500",
+  "umaResolutionStatuses": "[]"
+}

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -36,7 +36,10 @@ use axum::{
     routing::{delete, get, post},
 };
 use nautilus_common::{providers::InstrumentProvider, testing::wait_until_async};
-use nautilus_model::{identifiers::InstrumentId, instruments::Instrument};
+use nautilus_model::{
+    identifiers::InstrumentId,
+    instruments::{Instrument, InstrumentAny},
+};
 use nautilus_network::{http::HttpClient, retry::RetryConfig};
 use nautilus_polymarket::{
     common::{
@@ -3375,6 +3378,46 @@ async fn test_fetch_gamma_markets_paginated_uses_100_per_page() {
 
     // The local offset spans two pages: 87 markets x 2 tokens each
     assert_eq!(instruments.len(), 174);
+}
+
+#[rstest]
+#[case(false)]
+#[case(true)]
+#[tokio::test]
+async fn test_gamma_instruments_record_market_closure_state(#[case] closed: bool) {
+    let state = TestServerState::default();
+    let mut market = gamma_market_with_slug(
+        "closure-state",
+        "0xclosure000000000000000000000000000000000000000000000000000000001",
+        [
+            "31000000000000000000000000000000000000000000000000000000000001",
+            "41000000000000000000000000000000000000000000000000000000000002",
+        ],
+    );
+    market["closed"] = closed.into();
+    state
+        .gamma_markets_pages
+        .lock()
+        .await
+        .push_back(json!({"markets": [market]}));
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_gamma_domain_client(&addr);
+    let instruments = client
+        .request_instruments_by_params(GetGammaMarketsParams::default())
+        .await
+        .unwrap();
+
+    assert_eq!(instruments.len(), 2);
+
+    for instrument in &instruments {
+        let InstrumentAny::BinaryOption(binary) = instrument else {
+            panic!("Expected BinaryOption, was {instrument:?}");
+        };
+        let info = binary.info.as_ref().expect("info should be present");
+
+        assert_eq!(info.get_bool("closed"), Some(closed));
+    }
 }
 
 #[rstest]

--- a/docs/integrations/polymarket.md
+++ b/docs/integrations/polymarket.md
@@ -1357,6 +1357,20 @@ available partial result and logs a warning. A start-anchored request raises an 
 because Rust cannot guarantee complete results from the requested start; narrow the time window and
 retry.
 
+### Closed market cleanup
+
+Gamma `endDate` is a scheduled end, not proof that trading stopped. The client keeps cached
+instruments while Gamma reports `closed=false` and removes live state after a positive `closed=true`.
+
+The closure check runs on every resolve-poll tick, so retirement never trails closure by more than
+one cycle, and it retries failed requests on the next tick. A failed condition ID batch does not
+discard the closures confirmed by the other batches. If both Gamma lookups omit a market, the client
+keeps it because closure was not observed.
+
+Only live instruments carry this state. The historical data loader reports terminal state through
+`resolution_metadata` instead, so a backtest cannot see a market's current closure through
+`instrument.info`.
+
 ## Contributing
 
 :::info


### PR DESCRIPTION
## Summary

Observed: Polymarket can keep a market open after its Gamma `endDate`. One captured market was 68 days past that date while Gamma still reported `closed=false` and `acceptingOrders=true`. The existing expiry sweep removed cached live state based on time alone.

From code inspection: `expiration_ns` was the only cleanup gate. This PR records Gamma’s `closed` state, rechecks expired cached markets through the open and closed lookups, and removes their live state only after Gamma positively reports `closed=true`. Loading and execution paths remain in separate follow-up changes.

## Related issue

Related to #4689

## Verification

I verified this with:

- Live Gamma check: 12 of 12 closed markets were absent from the open lookup and present with `closed=true`
- Live lifecycle run: six instruments were removed after positive closure responses, while four past-end open controls remained
- `cargo test -p nautilus-polymarket --lib --tests`: passed
- `cargo nextest run -p nautilus-polymarket --features python`: 1,349 passed, 2 skipped
- `make pytest`: passed
- `cargo clippy -p nautilus-polymarket --all-targets -- -D warnings`: passed through pre-commit
- `cargo +nightly fmt -p nautilus-polymarket -- --check`: passed through pre-commit
- `make pre-commit`: all hooks passed except `test-wheel-publishing`, which failed with the known stale index link fixture
