### PR TITLE
Validate child instrument IDs in OrderBookDeltas

### DIFF
--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -2048,43 +2048,13 @@ impl DataEngine {
         Some(rebuilt)
     }
 
-    // Replays a day-start snapshot forward to the request's original start: when the first delta
-    // is an F_SNAPSHOT on a UTC day boundary, rebuilds the book from the pre-start deltas and
-    // replaces them with one snapshot keyed at the original start, then forwards the rest.
+    // Replays each instrument's day-start snapshot forward to the request's original start when
+    // that partition's first delta is an F_SNAPSHOT on a UTC day boundary, replacing its
+    // pre-start deltas with one snapshot keyed at the original start before forwarding the rest.
     fn book_deltas_snapshot_replay(&self, resp: &mut BookDeltasResponse) {
         let Some(original_start_ns) = resp.start else {
             return;
         };
-
-        let Some(first) = resp.data.first().copied() else {
-            return;
-        };
-
-        if !RecordFlag::F_SNAPSHOT.matches(first.flags) {
-            return;
-        }
-
-        if first.ts_init.as_u64() % NANOSECONDS_IN_DAY != 0 {
-            return;
-        }
-
-        // Nothing to fast-forward when the request starts at or before the day-start snapshot
-        if original_start_ns <= first.ts_init {
-            return;
-        }
-
-        if self
-            .cache
-            .borrow()
-            .instrument(&resp.instrument_id)
-            .is_none()
-        {
-            log::warn!(
-                "Instrument {} not found in cache, skipping snapshot replay",
-                resp.instrument_id,
-            );
-            return;
-        }
 
         let book_type = resp
             .params
@@ -2093,13 +2063,80 @@ impl DataEngine {
             .and_then(|s| BookType::from_str(s).ok())
             .unwrap_or(BookType::L2_MBP);
 
-        let mut book = OrderBook::new(resp.instrument_id, book_type);
+        let Some(first_instrument_id) = resp.data.first().map(|delta| delta.instrument_id) else {
+            return;
+        };
+
+        if resp
+            .data
+            .iter()
+            .all(|delta| delta.instrument_id == first_instrument_id)
+        {
+            let deltas = std::mem::take(&mut resp.data);
+            resp.data = self.replay_book_deltas_partition(
+                first_instrument_id,
+                deltas,
+                original_start_ns,
+                book_type,
+            );
+            return;
+        }
+
+        let partitions = partition_deltas_by_instrument(&resp.data);
+        let mut merged = Vec::with_capacity(resp.data.len());
+
+        for (partition_index, (instrument_id, deltas)) in partitions.into_iter().enumerate() {
+            let transformed = self.replay_book_deltas_partition(
+                instrument_id,
+                deltas,
+                original_start_ns,
+                book_type,
+            );
+            merged.extend(
+                transformed
+                    .into_iter()
+                    .enumerate()
+                    .map(|(relative_index, delta)| (delta, partition_index, relative_index)),
+            );
+        }
+
+        // Equal timestamps retain first-seen instrument order, then partition-relative order
+        merged.sort_by_key(|(delta, partition_index, relative_index)| {
+            (delta.ts_init, *partition_index, *relative_index)
+        });
+        resp.data = merged.into_iter().map(|(delta, _, _)| delta).collect();
+    }
+
+    fn replay_book_deltas_partition(
+        &self,
+        instrument_id: InstrumentId,
+        deltas: Vec<OrderBookDelta>,
+        original_start_ns: UnixNanos,
+        book_type: BookType,
+    ) -> Vec<OrderBookDelta> {
+        let Some(first) = deltas.first().copied() else {
+            return deltas;
+        };
+
+        if !RecordFlag::F_SNAPSHOT.matches(first.flags)
+            || first.ts_init.as_u64() % NANOSECONDS_IN_DAY != 0
+            || original_start_ns <= first.ts_init
+        {
+            return deltas;
+        }
+
+        if self.cache.borrow().instrument(&instrument_id).is_none() {
+            log::warn!("Instrument {instrument_id} not found in cache, skipping snapshot replay");
+            return deltas;
+        }
+
+        let mut book = OrderBook::new(instrument_id, book_type);
         let mut before: Vec<OrderBookDelta> = Vec::new();
         let mut after: Vec<OrderBookDelta> = Vec::new();
         let mut last_applied_ts: Option<UnixNanos> = None;
         let mut crossed = false;
 
-        for delta in &resp.data {
+        for delta in &deltas {
             if crossed {
                 after.push(*delta);
             } else {
@@ -2116,24 +2153,21 @@ impl DataEngine {
                 last_applied_ts = before.last().map(|d| d.ts_init);
             }
 
-            let batch = OrderBookDeltas::new(resp.instrument_id, before);
+            let batch = OrderBookDeltas::new(instrument_id, before);
             if let Err(e) = book.apply_deltas(&batch) {
-                log::error!(
-                    "Failed to rebuild book for snapshot replay on {}: {e}",
-                    resp.instrument_id,
-                );
-                return;
+                log::error!("Failed to rebuild book for snapshot replay on {instrument_id}: {e}");
+                return deltas;
             }
         }
 
         let Some(last_ts) = last_applied_ts else {
-            return;
+            return deltas;
         };
 
         let snapshot_ts = last_ts.max(original_start_ns);
         let mut new_data = book.to_deltas(snapshot_ts, snapshot_ts).deltas;
         new_data.extend(after);
-        resp.data = new_data;
+        new_data
     }
 
     fn handle_request_join(&mut self, req: RequestJoin) -> anyhow::Result<()> {
@@ -4005,10 +4039,40 @@ impl DataEngine {
     }
 
     fn handle_book_deltas_response(&self, resp: &BookDeltasResponse) {
-        if !self.cache_is_owned_by_live_subscription(&resp.instrument_id) {
+        let Some(first_instrument_id) = resp.data.first().map(|delta| delta.instrument_id) else {
+            return;
+        };
+
+        if resp
+            .data
+            .iter()
+            .all(|delta| delta.instrument_id == first_instrument_id)
+        {
+            self.apply_book_deltas_partition_to_cache(first_instrument_id, &resp.data);
+            publish_book_delta_frames(first_instrument_id, resp.data.iter().copied());
+            return;
+        }
+
+        let partitions = partition_deltas_by_instrument(&resp.data);
+
+        for (instrument_id, deltas) in &partitions {
+            self.apply_book_deltas_partition_to_cache(*instrument_id, deltas);
+        }
+
+        for (instrument_id, deltas) in partitions {
+            publish_book_delta_frames(instrument_id, deltas);
+        }
+    }
+
+    fn apply_book_deltas_partition_to_cache(
+        &self,
+        instrument_id: InstrumentId,
+        deltas: &[OrderBookDelta],
+    ) {
+        if !self.cache_is_owned_by_live_subscription(&instrument_id) {
             let mut cache = self.cache.as_ref().borrow_mut();
-            if let Some(book) = cache.order_book_mut(&resp.instrument_id) {
-                for delta in &resp.data {
+            if let Some(book) = cache.order_book_mut(&instrument_id) {
+                for delta in deltas {
                     if let Err(e) = book.apply_delta(delta) {
                         log::error!("Failed to apply historical delta to cache: {e}");
                     }
@@ -4016,34 +4080,10 @@ impl DataEngine {
             } else {
                 log::debug!(
                     "Skipping cache write for {} historical deltas on {}: no cache book yet",
-                    resp.data.len(),
-                    resp.instrument_id,
+                    deltas.len(),
+                    instrument_id,
                 );
             }
-        }
-
-        // Group deltas by `F_LAST` so each published batch preserves the original event
-        // boundary and metadata (timestamps and sequence from the closing delta), matching
-        // the live `handle_delta` buffering semantic. Collapsing the whole response into
-        // one batch would surface a synthetic event with the trailing delta's flags only.
-        if resp.data.is_empty() {
-            return;
-        }
-
-        let topic = switchboard::get_pipeline_book_deltas_topic(resp.instrument_id);
-        let mut frame: Vec<OrderBookDelta> = Vec::new();
-
-        for delta in &resp.data {
-            frame.push(*delta);
-            if RecordFlag::F_LAST.matches(delta.flags) {
-                let batch = OrderBookDeltas::new(resp.instrument_id, std::mem::take(&mut frame));
-                msgbus::publish_deltas(topic, &batch);
-            }
-        }
-
-        if !frame.is_empty() {
-            let batch = OrderBookDeltas::new(resp.instrument_id, frame);
-            msgbus::publish_deltas(topic, &batch);
         }
     }
 
@@ -5647,6 +5687,51 @@ fn rebuild_pipeline_response(
             None
         }
     }
+}
+
+fn publish_book_delta_frames(
+    instrument_id: InstrumentId,
+    deltas: impl IntoIterator<Item = OrderBookDelta>,
+) {
+    let topic = switchboard::get_pipeline_book_deltas_topic(instrument_id);
+    let mut frame: Vec<OrderBookDelta> = Vec::new();
+
+    // Group each instrument's deltas by `F_LAST` so each published batch preserves the original
+    // event boundary and metadata (timestamps and sequence from the closing delta), matching live
+    // `handle_delta` buffering. Collapsing a partition into one batch would surface a synthetic
+    // event with the trailing delta's flags only.
+    for delta in deltas {
+        frame.push(delta);
+        if RecordFlag::F_LAST.matches(delta.flags) {
+            let batch = OrderBookDeltas::new(instrument_id, std::mem::take(&mut frame));
+            msgbus::publish_deltas(topic, &batch);
+        }
+    }
+
+    if !frame.is_empty() {
+        let batch = OrderBookDeltas::new(instrument_id, frame);
+        msgbus::publish_deltas(topic, &batch);
+    }
+}
+
+// Returns first-seen instrument partitions while preserving relative delta order within each one.
+fn partition_deltas_by_instrument(
+    deltas: &[OrderBookDelta],
+) -> Vec<(InstrumentId, Vec<OrderBookDelta>)> {
+    let mut partition_indexes = AHashMap::new();
+    let mut partitions: Vec<(InstrumentId, Vec<OrderBookDelta>)> = Vec::new();
+
+    for delta in deltas {
+        let index = *partition_indexes
+            .entry(delta.instrument_id)
+            .or_insert_with(|| {
+                partitions.push((delta.instrument_id, Vec::new()));
+                partitions.len() - 1
+            });
+        partitions[index].1.push(*delta);
+    }
+
+    partitions
 }
 
 fn custom_response_data(resp: &CustomDataResponse, parent_id: UUID4) -> Option<Vec<CustomData>> {

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -2048,13 +2048,43 @@ impl DataEngine {
         Some(rebuilt)
     }
 
-    // Replays each instrument's day-start snapshot forward to the request's original start when
-    // that partition's first delta is an F_SNAPSHOT on a UTC day boundary, replacing its
-    // pre-start deltas with one snapshot keyed at the original start before forwarding the rest.
+    // Replays a day-start snapshot forward to the request's original start: when the first delta
+    // is an F_SNAPSHOT on a UTC day boundary, rebuilds the book from the pre-start deltas and
+    // replaces them with one snapshot keyed at the original start, then forwards the rest.
     fn book_deltas_snapshot_replay(&self, resp: &mut BookDeltasResponse) {
         let Some(original_start_ns) = resp.start else {
             return;
         };
+
+        let Some(first) = resp.data.first().copied() else {
+            return;
+        };
+
+        if !RecordFlag::F_SNAPSHOT.matches(first.flags) {
+            return;
+        }
+
+        if first.ts_init.as_u64() % NANOSECONDS_IN_DAY != 0 {
+            return;
+        }
+
+        // Nothing to fast-forward when the request starts at or before the day-start snapshot
+        if original_start_ns <= first.ts_init {
+            return;
+        }
+
+        if self
+            .cache
+            .borrow()
+            .instrument(&resp.instrument_id)
+            .is_none()
+        {
+            log::warn!(
+                "Instrument {} not found in cache, skipping snapshot replay",
+                resp.instrument_id,
+            );
+            return;
+        }
 
         let book_type = resp
             .params
@@ -2063,80 +2093,13 @@ impl DataEngine {
             .and_then(|s| BookType::from_str(s).ok())
             .unwrap_or(BookType::L2_MBP);
 
-        let Some(first_instrument_id) = resp.data.first().map(|delta| delta.instrument_id) else {
-            return;
-        };
-
-        if resp
-            .data
-            .iter()
-            .all(|delta| delta.instrument_id == first_instrument_id)
-        {
-            let deltas = std::mem::take(&mut resp.data);
-            resp.data = self.replay_book_deltas_partition(
-                first_instrument_id,
-                deltas,
-                original_start_ns,
-                book_type,
-            );
-            return;
-        }
-
-        let partitions = partition_deltas_by_instrument(&resp.data);
-        let mut merged = Vec::with_capacity(resp.data.len());
-
-        for (partition_index, (instrument_id, deltas)) in partitions.into_iter().enumerate() {
-            let transformed = self.replay_book_deltas_partition(
-                instrument_id,
-                deltas,
-                original_start_ns,
-                book_type,
-            );
-            merged.extend(
-                transformed
-                    .into_iter()
-                    .enumerate()
-                    .map(|(relative_index, delta)| (delta, partition_index, relative_index)),
-            );
-        }
-
-        // Equal timestamps retain first-seen instrument order, then partition-relative order
-        merged.sort_by_key(|(delta, partition_index, relative_index)| {
-            (delta.ts_init, *partition_index, *relative_index)
-        });
-        resp.data = merged.into_iter().map(|(delta, _, _)| delta).collect();
-    }
-
-    fn replay_book_deltas_partition(
-        &self,
-        instrument_id: InstrumentId,
-        deltas: Vec<OrderBookDelta>,
-        original_start_ns: UnixNanos,
-        book_type: BookType,
-    ) -> Vec<OrderBookDelta> {
-        let Some(first) = deltas.first().copied() else {
-            return deltas;
-        };
-
-        if !RecordFlag::F_SNAPSHOT.matches(first.flags)
-            || first.ts_init.as_u64() % NANOSECONDS_IN_DAY != 0
-            || original_start_ns <= first.ts_init
-        {
-            return deltas;
-        }
-
-        if self.cache.borrow().instrument(&instrument_id).is_none() {
-            log::warn!("Instrument {instrument_id} not found in cache, skipping snapshot replay");
-            return deltas;
-        }
-
-        let mut book = OrderBook::new(instrument_id, book_type);
+        let mut book = OrderBook::new(resp.instrument_id, book_type);
         let mut before: Vec<OrderBookDelta> = Vec::new();
         let mut after: Vec<OrderBookDelta> = Vec::new();
         let mut last_applied_ts: Option<UnixNanos> = None;
         let mut crossed = false;
 
-        for delta in &deltas {
+        for delta in &resp.data {
             if crossed {
                 after.push(*delta);
             } else {
@@ -2153,21 +2116,24 @@ impl DataEngine {
                 last_applied_ts = before.last().map(|d| d.ts_init);
             }
 
-            let batch = OrderBookDeltas::new(instrument_id, before);
+            let batch = OrderBookDeltas::new(resp.instrument_id, before);
             if let Err(e) = book.apply_deltas(&batch) {
-                log::error!("Failed to rebuild book for snapshot replay on {instrument_id}: {e}");
-                return deltas;
+                log::error!(
+                    "Failed to rebuild book for snapshot replay on {}: {e}",
+                    resp.instrument_id,
+                );
+                return;
             }
         }
 
         let Some(last_ts) = last_applied_ts else {
-            return deltas;
+            return;
         };
 
         let snapshot_ts = last_ts.max(original_start_ns);
         let mut new_data = book.to_deltas(snapshot_ts, snapshot_ts).deltas;
         new_data.extend(after);
-        new_data
+        resp.data = new_data;
     }
 
     fn handle_request_join(&mut self, req: RequestJoin) -> anyhow::Result<()> {
@@ -4039,40 +4005,10 @@ impl DataEngine {
     }
 
     fn handle_book_deltas_response(&self, resp: &BookDeltasResponse) {
-        let Some(first_instrument_id) = resp.data.first().map(|delta| delta.instrument_id) else {
-            return;
-        };
-
-        if resp
-            .data
-            .iter()
-            .all(|delta| delta.instrument_id == first_instrument_id)
-        {
-            self.apply_book_deltas_partition_to_cache(first_instrument_id, &resp.data);
-            publish_book_delta_frames(first_instrument_id, resp.data.iter().copied());
-            return;
-        }
-
-        let partitions = partition_deltas_by_instrument(&resp.data);
-
-        for (instrument_id, deltas) in &partitions {
-            self.apply_book_deltas_partition_to_cache(*instrument_id, deltas);
-        }
-
-        for (instrument_id, deltas) in partitions {
-            publish_book_delta_frames(instrument_id, deltas);
-        }
-    }
-
-    fn apply_book_deltas_partition_to_cache(
-        &self,
-        instrument_id: InstrumentId,
-        deltas: &[OrderBookDelta],
-    ) {
-        if !self.cache_is_owned_by_live_subscription(&instrument_id) {
+        if !self.cache_is_owned_by_live_subscription(&resp.instrument_id) {
             let mut cache = self.cache.as_ref().borrow_mut();
-            if let Some(book) = cache.order_book_mut(&instrument_id) {
-                for delta in deltas {
+            if let Some(book) = cache.order_book_mut(&resp.instrument_id) {
+                for delta in &resp.data {
                     if let Err(e) = book.apply_delta(delta) {
                         log::error!("Failed to apply historical delta to cache: {e}");
                     }
@@ -4080,10 +4016,34 @@ impl DataEngine {
             } else {
                 log::debug!(
                     "Skipping cache write for {} historical deltas on {}: no cache book yet",
-                    deltas.len(),
-                    instrument_id,
+                    resp.data.len(),
+                    resp.instrument_id,
                 );
             }
+        }
+
+        // Group deltas by `F_LAST` so each published batch preserves the original event
+        // boundary and metadata (timestamps and sequence from the closing delta), matching
+        // the live `handle_delta` buffering semantic. Collapsing the whole response into
+        // one batch would surface a synthetic event with the trailing delta's flags only.
+        if resp.data.is_empty() {
+            return;
+        }
+
+        let topic = switchboard::get_pipeline_book_deltas_topic(resp.instrument_id);
+        let mut frame: Vec<OrderBookDelta> = Vec::new();
+
+        for delta in &resp.data {
+            frame.push(*delta);
+            if RecordFlag::F_LAST.matches(delta.flags) {
+                let batch = OrderBookDeltas::new(resp.instrument_id, std::mem::take(&mut frame));
+                msgbus::publish_deltas(topic, &batch);
+            }
+        }
+
+        if !frame.is_empty() {
+            let batch = OrderBookDeltas::new(resp.instrument_id, frame);
+            msgbus::publish_deltas(topic, &batch);
         }
     }
 
@@ -5643,6 +5603,24 @@ fn rebuild_pipeline_response(
                     log::error!("Mixed-variant legs in pipeline {parent_id}");
                     return None;
                 };
+
+                // A book-delta batch is keyed by one instrument, so legs for different
+                // instruments cannot be concatenated into a single response. Matched by
+                // value as well as identity, mirroring `OrderBookDeltas::new_checked`,
+                // since legs crossing the FFI boundary do not share an intern pool.
+                let same_instrument = other.instrument_id == acc.instrument_id
+                    || (other.instrument_id.symbol.as_str() == acc.instrument_id.symbol.as_str()
+                        && other.instrument_id.venue.as_str() == acc.instrument_id.venue.as_str());
+
+                if !same_instrument {
+                    log::error!(
+                        "Mixed-instrument BookDeltas legs in pipeline {parent_id}: {} and {}",
+                        acc.instrument_id,
+                        other.instrument_id,
+                    );
+                    return None;
+                }
+
                 acc.data.extend(other.data);
             }
             acc.data.sort_by_key(|d| d.ts_init);
@@ -5687,51 +5665,6 @@ fn rebuild_pipeline_response(
             None
         }
     }
-}
-
-fn publish_book_delta_frames(
-    instrument_id: InstrumentId,
-    deltas: impl IntoIterator<Item = OrderBookDelta>,
-) {
-    let topic = switchboard::get_pipeline_book_deltas_topic(instrument_id);
-    let mut frame: Vec<OrderBookDelta> = Vec::new();
-
-    // Group each instrument's deltas by `F_LAST` so each published batch preserves the original
-    // event boundary and metadata (timestamps and sequence from the closing delta), matching live
-    // `handle_delta` buffering. Collapsing a partition into one batch would surface a synthetic
-    // event with the trailing delta's flags only.
-    for delta in deltas {
-        frame.push(delta);
-        if RecordFlag::F_LAST.matches(delta.flags) {
-            let batch = OrderBookDeltas::new(instrument_id, std::mem::take(&mut frame));
-            msgbus::publish_deltas(topic, &batch);
-        }
-    }
-
-    if !frame.is_empty() {
-        let batch = OrderBookDeltas::new(instrument_id, frame);
-        msgbus::publish_deltas(topic, &batch);
-    }
-}
-
-// Returns first-seen instrument partitions while preserving relative delta order within each one.
-fn partition_deltas_by_instrument(
-    deltas: &[OrderBookDelta],
-) -> Vec<(InstrumentId, Vec<OrderBookDelta>)> {
-    let mut partition_indexes = AHashMap::new();
-    let mut partitions: Vec<(InstrumentId, Vec<OrderBookDelta>)> = Vec::new();
-
-    for delta in deltas {
-        let index = *partition_indexes
-            .entry(delta.instrument_id)
-            .or_insert_with(|| {
-                partitions.push((delta.instrument_id, Vec::new()));
-                partitions.len() - 1
-            });
-        partitions[index].1.push(*delta);
-    }
-
-    partitions
 }
 
 fn custom_response_data(resp: &CustomDataResponse, parent_id: UUID4) -> Option<Vec<CustomData>> {

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -2014,8 +2014,9 @@ impl DataEngine {
         let (parent_start, parent_end) = parent_request_window(parent.as_ref());
         let rebuilt = rebuild_pipeline_response(parent_id, parent.as_ref(), legs);
 
-        // If the rebuild failed (mixed-variant or unsupported-variant legs), drop the
-        // associated `RequestJoin` so its staging maps do not leak. Without this the
+        // If the rebuild failed (mixed-variant, unsupported-variant, or mixed-instrument
+        // `BookDeltas` legs), drop the associated `RequestJoin` so its staging maps do not
+        // leak. Without this the
         // original join request stays in `pending_join_requests` and its
         // `parent_join_request_id` mapping stays live, neither of which will ever
         // resolve through normal flow.
@@ -5470,8 +5471,10 @@ fn log_if_empty_response<T, I: Display>(data: &[T], id: &I, correlation_id: &UUI
 /// Concatenates same-variant leg payloads into a single rebuilt response keyed by `parent_id`.
 ///
 /// Returns `None` when legs are mixed-variant or empty; pipelines only group legs of the same
-/// variant. The rebuilt response inherits `start` and `end` from the parent request when the
-/// parent is a `RequestJoin`; otherwise leg bounds are preserved on the first leg.
+/// variant. `BookDeltas` legs additionally return `None` when their wrapper instruments differ,
+/// since a book-delta batch is keyed by one instrument and cannot carry another's children.
+/// The rebuilt response inherits `start` and `end` from the parent request when the parent is a
+/// `RequestJoin`; otherwise leg bounds are preserved on the first leg.
 fn rebuild_pipeline_response(
     parent_id: UUID4,
     parent: Option<&RequestCommand>,

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -83,8 +83,6 @@ use nautilus_model::defi::{
 };
 #[cfg(feature = "defi")]
 use nautilus_model::enums::CurrencyType;
-#[cfg(feature = "streaming")]
-use nautilus_model::enums::{BookAction, OrderSide};
 use nautilus_model::{
     data::{
         Bar, BarType, BookOrder, CustomData, DEPTH10_LEN, Data, DataType, FundingRateUpdate,
@@ -97,8 +95,8 @@ use nautilus_model::{
         },
     },
     enums::{
-        AggressorSide, AssetClass, BookType, GreeksConvention, InstrumentClass,
-        InstrumentCloseType, MarketStatusAction, OptionKind, PriceType, RecordFlag,
+        AggressorSide, AssetClass, BookAction, BookType, GreeksConvention, InstrumentClass,
+        InstrumentCloseType, MarketStatusAction, OptionKind, OrderSide, PriceType, RecordFlag,
     },
     identifiers::{ClientId, InstrumentId, OptionSeriesId, Symbol, TradeId, TraderId, Venue},
     instruments::{
@@ -21462,6 +21460,239 @@ fn test_book_deltas_response_publishes_frames_by_f_last(
 }
 
 #[rstest]
+fn test_book_deltas_response_partitions_interleaved_instruments_before_framing(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+) {
+    let _ = stub_msgbus;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+    let mut data_engine = DataEngine::new(clock, cache, None);
+    let a = audusd_sim.id;
+    let b = gbpusd_sim.id;
+
+    let topic_a = switchboard::get_pipeline_book_deltas_topic(a);
+    let topic_b = switchboard::get_pipeline_book_deltas_topic(b);
+    let (handler_a, saver_a) =
+        get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from("partition-a")));
+    let (handler_b, saver_b) =
+        get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from("partition-b")));
+    msgbus::subscribe_book_deltas(topic_a.into(), handler_a, None);
+    msgbus::subscribe_book_deltas(topic_b.into(), handler_b, None);
+
+    data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
+        UUID4::new(),
+        client_id,
+        a,
+        vec![
+            delta_with_flag(a, 1_000, 0),
+            delta_with_flag(b, 2_000, 0),
+            delta_with_flag(a, 3_000, RecordFlag::F_LAST as u8),
+        ],
+        None,
+        None,
+        UnixNanos::default(),
+        None,
+    )));
+
+    let batches_a = saver_a.get_messages();
+    let batches_b = saver_b.get_messages();
+    assert_eq!(batches_a.len(), 1);
+    assert_eq!(batches_b.len(), 1);
+    assert_eq!(batches_a[0].instrument_id, a);
+    assert_eq!(batches_b[0].instrument_id, b);
+    assert_eq!(
+        batches_a[0]
+            .deltas
+            .iter()
+            .map(|delta| delta.ts_init.as_u64())
+            .collect::<Vec<_>>(),
+        vec![1_000, 3_000],
+    );
+    assert_eq!(batches_b[0].deltas, vec![delta_with_flag(b, 2_000, 0)]);
+}
+
+#[rstest]
+fn test_request_join_publishes_book_deltas_on_each_instrument_topic(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+) {
+    let _ = stub_msgbus;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+    advance_test_clock_to(&clock, 10_000_000_000);
+    let mut data_engine = DataEngine::new(clock, cache, None);
+    let a = audusd_sim.id;
+    let b = gbpusd_sim.id;
+    let leg_a = UUID4::new();
+    let leg_b = UUID4::new();
+    let join_id = UUID4::new();
+
+    let (handler_a, saver_a) =
+        get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from("join-deltas-a")));
+    let (handler_b, saver_b) =
+        get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from("join-deltas-b")));
+    msgbus::subscribe_book_deltas(
+        switchboard::get_pipeline_book_deltas_topic(a).into(),
+        handler_a,
+        None,
+    );
+    msgbus::subscribe_book_deltas(
+        switchboard::get_pipeline_book_deltas_topic(b).into(),
+        handler_b,
+        None,
+    );
+
+    data_engine
+        .execute_request(RequestCommand::Join(RequestJoin::new(
+            vec![leg_a, leg_b],
+            None,
+            None,
+            join_id,
+            UnixNanos::default(),
+            None,
+            None,
+        )))
+        .unwrap();
+
+    for (leg_id, instrument_id, ts) in [(leg_a, a, 1_000), (leg_b, b, 2_000)] {
+        data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
+            leg_id,
+            client_id,
+            instrument_id,
+            vec![delta_with_flag(instrument_id, ts, RecordFlag::F_LAST as u8)],
+            None,
+            None,
+            UnixNanos::default(),
+            None,
+        )));
+    }
+
+    assert_eq!(saver_a.get_messages().len(), 1);
+    assert_eq!(saver_b.get_messages().len(), 1);
+    assert_eq!(saver_a.get_messages()[0].deltas[0].instrument_id, a);
+    assert_eq!(saver_b.get_messages()[0].deltas[0].instrument_id, b);
+    assert_eq!(data_engine.pending_join_request_count(), 0);
+}
+
+#[rstest]
+#[case(false)]
+#[case(true)]
+fn test_book_deltas_response_routes_cache_by_partition_ownership(
+    #[case] owned_is_a: bool,
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+    venue: Venue,
+) {
+    let _ = stub_msgbus;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+    let mut data_engine = DataEngine::new(clock, cache.clone(), None);
+    let a = audusd_sim.id;
+    let b = gbpusd_sim.id;
+    let owned = if owned_is_a { a } else { b };
+
+    for instrument_id in [a, b] {
+        cache
+            .borrow_mut()
+            .add_order_book(OrderBook::new(instrument_id, BookType::L3_MBO))
+            .unwrap();
+    }
+
+    data_engine.execute(DataCommand::Subscribe(SubscribeCommand::BookDeltas(
+        SubscribeBookDeltas::new(
+            owned,
+            BookType::L3_MBO,
+            Some(client_id),
+            Some(venue),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            true,
+            None,
+            None,
+        ),
+    )));
+
+    let before_a = cache.borrow().order_book(&a).unwrap().update_count;
+    let before_b = cache.borrow().order_book(&b).unwrap().update_count;
+    data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
+        UUID4::new(),
+        client_id,
+        a,
+        vec![split_delta(a, 1_000), split_delta(b, 2_000)],
+        None,
+        None,
+        UnixNanos::default(),
+        None,
+    )));
+    let after_a = cache.borrow().order_book(&a).unwrap().update_count;
+    let after_b = cache.borrow().order_book(&b).unwrap().update_count;
+
+    if owned_is_a {
+        assert_eq!(after_a, before_a, "live-owned A must skip cache writes");
+        assert!(after_b > before_b, "unowned B must receive its cache write");
+    } else {
+        assert!(after_a > before_a, "unowned A must receive its cache write");
+        assert_eq!(after_b, before_b, "live-owned B must skip cache writes");
+    }
+}
+
+#[rstest]
+fn test_book_deltas_response_publishes_trailing_partitions_in_first_seen_order(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+) {
+    let _ = stub_msgbus;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+    let mut data_engine = DataEngine::new(clock, cache, None);
+    let a = audusd_sim.id;
+    let b = gbpusd_sim.id;
+    let (handler, saver) = get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from(
+        "trailing-partition-order",
+    )));
+    msgbus::subscribe_book_deltas(
+        switchboard::get_pipeline_book_deltas_topic(a).into(),
+        handler.clone(),
+        None,
+    );
+    msgbus::subscribe_book_deltas(
+        switchboard::get_pipeline_book_deltas_topic(b).into(),
+        handler,
+        None,
+    );
+
+    data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
+        UUID4::new(),
+        client_id,
+        a,
+        vec![delta_with_flag(b, 1_000, 0), delta_with_flag(a, 2_000, 0)],
+        None,
+        None,
+        UnixNanos::default(),
+        None,
+    )));
+
+    assert_eq!(
+        saver
+            .get_messages()
+            .iter()
+            .map(|batch| batch.instrument_id)
+            .collect::<Vec<_>>(),
+        vec![b, a],
+    );
+}
+
+#[rstest]
 fn test_book_deltas_response_applies_to_cache_when_no_subscription_but_book_exists(
     audusd_sim: CurrencyPair,
     stub_msgbus: Rc<RefCell<MessageBus>>,
@@ -21508,7 +21739,6 @@ fn test_book_deltas_response_applies_to_cache_when_no_subscription_but_book_exis
     );
 }
 
-#[cfg(feature = "streaming")]
 fn book_replay_delta(
     instrument_id: InstrumentId,
     ts: u64,
@@ -21528,6 +21758,180 @@ fn book_replay_delta(
         .ts_event(UnixNanos::from(ts))
         .ts_init(UnixNanos::from(ts))
         .build()
+}
+
+fn run_heterogeneous_replay_join(
+    data_engine: &mut DataEngine,
+    client_id: ClientId,
+    a: InstrumentId,
+    b: InstrumentId,
+    a_deltas: Vec<OrderBookDelta>,
+    b_deltas: Vec<OrderBookDelta>,
+) -> Vec<OrderBookDelta> {
+    let leg_a = UUID4::new();
+    let leg_b = UUID4::new();
+    let join_id = UUID4::new();
+    let (handler, saver) =
+        get_any_saving_handler::<BookDeltasResponse>(Some(Ustr::from("heterogeneous-replay-join")));
+    msgbus::register_response_handler(&join_id, handler);
+
+    data_engine
+        .execute_request(RequestCommand::Join(RequestJoin::new(
+            vec![leg_a, leg_b],
+            Some(UnixNanos::from(1_000).to_datetime_utc()),
+            Some(UnixNanos::from(3_000).to_datetime_utc()),
+            join_id,
+            UnixNanos::default(),
+            None,
+            None,
+        )))
+        .unwrap();
+
+    for (leg_id, instrument_id, deltas) in [(leg_a, a, a_deltas), (leg_b, b, b_deltas)] {
+        data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
+            leg_id,
+            client_id,
+            instrument_id,
+            deltas,
+            Some(UnixNanos::from(0)),
+            Some(UnixNanos::from(3_000)),
+            UnixNanos::default(),
+            None,
+        )));
+    }
+
+    let responses = saver.get_messages();
+    assert_eq!(responses.len(), 1);
+    assert!(
+        responses[0]
+            .data
+            .iter()
+            .all(|delta| delta.ts_init >= UnixNanos::from(1_000)),
+        "parent-window trim must run after replay",
+    );
+    responses[0].data.clone()
+}
+
+#[rstest]
+fn test_request_join_replays_later_eligible_partition_when_first_is_ineligible(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+) {
+    let _ = stub_msgbus;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+    advance_test_clock_to(&clock, 10_000_000_000);
+    let mut data_engine = DataEngine::new(clock, cache.clone(), None);
+    let a = audusd_sim.id;
+    let b = gbpusd_sim.id;
+    cache
+        .borrow_mut()
+        .add_instrument(InstrumentAny::CurrencyPair(audusd_sim))
+        .unwrap();
+    cache
+        .borrow_mut()
+        .add_instrument(InstrumentAny::CurrencyPair(gbpusd_sim))
+        .unwrap();
+
+    let a_after = book_replay_delta(a, 1_500, RecordFlag::F_LAST as u8, "1.00020", 2);
+    let data = run_heterogeneous_replay_join(
+        &mut data_engine,
+        client_id,
+        a,
+        b,
+        vec![book_replay_delta(a, 0, 0, "1.00000", 1), a_after],
+        vec![
+            book_replay_delta(
+                b,
+                0,
+                RecordFlag::F_SNAPSHOT as u8 | RecordFlag::F_LAST as u8,
+                "1.10000",
+                1,
+            ),
+            book_replay_delta(b, 1_500, RecordFlag::F_LAST as u8, "1.10020", 2),
+        ],
+    );
+
+    let a_data: Vec<_> = data
+        .iter()
+        .filter(|delta| delta.instrument_id == a)
+        .copied()
+        .collect();
+    let b_data: Vec<_> = data
+        .iter()
+        .filter(|delta| delta.instrument_id == b)
+        .copied()
+        .collect();
+    assert_eq!(a_data, vec![a_after], "ineligible A must remain unchanged");
+    assert_eq!(b_data[0].action, BookAction::Clear);
+    assert!(
+        b_data
+            .iter()
+            .all(|delta| delta.ts_init == UnixNanos::from(1_500))
+    );
+}
+
+#[rstest]
+fn test_request_join_replays_first_eligible_partition_when_later_is_ineligible(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+) {
+    let _ = stub_msgbus;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+    advance_test_clock_to(&clock, 10_000_000_000);
+    let mut data_engine = DataEngine::new(clock, cache.clone(), None);
+    let a = audusd_sim.id;
+    let b = gbpusd_sim.id;
+    cache
+        .borrow_mut()
+        .add_instrument(InstrumentAny::CurrencyPair(audusd_sim))
+        .unwrap();
+    cache
+        .borrow_mut()
+        .add_instrument(InstrumentAny::CurrencyPair(gbpusd_sim))
+        .unwrap();
+
+    let b_after = book_replay_delta(b, 1_600, RecordFlag::F_LAST as u8, "1.10020", 2);
+    let data = run_heterogeneous_replay_join(
+        &mut data_engine,
+        client_id,
+        a,
+        b,
+        vec![
+            book_replay_delta(
+                a,
+                0,
+                RecordFlag::F_SNAPSHOT as u8 | RecordFlag::F_LAST as u8,
+                "1.00000",
+                1,
+            ),
+            book_replay_delta(a, 1_500, RecordFlag::F_LAST as u8, "1.00020", 2),
+        ],
+        vec![book_replay_delta(b, 0, 0, "1.10000", 1), b_after],
+    );
+
+    let a_data: Vec<_> = data
+        .iter()
+        .filter(|delta| delta.instrument_id == a)
+        .copied()
+        .collect();
+    let b_data: Vec<_> = data
+        .iter()
+        .filter(|delta| delta.instrument_id == b)
+        .copied()
+        .collect();
+    assert_eq!(a_data[0].action, BookAction::Clear);
+    assert!(
+        a_data
+            .iter()
+            .all(|delta| delta.ts_init == UnixNanos::from(1_500))
+    );
+    assert_eq!(b_data, vec![b_after], "ineligible B must remain unchanged");
 }
 
 #[cfg(feature = "streaming")]

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -83,6 +83,8 @@ use nautilus_model::defi::{
 };
 #[cfg(feature = "defi")]
 use nautilus_model::enums::CurrencyType;
+#[cfg(feature = "streaming")]
+use nautilus_model::enums::{BookAction, OrderSide};
 use nautilus_model::{
     data::{
         Bar, BarType, BookOrder, CustomData, DEPTH10_LEN, Data, DataType, FundingRateUpdate,
@@ -95,8 +97,8 @@ use nautilus_model::{
         },
     },
     enums::{
-        AggressorSide, AssetClass, BookAction, BookType, GreeksConvention, InstrumentClass,
-        InstrumentCloseType, MarketStatusAction, OptionKind, OrderSide, PriceType, RecordFlag,
+        AggressorSide, AssetClass, BookType, GreeksConvention, InstrumentClass,
+        InstrumentCloseType, MarketStatusAction, OptionKind, PriceType, RecordFlag,
     },
     identifiers::{ClientId, InstrumentId, OptionSeriesId, Symbol, TradeId, TraderId, Venue},
     instruments::{
@@ -18511,6 +18513,168 @@ fn test_request_join_single_leg_fires_immediately(
     }
 }
 
+fn leg_book_deltas_response(
+    request_id: UUID4,
+    instrument_id: InstrumentId,
+    client_id: ClientId,
+    deltas: Vec<OrderBookDelta>,
+) -> DataResponse {
+    DataResponse::BookDeltas(BookDeltasResponse::new(
+        request_id,
+        client_id,
+        instrument_id,
+        deltas,
+        None,
+        None,
+        UnixNanos::default(),
+        None,
+    ))
+}
+
+#[rstest]
+fn test_request_join_rebuilds_same_instrument_book_deltas_legs(
+    audusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+) {
+    let _ = stub_msgbus;
+    let instrument_id = audusd_sim.id;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+    // Past the leg ts_init values, so the join's bound-date clamping does not
+    // collapse the parent window to 0.
+    advance_test_clock_to(&clock, 10_000_000_000);
+    let mut data_engine = DataEngine::new(clock, cache, None);
+
+    let leg_a = UUID4::new();
+    let leg_b = UUID4::new();
+    let join_id = UUID4::new();
+
+    data_engine
+        .execute_request(RequestCommand::Join(RequestJoin::new(
+            vec![leg_a, leg_b],
+            None,
+            None,
+            join_id,
+            UnixNanos::default(),
+            None,
+            None,
+        )))
+        .unwrap();
+
+    let (parent_handler, parent_saver) = get_any_saving_handler::<BookDeltasResponse>(Some(
+        Ustr::from("same-instrument-deltas-parent"),
+    ));
+    msgbus::register_response_handler(&join_id, parent_handler);
+
+    data_engine.response(leg_book_deltas_response(
+        leg_a,
+        instrument_id,
+        client_id,
+        vec![delta_with_flag(
+            instrument_id,
+            1_000,
+            RecordFlag::F_LAST as u8,
+        )],
+    ));
+    data_engine.response(leg_book_deltas_response(
+        leg_b,
+        instrument_id,
+        client_id,
+        vec![delta_with_flag(
+            instrument_id,
+            2_000,
+            RecordFlag::F_LAST as u8,
+        )],
+    ));
+
+    let responses = parent_saver.get_messages();
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].instrument_id, instrument_id);
+    assert_eq!(
+        responses[0]
+            .data
+            .iter()
+            .map(|delta| delta.ts_init.as_u64())
+            .collect::<Vec<_>>(),
+        vec![1_000, 2_000],
+    );
+    assert_eq!(data_engine.pending_join_request_count(), 0);
+}
+
+#[rstest]
+fn test_request_join_mixed_instrument_book_deltas_cleans_up_join_staging(
+    audusd_sim: CurrencyPair,
+    gbpusd_sim: CurrencyPair,
+    stub_msgbus: Rc<RefCell<MessageBus>>,
+    client_id: ClientId,
+) {
+    let _ = stub_msgbus;
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
+    // Past the leg ts_init values, so the deltas survive the parent-window trim and
+    // reach the response handler when the rebuild is not refused.
+    advance_test_clock_to(&clock, 10_000_000_000);
+    let mut data_engine = DataEngine::new(clock, cache, None);
+
+    let leg_a = UUID4::new();
+    let leg_b = UUID4::new();
+    let join_id = UUID4::new();
+
+    data_engine
+        .execute_request(RequestCommand::Join(RequestJoin::new(
+            vec![leg_a, leg_b],
+            None,
+            None,
+            join_id,
+            UnixNanos::default(),
+            None,
+            None,
+        )))
+        .unwrap();
+
+    let (parent_handler, parent_saver) = get_any_saving_handler::<BookDeltasResponse>(Some(
+        Ustr::from("mixed-instrument-deltas-parent"),
+    ));
+    msgbus::register_response_handler(&join_id, parent_handler);
+
+    data_engine.response(leg_book_deltas_response(
+        leg_a,
+        audusd_sim.id,
+        client_id,
+        vec![delta_with_flag(
+            audusd_sim.id,
+            1_000,
+            RecordFlag::F_LAST as u8,
+        )],
+    ));
+    data_engine.response(leg_book_deltas_response(
+        leg_b,
+        gbpusd_sim.id,
+        client_id,
+        vec![delta_with_flag(
+            gbpusd_sim.id,
+            2_000,
+            RecordFlag::F_LAST as u8,
+        )],
+    ));
+
+    assert!(
+        parent_saver.get_messages().is_empty(),
+        "mixed-instrument rebuild must not emit a parent response",
+    );
+    assert_eq!(
+        data_engine.request_pipeline_count(),
+        0,
+        "pipeline state must be cleared after a failed rebuild",
+    );
+    assert_eq!(
+        data_engine.pending_join_request_count(),
+        0,
+        "pending join must be cleared after a failed rebuild to prevent leaks",
+    );
+}
+
 #[rstest]
 fn test_request_join_mixed_variants_cleans_up_join_staging(
     audusd_sim: CurrencyPair,
@@ -21460,239 +21624,6 @@ fn test_book_deltas_response_publishes_frames_by_f_last(
 }
 
 #[rstest]
-fn test_book_deltas_response_partitions_interleaved_instruments_before_framing(
-    audusd_sim: CurrencyPair,
-    gbpusd_sim: CurrencyPair,
-    stub_msgbus: Rc<RefCell<MessageBus>>,
-    client_id: ClientId,
-) {
-    let _ = stub_msgbus;
-    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
-    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
-    let mut data_engine = DataEngine::new(clock, cache, None);
-    let a = audusd_sim.id;
-    let b = gbpusd_sim.id;
-
-    let topic_a = switchboard::get_pipeline_book_deltas_topic(a);
-    let topic_b = switchboard::get_pipeline_book_deltas_topic(b);
-    let (handler_a, saver_a) =
-        get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from("partition-a")));
-    let (handler_b, saver_b) =
-        get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from("partition-b")));
-    msgbus::subscribe_book_deltas(topic_a.into(), handler_a, None);
-    msgbus::subscribe_book_deltas(topic_b.into(), handler_b, None);
-
-    data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
-        UUID4::new(),
-        client_id,
-        a,
-        vec![
-            delta_with_flag(a, 1_000, 0),
-            delta_with_flag(b, 2_000, 0),
-            delta_with_flag(a, 3_000, RecordFlag::F_LAST as u8),
-        ],
-        None,
-        None,
-        UnixNanos::default(),
-        None,
-    )));
-
-    let batches_a = saver_a.get_messages();
-    let batches_b = saver_b.get_messages();
-    assert_eq!(batches_a.len(), 1);
-    assert_eq!(batches_b.len(), 1);
-    assert_eq!(batches_a[0].instrument_id, a);
-    assert_eq!(batches_b[0].instrument_id, b);
-    assert_eq!(
-        batches_a[0]
-            .deltas
-            .iter()
-            .map(|delta| delta.ts_init.as_u64())
-            .collect::<Vec<_>>(),
-        vec![1_000, 3_000],
-    );
-    assert_eq!(batches_b[0].deltas, vec![delta_with_flag(b, 2_000, 0)]);
-}
-
-#[rstest]
-fn test_request_join_publishes_book_deltas_on_each_instrument_topic(
-    audusd_sim: CurrencyPair,
-    gbpusd_sim: CurrencyPair,
-    stub_msgbus: Rc<RefCell<MessageBus>>,
-    client_id: ClientId,
-) {
-    let _ = stub_msgbus;
-    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
-    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
-    advance_test_clock_to(&clock, 10_000_000_000);
-    let mut data_engine = DataEngine::new(clock, cache, None);
-    let a = audusd_sim.id;
-    let b = gbpusd_sim.id;
-    let leg_a = UUID4::new();
-    let leg_b = UUID4::new();
-    let join_id = UUID4::new();
-
-    let (handler_a, saver_a) =
-        get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from("join-deltas-a")));
-    let (handler_b, saver_b) =
-        get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from("join-deltas-b")));
-    msgbus::subscribe_book_deltas(
-        switchboard::get_pipeline_book_deltas_topic(a).into(),
-        handler_a,
-        None,
-    );
-    msgbus::subscribe_book_deltas(
-        switchboard::get_pipeline_book_deltas_topic(b).into(),
-        handler_b,
-        None,
-    );
-
-    data_engine
-        .execute_request(RequestCommand::Join(RequestJoin::new(
-            vec![leg_a, leg_b],
-            None,
-            None,
-            join_id,
-            UnixNanos::default(),
-            None,
-            None,
-        )))
-        .unwrap();
-
-    for (leg_id, instrument_id, ts) in [(leg_a, a, 1_000), (leg_b, b, 2_000)] {
-        data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
-            leg_id,
-            client_id,
-            instrument_id,
-            vec![delta_with_flag(instrument_id, ts, RecordFlag::F_LAST as u8)],
-            None,
-            None,
-            UnixNanos::default(),
-            None,
-        )));
-    }
-
-    assert_eq!(saver_a.get_messages().len(), 1);
-    assert_eq!(saver_b.get_messages().len(), 1);
-    assert_eq!(saver_a.get_messages()[0].deltas[0].instrument_id, a);
-    assert_eq!(saver_b.get_messages()[0].deltas[0].instrument_id, b);
-    assert_eq!(data_engine.pending_join_request_count(), 0);
-}
-
-#[rstest]
-#[case(false)]
-#[case(true)]
-fn test_book_deltas_response_routes_cache_by_partition_ownership(
-    #[case] owned_is_a: bool,
-    audusd_sim: CurrencyPair,
-    gbpusd_sim: CurrencyPair,
-    stub_msgbus: Rc<RefCell<MessageBus>>,
-    client_id: ClientId,
-    venue: Venue,
-) {
-    let _ = stub_msgbus;
-    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
-    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
-    let mut data_engine = DataEngine::new(clock, cache.clone(), None);
-    let a = audusd_sim.id;
-    let b = gbpusd_sim.id;
-    let owned = if owned_is_a { a } else { b };
-
-    for instrument_id in [a, b] {
-        cache
-            .borrow_mut()
-            .add_order_book(OrderBook::new(instrument_id, BookType::L3_MBO))
-            .unwrap();
-    }
-
-    data_engine.execute(DataCommand::Subscribe(SubscribeCommand::BookDeltas(
-        SubscribeBookDeltas::new(
-            owned,
-            BookType::L3_MBO,
-            Some(client_id),
-            Some(venue),
-            UUID4::new(),
-            UnixNanos::default(),
-            None,
-            true,
-            None,
-            None,
-        ),
-    )));
-
-    let before_a = cache.borrow().order_book(&a).unwrap().update_count;
-    let before_b = cache.borrow().order_book(&b).unwrap().update_count;
-    data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
-        UUID4::new(),
-        client_id,
-        a,
-        vec![split_delta(a, 1_000), split_delta(b, 2_000)],
-        None,
-        None,
-        UnixNanos::default(),
-        None,
-    )));
-    let after_a = cache.borrow().order_book(&a).unwrap().update_count;
-    let after_b = cache.borrow().order_book(&b).unwrap().update_count;
-
-    if owned_is_a {
-        assert_eq!(after_a, before_a, "live-owned A must skip cache writes");
-        assert!(after_b > before_b, "unowned B must receive its cache write");
-    } else {
-        assert!(after_a > before_a, "unowned A must receive its cache write");
-        assert_eq!(after_b, before_b, "live-owned B must skip cache writes");
-    }
-}
-
-#[rstest]
-fn test_book_deltas_response_publishes_trailing_partitions_in_first_seen_order(
-    audusd_sim: CurrencyPair,
-    gbpusd_sim: CurrencyPair,
-    stub_msgbus: Rc<RefCell<MessageBus>>,
-    client_id: ClientId,
-) {
-    let _ = stub_msgbus;
-    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
-    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
-    let mut data_engine = DataEngine::new(clock, cache, None);
-    let a = audusd_sim.id;
-    let b = gbpusd_sim.id;
-    let (handler, saver) = get_typed_message_saving_handler::<OrderBookDeltas>(Some(Ustr::from(
-        "trailing-partition-order",
-    )));
-    msgbus::subscribe_book_deltas(
-        switchboard::get_pipeline_book_deltas_topic(a).into(),
-        handler.clone(),
-        None,
-    );
-    msgbus::subscribe_book_deltas(
-        switchboard::get_pipeline_book_deltas_topic(b).into(),
-        handler,
-        None,
-    );
-
-    data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
-        UUID4::new(),
-        client_id,
-        a,
-        vec![delta_with_flag(b, 1_000, 0), delta_with_flag(a, 2_000, 0)],
-        None,
-        None,
-        UnixNanos::default(),
-        None,
-    )));
-
-    assert_eq!(
-        saver
-            .get_messages()
-            .iter()
-            .map(|batch| batch.instrument_id)
-            .collect::<Vec<_>>(),
-        vec![b, a],
-    );
-}
-
-#[rstest]
 fn test_book_deltas_response_applies_to_cache_when_no_subscription_but_book_exists(
     audusd_sim: CurrencyPair,
     stub_msgbus: Rc<RefCell<MessageBus>>,
@@ -21739,6 +21670,7 @@ fn test_book_deltas_response_applies_to_cache_when_no_subscription_but_book_exis
     );
 }
 
+#[cfg(feature = "streaming")]
 fn book_replay_delta(
     instrument_id: InstrumentId,
     ts: u64,
@@ -21758,180 +21690,6 @@ fn book_replay_delta(
         .ts_event(UnixNanos::from(ts))
         .ts_init(UnixNanos::from(ts))
         .build()
-}
-
-fn run_heterogeneous_replay_join(
-    data_engine: &mut DataEngine,
-    client_id: ClientId,
-    a: InstrumentId,
-    b: InstrumentId,
-    a_deltas: Vec<OrderBookDelta>,
-    b_deltas: Vec<OrderBookDelta>,
-) -> Vec<OrderBookDelta> {
-    let leg_a = UUID4::new();
-    let leg_b = UUID4::new();
-    let join_id = UUID4::new();
-    let (handler, saver) =
-        get_any_saving_handler::<BookDeltasResponse>(Some(Ustr::from("heterogeneous-replay-join")));
-    msgbus::register_response_handler(&join_id, handler);
-
-    data_engine
-        .execute_request(RequestCommand::Join(RequestJoin::new(
-            vec![leg_a, leg_b],
-            Some(UnixNanos::from(1_000).to_datetime_utc()),
-            Some(UnixNanos::from(3_000).to_datetime_utc()),
-            join_id,
-            UnixNanos::default(),
-            None,
-            None,
-        )))
-        .unwrap();
-
-    for (leg_id, instrument_id, deltas) in [(leg_a, a, a_deltas), (leg_b, b, b_deltas)] {
-        data_engine.response(DataResponse::BookDeltas(BookDeltasResponse::new(
-            leg_id,
-            client_id,
-            instrument_id,
-            deltas,
-            Some(UnixNanos::from(0)),
-            Some(UnixNanos::from(3_000)),
-            UnixNanos::default(),
-            None,
-        )));
-    }
-
-    let responses = saver.get_messages();
-    assert_eq!(responses.len(), 1);
-    assert!(
-        responses[0]
-            .data
-            .iter()
-            .all(|delta| delta.ts_init >= UnixNanos::from(1_000)),
-        "parent-window trim must run after replay",
-    );
-    responses[0].data.clone()
-}
-
-#[rstest]
-fn test_request_join_replays_later_eligible_partition_when_first_is_ineligible(
-    audusd_sim: CurrencyPair,
-    gbpusd_sim: CurrencyPair,
-    stub_msgbus: Rc<RefCell<MessageBus>>,
-    client_id: ClientId,
-) {
-    let _ = stub_msgbus;
-    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
-    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
-    advance_test_clock_to(&clock, 10_000_000_000);
-    let mut data_engine = DataEngine::new(clock, cache.clone(), None);
-    let a = audusd_sim.id;
-    let b = gbpusd_sim.id;
-    cache
-        .borrow_mut()
-        .add_instrument(InstrumentAny::CurrencyPair(audusd_sim))
-        .unwrap();
-    cache
-        .borrow_mut()
-        .add_instrument(InstrumentAny::CurrencyPair(gbpusd_sim))
-        .unwrap();
-
-    let a_after = book_replay_delta(a, 1_500, RecordFlag::F_LAST as u8, "1.00020", 2);
-    let data = run_heterogeneous_replay_join(
-        &mut data_engine,
-        client_id,
-        a,
-        b,
-        vec![book_replay_delta(a, 0, 0, "1.00000", 1), a_after],
-        vec![
-            book_replay_delta(
-                b,
-                0,
-                RecordFlag::F_SNAPSHOT as u8 | RecordFlag::F_LAST as u8,
-                "1.10000",
-                1,
-            ),
-            book_replay_delta(b, 1_500, RecordFlag::F_LAST as u8, "1.10020", 2),
-        ],
-    );
-
-    let a_data: Vec<_> = data
-        .iter()
-        .filter(|delta| delta.instrument_id == a)
-        .copied()
-        .collect();
-    let b_data: Vec<_> = data
-        .iter()
-        .filter(|delta| delta.instrument_id == b)
-        .copied()
-        .collect();
-    assert_eq!(a_data, vec![a_after], "ineligible A must remain unchanged");
-    assert_eq!(b_data[0].action, BookAction::Clear);
-    assert!(
-        b_data
-            .iter()
-            .all(|delta| delta.ts_init == UnixNanos::from(1_500))
-    );
-}
-
-#[rstest]
-fn test_request_join_replays_first_eligible_partition_when_later_is_ineligible(
-    audusd_sim: CurrencyPair,
-    gbpusd_sim: CurrencyPair,
-    stub_msgbus: Rc<RefCell<MessageBus>>,
-    client_id: ClientId,
-) {
-    let _ = stub_msgbus;
-    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
-    let cache: Rc<RefCell<Cache>> = Rc::new(RefCell::new(Cache::default()));
-    advance_test_clock_to(&clock, 10_000_000_000);
-    let mut data_engine = DataEngine::new(clock, cache.clone(), None);
-    let a = audusd_sim.id;
-    let b = gbpusd_sim.id;
-    cache
-        .borrow_mut()
-        .add_instrument(InstrumentAny::CurrencyPair(audusd_sim))
-        .unwrap();
-    cache
-        .borrow_mut()
-        .add_instrument(InstrumentAny::CurrencyPair(gbpusd_sim))
-        .unwrap();
-
-    let b_after = book_replay_delta(b, 1_600, RecordFlag::F_LAST as u8, "1.10020", 2);
-    let data = run_heterogeneous_replay_join(
-        &mut data_engine,
-        client_id,
-        a,
-        b,
-        vec![
-            book_replay_delta(
-                a,
-                0,
-                RecordFlag::F_SNAPSHOT as u8 | RecordFlag::F_LAST as u8,
-                "1.00000",
-                1,
-            ),
-            book_replay_delta(a, 1_500, RecordFlag::F_LAST as u8, "1.00020", 2),
-        ],
-        vec![book_replay_delta(b, 0, 0, "1.10000", 1), b_after],
-    );
-
-    let a_data: Vec<_> = data
-        .iter()
-        .filter(|delta| delta.instrument_id == a)
-        .copied()
-        .collect();
-    let b_data: Vec<_> = data
-        .iter()
-        .filter(|delta| delta.instrument_id == b)
-        .copied()
-        .collect();
-    assert_eq!(a_data[0].action, BookAction::Clear);
-    assert!(
-        a_data
-            .iter()
-            .all(|delta| delta.ts_init == UnixNanos::from(1_500))
-    );
-    assert_eq!(b_data, vec![b_after], "ineligible B must remain unchanged");
 }
 
 #[cfg(feature = "streaming")]

--- a/crates/model/src/data/deltas.rs
+++ b/crates/model/src/data/deltas.rs
@@ -87,14 +87,24 @@ impl OrderBookDeltas {
         deltas: Vec<OrderBookDelta>,
     ) -> anyhow::Result<Self> {
         check_predicate_true(!deltas.is_empty(), "`deltas` cannot be empty")?;
-        check_predicate_true(
-            deltas.iter().all(|delta| {
-                instrument_id == delta.instrument_id
-                    || (instrument_id.symbol.as_str() == delta.instrument_id.symbol.as_str()
-                        && instrument_id.venue.as_str() == delta.instrument_id.venue.as_str())
-            }),
-            "`deltas` instrument IDs must match `instrument_id`",
-        )?;
+
+        let mismatch = deltas.iter().enumerate().find(|(_, delta)| {
+            instrument_id != delta.instrument_id
+                && (instrument_id.symbol.as_str() != delta.instrument_id.symbol.as_str()
+                    || instrument_id.venue.as_str() != delta.instrument_id.venue.as_str())
+        });
+
+        if let Some((index, delta)) = mismatch {
+            check_predicate_true(
+                false,
+                &format!(
+                    "`deltas` instrument IDs must match `instrument_id` {instrument_id}, but \
+                     delta at index {index} of {} has {}",
+                    deltas.len(),
+                    delta.instrument_id,
+                ),
+            )?;
+        }
         let last = deltas.last().expect("deltas not empty");
         let flags = last.flags;
         let sequence = last.sequence;
@@ -333,7 +343,10 @@ mod tests {
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            "`deltas` instrument IDs must match `instrument_id`"
+            format!(
+                "`deltas` instrument IDs must match `instrument_id` EURUSD.SIM, but delta at \
+                 index {mismatch_index} of 2 has GBPUSD.SIM"
+            )
         );
     }
 

--- a/crates/model/src/data/deltas.rs
+++ b/crates/model/src/data/deltas.rs
@@ -61,7 +61,8 @@ impl OrderBookDeltas {
     ///
     /// # Panics
     ///
-    /// Panics if `deltas` is empty.
+    /// Panics if `deltas` is empty or contains an instrument ID that does not match
+    /// `instrument_id`.
     #[must_use]
     pub fn new(instrument_id: InstrumentId, deltas: Vec<OrderBookDelta>) -> Self {
         Self::new_checked(instrument_id, deltas).expect(FAILED)
@@ -71,7 +72,8 @@ impl OrderBookDeltas {
     ///
     /// # Errors
     ///
-    /// Returns an error if `deltas` is empty.
+    /// Returns an error if `deltas` is empty or contains an instrument ID that does not match
+    /// `instrument_id`.
     ///
     /// # Notes
     ///
@@ -85,6 +87,14 @@ impl OrderBookDeltas {
         deltas: Vec<OrderBookDelta>,
     ) -> anyhow::Result<Self> {
         check_predicate_true(!deltas.is_empty(), "`deltas` cannot be empty")?;
+        check_predicate_true(
+            deltas.iter().all(|delta| {
+                instrument_id == delta.instrument_id
+                    || (instrument_id.symbol.as_str() == delta.instrument_id.symbol.as_str()
+                        && instrument_id.venue.as_str() == delta.instrument_id.venue.as_str())
+            }),
+            "`deltas` instrument IDs must match `instrument_id`",
+        )?;
         let last = deltas.last().expect("deltas not empty");
         let flags = last.flags;
         let sequence = last.sequence;
@@ -297,6 +307,37 @@ mod tests {
     }
 
     #[rstest]
+    fn test_order_book_deltas_new_checked_accepts_homogeneous_deltas() {
+        let instrument_id = InstrumentId::from("EURUSD.SIM");
+        let delta1 = create_test_delta();
+        let mut delta2 = create_test_delta();
+        delta2.sequence = 124;
+
+        let result = OrderBookDeltas::new_checked(instrument_id, vec![delta1, delta2]);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().deltas.len(), 2);
+    }
+
+    #[rstest]
+    #[case::first(0)]
+    #[case::later(1)]
+    fn test_order_book_deltas_new_checked_rejects_mismatched_instrument(
+        #[case] mismatch_index: usize,
+    ) {
+        let instrument_id = InstrumentId::from("EURUSD.SIM");
+        let mut deltas = vec![create_test_delta(), create_test_delta()];
+        deltas[mismatch_index].instrument_id = InstrumentId::from("GBPUSD.SIM");
+
+        let result = OrderBookDeltas::new_checked(instrument_id, deltas);
+
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "`deltas` instrument IDs must match `instrument_id`"
+        );
+    }
+
+    #[rstest]
     fn test_order_book_deltas_new_checked_empty_deltas() {
         let instrument_id = InstrumentId::from("EURUSD.SIM");
 
@@ -481,8 +522,8 @@ mod tests {
 
     #[rstest]
     fn test_order_book_deltas_single_delta() {
-        let instrument_id = InstrumentId::from("BTCUSD.CRYPTO");
         let delta = create_test_delta();
+        let instrument_id = delta.instrument_id;
 
         let deltas = OrderBookDeltas::new(instrument_id, vec![delta]);
 

--- a/crates/model/src/orderbook/tests.rs
+++ b/crates/model/src/orderbook/tests.rs
@@ -7918,6 +7918,90 @@ fn test_apply_delta_error_when_order_not_found_for_side_resolution() {
 }
 
 #[rstest]
+fn test_apply_deltas_does_not_validate_children_constructed_literally() {
+    let instrument_id = InstrumentId::from("AAPL.XNAS");
+    let other_id = InstrumentId::from("MSFT.XNAS");
+    let good_delta = OrderBookDelta::new(
+        instrument_id,
+        BookAction::Add,
+        BookOrder::new(
+            OrderSide::Buy,
+            Price::from("100.00"),
+            Quantity::from("10"),
+            1,
+        ),
+        0,
+        1,
+        1.into(),
+        1.into(),
+    );
+    let foreign_delta = OrderBookDelta::new(
+        other_id,
+        BookAction::Add,
+        BookOrder::new(
+            OrderSide::Sell,
+            Price::from("101.00"),
+            Quantity::from("5"),
+            2,
+        ),
+        0,
+        2,
+        2.into(),
+        2.into(),
+    );
+    let deltas = OrderBookDeltas {
+        instrument_id,
+        deltas: vec![good_delta, foreign_delta],
+        flags: 0,
+        sequence: 2,
+        ts_event: 2.into(),
+        ts_init: 2.into(),
+    };
+    let mut book = OrderBook::new(instrument_id, BookType::L3_MBO);
+
+    // A literal struct bypasses `new_checked`, so the foreign child still reaches
+    // the book: `apply_deltas` validates the wrapper only.
+    let result = book.apply_deltas(&deltas);
+
+    assert!(result.is_ok());
+    assert_eq!(book.best_bid_price(), Some(Price::from("100.00")));
+    assert_eq!(book.best_ask_price(), Some(Price::from("101.00")));
+    assert_eq!(book.update_count, 2);
+
+    // Priced inside the resting ask so it becomes the best, making its arrival
+    // observable rather than hidden behind the level from the first batch.
+    let mismatched_delta = OrderBookDelta::new(
+        other_id,
+        BookAction::Add,
+        BookOrder::new(
+            OrderSide::Sell,
+            Price::from("100.50"),
+            Quantity::from("7"),
+            3,
+        ),
+        0,
+        3,
+        3.into(),
+        3.into(),
+    );
+    // The unchecked form is a documented FFI accommodation; pin that it still
+    // accepts a foreign child rather than preserving that by omission.
+    let mismatched_deltas = OrderBookDeltas {
+        instrument_id,
+        deltas: vec![mismatched_delta],
+        flags: 0,
+        sequence: 3,
+        ts_event: 3.into(),
+        ts_init: 3.into(),
+    };
+
+    book.apply_deltas_unchecked(&mismatched_deltas).unwrap();
+
+    assert_eq!(book.best_ask_price(), Some(Price::from("100.50")));
+    assert_eq!(book.update_count, 3);
+}
+
+#[rstest]
 fn test_apply_delta_skips_update_delete_when_order_not_found() {
     let instrument_id = InstrumentId::from("AAPL.XNAS");
     let mut book = OrderBook::new(instrument_id, BookType::L3_MBO);

--- a/crates/serialization/tests/test_market_data_sbe.rs
+++ b/crates/serialization/tests/test_market_data_sbe.rs
@@ -148,9 +148,14 @@ fn test_order_book_deltas_roundtrip() {
 
 #[rstest]
 fn test_order_book_deltas_preserve_delta_instrument_ids() {
-    let value = OrderBookDeltas::new(
-        InstrumentId::from("AAPL.XNAS"),
-        vec![
+    // Built as a literal because `OrderBookDeltas::new` rejects children whose
+    // instrument ID differs from the wrapper's. The heterogeneity is the point
+    // here: SBE encodes each child's own ID, and this pins that it survives a
+    // round trip. Wrapper metadata matches what the constructor derives from
+    // the last child.
+    let value = OrderBookDeltas {
+        instrument_id: InstrumentId::from("AAPL.XNAS"),
+        deltas: vec![
             OrderBookDelta::new(
                 InstrumentId::from("AAPL.XNAS"),
                 BookAction::Add,
@@ -180,7 +185,11 @@ fn test_order_book_deltas_preserve_delta_instrument_ids() {
                 13.into(),
             ),
         ],
-    );
+        flags: 1,
+        sequence: 2,
+        ts_event: 12.into(),
+        ts_init: 13.into(),
+    };
 
     let bytes = value.to_sbe().unwrap();
     let decoded = OrderBookDeltas::from_sbe(&bytes).unwrap();

--- a/docs/concepts/data/order_book_deltas.md
+++ b/docs/concepts/data/order_book_deltas.md
@@ -17,6 +17,7 @@ It reduces per‑message overhead when an adapter receives or produces several c
 ## Behavior
 
 - The batch must contain at least one delta.
+- Every delta's `instrument_id` must match the batch `instrument_id`.
 - The batch metadata mirrors the final delta.
 - The final delta should carry `F_LAST` when it closes a logical event group.
 - Snapshot batches usually begin with a `CLEAR` delta and end with `F_SNAPSHOT | F_LAST`.


### PR DESCRIPTION
`OrderBookDeltas` pairs a wrapper `instrument_id` with children that each carry their own, and nothing requires the two to agree.

## Children are never checked against the wrapper

`OrderBookDeltas::new_checked` validates only that the vector is non-empty, then takes `flags`, `sequence`, `ts_event` and `ts_init` from the last child. `OrderBook::apply_deltas` compares the wrapper against the book and delegates to `apply_deltas_unchecked`, which applies each child through `apply_delta_unchecked`, so no child's instrument ID is compared to anything. The singular `apply_delta` does check its delta's ID before delegating; the batch path has no equivalent.

`new_checked` now rejects a batch whose children disagree with the wrapper. The comparison is pointer-first with a string-value fallback, because `InstrumentId` equality is `Ustr` pointer equality and that is the reason `apply_delta_unchecked` exists at all: the fallback compares `symbol` and `venue` as strings, so identifiers interned in different pools compare equal when their values match. Ordinary in-process data takes the pointer path and never evaluates the fallback.

No in-tree caller is affected, since every built-in assembler resolves one instrument and uses it for the wrapper and each child.

The check is not repeated in `apply_deltas`. A batch is constructed once and may be applied by several consumers, and application is the hot path. Construction is also not a complete boundary: the struct's fields are public, the Cap'n Proto and SBE decoders build it literally, and derived `Deserialize` bypasses it. This closes the ordinary construction route rather than making the type invariant-preserving.

## Testing

`test_order_book_deltas_new_checked_rejects_mismatched_instrument` covers a mismatched first child and a mismatched later child, so the whole vector is examined rather than its head; a homogeneous multi-child case is the control. Both rejection cases fail against the unfixed constructor.

`test_apply_deltas_does_not_validate_children_constructed_literally` builds the struct literally to bypass the constructor and pins what remains: `apply_deltas` returns `Ok` with the foreign child's level resting in the book, and `apply_deltas_unchecked` still applies one. It records the boundary rather than asserting a rollback that does not occur.

Two existing tests met the new contract in opposite ways. `test_order_book_deltas_single_delta` paired a `BTCUSD.CRYPTO` wrapper with a `EURUSD.SIM` fixture child while asserting only metadata propagation, and now takes its wrapper from the child. The SBE round-trip fixture `test_order_book_deltas_preserve_delta_instrument_ids` is heterogeneous on purpose, since it exists to prove each child's ID is encoded independently, so it constructs its value literally and preserves that coverage; the encoded input is unchanged.
