### PR TITLE
Fix Hyperliquid historical candle timestamps

### DIFF
--- a/crates/adapters/hyperliquid/src/data.rs
+++ b/crates/adapters/hyperliquid/src/data.rs
@@ -66,7 +66,7 @@ use crate::{
     common::{
         consts::HYPERLIQUID_VENUE,
         credential::{Secrets, credential_env_vars},
-        parse::bar_type_to_interval,
+        parse::{bar_type_to_interval, millis_to_nanos},
     },
     config::HyperliquidDataClientConfig,
     data_types::register_hyperliquid_custom_data,
@@ -2009,8 +2009,12 @@ pub(crate) fn candle_to_bar(
     price_precision: u8,
     size_precision: u8,
 ) -> anyhow::Result<Bar> {
-    let ts_init = UnixNanos::from(candle.timestamp * 1_000_000);
-    let ts_event = ts_init;
+    let ts_event = millis_to_nanos(candle.timestamp)?;
+    let close_boundary = candle
+        .end_timestamp
+        .checked_add(1)
+        .context("candle close boundary overflow")?;
+    let ts_init = millis_to_nanos(close_boundary)?;
 
     let open = Price::from_decimal_dp(candle.open, price_precision)
         .map_err(|e| anyhow::anyhow!("invalid open price: {e}"))?;
@@ -2074,8 +2078,10 @@ async fn request_bars_from_http(
         .await
         .context("failed to fetch candle snapshot from Hyperliquid")?;
 
+    let now_ms = now.as_millisecond() as u64;
     let mut bars: Vec<Bar> = candles
         .iter()
+        .filter(|candle| candle.end_timestamp < now_ms)
         .filter_map(|candle| {
             candle_to_bar(candle, bar_type, price_precision, size_precision)
                 .map_err(|e| {
@@ -2116,6 +2122,50 @@ mod tests {
 
     fn btc_perp_id() -> InstrumentId {
         InstrumentId::from("BTC-PERP.HYPERLIQUID")
+    }
+
+    #[rstest]
+    fn test_candle_to_bar_uses_causal_initialization_timestamp() {
+        let candle = HyperliquidCandle {
+            timestamp: 1_700_000_000_000,
+            end_timestamp: 1_700_000_059_999,
+            open: dec!(100.0),
+            high: dec!(101.0),
+            low: dec!(99.0),
+            close: dec!(100.5),
+            volume: dec!(10.0),
+            num_trades: Some(42),
+        };
+        let bar_type = BarType::from("BTC-USD-PERP.HYPERLIQUID-1-MINUTE-LAST-EXTERNAL");
+
+        let bar = candle_to_bar(&candle, bar_type, 1, 1).unwrap();
+
+        assert_eq!(candle.end_timestamp - candle.timestamp, 59_999);
+        assert_eq!(bar.ts_event, millis_to_nanos(candle.timestamp).unwrap());
+        assert_eq!(
+            bar.ts_init,
+            millis_to_nanos(candle.end_timestamp + 1).unwrap()
+        );
+        assert!(bar.ts_init > bar.ts_event);
+    }
+
+    #[rstest]
+    fn test_candle_to_bar_rejects_close_boundary_overflow() {
+        let candle = HyperliquidCandle {
+            timestamp: 1_700_000_000_000,
+            end_timestamp: u64::MAX,
+            open: dec!(100.0),
+            high: dec!(101.0),
+            low: dec!(99.0),
+            close: dec!(100.5),
+            volume: dec!(10.0),
+            num_trades: Some(42),
+        };
+        let bar_type = BarType::from("BTC-USD-PERP.HYPERLIQUID-1-MINUTE-LAST-EXTERNAL");
+
+        let err = candle_to_bar(&candle, bar_type, 1, 1).unwrap_err();
+
+        assert!(err.to_string().contains("close boundary overflow"));
     }
 
     #[rstest]

--- a/crates/adapters/hyperliquid/src/http/models.rs
+++ b/crates/adapters/hyperliquid/src/http/models.rs
@@ -469,7 +469,7 @@ pub struct HyperliquidCandle {
     /// Candle start timestamp in milliseconds.
     #[serde(rename = "t")]
     pub timestamp: u64,
-    /// Candle end timestamp in milliseconds.
+    /// Candle end timestamp in milliseconds, inclusive.
     #[serde(rename = "T")]
     pub end_timestamp: u64,
     /// Open price.

--- a/crates/adapters/hyperliquid/src/websocket/parse.rs
+++ b/crates/adapters/hyperliquid/src/websocket/parse.rs
@@ -652,8 +652,8 @@ mod tests {
             },
         },
         websocket::messages::{
-            FillLiquidationData, PerpsAssetCtx, SharedAssetCtx, SpotAssetCtx, WsBasicOrderData,
-            WsBookData, WsLevelData,
+            CandleData, FillLiquidationData, PerpsAssetCtx, SharedAssetCtx, SpotAssetCtx,
+            WsBasicOrderData, WsBookData, WsLevelData,
         },
     };
 
@@ -688,6 +688,30 @@ mod tests {
             UnixNanos::default(),
             UnixNanos::default(),
         ))
+    }
+
+    #[rstest]
+    fn test_parse_ws_candle_preserves_open_event_and_receipt_initialization_timestamps() {
+        let instrument = create_test_instrument();
+        let bar_type = BarType::from("BTC-PERP.HYPERLIQUID-1-MINUTE-LAST-EXTERNAL");
+        let candle = CandleData {
+            t: 1_700_000_000_000,
+            close_time: 1_700_000_059_999,
+            s: Ustr::from("BTC"),
+            i: Ustr::from("1m"),
+            o: dec!(100.0),
+            c: dec!(100.5),
+            h: dec!(101.0),
+            l: dec!(99.0),
+            v: dec!(10.0),
+            n: 42,
+        };
+        let receipt_timestamp = UnixNanos::from(1_700_000_060_123_000_000);
+
+        let bar = parse_ws_candle(&candle, &instrument, &bar_type, receipt_timestamp).unwrap();
+
+        assert_eq!(bar.ts_event, millis_to_nanos(candle.t).unwrap());
+        assert_eq!(bar.ts_init, receipt_timestamp);
     }
 
     #[rstest]

--- a/crates/adapters/hyperliquid/tests/data_client.rs
+++ b/crates/adapters/hyperliquid/tests/data_client.rs
@@ -46,10 +46,10 @@ use nautilus_common::{
     messages::{
         DataEvent, DataResponse,
         data::{
-            RequestBookSnapshot, RequestCustomData, RequestFundingRates, RequestInstrument,
-            RequestInstruments, RequestTrades, SubscribeBookDeltas, SubscribeCustomData,
-            SubscribeMarkPrices, SubscribeQuotes, SubscribeTrades, UnsubscribeCustomData,
-            UnsubscribeMarkPrices,
+            RequestBars, RequestBookSnapshot, RequestCustomData, RequestFundingRates,
+            RequestInstrument, RequestInstruments, RequestTrades, SubscribeBookDeltas,
+            SubscribeCustomData, SubscribeMarkPrices, SubscribeQuotes, SubscribeTrades,
+            UnsubscribeCustomData, UnsubscribeMarkPrices,
         },
     },
     testing::wait_until_async,
@@ -72,7 +72,7 @@ use nautilus_hyperliquid::{
     },
 };
 use nautilus_model::{
-    data::{CustomData, Data, DataType},
+    data::{BarType, CustomData, Data, DataType},
     enums::BookType,
     identifiers::InstrumentId,
     instruments::Instrument,
@@ -254,18 +254,32 @@ async fn handle_info(State(state): State<TestServerState>, body: axum::body::Byt
             }
             Json(load_json("http_recent_trades_btc.json")).into_response()
         }
-        "candleSnapshot" => Json(json!([{
-            "t": 1703875200000u64,
-            "T": 1703875260000u64,
-            "s": "BTC",
-            "i": "1m",
-            "o": "98450.00",
-            "c": "98460.00",
-            "h": "98470.00",
-            "l": "98440.00",
-            "v": "100.5",
-            "n": 50
-        }]))
+        "candleSnapshot" => Json(json!([
+            {
+                "t": 1703875200000u64,
+                "T": 1703875259999u64,
+                "s": "BTC",
+                "i": "1m",
+                "o": "98450.00",
+                "c": "98460.00",
+                "h": "98470.00",
+                "l": "98440.00",
+                "v": "100.5",
+                "n": 50
+            },
+            {
+                "t": 4_102_444_800_000u64,
+                "T": 4_102_444_859_999u64,
+                "s": "BTC",
+                "i": "1m",
+                "o": "98460.00",
+                "c": "98470.00",
+                "h": "98480.00",
+                "l": "98450.00",
+                "v": "200.5",
+                "n": 60
+            }
+        ]))
         .into_response(),
         "clearinghouseState" => Json(json!({
             "marginSummary": {
@@ -2406,6 +2420,55 @@ async fn test_data_client_request_trades() {
             );
         }
         other => panic!("Expected Trades response, was: {other:?}"),
+    }
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_data_client_request_bars_filters_unfinished_candle() {
+    let state = TestServerState::default();
+    let addr = start_mock_server(state).await;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+    set_data_event_sender(tx);
+
+    let config = create_data_client_config(addr);
+    let mut client = HyperliquidDataClient::new(*HYPERLIQUID_CLIENT_ID, config).unwrap();
+    client.connect().await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    while rx.try_recv().is_ok() {}
+
+    let bar_type = BarType::from("BTC-USD-PERP.HYPERLIQUID-1-MINUTE-LAST-EXTERNAL");
+    let request = RequestBars::new(
+        bar_type,
+        None,
+        None,
+        None,
+        Some(*HYPERLIQUID_CLIENT_ID),
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+    );
+    client.request_bars(request).unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("timeout waiting for bars response")
+        .expect("channel closed");
+
+    match event {
+        DataEvent::Response(DataResponse::Bars(bars_response)) => {
+            assert_eq!(bars_response.bar_type, bar_type);
+            assert_eq!(bars_response.data.len(), 1);
+
+            let bar = bars_response.data[0];
+            assert_eq!(bar.ts_event, UnixNanos::from(1_703_875_200_000_000_000));
+            assert_eq!(bar.ts_init, UnixNanos::from(1_703_875_260_000_000_000));
+        }
+        other => panic!("Expected Bars response, was: {other:?}"),
     }
 
     client.disconnect().await.unwrap();


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed CONTRIBUTING.md and AI_POLICY.md
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally
- [x] I have not modified `RELEASES.md`

## Summary

Historical HTTP candle conversion now retains the venue's interval-open event timestamp while initializing completed bars at the causal close boundary (`T + 1 ms`). The data-client HTTP request path now excludes the current unfinished candle, matching the direct HTTP client behavior.

Focused regression coverage verifies HTTP timestamps, unchanged WebSocket receipt-time initialization, and data-client filtering.

## Related issues/PRs

Related to #4711.

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

N/A.

## Documentation

- [x] Documentation changes follow the style guide

## Testing

- [x] I added/updated tests to cover new or changed logic

Validated with `cargo +nightly fmt --all -- --check`, `cargo test -p nautilus-hyperliquid --lib --test data_client` (718 library and 39 integration tests), `cargo check`, and Clippy with warnings denied.
