### PR TITLE
Bound nesting depth in the synthetic formula parser

### DIFF
--- a/crates/model/src/expressions/error.rs
+++ b/crates/model/src/expressions/error.rs
@@ -71,6 +71,10 @@ pub(crate) enum ExpressionError {
     InputCountMismatch { expected: usize, actual: usize },
     #[error("Expression requires {depth} stack slots, maximum is {max}")]
     StackOverflow { depth: usize, max: usize },
+    #[error(
+        "Expression nesting depth {depth} exceeds maximum {max} (the top-level expression counts as one level)"
+    )]
+    ExpressionDepthExceeded { depth: usize, max: usize },
     #[error("Expression defines {count} local variables, maximum is {max}")]
     TooManyLocals { count: usize, max: usize },
     #[error("Expression result is empty")]

--- a/crates/model/src/expressions/parser.rs
+++ b/crates/model/src/expressions/parser.rs
@@ -19,6 +19,21 @@ use super::{
     lexer::{Token, TokenKind},
 };
 
+/// Maximum syntax nesting and constructed AST depth accepted by the parser,
+/// counting the top-level expression as one level.
+///
+/// Bounds both the parser's own recursion (parentheses, prefix operators,
+/// right-associative `^`, call arguments) and the depth of the tree it
+/// constructs (a left-associated operator chain builds an O(n)-deep tree with
+/// O(1) parser recursion), so parsing, `compile_expr`, and drop glue all stay
+/// within a fixed stack budget. On a 2 MiB thread in debug builds the walks
+/// overflow at depths of roughly 300 (nested parentheses and prefix chains),
+/// 400 (compiling and dropping a left-associated chain), and 1200 (a
+/// right-associative chain); release builds clear depth 1024 on every walk.
+/// 128 keeps better than a 2x margin below the lowest of those cliffs. The
+/// documented eight-component weighted sum has depth 9.
+const MAX_EXPRESSION_DEPTH: usize = 128;
+
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct Program {
     pub statements: Vec<Statement>,
@@ -76,6 +91,11 @@ pub(super) enum BinaryOp {
     Or,
 }
 
+struct ParsedExpr {
+    expr: Expr,
+    depth: usize,
+}
+
 pub(super) fn parse(tokens: &[Token]) -> Result<Program> {
     Parser::new(tokens).parse_program()
 }
@@ -131,15 +151,15 @@ impl<'a> Parser<'a> {
             self.advance();
             self.advance();
 
-            let expr = self.parse_expression(0)?;
+            let expr = self.parse_expression(0, 1)?.expr;
             return Ok(Statement::Assign { name, expr });
         }
 
-        Ok(Statement::Expr(self.parse_expression(0)?))
+        Ok(Statement::Expr(self.parse_expression(0, 1)?.expr))
     }
 
-    fn parse_expression(&mut self, min_precedence: u8) -> Result<Expr> {
-        let mut expr = self.parse_prefix()?;
+    fn parse_expression(&mut self, min_precedence: u8, syntax_depth: usize) -> Result<ParsedExpr> {
+        let mut parsed = self.parse_prefix(syntax_depth)?;
 
         while let Some((op, precedence, right_associative)) = self.current_binary_op() {
             if precedence < min_precedence {
@@ -152,61 +172,100 @@ impl<'a> Parser<'a> {
             } else {
                 precedence + 1
             };
-            let right = self.parse_expression(next_min_precedence)?;
-            expr = Expr::Binary {
-                left: Box::new(expr),
-                op,
-                right: Box::new(right),
+            let child_syntax_depth = Self::next_syntax_depth(syntax_depth)?;
+            let right = self.parse_expression(next_min_precedence, child_syntax_depth)?;
+            let depth = Self::parent_depth(parsed.depth.max(right.depth))?;
+            parsed = ParsedExpr {
+                expr: Expr::Binary {
+                    left: Box::new(parsed.expr),
+                    op,
+                    right: Box::new(right.expr),
+                },
+                depth,
             };
         }
 
-        Ok(expr)
+        Ok(parsed)
     }
 
-    fn parse_prefix(&mut self) -> Result<Expr> {
+    fn parse_prefix(&mut self, syntax_depth: usize) -> Result<ParsedExpr> {
         let token = self.current().clone();
         match token.kind {
             TokenKind::Number(value) => {
                 self.advance();
-                Ok(Expr::Number(value))
+                Ok(ParsedExpr {
+                    expr: Expr::Number(value),
+                    depth: 1,
+                })
             }
             TokenKind::Bool(value) => {
                 self.advance();
-                Ok(Expr::Bool(value))
+                Ok(ParsedExpr {
+                    expr: Expr::Bool(value),
+                    depth: 1,
+                })
             }
             TokenKind::Binding(slot) => {
                 self.advance();
-                Ok(Expr::Input(slot))
+                Ok(ParsedExpr {
+                    expr: Expr::Input(slot),
+                    depth: 1,
+                })
             }
             TokenKind::Ident(name) => {
                 self.advance();
 
                 if matches!(self.current().kind, TokenKind::LeftParen) {
                     self.advance();
-                    let args = self.parse_call_args()?;
-                    Ok(Expr::Call { name, args })
+                    let child_depth = Self::next_syntax_depth(syntax_depth)?;
+                    let args = self.parse_call_args(child_depth)?;
+                    let max_arg_depth = args.iter().map(|arg| arg.depth).max().unwrap_or(0);
+                    let depth = Self::parent_depth(max_arg_depth)?;
+                    Ok(ParsedExpr {
+                        expr: Expr::Call {
+                            name,
+                            args: args.into_iter().map(|arg| arg.expr).collect(),
+                        },
+                        depth,
+                    })
                 } else {
-                    Ok(Expr::Name(name))
+                    Ok(ParsedExpr {
+                        expr: Expr::Name(name),
+                        depth: 1,
+                    })
                 }
             }
             TokenKind::LeftParen => {
                 self.advance();
-                let expr = self.parse_expression(0)?;
+                let depth = Self::next_syntax_depth(syntax_depth)?;
+                let expr = self.parse_expression(0, depth)?;
                 self.expect_right_paren(token.position)?;
                 Ok(expr)
             }
             TokenKind::Minus => {
                 self.advance();
-                Ok(Expr::Unary {
-                    op: UnaryOp::Neg,
-                    expr: Box::new(self.parse_expression(7)?),
+                let syntax_depth = Self::next_syntax_depth(syntax_depth)?;
+                let child = self.parse_expression(7, syntax_depth)?;
+                let depth = Self::parent_depth(child.depth)?;
+                Ok(ParsedExpr {
+                    expr: Expr::Unary {
+                        op: UnaryOp::Neg,
+                        expr: Box::new(child.expr),
+                    },
+                    depth,
                 })
             }
             TokenKind::Bang => {
                 self.advance();
-                Ok(Expr::Unary {
-                    op: UnaryOp::Not,
-                    expr: Box::new(self.parse_expression(7)?),
+                let syntax_depth = Self::next_syntax_depth(syntax_depth)?;
+                let child = self.parse_expression(7, syntax_depth)?;
+                let depth = Self::parent_depth(child.depth)?;
+                Ok(ParsedExpr {
+                    expr: Expr::Unary {
+                        op: UnaryOp::Not,
+                        expr: Box::new(child.expr),
+                    },
+                    depth,
                 })
             }
             _ => Err(ExpressionError::UnexpectedToken {
@@ -217,7 +276,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_call_args(&mut self) -> Result<Vec<Expr>> {
+    fn parse_call_args(&mut self, syntax_depth: usize) -> Result<Vec<ParsedExpr>> {
         let mut args = Vec::new();
 
         if matches!(self.current().kind, TokenKind::RightParen) {
@@ -226,7 +285,7 @@ impl<'a> Parser<'a> {
         }
 
         loop {
-            args.push(self.parse_expression(0)?);
+            args.push(self.parse_expression(0, syntax_depth)?);
 
             match self.current().kind {
                 TokenKind::Comma => {
@@ -245,6 +304,22 @@ impl<'a> Parser<'a> {
                     });
                 }
             }
+        }
+    }
+
+    fn next_syntax_depth(depth: usize) -> Result<usize> {
+        Self::parent_depth(depth)
+    }
+
+    fn parent_depth(child_depth: usize) -> Result<usize> {
+        let depth = child_depth + 1;
+        if depth > MAX_EXPRESSION_DEPTH {
+            Err(ExpressionError::ExpressionDepthExceeded {
+                depth,
+                max: MAX_EXPRESSION_DEPTH,
+            })
+        } else {
+            Ok(depth)
         }
     }
 
@@ -309,10 +384,12 @@ impl<'a> Parser<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::thread;
+
     use rstest::rstest;
 
     use super::*;
-    use crate::expressions::{Bindings, lexer::tokenize};
+    use crate::expressions::{Bindings, eval, lexer::tokenize};
 
     fn parse_program(source: &str, bindings: &Bindings) -> Program {
         let tokens = tokenize(source, bindings).unwrap();
@@ -420,5 +497,112 @@ mod tests {
         let error = parse(&tokens).unwrap_err();
 
         assert_eq!(error, ExpressionError::MissingClosingParen { position: 0 });
+    }
+
+    #[rstest]
+    fn test_expression_depth_limit_on_constrained_stack() {
+        thread::Builder::new()
+            .stack_size(2 * 1024 * 1024)
+            .spawn(|| {
+                let bindings = Bindings::new();
+
+                let parens = format!(
+                    "{}1{}",
+                    "(".repeat(MAX_EXPRESSION_DEPTH - 1),
+                    ")".repeat(MAX_EXPRESSION_DEPTH - 1)
+                );
+                drop(parse_program(&parens, &bindings));
+
+                let prefixes = format!("{}1", "-".repeat(MAX_EXPRESSION_DEPTH - 1));
+                let prefix_tokens = tokenize(&prefixes, &bindings).unwrap();
+                let prefix_program = parse(&prefix_tokens).unwrap();
+                drop(prefix_program);
+
+                let spine = std::iter::repeat_n("1", MAX_EXPRESSION_DEPTH)
+                    .collect::<Vec<_>>()
+                    .join(" + ");
+                let spine_tokens = tokenize(&spine, &bindings).unwrap();
+                let spine_program = parse(&spine_tokens).unwrap();
+                let compiled = eval::compile(&spine_program, &bindings).unwrap();
+                drop(compiled);
+                drop(spine_program);
+
+                let drop_tokens = tokenize(&spine, &bindings).unwrap();
+                let drop_program = parse(&drop_tokens).unwrap();
+                drop(drop_program);
+
+                let right_spine = std::iter::repeat_n("2", MAX_EXPRESSION_DEPTH)
+                    .collect::<Vec<_>>()
+                    .join(" ^ ");
+                let right_tokens = tokenize(&right_spine, &bindings).unwrap();
+                let right_program = parse(&right_tokens).unwrap();
+                drop(right_program);
+
+                let excessive_spine = format!("{spine} + 1");
+                let excessive_tokens = tokenize(&excessive_spine, &bindings).unwrap();
+                assert_eq!(
+                    parse(&excessive_tokens).unwrap_err(),
+                    ExpressionError::ExpressionDepthExceeded {
+                        depth: MAX_EXPRESSION_DEPTH + 1,
+                        max: MAX_EXPRESSION_DEPTH,
+                    }
+                );
+
+                let excessive_right_spine = format!("{right_spine} ^ 2");
+                let excessive_tokens = tokenize(&excessive_right_spine, &bindings).unwrap();
+                assert_eq!(
+                    parse(&excessive_tokens).unwrap_err(),
+                    ExpressionError::ExpressionDepthExceeded {
+                        depth: MAX_EXPRESSION_DEPTH + 1,
+                        max: MAX_EXPRESSION_DEPTH,
+                    }
+                );
+
+                let excessive_parens = format!(
+                    "{}1{}",
+                    "(".repeat(MAX_EXPRESSION_DEPTH),
+                    ")".repeat(MAX_EXPRESSION_DEPTH)
+                );
+                let excessive_tokens = tokenize(&excessive_parens, &bindings).unwrap();
+                assert_eq!(
+                    parse(&excessive_tokens).unwrap_err(),
+                    ExpressionError::ExpressionDepthExceeded {
+                        depth: MAX_EXPRESSION_DEPTH + 1,
+                        max: MAX_EXPRESSION_DEPTH,
+                    }
+                );
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    #[rstest]
+    fn test_deep_expression_returns_error_without_crashing_process() {
+        thread::Builder::new()
+            .stack_size(2 * 1024 * 1024)
+            .spawn(|| {
+                let bindings = Bindings::new();
+                let source = format!("{}1", "-".repeat(10_000));
+                let tokens = tokenize(&source, &bindings).unwrap();
+
+                assert!(matches!(
+                    parse(&tokens),
+                    Err(ExpressionError::ExpressionDepthExceeded { .. })
+                ));
+
+                let source = std::iter::repeat_n("2", 10_000)
+                    .collect::<Vec<_>>()
+                    .join(" ^ ");
+                let tokens = tokenize(&source, &bindings).unwrap();
+
+                assert!(matches!(
+                    parse(&tokens),
+                    Err(ExpressionError::ExpressionDepthExceeded { .. })
+                ));
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 }

--- a/crates/model/src/expressions/parser.rs
+++ b/crates/model/src/expressions/parser.rs
@@ -538,6 +538,19 @@ mod tests {
                 let right_program = parse(&right_tokens).unwrap();
                 drop(right_program);
 
+                // A call nests both the syntax depth and the argument's own depth, so
+                // `MAX_EXPRESSION_DEPTH - 1` nested calls sit exactly at the limit.
+                let calls = format!(
+                    "{}1{}",
+                    "abs(".repeat(MAX_EXPRESSION_DEPTH - 1),
+                    ")".repeat(MAX_EXPRESSION_DEPTH - 1)
+                );
+                let call_tokens = tokenize(&calls, &bindings).unwrap();
+                let call_program = parse(&call_tokens).unwrap();
+                let call_compiled = eval::compile(&call_program, &bindings).unwrap();
+                drop(call_compiled);
+                drop(call_program);
+
                 let excessive_spine = format!("{spine} + 1");
                 let excessive_tokens = tokenize(&excessive_spine, &bindings).unwrap();
                 assert_eq!(
@@ -564,6 +577,20 @@ mod tests {
                     ")".repeat(MAX_EXPRESSION_DEPTH)
                 );
                 let excessive_tokens = tokenize(&excessive_parens, &bindings).unwrap();
+                assert_eq!(
+                    parse(&excessive_tokens).unwrap_err(),
+                    ExpressionError::ExpressionDepthExceeded {
+                        depth: MAX_EXPRESSION_DEPTH + 1,
+                        max: MAX_EXPRESSION_DEPTH,
+                    }
+                );
+
+                let excessive_calls = format!(
+                    "{}1{}",
+                    "abs(".repeat(MAX_EXPRESSION_DEPTH),
+                    ")".repeat(MAX_EXPRESSION_DEPTH)
+                );
+                let excessive_tokens = tokenize(&excessive_calls, &bindings).unwrap();
                 assert_eq!(
                     parse(&excessive_tokens).unwrap_err(),
                     ExpressionError::ExpressionDepthExceeded {

--- a/crates/model/src/instruments/synthetic.rs
+++ b/crates/model/src/instruments/synthetic.rs
@@ -544,6 +544,32 @@ mod tests {
     }
 
     #[rstest]
+    fn test_new_checked_rejects_excessive_expression_depth() {
+        let formula = std::iter::repeat_n("1", 129)
+            .collect::<Vec<_>>()
+            .join(" + ");
+
+        let error = SyntheticInstrument::new_checked(
+            Symbol::from("DEEP"),
+            2,
+            Vec::new(),
+            &formula,
+            0.into(),
+            0.into(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            &error,
+            SyntheticInstrumentError::Expression { .. }
+        ));
+        assert_eq!(
+            error.to_string(),
+            "Expression nesting depth 129 exceeds maximum 128 (the top-level expression counts as one level)"
+        );
+    }
+
+    #[rstest]
     fn test_new_checked_rejects_invalid_precision_with_validation_error() {
         let components = vec![
             InstrumentId::from_str("BTC.BINANCE").unwrap(),

--- a/docs/concepts/synthetics.md
+++ b/docs/concepts/synthetics.md
@@ -92,10 +92,10 @@ statement the value you want the synthetic to produce.
 The expression engine enforces the following compile-time limits. Formulas that exceed them
 produce a clear error at construction time.
 
-| Limit           | Value | Description                                                    |
-| --------------- | ----- | -------------------------------------------------------------- |
-| Stack depth     | 32    | Maximum number of intermediate values on the evaluation stack. |
-| Local variables | 16    | Maximum number of distinct local variable names.               |
+| Limit           | Value | Description                                                                                     |
+| --------------- | ----- | ----------------------------------------------------------------------------------------------- |
+| Stack depth     | 32    | Maximum number of intermediate values on the evaluation stack.                                  |
+| Local variables | 16    | Maximum number of distinct local variable names.                                                |
 | Nesting depth   | 128   | Maximum syntax nesting and expression tree depth; the top‑level expression counts as one level. |
 
 A weighted sum of 8 components uses a peak stack depth of 3 and zero locals. A weighted sum of

--- a/docs/concepts/synthetics.md
+++ b/docs/concepts/synthetics.md
@@ -96,9 +96,11 @@ produce a clear error at construction time.
 | --------------- | ----- | -------------------------------------------------------------- |
 | Stack depth     | 32    | Maximum number of intermediate values on the evaluation stack. |
 | Local variables | 16    | Maximum number of distinct local variable names.               |
+| Nesting depth   | 128   | Maximum syntax nesting and expression tree depth; the top‑level expression counts as one level. |
 
-These limits are generous for any realistic pricing formula. A weighted sum of 8 components
-uses a peak stack depth of 3 and zero locals.
+A weighted sum of 8 components uses a peak stack depth of 3 and zero locals. A weighted sum of
+N components builds a tree of depth N + 1, so the nesting depth limit caps a weighted sum at
+127 components.
 
 ### Examples
 


### PR DESCRIPTION
The synthetic-instrument formula language enforces two compile-time resource limits, an evaluation-stack depth of 32 and 16 local variables, but nothing bounds how deeply a formula may nest.

## Unbounded recursion in the parser

`parse_prefix` in `crates/model/src/expressions/parser.rs` recurses into `parse_expression` for parentheses, both prefix operators and call arguments, and `parse_expression` recurses for right-associative `^`. None of those sites tracked depth, so a sufficiently nested formula consumes more call-stack budget than the thread has and ends the process rather than returning the typed error every other malformed formula produces. The existing `MAX_STACK` check cannot cover this: it bounds the compiled VM's operand stack and is evaluated in `compile` after the recursive walk has already run.

Parser recursion depth and tree depth are separate quantities and both need bounding. `((((1))))` recurses deeply but yields a single leaf, while `1 + 1 + 1 + ...` is assembled by the loop in `parse_expression` with O(1) recursion into an O(n)-deep left-associated tree, which is then walked recursively by `compile_expr` and by drop glue, and which passes `MAX_STACK` because a left spine needs about two operand slots.

The parser now carries each subtree's depth in its parse result and threads a syntax-nesting depth through the recursive calls, checking both against `MAX_EXPRESSION_DEPTH = 128` before constructing each parent node, so no over-limit tree is ever built and an error path never owns one. Exceeding it returns `ExpressionDepthExceeded { depth, max }`; the top-level expression counts as one level, so 127 nested parentheses are accepted. The limit is empirical: on a 2 MiB thread in debug builds the walks fail at roughly 300 for parentheses and prefix chains, 400 for compiling and dropping a left-associated chain, and 1200 for a right-associative chain, with release clearing 1024 on every walk, so 128 holds better than a 2x margin below the lowest. A weighted sum of N components builds a tree of depth N + 1, which caps such a formula at 127 components.

The `### Limits` table in `docs/concepts/synthetics.md` gains a row. The sentence claiming the limits are "generous for any realistic pricing formula" is removed, since an eight-component example does not establish what realistic formulas require and the table now states a component ceiling.

## Testing

`test_expression_depth_limit_on_constrained_stack` parses, compiles and drops each shape at exactly the limit and asserts rejection one level past it, covering nested parentheses, a prefix chain, a left-associated spine and a right-associative `^` chain. `test_deep_expression_returns_error_without_crashing_process` submits 10,000-deep prefix and `^` inputs. `test_new_checked_rejects_excessive_expression_depth` covers the public `SyntheticInstrument` path. Both parser tests run on an explicitly sized 2 MiB thread so the bound is exercised against a known stack budget rather than the harness default.

The new assertions fail against the unmodified parser: the boundary cases parse successfully and `unwrap_err` panics, and the 10,000-deep inputs exhaust the child thread instead of returning the error.
