### PR TITLE
Correct the f32 exp approximation outside its normal exponent range

### DIFF
--- a/crates/model/src/data/black_scholes.rs
+++ b/crates/model/src/data/black_scholes.rs
@@ -128,6 +128,15 @@ impl BlackScholesReal for f32 {
             std::f32::consts::LOG2_E,
             if self > 0.0 { 0.5 } else { -0.5 },
         )) as i32;
+
+        if k <= -151 {
+            return 0.0;
+        }
+
+        if k >= 129 {
+            return Self::INFINITY;
+        }
+
         let r = self - (k as Self * 0.693_145_75) - (k as Self * 1.428_606_8e-6);
         let mut res = 0.001_388_89_f32;
         res = r.mul_add(res, 0.008_333_33);
@@ -135,7 +144,19 @@ impl BlackScholesReal for f32 {
         res = r.mul_add(res, 0.166_666_67);
         res = r.mul_add(res, 0.5);
         res = r.mul_add(res, 1.0);
-        r.mul_add(res, 1.0) * Self::from_bits(((k + 127) as u32) << 23)
+        if (-126..=127).contains(&k) {
+            r.mul_add(res, 1.0) * Self::from_bits(((k + 127) as u32) << 23)
+        } else {
+            // Split 2^k across two valid biased exponents; a single one would be
+            // out of range here. Apply them in sequence: pre-multiplying the two
+            // factors underflows to zero at k = -150 before the polynomial can
+            // round the result up into the subnormal range.
+            let ka = k >> 1;
+            let kb = k - ka;
+            r.mul_add(res, 1.0)
+                * Self::from_bits(((ka + 127) as u32) << 23)
+                * Self::from_bits(((kb + 127) as u32) << 23)
+        }
     }
 
     #[inline(always)]
@@ -373,6 +394,73 @@ mod tests {
 
     use super::*;
     use crate::data::greeks::black_scholes_greeks_exact;
+
+    fn assert_exp_close(actual: f32, expected: f32, max_ulps: u32) {
+        assert_eq!(actual.is_nan(), expected.is_nan());
+        assert_eq!(actual.is_infinite(), expected.is_infinite());
+        assert_eq!(actual.is_sign_negative(), expected.is_sign_negative());
+        if actual.is_finite() {
+            assert!(
+                actual.to_bits().abs_diff(expected.to_bits()) <= max_ulps,
+                "exp mismatch: actual={actual:e} ({:#010x}), expected={expected:e} ({:#010x})",
+                actual.to_bits(),
+                expected.to_bits(),
+            );
+        }
+    }
+
+    #[rstest]
+    fn test_exp_exponent_boundaries() {
+        let ln_2 = std::f32::consts::LN_2;
+        let inputs = [
+            -126.5 * ln_2 - 0.000_1,
+            -126.5 * ln_2 + 0.000_1,
+            -127.5 * ln_2 - 0.000_1,
+            -127.5 * ln_2 + 0.000_1,
+            -150.0 * ln_2 + 0.1,
+            88.7,
+            88.8,
+            129.0 * ln_2,
+        ];
+
+        for input in inputs {
+            assert_exp_close(<f32 as BlackScholesReal>::exp(input), input.exp(), 3);
+        }
+    }
+
+    #[rstest]
+    fn test_exp_tail_sweep() {
+        let mut previous = 0.0;
+        let mut input = -105.0_f32;
+        while input <= 89.0 {
+            let actual = <f32 as BlackScholesReal>::exp(input);
+            assert!(!actual.is_nan(), "exp({input}) returned NaN");
+            assert!(actual >= 0.0, "exp({input}) returned {actual}");
+            assert!(
+                actual >= previous,
+                "exp is not monotonic at {input}: {actual} < {previous}"
+            );
+            assert_exp_close(actual, input.exp(), 3);
+            previous = actual;
+            input += 0.031_25;
+        }
+    }
+
+    #[rstest]
+    fn test_exp_extreme_inputs() {
+        for input in [-1e10_f32, -1e30, f32::NEG_INFINITY] {
+            assert_eq!(<f32 as BlackScholesReal>::exp(input), 0.0, "input={input}");
+        }
+
+        for input in [1e10_f32, 1e30, f32::INFINITY] {
+            assert_eq!(
+                <f32 as BlackScholesReal>::exp(input),
+                f32::INFINITY,
+                "input={input}"
+            );
+        }
+        assert!(<f32 as BlackScholesReal>::exp(f32::NAN).is_nan());
+    }
 
     #[rstest]
     fn test_accuracy_1e7() {


### PR DESCRIPTION
`<f32 as BlackScholesReal>::exp` in `crates/model/src/data/black_scholes.rs` reconstructs its `2^k` scale factor from raw IEEE-754 bits without checking that `k` fits an exponent field.

## Out-of-range exponent reconstruction

The approximation ends with `r.mul_add(res, 1.0) * f32::from_bits(((k + 127) as u32) << 23)`, where `k` is the range-reduction exponent. Once `k` leaves `[-126, 127]` the biased value is no longer a valid exponent field: it goes negative, the `as u32` wraps, and the shift writes those bits into the sign and exponent. The corruption then depends on `k` rather than taking one form. Against the correctly rounded `f32::exp`, `k = -127` gives exactly zero where `7.54e-39` is right, `k = -128` gives `-inf` where `3.88e-39` is right, `k = -129` gives `-2.31e+38` where `1.99e-39` is right, and on the positive side `k = 128` gives `inf` where the finite `2.72e+38` is right. A large enough argument additionally saturates the `f32 -> i32` conversion of `k`, which leaves `r` unreduced and the polynomial itself invalid, so repairing only the scale factor would not be sufficient.

`exp` now classifies `k` before evaluating the polynomial: `k <= -151` returns zero, since every exact result there is below half the smallest subnormal, and `k >= 129` returns infinity. The ordinary `-126..=127` range keeps the existing single-factor expression, so arithmetic on the common path is unchanged. The two remaining intervals, `-150..=-127` and `128`, straddle the subnormal and overflow boundaries and are computed by splitting `2^k` across two valid biased exponents, applied to the polynomial one after the other. Pre-multiplying the two scale factors instead underflows to zero at `k = -150` before the polynomial can round the result up into the subnormal range, and a comment records that so the multiply is not folded later.

The trait method is reached from the generic kernels through the discount and carry factors, `-r*t` and `(b-r)*t`, in `compute_greeks`, `compute_iv_and_greeks` and `pricing_kernel`. Reaching the negative tail needs `r*t >= 87.7`, which realistic rates and tenors do not produce, and the `cdf_with_pdf` calls resolve to the inherent `f32::exp` rather than to this method. So this corrects an exported numerical primitive; it does not change option greeks under ordinary inputs.

## Testing

`test_exp_exponent_boundaries` pins both sides of the `k = -126/-127` and `k = -127/-128` transitions, a point inside `k = -150` that must round to the smallest subnormal, and the finite and overflowing sides of the positive cutoff near `ln(f32::MAX)`. Each case is compared against `f32::exp` on classification, sign and a three-ULP bound; bit distance is used rather than relative error because the subnormal results carry progressively fewer significand bits. The `k = -150` case is what catches a later rewrite that pre-multiplies the two scale factors.

`test_exp_tail_sweep` walks the argument range that spans every affected exponent and asserts the result is non-negative, monotonically non-decreasing, never NaN, and equal to `f32::exp` within the same bound. `test_exp_extreme_inputs` covers the saturating conversions and the infinities.

All three fail against the unfixed implementation, reporting a premature zero at the first boundary, `-2.9e31` for `exp(-105)`, and `inf` for `exp(-1e10)`. The existing accuracy tests pass with their tolerances unchanged, which is the check that the common path is untouched.

## Question on the `cdf_with_pdf` binding

`cdf_with_pdf` calls the inherent `f32::exp` twice per calculation, while the discount and carry expressions call this approximation three times. Was that distinction intentional? I have left the behaviour as it is, since changing it would move numerical output on the pricing path.
