### PR TITLE
Isolate registry verifier tests from fork metadata

### DIFF
--- a/scripts/ci/test-verify-published-registries-crates.bash
+++ b/scripts/ci/test-verify-published-registries-crates.bash
@@ -310,6 +310,7 @@ run_verifier() {
     env \
       PATH="${mock_bin}:${PATH}" \
       TAG_NAME=v1.2.3 \
+      GITHUB_REPOSITORY=nautechsystems/nautilus_trader \
       GITHUB_SHA=abc123 \
       REGISTRY_PROPAGATION_TIMEOUT_SECONDS=1 \
       REGISTRY_PROPAGATION_POLL_SECONDS=1 \


### PR DESCRIPTION
- [x] This is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed CONTRIBUTING.md and AI_POLICY.md
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed
- [x] I ran all relevant tests locally and described the broader-suite limitation below
- [x] I have not modified `RELEASES.md`

## Summary

Pin the official repository identity inside the published-registry test fixture so GitHub Actions running in a fork cannot leak its `GITHUB_REPOSITORY` value into the fixture. This keeps the fixed crates.io and PyPI publisher data internally consistent while leaving production provenance verification unchanged.

## Related issues/PRs

None.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [ ] Documentation changes follow the style guide (not applicable; no documentation changed)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` (not applicable)

## Testing

- [x] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Validated locally with:

- `bash -n scripts/ci/test-verify-published-registries-crates.bash`
- the registry test under both fork and official `GITHUB_REPOSITORY` values
- file-scoped `shfmt`, `shellcheck`, trailing-whitespace, and diff checks
- the remaining release-verification script tests after the unrelated failure described below

Full `make test-scripts` on macOS stops before this test in the unchanged `test-publish-wheels.bash` orphan-deletion assertion (`Failed orphan deletion left a stale index link`). The affected registry test passes independently. Full `make format` and `make pre-commit` were not run locally because of local resource constraints; the file-scoped hooks relevant to this Bash-only change passed.