### PR TITLE
Expose the risk engine's price sanity check

### DIFF
--- a/crates/risk/src/engine/mod.rs
+++ b/crates/risk/src/engine/mod.rs
@@ -1914,7 +1914,15 @@ impl RiskEngine {
         );
     }
 
-    fn check_price(instrument: &InstrumentAny, price: Option<Price>) -> Option<String> {
+    /// Checks `price` against `instrument`, returning a reason when it is invalid.
+    ///
+    /// Returns `None` when `price` is absent or passes these checks, or a human-readable
+    /// reason when it does not. A `None` result is not a statement that the order is
+    /// valid: only decimal precision against the instrument's `price_precision`, and a
+    /// non-positive price where the instrument disallows one, are checked here. Venue
+    /// increment rules, notional bounds, and account state are not.
+    #[must_use]
+    pub fn check_price(instrument: &InstrumentAny, price: Option<Price>) -> Option<String> {
         let price_val = price?;
 
         if price_val.precision > instrument.price_precision() {
@@ -1950,7 +1958,8 @@ impl RiskEngine {
             ));
         }
 
-        // Skip min/max checks for quote quantities (they will be checked in check_orders_risk using effective_quantity)
+        // Base-quantity bounds do not apply to quote-denominated orders and are not
+        // re-checked later. Applicable notional limits are checked during account risk.
         if is_quote_quantity {
             return None;
         }

--- a/crates/risk/tests/risk_engine.rs
+++ b/crates/risk/tests/risk_engine.rs
@@ -8377,3 +8377,32 @@ fn test_submit_sell_cash_account_with_long_position_reduces_then_passes(
         get_execute_order_event_handler_messages(&execute_order_event_handler);
     assert_eq!(saved_execute_messages.len(), 1);
 }
+
+#[rstest]
+fn test_check_price_accepts_a_valid_price(instrument_audusd: InstrumentAny) {
+    assert_eq!(
+        RiskEngine::check_price(&instrument_audusd, Some(Price::from("0.75000"))),
+        None
+    );
+}
+
+#[rstest]
+fn test_check_price_accepts_no_price(instrument_audusd: InstrumentAny) {
+    assert_eq!(RiskEngine::check_price(&instrument_audusd, None), None);
+}
+
+#[rstest]
+fn test_check_price_rejects_excess_precision(instrument_audusd: InstrumentAny) {
+    let reason = RiskEngine::check_price(&instrument_audusd, Some(Price::from("0.750000")))
+        .expect("a price with more precision than the instrument must be rejected");
+
+    assert!(reason.contains("precision 6 > 5"), "{reason}");
+}
+
+#[rstest]
+fn test_check_price_rejects_non_positive_price(instrument_audusd: InstrumentAny) {
+    let reason = RiskEngine::check_price(&instrument_audusd, Some(Price::from("0.00000")))
+        .expect("a non-positive price must be rejected where the instrument disallows one");
+
+    assert!(reason.contains("<= 0"), "{reason}");
+}


### PR DESCRIPTION
`RiskEngine::check_price` is a side-effect-free instrument-level check that callers outside the crate cannot reach.

## Making the price check callable

`check_price` is an associated function taking only an `InstrumentAny` and an `Option<Price>`, reading `price_precision` and `allows_negative_price` and returning a reason or `None`. It touches no config, cache, clock, portfolio or account state, and emits nothing. This PR makes it `pub`.

This exposes the existing rule so Rust callers that intentionally route orders directly to execution can apply exactly the same pre-trade check without duplicating policy or emitting denial events. There is no in-tree caller for it.

The rustdoc states what a `None` result does not mean: only decimal precision and the non-positive case are checked, and venue increment rules, notional bounds, and account state are not. One consequence to note is that the human-readable reason becomes public surface, so its wording is harder to change afterwards.

## Correcting a comment in `check_quantity`

Separately, its comment said the skipped `min_quantity`/`max_quantity` bounds "will be checked in `check_orders_risk` using `effective_quantity`". They are not - `check_orders_risk_for_account` guards the same comparisons with `if !order.is_quote_quantity()` and skips them for the same reason. The behaviour is deliberate and unchanged; only the comment described a second check that does not exist. I bundled that here rather than as a separate PR. Let me know if that was a mistake.

## Testing

Four tests in `crates/risk/tests/risk_engine.rs`, which call the function from outside the crate - the surface being exposed. They cover an absent price, a valid price, an excess-precision rejection, and a non-positive rejection where the instrument disallows one, matching the function's four control-flow outcomes. No behaviour changed, so there is no differential claim to make: they pin the newly public contract rather than a fix.
