### PR TITLE
Reserve nothing for a buy at a negative price

### DIFF
--- a/crates/model/src/accounts/base.rs
+++ b/crates/model/src/accounts/base.rs
@@ -25,6 +25,7 @@ use nautilus_core::{
     correctness::{FAILED, check_equal},
     datetime::secs_to_nanos_unchecked,
 };
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -271,9 +272,13 @@ impl BaseAccount {
             .unwrap_or(instrument.quote_currency());
         let quote_currency = instrument.quote_currency();
         let amount = match side {
+            // A buy at a negative price settles as a credit rather than a debit, so it
+            // reserves nothing. Clamping per order rather than after aggregation keeps a
+            // negative-price buy from financing a positive-price one before either fills.
             OrderSide::Buy => instrument
                 .try_calculate_notional_value(quantity, price, use_quote_for_inverse)?
-                .as_decimal(),
+                .as_decimal()
+                .max(Decimal::ZERO),
             OrderSide::Sell => quantity.as_decimal(),
             OrderSide::NoOrderSide => {
                 anyhow::bail!("Invalid `OrderSide` in `base_calculate_balance_locked`: {side}")

--- a/crates/model/src/accounts/cash.rs
+++ b/crates/model/src/accounts/cash.rs
@@ -381,8 +381,8 @@ mod tests {
         events::{AccountState, account::stubs::*},
         identifiers::{AccountId, InstrumentId, position_id::PositionId, stubs::uuid4},
         instruments::{
-            CryptoFuture, CryptoPerpetual, CurrencyPair, Equity, Instrument, InstrumentAny,
-            stubs::*,
+            Commodity, CryptoFuture, CryptoPerpetual, CurrencyPair, Equity, Instrument,
+            InstrumentAny, stubs::*,
         },
         orders::{builder::OrderTestBuilder, stubs::TestOrderEventStubs},
         position::Position,
@@ -395,6 +395,53 @@ mod tests {
             format!("{cash_account}"),
             "CashAccount(id=SIM-001, type=CASH, base=USD)"
         );
+    }
+
+    #[rstest]
+    fn test_calculate_balance_locked_buy_at_negative_price_reserves_nothing(
+        mut cash_account: CashAccount,
+        commodity_gold: Commodity,
+    ) {
+        let instrument = InstrumentAny::Commodity(commodity_gold);
+        assert!(
+            instrument.allows_negative_price(),
+            "fixture must admit a negative price for this case to arise"
+        );
+
+        let locked = cash_account
+            .calculate_balance_locked(
+                &instrument,
+                OrderSide::Buy,
+                Quantity::from("1"),
+                Price::from("-10.00"),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(locked, Money::from("0.00 USD"));
+
+        // Storing it must not trip the non-negative invariant in `update_balance_locked`.
+        cash_account.update_balance_locked(instrument.id(), locked);
+    }
+
+    #[rstest]
+    fn test_calculate_balance_locked_buy_at_positive_price_reserves_the_notional(
+        mut cash_account: CashAccount,
+        commodity_gold: Commodity,
+    ) {
+        let instrument = InstrumentAny::Commodity(commodity_gold);
+
+        let locked = cash_account
+            .calculate_balance_locked(
+                &instrument,
+                OrderSide::Buy,
+                Quantity::from("1"),
+                Price::from("10.00"),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(locked, Money::from("10.00 USD"));
     }
 
     #[rstest]


### PR DESCRIPTION
The risk engine admits a negative price for instruments that allow one, and the portfolio's locked-balance recalculation then aborts the process on the result.

## A negative-price buy computes a negative reservation

`Commodity::allows_negative_price` returns `true` - spot commodities such as electricity or oil do trade negative - so `RiskEngine::check_price`, which rejects a non-positive price only when the instrument disallows it, accepts the order and it becomes open. When the accepted event reaches `Portfolio::update_order`, a cash account dispatches to `update_balance_locked`, which walks the open orders and calls `base_calculate_balance_locked` for each. Its `OrderSide::Buy` arm reserves `try_calculate_notional_value(quantity, price, ..)`, so a negative price yields a negative notional, and `CashAccount::update_balance_locked` opens with `assert!(locked.raw >= 0)`. Release builds use `panic = "abort"`, so this terminates the process. Sells are unaffected: their amount is the quantity, which is never negative.

A locked balance is cash that must stay unavailable so the order can settle. A buy at a negative price settles as a credit rather than a debit, so it needs no reservation, and reserving a negative amount would instead increase the free balance. The buy arm now clamps the notional to zero.

The clamp is per order rather than applied to the aggregate, so that a negative-price buy cannot finance a positive-price one before either fills - the reservation is `sum(max(debit, 0))`, not `max(sum(debit), 0)`.

The assertion in `update_balance_locked` is deliberately retained. A stored negative lock would corrupt free-balance semantics, so it remains useful as a last-line invariant against an internal caller; what changes is that the calculation no longer produces one. Admission continues to decide whether a price is legal, and the locked-balance calculation decides how much non-negative cash a legal order reserves.

Inverse instruments are unaffected either way: with `use_quote_for_inverse` false the valuation rejects a non-positive price before the clamp, and with it true the notional is quantity-denominated and already non-negative. `BettingAccount` has its own separate calculation. Portfolio margin accounting uses the separate margin-model path and is outside the scope of this fix.

## Testing

`test_calculate_balance_locked_buy_at_negative_price_reserves_nothing` asserts the fixture admits a negative price, calculates the lock for a buy at `-10.00`, asserts it is `0.00 USD`, and then passes it to `update_balance_locked` so the retained invariant is exercised rather than assumed. `test_calculate_balance_locked_buy_at_positive_price_reserves_the_notional` pins that an ordinary buy still reserves `10.00 USD`, so the clamp cannot silently swallow every reservation.

Against the unmodified calculation the first test fails with `left: -10.00, right: 0` in both the default and ffi sweeps. The assertion on the calculated value comes before the `update_balance_locked` call deliberately, so the old behaviour is reported as a failing assertion rather than aborting the test binary.
