### PR TITLE
Add sum iterator trait to Quantity

### DIFF
--- a/crates/model/src/types/quantity.rs
+++ b/crates/model/src/types/quantity.rs
@@ -43,6 +43,7 @@ use std::{
     cmp::Ordering,
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
+    iter::Sum,
     ops::{Add, Deref, Div, Mul, Sub},
     str::FromStr,
 };
@@ -707,6 +708,18 @@ impl Add for Quantity {
     }
 }
 
+impl Sum for Quantity {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::from(0), |acc, x| acc + x)
+    }
+}
+
+impl<'a> Sum<&'a Self> for Quantity {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::from(0), |acc, x| acc + *x)
+    }
+}
+
 impl Sub for Quantity {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
@@ -996,6 +1009,45 @@ mod tests {
         let result = q1 + q2;
         assert_eq!(result.precision, 2);
         assert_eq!(result.as_f64(), 2.0);
+    }
+
+    #[rstest]
+    fn test_sum_owned_quantities() {
+        let quantities = [Quantity::new(1.25, 2), Quantity::new(2.75, 2)];
+        let result: Quantity = quantities.into_iter().sum();
+
+        assert_eq!(result.as_decimal(), dec!(4.00));
+        assert_eq!(result.precision, 2);
+    }
+
+    #[rstest]
+    fn test_sum_borrowed_quantities() {
+        let quantities = [Quantity::new(0.125, 3), Quantity::new(0.375, 3)];
+        let result: Quantity = quantities.iter().sum();
+
+        assert_eq!(result.as_decimal(), dec!(0.500));
+        assert_eq!(result.precision, 3);
+    }
+
+    #[rstest]
+    fn test_sum_mixed_precision_quantities() {
+        let quantities = [
+            Quantity::new(1.2, 1),
+            Quantity::new(3.45, 2),
+            Quantity::new(0.006, 3),
+        ];
+        let result: Quantity = quantities.into_iter().sum();
+
+        assert_eq!(result.as_decimal(), dec!(4.656));
+        assert_eq!(result.precision, 3);
+    }
+
+    #[rstest]
+    fn test_sum_empty_quantity_iterator() {
+        let result: Quantity = std::iter::empty::<Quantity>().sum();
+
+        assert_eq!(result.as_decimal(), dec!(0));
+        assert_eq!(result.precision, 0);
     }
 
     #[rstest]


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

Complete the `Quantity` iterator summation started in
[PR #4677](https://github.com/nautechsystems/nautilus_trader/pull/4677) by @sbOogway. Owned and
borrowed iterators now use the existing `Quantity` addition behavior, including checked raw
addition and maximum operand precision.

### Summation flow

```mermaid
flowchart LR
    Owned["Owned quantities"] --> SumOwned["Sum for Quantity"]
    Borrowed["Borrowed quantities"] --> SumBorrowed["Sum for quantity references"]
    Empty["Empty iterator"] --> Fold["Fold from zero"]
    SumOwned --> Fold
    SumBorrowed --> Fold
    Fold --> Add["Quantity addition"]
    Add --> Result["Raw total with maximum precision"]
```

### Changes

- Implement `Sum<Quantity>` and `Sum<&Quantity>` beside the existing `Add` implementation.
- Preserve mixed-precision behavior by folding through `Quantity::add`.
- Preserve the empty iterator result as zero with precision `0`.
- Add exact tests for owned, borrowed, mixed-precision, and empty iterators.
- Apply the required Rust import formatting.

### Verification

- `cargo test --locked -p nautilus-model --lib test_sum` passed: 4 tests.
- `make pre-commit` passed every hook, including Rust formatting, Clippy, docs, and cargo machete.
- `git diff --check` passed.

Supersedes #4677.
