### PR TITLE
Make live reconciliation account-atomic

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -20,7 +20,14 @@
 
 #[cfg(feature = "node")]
 use std::collections::HashSet;
-use std::{cell::RefCell, fmt::Debug, rc::Rc, str::FromStr, sync::LazyLock, time::Duration};
+use std::{
+    cell::RefCell,
+    fmt::{Debug, Display},
+    rc::Rc,
+    str::FromStr,
+    sync::LazyLock,
+    time::Duration,
+};
 
 use indexmap::{IndexMap, IndexSet};
 use nautilus_common::{
@@ -160,6 +167,199 @@ pub struct ReconciliationResult {
     pub events: Vec<OrderEventAny>,
     /// External orders that need to be registered with execution clients.
     pub external_orders: Vec<ExternalOrderMetadata>,
+    /// Reason the complete mass status was rejected before state mutation.
+    pub rejection: Option<ReconciliationRejection>,
+    /// Exactly-once accounting for position reports in the mass status.
+    pub position_reports: PositionReconciliationSummary,
+}
+
+/// Exactly-once accounting for position reports consumed from one mass status.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PositionReconciliationSummary {
+    unchanged: usize,
+    applied: usize,
+    rejected: usize,
+    filtered: usize,
+    generation_disabled: usize,
+    insufficient_evidence: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PositionReconciliationSkip {
+    Filtered,
+    GenerationDisabled,
+    InsufficientEvidence,
+}
+
+#[derive(Debug)]
+enum PositionReconciliationOutcome {
+    Unchanged,
+    Applied(Vec<OrderEventAny>),
+    Skipped(PositionReconciliationSkip),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PositionReportGroupDisposition {
+    Reconcile,
+    Skipped(PositionReconciliationSkip),
+}
+
+impl PositionReconciliationOutcome {
+    fn from_events(events: Option<Vec<OrderEventAny>>) -> Self {
+        match events {
+            Some(events) if events.is_empty() => Self::Unchanged,
+            Some(events) => Self::Applied(events),
+            None => Self::Skipped(PositionReconciliationSkip::InsufficientEvidence),
+        }
+    }
+}
+
+impl PositionReconciliationSummary {
+    /// Returns the number of reports represented by this summary.
+    #[must_use]
+    pub const fn received(&self) -> usize {
+        self.unchanged
+            + self.applied
+            + self.rejected
+            + self.filtered
+            + self.generation_disabled
+            + self.insufficient_evidence
+    }
+
+    /// Returns the number of reports already equal to post-fill cached state.
+    #[must_use]
+    pub const fn unchanged(&self) -> usize {
+        self.unchanged
+    }
+
+    /// Returns the number of reports that produced reconciliation events.
+    #[must_use]
+    pub const fn applied(&self) -> usize {
+        self.applied
+    }
+
+    /// Returns the number of reports intentionally not applied.
+    #[must_use]
+    pub const fn skipped(&self) -> usize {
+        self.rejected + self.filtered + self.generation_disabled + self.insufficient_evidence
+    }
+
+    /// Returns the number of reports skipped because the complete mass status was rejected.
+    #[must_use]
+    pub const fn rejected(&self) -> usize {
+        self.rejected
+    }
+
+    /// Returns the number of reports excluded by reconciliation configuration.
+    #[must_use]
+    pub const fn filtered(&self) -> usize {
+        self.filtered
+    }
+
+    /// Returns the number of discrepant reports not applied because generation is disabled.
+    #[must_use]
+    pub const fn generation_disabled(&self) -> usize {
+        self.generation_disabled
+    }
+
+    /// Returns the number of discrepant reports lacking representable synthetic-event evidence.
+    #[must_use]
+    pub const fn insufficient_evidence(&self) -> usize {
+        self.insufficient_evidence
+    }
+
+    fn record(&mut self, outcome: &PositionReconciliationOutcome) {
+        match outcome {
+            PositionReconciliationOutcome::Unchanged => self.unchanged += 1,
+            PositionReconciliationOutcome::Applied(_) => self.applied += 1,
+            PositionReconciliationOutcome::Skipped(reason) => match reason {
+                PositionReconciliationSkip::Filtered => self.filtered += 1,
+                PositionReconciliationSkip::GenerationDisabled => {
+                    self.generation_disabled += 1;
+                }
+                PositionReconciliationSkip::InsufficientEvidence => {
+                    self.insufficient_evidence += 1;
+                }
+            },
+        }
+    }
+
+    fn reject_all(received: usize) -> Self {
+        Self {
+            rejected: received,
+            ..Self::default()
+        }
+    }
+}
+
+/// Report category whose account violated a mass-status envelope.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReconciliationReportKind {
+    /// Order status report.
+    Order,
+    /// Fill report.
+    Fill,
+    /// Position status report.
+    Position,
+}
+
+impl Display for ReconciliationReportKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Order => f.write_str("order"),
+            Self::Fill => f.write_str("fill"),
+            Self::Position => f.write_str("position"),
+        }
+    }
+}
+
+/// Reason an execution mass status was rejected before state mutation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReconciliationRejection {
+    /// The envelope account is absent from the cache.
+    AccountNotCached {
+        /// Account declared by the mass-status envelope.
+        account_id: AccountId,
+    },
+    /// A child report account differs from the envelope account.
+    ReportAccountMismatch {
+        /// Account declared by the mass-status envelope.
+        envelope_account_id: AccountId,
+        /// Account declared by the child report.
+        report_account_id: AccountId,
+        /// Category of the mismatched child report.
+        report_kind: ReconciliationReportKind,
+    },
+}
+
+impl Display for ReconciliationRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AccountNotCached { account_id } => {
+                write!(f, "mass-status account {account_id} is not cached")
+            }
+            Self::ReportAccountMismatch {
+                envelope_account_id,
+                report_account_id,
+                report_kind,
+            } => write!(
+                f,
+                "{report_kind} report account {report_account_id} does not match mass-status account {envelope_account_id}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ReconciliationRejection {}
+
+impl ReconciliationResult {
+    fn rejected(rejection: ReconciliationRejection, position_reports: usize) -> Self {
+        Self {
+            rejection: Some(rejection),
+            position_reports: PositionReconciliationSummary::reject_all(position_reports),
+            ..Self::default()
+        }
+    }
 }
 
 /// Result of inflight order checks containing terminal events and intermediate queries.
@@ -476,6 +676,124 @@ impl ExecutionManager {
             .unwrap_or(DEFAULT_POSITION_RECONCILIATION_TOLERANCE)
     }
 
+    fn validate_mass_status_account_scope(
+        &self,
+        mass_status: &ExecutionMassStatus,
+    ) -> Result<(), ReconciliationRejection> {
+        let envelope_account_id = mass_status.account_id;
+        if self.cache.borrow().account(&envelope_account_id).is_none() {
+            return Err(ReconciliationRejection::AccountNotCached {
+                account_id: envelope_account_id,
+            });
+        }
+
+        let order_reports = mass_status.order_reports();
+        let fill_reports = mass_status.fill_reports();
+        let position_reports = mass_status.position_reports();
+        let mut report_accounts = order_reports
+            .values()
+            .map(|report| (ReconciliationReportKind::Order, report.account_id))
+            .chain(
+                fill_reports
+                    .values()
+                    .flatten()
+                    .map(|report| (ReconciliationReportKind::Fill, report.account_id)),
+            )
+            .chain(
+                position_reports
+                    .values()
+                    .flatten()
+                    .map(|report| (ReconciliationReportKind::Position, report.account_id)),
+            );
+
+        if let Some((report_kind, report_account_id)) =
+            report_accounts.find(|(_, account_id)| *account_id != envelope_account_id)
+        {
+            return Err(ReconciliationRejection::ReportAccountMismatch {
+                envelope_account_id,
+                report_account_id,
+                report_kind,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn classify_mass_position_group(
+        &self,
+        instrument_id: InstrumentId,
+        reports: &[PositionStatusReport],
+        instruments_with_unattributed_fills: &IndexSet<InstrumentId>,
+    ) -> PositionReportGroupDisposition {
+        if self.config.filter_position_reports {
+            return PositionReportGroupDisposition::Skipped(PositionReconciliationSkip::Filtered);
+        }
+
+        if !self.should_reconcile_instrument(&instrument_id) {
+            return PositionReportGroupDisposition::Skipped(PositionReconciliationSkip::Filtered);
+        }
+
+        let hedge_mode = reports
+            .iter()
+            .any(|report| report.venue_position_id.is_some());
+        if !hedge_mode || !instruments_with_unattributed_fills.contains(&instrument_id) {
+            return PositionReportGroupDisposition::Reconcile;
+        }
+
+        PositionReportGroupDisposition::Skipped(PositionReconciliationSkip::InsufficientEvidence)
+    }
+
+    fn hedge_position_baseline(
+        &self,
+        reports: &IndexMap<InstrumentId, Vec<PositionStatusReport>>,
+    ) -> IndexMap<PositionId, Position> {
+        let cache = self.cache.borrow();
+
+        reports
+            .values()
+            .flatten()
+            .filter_map(|report| report.venue_position_id)
+            .filter_map(|position_id| {
+                cache
+                    .position_owned(&position_id)
+                    .map(|position| (position_id, position))
+            })
+            .collect()
+    }
+
+    fn project_attributed_hedge_fills(
+        &self,
+        baseline: &IndexMap<PositionId, Position>,
+        fills: &[OrderFilled],
+    ) -> IndexMap<PositionId, Position> {
+        let mut projected: IndexMap<PositionId, Position> = IndexMap::new();
+
+        for fill in fills {
+            let Some(position_id) = fill.position_id else {
+                continue;
+            };
+
+            if let Some(position) = projected.get_mut(&position_id) {
+                position.apply(fill);
+                continue;
+            }
+
+            let position = if let Some(position) = baseline.get(&position_id) {
+                let mut position = position.clone();
+                position.apply(fill);
+                position
+            } else {
+                let Some(instrument) = self.get_instrument(&fill.instrument_id) else {
+                    continue;
+                };
+                Position::new(&instrument, fill.clone())
+            };
+            projected.insert(position_id, position);
+        }
+
+        projected
+    }
+
     /// Reconciles orders and fills from a mass status report.
     ///
     /// Order events are collected, sorted globally by `ts_event`, then processed through
@@ -492,6 +810,15 @@ impl ExecutionManager {
         mass_status: ExecutionMassStatus,
         exec_engine: Rc<RefCell<ExecutionEngine>>,
     ) -> ReconciliationResult {
+        let mass_position_reports = mass_status.position_reports();
+        let position_report_count: usize = mass_position_reports.values().map(Vec::len).sum();
+
+        if let Err(rejection) = self.validate_mass_status_account_scope(&mass_status) {
+            log::error!("Rejected ExecutionMassStatus: {rejection}");
+            return ReconciliationResult::rejected(rejection, position_report_count);
+        }
+        let hedge_position_baseline = self.hedge_position_baseline(&mass_position_reports);
+
         // Publish raw reports before any state mutation (including fill adjustment
         // below, which can synthesise replacement order/fill reports). The
         // execution engine's per-report `reconcile_*` entry points are bypassed by
@@ -514,7 +841,7 @@ impl ExecutionManager {
         let raw_position_topic =
             MessagingSwitchboard::reconciliation_raw_position_status_report_topic();
 
-        for reports in mass_status.position_reports().values() {
+        for reports in mass_position_reports.values() {
             for report in reports {
                 msgbus::publish_any(raw_position_topic, report);
             }
@@ -523,7 +850,7 @@ impl ExecutionManager {
         let venue = mass_status.venue;
         let order_count = mass_status.order_reports().len();
         let fill_count: usize = mass_status.fill_reports().values().map(|v| v.len()).sum();
-        let position_count = mass_status.position_reports().len();
+        let position_count = position_report_count;
 
         log_info!(
             "Reconciling ExecutionMassStatus for {venue}",
@@ -890,33 +1217,39 @@ impl ExecutionManager {
         }
 
         events.sort_by_key(|e| e.ts_event());
+        let mut applied_position_fills = Vec::new();
 
         for event in &events {
-            if let OrderEventAny::Filled(fill) = event
-                && (retained_fill_state.fill_keys.contains(&(
-                    fill.account_id,
-                    fill.instrument_id,
-                    fill.trade_id,
-                )) || ((retained_fill_state.missing_order_ids.contains(&(
-                    fill.account_id,
-                    fill.instrument_id,
-                    fill.client_order_id,
-                )) || retained_fill_state.missing_venue_order_ids.contains(&(
-                    fill.account_id,
-                    fill.instrument_id,
-                    fill.venue_order_id,
-                ))) && !reported_fill_keys.contains(&(
-                    fill.account_id,
-                    fill.instrument_id,
-                    fill.trade_id,
-                ))) || retained_fill_state
-                    .netting_lifecycle_starts
-                    .get(&(fill.account_id, fill.instrument_id, fill.strategy_id))
-                    .is_some_and(|ts_opened| fill.ts_event < *ts_opened))
-            {
-                exec_engine.borrow_mut().project_reconciliation_fill(fill);
-            } else {
-                exec_engine.borrow_mut().process(event);
+            let project_fill = matches!(
+                event,
+                OrderEventAny::Filled(fill)
+                    if retained_fill_state.fill_keys.contains(&(
+                        fill.account_id,
+                        fill.instrument_id,
+                        fill.trade_id,
+                    )) || ((retained_fill_state.missing_order_ids.contains(&(
+                        fill.account_id,
+                        fill.instrument_id,
+                        fill.client_order_id,
+                    )) || retained_fill_state.missing_venue_order_ids.contains(&(
+                        fill.account_id,
+                        fill.instrument_id,
+                        fill.venue_order_id,
+                    ))) && !reported_fill_keys.contains(&(
+                        fill.account_id,
+                        fill.instrument_id,
+                        fill.trade_id,
+                    ))) || retained_fill_state
+                        .netting_lifecycle_starts
+                        .get(&(fill.account_id, fill.instrument_id, fill.strategy_id))
+                        .is_some_and(|ts_opened| fill.ts_event < *ts_opened)
+            );
+
+            match (project_fill, event) {
+                (true, OrderEventAny::Filled(fill)) => {
+                    exec_engine.borrow_mut().project_reconciliation_fill(fill);
+                }
+                _ => exec_engine.borrow_mut().process(event),
             }
 
             if let OrderEventAny::Filled(fill) = event
@@ -924,63 +1257,56 @@ impl ExecutionManager {
                 && self.is_fill_applied(fill, fill_key)
             {
                 self.processed_fills.mark(fill_key);
+
+                if !project_fill {
+                    applied_position_fills.push(fill.clone());
+                }
             }
         }
 
-        let mut positions_created = 0usize;
+        let projected_hedge_positions =
+            self.project_attributed_hedge_fills(&hedge_position_baseline, &applied_position_fills);
 
-        if !self.config.filter_position_reports {
-            // Collect instruments with fills that lack venue_position_id (can't attribute to
-            // specific hedge position, so must skip all hedge reports for that instrument)
-            let instruments_with_unattributed_fills: IndexSet<InstrumentId> = mass_status
-                .fill_reports()
-                .values()
-                .flatten()
-                .filter(|f| f.venue_position_id.is_none())
-                .map(|f| f.instrument_id)
-                .chain(
-                    mass_status
-                        .order_reports()
-                        .values()
-                        .filter(|r| !r.filled_qty.is_zero() && r.venue_position_id.is_none())
-                        .map(|r| r.instrument_id),
-                )
-                .collect();
+        let instruments_with_unattributed_fills: IndexSet<InstrumentId> = adjusted_fill_reports
+            .values()
+            .flatten()
+            .filter(|report| report.venue_position_id.is_none())
+            .map(|report| report.instrument_id)
+            .chain(
+                adjusted_order_reports
+                    .values()
+                    .filter(|report| {
+                        !report.filled_qty.is_zero() && report.venue_position_id.is_none()
+                    })
+                    .map(|report| report.instrument_id),
+            )
+            .collect();
+        let mut position_reports = PositionReconciliationSummary::default();
 
-            let positions_with_fills: IndexSet<PositionId> = mass_status
-                .fill_reports()
-                .values()
-                .flatten()
-                .filter_map(|f| f.venue_position_id)
-                .chain(
-                    mass_status
-                        .order_reports()
-                        .values()
-                        .filter(|r| !r.filled_qty.is_zero())
-                        .filter_map(|r| r.venue_position_id),
-                )
-                .collect();
+        for (instrument_id, reports) in mass_position_reports {
+            let disposition = self.classify_mass_position_group(
+                instrument_id,
+                &reports,
+                &instruments_with_unattributed_fills,
+            );
 
-            for (instrument_id, reports) in mass_status.position_reports() {
-                if !self.should_reconcile_instrument(&instrument_id) {
-                    log::debug!(
-                        "Skipping position reports for {instrument_id}: not in reconciliation_instrument_ids"
-                    );
-                    continue;
-                }
-
-                for report in reports {
-                    if let Some(position_events) = self.reconcile_position_report(
+            for report in reports {
+                let outcome = match disposition {
+                    PositionReportGroupDisposition::Reconcile => self.reconcile_position_report(
                         &report,
                         mass_status.account_id,
-                        &instruments_with_unattributed_fills,
-                        &positions_with_fills,
-                    ) {
-                        for event in position_events {
-                            exec_engine.borrow_mut().process(&event);
-                            events.push(event);
-                        }
-                        positions_created += 1;
+                        &projected_hedge_positions,
+                    ),
+                    PositionReportGroupDisposition::Skipped(reason) => {
+                        PositionReconciliationOutcome::Skipped(reason)
+                    }
+                };
+                position_reports.record(&outcome);
+
+                if let PositionReconciliationOutcome::Applied(position_events) = outcome {
+                    for event in position_events {
+                        exec_engine.borrow_mut().process(&event);
+                        events.push(event);
                     }
                 }
             }
@@ -1000,12 +1326,23 @@ impl ExecutionManager {
 
         log::info!(
             color = LogColor::Blue as u8;
-            "Reconciliation complete for {venue}: reconciled={orders_reconciled}, external={external_orders_created}, open={open_orders_initialized}, fills={fills_applied}, positions={positions_created}, skipped={orders_skipped_duplicate}, filtered={orders_skipped_filtered}",
+            "Reconciliation complete for {venue}: reconciled={orders_reconciled}, external={external_orders_created}, open={open_orders_initialized}, fills={fills_applied}, position_reports={}, positions_applied={}, positions_unchanged={}, positions_skipped={} (filtered={}, generation_disabled={}, insufficient_evidence={}), skipped={orders_skipped_duplicate}, filtered={orders_skipped_filtered}",
+            position_reports.received(),
+            position_reports.applied(),
+            position_reports.unchanged(),
+            position_reports.skipped(),
+            position_reports.filtered(),
+            position_reports.generation_disabled(),
+            position_reports.insufficient_evidence(),
         );
+
+        debug_assert_eq!(position_reports.received(), position_report_count);
 
         ReconciliationResult {
             events,
             external_orders,
+            rejection: None,
+            position_reports,
         }
     }
 
@@ -1867,6 +2204,23 @@ impl ExecutionManager {
         failed_clients: &IndexSet<ClientId>,
     ) -> Vec<OrderEventAny> {
         log::debug!("Checking position consistency between cached-state and venues");
+
+        let report_count = reports.len();
+        let uncached_accounts = {
+            let cache = self.cache.borrow();
+            reports
+                .iter()
+                .map(|report| report.account_id)
+                .filter(|account_id| cache.account(account_id).is_none())
+                .collect::<IndexSet<_>>()
+        };
+
+        if !uncached_accounts.is_empty() {
+            log::warn!(
+                "Rejected periodic position reconciliation: position_reports={report_count}, uncached_accounts={uncached_accounts:?}"
+            );
+            return Vec::new();
+        }
 
         let mut venue_positions: IndexMap<InstrumentAccountKey, Vec<PositionStatusReport>> =
             IndexMap::new();
@@ -3016,16 +3370,10 @@ impl ExecutionManager {
         &self,
         report: &PositionStatusReport,
         account_id: AccountId,
-        instruments_with_unattributed_fills: &IndexSet<InstrumentId>,
-        positions_with_fills: &IndexSet<PositionId>,
-    ) -> Option<Vec<OrderEventAny>> {
+        projected_hedge_positions: &IndexMap<PositionId, Position>,
+    ) -> PositionReconciliationOutcome {
         if report.venue_position_id.is_some() {
-            self.reconcile_position_report_hedging(
-                report,
-                account_id,
-                instruments_with_unattributed_fills,
-                positions_with_fills,
-            )
+            self.reconcile_position_report_hedging(report, account_id, projected_hedge_positions)
         } else {
             self.reconcile_position_report_netting(report, account_id)
         }
@@ -3035,33 +3383,42 @@ impl ExecutionManager {
         &self,
         report: &PositionStatusReport,
         account_id: AccountId,
-        instruments_with_unattributed_fills: &IndexSet<InstrumentId>,
-        positions_with_fills: &IndexSet<PositionId>,
-    ) -> Option<Vec<OrderEventAny>> {
-        let venue_position_id = report.venue_position_id?;
-
-        // Skip if batch already has fills for this position (will be created from fills)
-        if positions_with_fills.contains(&venue_position_id) {
-            log::debug!(
-                "Skipping hedge position {venue_position_id} reconciliation: fills already in batch"
+        projected_hedge_positions: &IndexMap<PositionId, Position>,
+    ) -> PositionReconciliationOutcome {
+        let Some(venue_position_id) = report.venue_position_id else {
+            return PositionReconciliationOutcome::Skipped(
+                PositionReconciliationSkip::InsufficientEvidence,
             );
-            return None;
-        }
-
-        // Skip if fills exist for this instrument but lack venue_position_id
-        // (can't determine which hedge position they belong to)
-        if instruments_with_unattributed_fills.contains(&report.instrument_id) {
-            log::debug!(
-                "Skipping hedge position {venue_position_id} reconciliation: unattributed fills in batch"
-            );
-            return None;
-        }
+        };
 
         log::debug!(
             "Reconciling HEDGE position for {}, venue_position_id={}",
             report.instrument_id,
             venue_position_id
         );
+
+        if let Some(projected_position) = projected_hedge_positions.get(&venue_position_id) {
+            let projected_qty = projected_position.signed_decimal_qty();
+            let tolerance = self.position_reconciliation_tolerance(account_id);
+            if (projected_qty - report.signed_decimal_qty).abs() <= tolerance {
+                return PositionReconciliationOutcome::Unchanged;
+            }
+
+            if !self.config.generate_missing_orders {
+                return PositionReconciliationOutcome::Skipped(
+                    PositionReconciliationSkip::GenerationDisabled,
+                );
+            }
+
+            return PositionReconciliationOutcome::from_events(
+                self.reconcile_hedge_position_discrepancy(
+                    report,
+                    account_id,
+                    projected_position,
+                    projected_qty,
+                ),
+            );
+        }
 
         let position = {
             let cache = self.cache.borrow();
@@ -3077,45 +3434,38 @@ impl ExecutionManager {
                     log::debug!(
                         "Hedge position {venue_position_id} matches venue: qty={cached_signed_qty}"
                     );
-                    return None;
-                }
-
-                if venue_signed_qty == Decimal::ZERO && cached_signed_qty == Decimal::ZERO {
-                    return None;
+                    return PositionReconciliationOutcome::Unchanged;
                 }
 
                 if !self.config.generate_missing_orders {
-                    log::error!(
-                        "Cannot reconcile {} {}: position net qty {} != reported net qty {} \
-                         and `generate_missing_orders` is disabled",
-                        report.instrument_id,
-                        venue_position_id,
-                        cached_signed_qty,
-                        venue_signed_qty
+                    return PositionReconciliationOutcome::Skipped(
+                        PositionReconciliationSkip::GenerationDisabled,
                     );
-                    return None;
                 }
 
-                self.reconcile_hedge_position_discrepancy(
-                    report,
-                    account_id,
-                    &position,
-                    cached_signed_qty,
+                PositionReconciliationOutcome::from_events(
+                    self.reconcile_hedge_position_discrepancy(
+                        report,
+                        account_id,
+                        &position,
+                        cached_signed_qty,
+                    ),
                 )
             }
             None => {
                 if report.signed_decimal_qty == Decimal::ZERO {
-                    return None;
+                    return PositionReconciliationOutcome::Unchanged;
                 }
 
                 if !self.config.generate_missing_orders {
-                    log::error!(
-                        "Cannot reconcile position: {venue_position_id} not found and `generate_missing_orders` is disabled"
+                    return PositionReconciliationOutcome::Skipped(
+                        PositionReconciliationSkip::GenerationDisabled,
                     );
-                    return None;
                 }
 
-                self.reconcile_missing_hedge_position(report, account_id)
+                PositionReconciliationOutcome::from_events(
+                    self.reconcile_missing_hedge_position(report, account_id),
+                )
             }
         }
     }
@@ -3203,12 +3553,16 @@ impl ExecutionManager {
         &self,
         report: &PositionStatusReport,
         account_id: AccountId,
-    ) -> Option<Vec<OrderEventAny>> {
+    ) -> PositionReconciliationOutcome {
         let instrument_id = report.instrument_id;
 
         log::debug!("Reconciling NET position for {instrument_id}");
 
-        let instrument = self.get_instrument(&instrument_id)?;
+        let Some(instrument) = self.get_instrument(&instrument_id) else {
+            return PositionReconciliationOutcome::Skipped(
+                PositionReconciliationSkip::InsufficientEvidence,
+            );
+        };
 
         let (cached_signed_qty, cached_avg_px) = {
             let cache = self.cache.borrow();
@@ -3251,24 +3605,27 @@ impl ExecutionManager {
         let tolerance = self.position_reconciliation_tolerance(account_id);
         if (cached_signed_qty - venue_signed_qty).abs() <= tolerance {
             log::debug!("Position quantities match for {instrument_id}, no reconciliation needed");
-            return None;
+            return PositionReconciliationOutcome::Unchanged;
         }
 
         if !self.config.generate_missing_orders {
-            log::debug!(
-                "Discrepancy for {instrument_id} position when `generate_missing_orders` disabled, skipping"
+            return PositionReconciliationOutcome::Skipped(
+                PositionReconciliationSkip::GenerationDisabled,
             );
-            return None;
         }
 
         let diff = (cached_signed_qty - venue_signed_qty).abs();
-        let diff_qty = Quantity::from_decimal_dp(diff, instrument.size_precision()).ok()?;
+        let Ok(diff_qty) = Quantity::from_decimal_dp(diff, instrument.size_precision()) else {
+            return PositionReconciliationOutcome::Skipped(
+                PositionReconciliationSkip::InsufficientEvidence,
+            );
+        };
 
         if diff_qty.is_zero() {
             log::debug!(
                 "Difference quantity rounds to zero for {instrument_id}, skipping order generation"
             );
-            return None;
+            return PositionReconciliationOutcome::Unchanged;
         }
 
         let crosses_zero = cached_signed_qty != Decimal::ZERO
@@ -3278,7 +3635,7 @@ impl ExecutionManager {
 
         if crosses_zero {
             let ts_now = self.clock.borrow().timestamp_ns();
-            return self.reconcile_cross_zero_position(
+            return PositionReconciliationOutcome::from_events(self.reconcile_cross_zero_position(
                 &instrument,
                 account_id,
                 instrument_id,
@@ -3288,21 +3645,25 @@ impl ExecutionManager {
                 report.avg_px_open,
                 ts_now,
                 report.ts_last,
-            );
+            ));
         }
 
         if cached_signed_qty == Decimal::ZERO {
-            return self.create_position_from_report(report, account_id, &instrument);
+            return PositionReconciliationOutcome::from_events(self.create_position_from_report(
+                report,
+                account_id,
+                &instrument,
+            ));
         }
 
-        self.create_position_reconciliation_order(
+        PositionReconciliationOutcome::from_events(self.create_position_reconciliation_order(
             report,
             account_id,
             &instrument,
             cached_signed_qty,
             diff_qty,
             cached_avg_px,
-        )
+        ))
     }
 
     fn create_position_reconciliation_order(
@@ -4034,8 +4395,10 @@ mod tests {
     use nautilus_core::datetime::NANOSECONDS_IN_SECOND;
     use nautilus_execution::reconciliation::generate_reconciliation_order_events;
     use nautilus_model::{
+        accounts::AccountAny,
         enums::{LiquiditySide, OmsType, PositionSideSpecified},
         events::order::spec::{OrderPendingUpdateSpec, OrderUpdatedSpec},
+        identifiers::PositionId,
         instruments::{
             Instrument,
             stubs::{crypto_perpetual_ethusdt, xbtusd_bitmex},
@@ -4046,6 +4409,50 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    #[rstest]
+    fn test_periodic_uncached_account_rejects_complete_pass_without_touching_retry_state() {
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let mut manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default());
+        let instrument_id = InstrumentId::from("ETHUSDT.BINANCE");
+        let account_id = AccountId::from("UNCACHED-001");
+        let key = (instrument_id, account_id);
+        manager.position_reconciliation_states.insert(
+            key,
+            PositionReconciliationState {
+                report_shape: PositionReportShape::Unambiguous,
+                retries: 3,
+            },
+        );
+        let check = manager.prepare_position_report_check(UUID4::new(), &[]);
+        let report = PositionStatusReport::new(
+            account_id,
+            instrument_id,
+            PositionSideSpecified::Flat,
+            Quantity::zero(0),
+            UnixNanos::from(1),
+            UnixNanos::from(1),
+            None,
+            None,
+            None,
+        );
+
+        let events = manager.reconcile_position_reports(
+            &check,
+            vec![report],
+            &IndexSet::new(),
+            &IndexSet::new(),
+        );
+
+        assert!(events.is_empty());
+        let state = manager
+            .position_reconciliation_states
+            .get(&key)
+            .expect("uncached account must not alter its retry state");
+        assert_eq!(state.retries, 3);
+        assert!(state.report_shape == PositionReportShape::Unambiguous);
+    }
 
     #[rstest]
     fn test_clear_recon_tracking_removes_targeted_query() {
@@ -4710,6 +5117,9 @@ mod tests {
         quantity: &str,
         price: &str,
     ) -> Position {
+        let account = AccountAny::default();
+        let account_id = account.id();
+        cache.borrow_mut().add_account(account).unwrap();
         let order = OrderTestBuilder::new(OrderType::Market)
             .instrument_id(instrument.id())
             .side(side)
@@ -4725,7 +5135,7 @@ mod tests {
             None,
             None,
             None,
-            Some(AccountId::from("TEST-001")),
+            Some(account_id),
         );
         let order_filled: OrderFilled = fill.into();
         let position = Position::new(instrument, order_filled);

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -325,9 +325,9 @@ impl LiveNode {
 
     /// Starts the live node without entering a select loop.
     ///
-    /// Connects clients, runs reconciliation, and starts the trader, but does
-    /// not consume the runner or drive channel receivers. Channel traffic that
-    /// arrives after startup is not serviced until the caller provides a loop.
+    /// Connects clients, runs reconciliation, and starts the trader while routing
+    /// startup channel traffic. Channel traffic that arrives after startup is not
+    /// serviced until the caller polls the node.
     ///
     /// For a self-contained entry point that owns the event loop, use [`run`](Self::run).
     ///
@@ -374,52 +374,83 @@ impl LiveNode {
         }
 
         let connection_deadline = dst::time::Instant::now() + self.config.timeout_connection;
+        let mut pending = PendingEvents::default();
 
-        // Connect data clients first and flush instrument events into cache
-        if let Err(e) = self.connect_data_phase(connection_deadline).await {
+        // Drive every startup phase through the same event-routing contract as `run`.
+        let Some(mut runner) = self.runner.take() else {
+            return self
+                .abort_startup_with_error(
+                    "Startup event routing unavailable",
+                    anyhow::anyhow!("LiveNode runner is unavailable"),
+                )
+                .await;
+        };
+        let data_connect_result = drive_with_runner_event_buffering(
+            self.connect_data_phase(connection_deadline),
+            &mut runner,
+            &mut pending,
+        )
+        .await;
+
+        if let Err(e) = data_connect_result {
+            self.runner = Some(runner);
+            pending.drain();
             return self
                 .abort_startup_with_error("Data client connection timed out", e)
                 .await;
         }
 
-        if let Some(runner) = self.runner.as_mut() {
-            runner.flush_pending_data();
-        }
+        pending.drain_data();
 
-        if let Err(e) = self.connect_exec_clients(connection_deadline).await {
+        let engine_connection_result = drive_with_runner_event_buffering(
+            self.connect_exec_phase(connection_deadline),
+            &mut runner,
+            &mut pending,
+        )
+        .await;
+        pending.drain();
+
+        let engine_connection_status = match engine_connection_result {
+            Ok(status) => status,
+            Err(e) => {
+                self.runner = Some(runner);
+                return self
+                    .abort_startup_with_error("Execution client connection timed out", e)
+                    .await;
+            }
+        };
+
+        if engine_connection_status == EngineConnectionStatus::TimedOut {
+            self.runner = Some(runner);
             return self
-                .abort_startup_with_error("Execution client connection timed out", e)
+                .abort_startup_with_error(
+                    "Engine readiness timed out",
+                    anyhow::anyhow!("readiness timeout while waiting for engine connections"),
+                )
                 .await;
         }
 
-        if let Some(reason) = self.startup_abort_reason() {
+        if let Some(reason) = engine_connection_status
+            .abort_reason()
+            .or_else(|| self.startup_abort_reason())
+        {
+            self.runner = Some(runner);
             self.abort_startup(reason).await?;
             return Ok(());
         }
 
-        match self.await_engines_connected(connection_deadline).await {
-            EngineConnectionStatus::Connected => {}
-            EngineConnectionStatus::TimedOut => {
-                return self
-                    .abort_startup_with_error(
-                        "Engine readiness timed out",
-                        anyhow::anyhow!("readiness timeout while waiting for engine connections"),
-                    )
-                    .await;
-            }
-            EngineConnectionStatus::StopRequested => {
-                self.abort_startup("Stop signal received during startup")
-                    .await?;
-                return Ok(());
-            }
-            EngineConnectionStatus::ShutdownRequested => {
-                self.abort_startup("Shutdown signal received during startup")
-                    .await?;
-                return Ok(());
-            }
-        }
+        debug_assert_eq!(engine_connection_status, EngineConnectionStatus::Connected);
 
-        if let Err(e) = self.perform_startup_reconciliation().await {
+        let reconciliation_result = drive_with_runner_event_buffering(
+            self.perform_startup_reconciliation(),
+            &mut runner,
+            &mut pending,
+        )
+        .await;
+        self.runner = Some(runner);
+        pending.drain();
+
+        if let Err(e) = reconciliation_result {
             if let Err(finalize_err) = self.abort_startup("Startup reconciliation failed").await {
                 anyhow::bail!(
                     "startup reconciliation failed: {e}; failed to finalize startup abort: {finalize_err}"
@@ -766,6 +797,12 @@ impl LiveNode {
                         .reconcile_execution_mass_status(mass_status, exec_engine_rc)
                         .await;
 
+                    if let Some(rejection) = &result.rejection {
+                        anyhow::bail!(
+                            "ExecutionMassStatus from {client_id} was rejected: {rejection}"
+                        );
+                    }
+
                     if result.events.is_empty() {
                         log_info!(
                             "Reconciliation for {} succeeded",
@@ -1043,7 +1080,26 @@ impl LiveNode {
         debug_assert_eq!(engine_connection_status, EngineConnectionStatus::Connected);
 
         // Run reconciliation now that instruments are in cache and start trader
-        if let Err(e) = self.perform_startup_reconciliation().await {
+        let reconciliation_result = drive_with_event_buffering(
+            self.perform_startup_reconciliation(),
+            &mut pending,
+            &mut time_evt_rx,
+            &mut data_evt_rx,
+            &mut data_cmd_rx,
+            &mut exec_evt_rx,
+            &mut exec_cmd_rx,
+        )
+        .await;
+        flush_all_pending(
+            &mut pending,
+            &mut time_evt_rx,
+            &mut data_evt_rx,
+            &mut data_cmd_rx,
+            &mut exec_evt_rx,
+            &mut exec_cmd_rx,
+        );
+
+        if let Err(e) = reconciliation_result {
             let result = self.abort_startup("Startup reconciliation failed").await;
             Self::drain_channels(
                 &mut time_evt_rx,
@@ -3030,32 +3086,7 @@ fn flush_all_pending(
     }
 
     while let Ok(evt) = exec_evt_rx.try_recv() {
-        match evt {
-            ExecutionEvent::Account(_) => {
-                AsyncRunner::handle_exec_event(evt);
-            }
-            ExecutionEvent::Report(report) => {
-                pending.exec_reports.push(report);
-            }
-            ExecutionEvent::Order(order_evt) => {
-                pending.order_evts.push(order_evt);
-            }
-            ExecutionEvent::OrderSubmittedBatch(batch) => {
-                for submitted in batch {
-                    pending.order_evts.push(OrderEventAny::Submitted(submitted));
-                }
-            }
-            ExecutionEvent::OrderAcceptedBatch(batch) => {
-                for accepted in batch {
-                    pending.order_evts.push(OrderEventAny::Accepted(accepted));
-                }
-            }
-            ExecutionEvent::OrderCanceledBatch(batch) => {
-                for canceled in batch {
-                    pending.order_evts.push(OrderEventAny::Canceled(canceled));
-                }
-            }
-        }
+        pending.capture_execution_event(evt);
     }
 
     while let Ok(cmd) = exec_cmd_rx.try_recv() {
@@ -3091,35 +3122,7 @@ async fn drive_with_event_buffering<F: std::future::Future>(
                 let _ = AsyncRunner::handle_time_event(handler);
             }
             Some(evt) = exec_evt_rx.recv() => {
-                // Account events are safe to process immediately. Report and
-                // Order events need ExecEngine borrow_mut which may conflict
-                // with the borrow held by the driven future.
-                match evt {
-                    ExecutionEvent::Account(_) => {
-                        AsyncRunner::handle_exec_event(evt);
-                    }
-                    ExecutionEvent::Report(report) => {
-                        pending.exec_reports.push(report);
-                    }
-                    ExecutionEvent::Order(order_evt) => {
-                        pending.order_evts.push(order_evt);
-                    }
-                    ExecutionEvent::OrderSubmittedBatch(batch) => {
-                        for submitted in batch {
-                            pending.order_evts.push(OrderEventAny::Submitted(submitted));
-                        }
-                    }
-                    ExecutionEvent::OrderAcceptedBatch(batch) => {
-                        for accepted in batch {
-                            pending.order_evts.push(OrderEventAny::Accepted(accepted));
-                        }
-                    }
-                    ExecutionEvent::OrderCanceledBatch(batch) => {
-                        for canceled in batch {
-                            pending.order_evts.push(OrderEventAny::Canceled(canceled));
-                        }
-                    }
-                }
+                pending.capture_execution_event(evt);
             }
             Some(cmd) = exec_cmd_rx.recv() => {
                 pending.exec_cmds.push(cmd);
@@ -3132,6 +3135,32 @@ async fn drive_with_event_buffering<F: std::future::Future>(
             }
         }
     }
+}
+
+/// Drives a startup future while preserving the same event-routing contract as [`LiveNode::run`].
+async fn drive_with_runner_event_buffering<F: std::future::Future>(
+    future: F,
+    runner: &mut AsyncRunner,
+    pending: &mut PendingEvents,
+) -> F::Output {
+    tokio::pin!(future);
+
+    let result = loop {
+        tokio::select! {
+            biased;
+
+            result = &mut future => break result,
+            event = runner.recv() => {
+                let Some(event) = event else {
+                    break future.await;
+                };
+                pending.capture_runner_event(event);
+            }
+        }
+    };
+
+    runner.poll_pending(|event| pending.capture_runner_event(event));
+    result
 }
 
 #[derive(Default)]
@@ -3150,6 +3179,35 @@ impl PendingEvents {
             && self.exec_cmds.is_empty()
             && self.exec_reports.is_empty()
             && self.order_evts.is_empty()
+    }
+
+    fn capture_execution_event(&mut self, event: ExecutionEvent) {
+        match event {
+            ExecutionEvent::Account(_) => AsyncRunner::handle_exec_event(event),
+            ExecutionEvent::Report(report) => self.exec_reports.push(report),
+            ExecutionEvent::Order(order_event) => self.order_evts.push(order_event),
+            ExecutionEvent::OrderSubmittedBatch(batch) => self
+                .order_evts
+                .extend(batch.into_iter().map(OrderEventAny::Submitted)),
+            ExecutionEvent::OrderAcceptedBatch(batch) => self
+                .order_evts
+                .extend(batch.into_iter().map(OrderEventAny::Accepted)),
+            ExecutionEvent::OrderCanceledBatch(batch) => self
+                .order_evts
+                .extend(batch.into_iter().map(OrderEventAny::Canceled)),
+        }
+    }
+
+    fn capture_runner_event(&mut self, event: PendingRunnerEvent) {
+        match event {
+            PendingRunnerEvent::Time(message) => {
+                let _ = AsyncRunner::handle_time_event(message);
+            }
+            PendingRunnerEvent::ExecEvent(event) => self.capture_execution_event(event),
+            PendingRunnerEvent::ExecCommand(command) => self.exec_cmds.push(command),
+            PendingRunnerEvent::DataEvent(event) => self.data_evts.push(event),
+            PendingRunnerEvent::DataCommand(command) => self.data_cmds.push(command),
+        }
     }
 
     /// Drains only data events and commands into the cache.
@@ -6613,6 +6671,29 @@ mod tests {
         assert!(pending.order_evts.is_empty());
         assert!(pending.exec_cmds.is_empty());
         assert!(exec_evt_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_runner_startup_driver_routes_accounts_and_buffers_mutating_events() {
+        let mut runner = AsyncRunner::new();
+        runner.bind_senders();
+        let exec_event_sender = get_exec_event_sender();
+        let mut pending = PendingEvents::default();
+
+        drive_with_runner_event_buffering(
+            async move {
+                exec_event_sender.send(stub_account_event()).unwrap();
+                exec_event_sender.send(stub_order_event()).unwrap();
+                tokio::task::yield_now().await;
+            },
+            &mut runner,
+            &mut pending,
+        )
+        .await;
+
+        assert_eq!(pending.order_evts.len(), 1);
+        assert!(pending.exec_reports.is_empty());
+        assert!(pending.exec_cmds.is_empty());
     }
 
     #[rstest]

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -54,7 +54,9 @@ use nautilus_execution::{
         create_position_reconciliation_venue_order_id, process_mass_status_for_reconciliation,
     },
 };
-use nautilus_live::manager::{ExecutionManager, ExecutionManagerConfig};
+use nautilus_live::manager::{
+    ExecutionManager, ExecutionManagerConfig, ReconciliationRejection, ReconciliationReportKind,
+};
 use nautilus_model::{
     accounts::{AccountAny, MarginAccount},
     enums::{
@@ -104,6 +106,25 @@ struct TestContext {
     exec_engine: Rc<RefCell<ExecutionEngine>>,
 }
 
+fn test_account(account_id: AccountId) -> AccountAny {
+    let account_state = AccountState::new(
+        account_id,
+        AccountType::Margin,
+        vec![AccountBalance::new(
+            Money::from("1000000 USDT"),
+            Money::from("0 USDT"),
+            Money::from("1000000 USDT"),
+        )],
+        vec![],
+        true,
+        UUID4::new(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        Some(Currency::USDT()),
+    );
+    AccountAny::Margin(MarginAccount::new(account_state, true))
+}
+
 impl TestContext {
     fn new() -> Self {
         Self::with_config(ExecutionManagerConfig::default())
@@ -114,23 +135,10 @@ impl TestContext {
         let cache = Rc::new(RefCell::new(Cache::default()));
 
         // Add test account to cache (required for position creation in ExecutionEngine)
-        let account_state = AccountState::new(
-            test_account_id(),
-            AccountType::Margin,
-            vec![AccountBalance::new(
-                Money::from("1000000 USDT"),
-                Money::from("0 USDT"),
-                Money::from("1000000 USDT"),
-            )],
-            vec![],
-            true,
-            UUID4::new(),
-            UnixNanos::default(),
-            UnixNanos::default(),
-            Some(Currency::USDT()),
-        );
-        let account = AccountAny::Margin(MarginAccount::new(account_state, true));
-        cache.borrow_mut().add_account(account).unwrap();
+        cache
+            .borrow_mut()
+            .add_account(test_account(test_account_id()))
+            .unwrap();
 
         let manager = ExecutionManager::new(clock.clone(), cache.clone(), config);
         let mut engine = ExecutionEngine::new(clock.clone(), cache.clone(), None);
@@ -162,6 +170,13 @@ impl TestContext {
 
     fn add_instrument(&self, instrument: InstrumentAny) {
         self.cache.borrow_mut().add_instrument(instrument).unwrap();
+    }
+
+    fn add_account(&self, account_id: AccountId) {
+        self.cache
+            .borrow_mut()
+            .add_account(test_account(account_id))
+            .unwrap();
     }
 
     fn add_order(&self, order: OrderAny) {
@@ -683,6 +698,100 @@ async fn test_reconcile_mass_status_with_empty_reports() {
         .await;
 
     assert!(result.events.is_empty());
+    assert!(result.rejection.is_none());
+}
+
+#[tokio::test]
+async fn test_reconcile_mass_status_rejects_uncached_envelope_account() {
+    let mut ctx = TestContext::new();
+    let account_id = AccountId::from("UNCACHED-001");
+    let mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        account_id,
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(
+        result.rejection,
+        Some(ReconciliationRejection::AccountNotCached { account_id })
+    );
+    assert!(result.events.is_empty());
+    assert!(result.external_orders.is_empty());
+}
+
+#[tokio::test]
+async fn test_reconcile_mass_status_rejects_child_account_mismatch_atomically() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let report_account_id = AccountId::from("TEST-002");
+    ctx.add_instrument(instrument);
+    ctx.add_account(report_account_id);
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_fill_reports(vec![FillReport::new(
+        test_account_id(),
+        instrument_id,
+        VenueOrderId::from("V-SCOPE-001"),
+        TradeId::from("T-SCOPE-001"),
+        OrderSide::Buy,
+        Quantity::from("1.0"),
+        Price::from("3000.00"),
+        Money::from("0 USDT"),
+        LiquiditySide::Taker,
+        None,
+        None,
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )]);
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        report_account_id,
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("3.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        None,
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(
+        result.rejection,
+        Some(ReconciliationRejection::ReportAccountMismatch {
+            envelope_account_id: test_account_id(),
+            report_account_id,
+            report_kind: ReconciliationReportKind::Position,
+        })
+    );
+    assert!(result.events.is_empty());
+    assert!(
+        ctx.cache
+            .borrow()
+            .positions(None, None, None, None, None)
+            .is_empty()
+    );
+    assert_eq!(result.position_reports.received(), 1);
+    assert_eq!(result.position_reports.rejected(), 1);
 }
 
 #[tokio::test]
@@ -5645,10 +5754,16 @@ async fn test_reconcile_mass_status_routes_to_netting_without_venue_position_id(
     assert!(!result.events.is_empty());
 }
 
+#[rstest]
+#[case("5.0", 1, 0, 1)]
+#[case("6.0", 2, 1, 0)]
 #[tokio::test]
-async fn test_reconcile_mass_status_skips_hedge_position_when_fills_in_batch() {
-    // Tests that hedge position reconciliation is skipped when fills for the same
-    // venue_position_id exist in the batch (prevents duplicate synthetic orders)
+async fn test_reconcile_mass_status_projects_attributed_hedge_fill_before_position_report(
+    #[case] report_qty: &str,
+    #[case] expected_fills: usize,
+    #[case] expected_applied: usize,
+    #[case] expected_unchanged: usize,
+) {
     let mut ctx = TestContext::new();
     let instrument_id = test_instrument_id();
     let client_order_id = ClientOrderId::from("O-001");
@@ -5656,7 +5771,14 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_fills_in_batch() {
     let venue_position_id = PositionId::from("P-HEDGE-001");
 
     ctx.add_instrument(test_instrument());
-    let order = create_limit_order("O-001", instrument_id, OrderSide::Buy, "5.0", "3000.00");
+    let order = create_accepted_order(
+        "O-001",
+        instrument_id,
+        OrderSide::Buy,
+        "5.0",
+        "3000.00",
+        venue_order_id,
+    );
     ctx.add_order(order);
 
     let mut mass_status = ExecutionMassStatus::new(
@@ -5691,7 +5813,7 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_fills_in_batch() {
         test_account_id(),
         instrument_id,
         PositionSideSpecified::Long,
-        Quantity::from("5.0"),
+        Quantity::from(report_qty),
         UnixNanos::from(1_000_000),
         UnixNanos::from(1_000_000),
         None,
@@ -5705,9 +5827,18 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_fills_in_batch() {
         .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
         .await;
 
-    // Should only have fill event, no synthetic order from position report
-    assert_eq!(result.events.len(), 1);
-    assert!(matches!(result.events[0], OrderEventAny::Filled(_)));
+    assert_eq!(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, OrderEventAny::Filled(_)))
+            .count(),
+        expected_fills,
+    );
+    assert_eq!(result.position_reports.received(), 1);
+    assert_eq!(result.position_reports.applied(), expected_applied);
+    assert_eq!(result.position_reports.unchanged(), expected_unchanged);
+    assert_eq!(result.position_reports.skipped(), 0);
 }
 
 #[tokio::test]
@@ -5781,10 +5912,7 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_filled_order_in_ba
 }
 
 #[tokio::test]
-async fn test_reconcile_mass_status_skips_hedge_position_when_fills_lack_position_id() {
-    // Tests that hedge position reconciliation is skipped when fills exist for the
-    // instrument but lack venue_position_id (common when venues only include IDs on
-    // position reports)
+async fn test_reconcile_mass_status_counts_ambiguous_unattributed_hedge_report() {
     let mut ctx = TestContext::new();
     let instrument_id = test_instrument_id();
     let client_order_id = ClientOrderId::from("O-001");
@@ -5840,9 +5968,89 @@ async fn test_reconcile_mass_status_skips_hedge_position_when_fills_lack_positio
         .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
         .await;
 
-    // Should only have fill event, position report skipped due to instrument-level fill
+    // The fill cannot be attributed to the hedge report, so no synthetic position event is safe.
     assert_eq!(result.events.len(), 1);
     assert!(matches!(result.events[0], OrderEventAny::Filled(_)));
+    assert_eq!(result.position_reports.received(), 1);
+    assert_eq!(result.position_reports.skipped(), 1);
+    assert_eq!(result.position_reports.insufficient_evidence(), 1);
+}
+
+#[tokio::test]
+async fn test_reconcile_mass_status_counts_unattributed_hedge_aggregate_mismatch() {
+    let mut ctx = TestContext::new();
+    let instrument = test_instrument();
+    let instrument_id = instrument.id();
+    let position_id = PositionId::from("P-HEDGE-UNATTRIBUTED");
+    let client_order_id = ClientOrderId::from("O-HEDGE-UNATTRIBUTED");
+    let venue_order_id = VenueOrderId::from("V-HEDGE-UNATTRIBUTED");
+    ctx.add_instrument(instrument.clone());
+    ctx.add_position(&create_test_position(
+        &instrument,
+        position_id,
+        OrderSide::Buy,
+        "2.0",
+        "3000.00",
+    ));
+    ctx.add_order(create_limit_order(
+        client_order_id.as_str(),
+        instrument_id,
+        OrderSide::Buy,
+        "1.0",
+        "3000.00",
+    ));
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_fill_reports(vec![FillReport::new(
+        test_account_id(),
+        instrument_id,
+        venue_order_id,
+        TradeId::from("T-HEDGE-UNATTRIBUTED"),
+        OrderSide::Buy,
+        Quantity::from("1.0"),
+        Price::from("3000.00"),
+        Money::from("0.50 USDT"),
+        LiquiditySide::Maker,
+        Some(client_order_id),
+        None,
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )]);
+    mass_status.add_position_reports(vec![PositionStatusReport::new(
+        test_account_id(),
+        instrument_id,
+        PositionSideSpecified::Long,
+        Quantity::from("5.0"),
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+        Some(position_id),
+        Some(dec!(3000.00)),
+    )]);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    assert_eq!(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, OrderEventAny::Filled(_)))
+            .count(),
+        1
+    );
+    assert_eq!(result.position_reports.received(), 1);
+    assert_eq!(result.position_reports.skipped(), 1);
+    assert_eq!(result.position_reports.insufficient_evidence(), 1);
 }
 
 #[tokio::test]
@@ -6130,6 +6338,9 @@ async fn test_reconcile_hedge_position_discrepancy_disabled() {
         result.events.is_empty(),
         "Expected no events when generate_missing_orders is disabled"
     );
+    assert_eq!(result.position_reports.received(), 1);
+    assert_eq!(result.position_reports.skipped(), 1);
+    assert_eq!(result.position_reports.generation_disabled(), 1);
 }
 
 #[tokio::test]

--- a/crates/live/tests/node.rs
+++ b/crates/live/tests/node.rs
@@ -38,8 +38,9 @@ use nautilus_common::{
     component::Component,
     enums::Environment,
     factories::{ClientConfig, DataClientFactory, ExecutionClientFactory},
-    live::dst,
+    live::{dst, runner::get_exec_event_sender},
     messages::{
+        ExecutionEvent,
         execution::{
             CancelAllOrders, GenerateOrderStatusReport, GenerateOrderStatusReports,
             GeneratePositionStatusReports, QueryOrder,
@@ -337,6 +338,7 @@ mod serial_tests {
     struct StartupMassStatusExecutionClient {
         state: StartupMassStatusClientState,
         behavior: StartupMassStatusBehavior,
+        cache: CacheView,
     }
 
     struct FailingDisconnectDataClient {
@@ -356,8 +358,16 @@ mod serial_tests {
     impl StartupMassStatusExecutionClient {
         const CLIENT_ID: &'static str = "STARTUP-MASS-STATUS";
 
-        fn new(state: StartupMassStatusClientState, behavior: StartupMassStatusBehavior) -> Self {
-            Self { state, behavior }
+        fn new(
+            state: StartupMassStatusClientState,
+            behavior: StartupMassStatusBehavior,
+            cache: CacheView,
+        ) -> Self {
+            Self {
+                state,
+                behavior,
+                cache,
+            }
         }
     }
 
@@ -457,11 +467,12 @@ mod serial_tests {
             &self,
             _name: &str,
             _config: &dyn ClientConfig,
-            _cache: CacheView,
+            cache: CacheView,
         ) -> anyhow::Result<Box<dyn ExecutionClient>> {
             Ok(Box::new(StartupMassStatusExecutionClient::new(
                 self.state.clone(),
                 self.behavior,
+                cache,
             )))
         }
 
@@ -692,7 +703,7 @@ mod serial_tests {
         }
 
         fn account_id(&self) -> AccountId {
-            AccountId::from("STARTUP-MASS-STATUS-001")
+            AccountAny::default().id()
         }
 
         fn venue(&self) -> Venue {
@@ -737,6 +748,19 @@ mod serial_tests {
         }
 
         async fn connect(&mut self) -> anyhow::Result<()> {
+            let account = AccountAny::default();
+            let account_id = account.id();
+            let account_state = account
+                .last_event()
+                .expect("default test account has an initial state");
+            get_exec_event_sender()
+                .send(ExecutionEvent::Account(account_state))
+                .map_err(|e| anyhow::anyhow!("failed to emit account state: {e}"))?;
+
+            while self.cache.borrow().account(&account_id).is_none() {
+                tokio::task::yield_now().await;
+            }
+
             self.state.connected.store(true, Ordering::Relaxed);
             Ok(())
         }
@@ -2163,6 +2187,14 @@ mod serial_tests {
         assert!(state.mass_status_requested.load(Ordering::Relaxed));
         assert_eq!(handle.state(), NodeState::Running);
         assert!(state.connected.load(Ordering::Relaxed));
+        assert!(
+            node.kernel()
+                .cache
+                .borrow()
+                .account(&AccountAny::default().id())
+                .is_some(),
+            "start must route the account event required to complete client connection",
+        );
 
         node.stop().await.unwrap();
 
@@ -2245,7 +2277,7 @@ mod serial_tests {
         let strategy_id = StrategyId::from("STOP-ON-START-001");
         let instrument = crypto_perpetual_ethusdt();
         let instrument_id = instrument.id();
-        let account_id = AccountId::from("STARTUP-MASS-STATUS-001");
+        let account_id = AccountAny::default().id();
         let client_id = ClientId::from(StartupMassStatusExecutionClient::CLIENT_ID);
         let stop_count = Arc::new(AtomicUsize::new(0));
 


### PR DESCRIPTION
## Problem

Live reconciliation can begin before startup account events reach the cache, can mix a mass-status envelope account with child-report accounts, and cannot distinguish position reports already satisfied by accepted batch fills from reports that still require reconciliation.

## Solution

- Drive `LiveNode::start()` and `run()` through the same startup event-routing contract: account events apply immediately while reports, orders, and commands remain buffered until their phase boundary.
- Validate the complete mass-status account scope before raw publication or state mutation. Unknown envelope accounts and mismatched child accounts reject the whole batch.
- Represent every position report with one closed reconciliation outcome and derive aggregate counts from those mutually exclusive outcomes.
- Project only fills actually accepted by the execution engine onto a hedge-position baseline, then reconcile the exact residual. Unattributed hedge fills fail closed as insufficient evidence.
- Validate periodic report accounts before Flat shortcuts or retry-state mutation, and count generation-disabled and insufficient-evidence skips explicitly.

## Scope

This is a live-node and execution-manager reconciliation change only. It supersedes #4693, adds no adapter-specific policy, and introduces no persistent reconciliation state or compatibility path.
