### PR TITLE
Retain open Polymarket markets during auto-load

### DIFF
--- a/crates/adapters/polymarket/src/data/auto_load.rs
+++ b/crates/adapters/polymarket/src/data/auto_load.rs
@@ -25,10 +25,12 @@ use nautilus_model::{
 use super::{
     PolymarketDataClient,
     instruments::{
-        cache_instrument, publish_cached_condition_closed, query_positive_closed_condition_ids,
+        apply_live_instrument, publish_cached_condition_closed, query_positive_closed_condition_ids,
     },
-    runtime::{is_condition_closed, retire_closed_condition_state},
-    subscriptions::{resolve_token_id_from, sync_ws_subscription_async},
+    runtime::{
+        is_condition_closed, register_closed_condition_for_live_data, retire_closed_condition_state,
+    },
+    subscriptions::{resolve_token_id_from, sync_ws_subscription_with_terminal_async},
 };
 use crate::{
     common::consts::GAMMA_CONDITION_IDS_BATCH_SIZE, filters::market_closed,
@@ -304,11 +306,7 @@ impl PolymarketDataClient {
                 for (condition_id, outcome) in &outcomes {
                     match outcome {
                         AutoLoadOutcome::Open(loaded) => {
-                            let closed = closed_condition_ids
-                                .lock()
-                                .expect("closed_condition_ids mutex poisoned");
-
-                            if cancellation.is_cancelled() || closed.contains(condition_id) {
+                            if cancellation.is_cancelled() {
                                 continue;
                             }
 
@@ -321,20 +319,37 @@ impl PolymarketDataClient {
                                     continue;
                                 }
 
-                                cache_instrument(&instruments, &token_meta, instrument);
                                 let instrument_id = instrument.id();
-                                if let Err(e) =
-                                    data_sender.send(DataEvent::Instrument(instrument.clone()))
-                                {
-                                    log::error!(
-                                        "Failed to emit auto-loaded instrument {instrument_id}: {e}"
-                                    );
-                                }
+                                apply_live_instrument(
+                                    &closed_condition_ids,
+                                    &instruments,
+                                    &token_meta,
+                                    instrument,
+                                    |instrument| {
+                                        if let Err(e) = data_sender
+                                            .send(DataEvent::Instrument(instrument.clone()))
+                                        {
+                                            log::error!(
+                                                "Failed to emit auto-loaded instrument {instrument_id}: {e}"
+                                            );
+                                        }
+                                    },
+                                );
                             }
                         }
                         AutoLoadOutcome::Closed => {
+                            if !register_closed_condition_for_live_data(
+                                &closed_condition_ids,
+                                &ws_sub_mutex,
+                                condition_id,
+                                Some(&cancellation),
+                            )
+                            .await
                             {
-                                let mut closed = closed_condition_ids
+                                return;
+                            }
+                            {
+                                let closed = closed_condition_ids
                                     .lock()
                                     .expect("closed_condition_ids mutex poisoned");
 
@@ -342,7 +357,7 @@ impl PolymarketDataClient {
                                     return;
                                 }
 
-                                closed.insert(condition_id.clone());
+                                debug_assert!(closed.contains(condition_id));
                                 publish_cached_condition_closed(
                                     condition_id,
                                     &instruments,
@@ -406,17 +421,20 @@ impl PolymarketDataClient {
                             if loaded_ids.contains(id)
                                 && let Ok(token_id) = resolve_token_id_from(&instruments, *id)
                             {
-                                sync_ws_subscription_async(
+                                sync_ws_subscription_with_terminal_async(
                                     *id,
                                     token_id,
                                     active_quote_subs.clone(),
                                     active_delta_subs.clone(),
                                     active_trade_subs.clone(),
+                                    closed_condition_ids.clone(),
                                     ws_open_tokens.clone(),
                                     ws_sub_mutex.clone(),
                                     ws_client.clone(),
                                 )
                                 .await;
+                            } else {
+                                next_batch.insert(*id);
                             }
                         }
                         Some(AutoLoadOutcome::Closed) => {

--- a/crates/adapters/polymarket/src/data/auto_load.rs
+++ b/crates/adapters/polymarket/src/data/auto_load.rs
@@ -15,7 +15,7 @@
 
 use std::time::Duration;
 
-use ahash::AHashSet;
+use ahash::{AHashMap, AHashSet};
 use nautilus_common::{live::get_runtime, messages::DataEvent};
 use nautilus_model::{
     identifiers::InstrumentId,
@@ -24,17 +24,32 @@ use nautilus_model::{
 
 use super::{
     PolymarketDataClient,
-    instruments::cache_instrument,
-    runtime::{is_instrument_expired, retire_local_instrument_state},
+    instruments::{
+        cache_instrument, publish_cached_condition_closed, query_positive_closed_condition_ids,
+    },
+    runtime::{is_condition_closed, retire_closed_condition_state},
     subscriptions::{resolve_token_id_from, sync_ws_subscription_async},
 };
 use crate::{
-    common::consts::GAMMA_CONDITION_IDS_BATCH_SIZE, http::query::GetGammaMarketsParams,
-    providers::extract_condition_id,
+    common::consts::GAMMA_CONDITION_IDS_BATCH_SIZE, filters::market_closed,
+    http::query::GetGammaMarketsParams, providers::extract_condition_id,
 };
+
+#[derive(Debug)]
+enum AutoLoadOutcome {
+    Open(Vec<InstrumentAny>),
+    Closed,
+    Unknown,
+}
 
 impl PolymarketDataClient {
     pub(super) fn queue_pending_load(&self, instrument_id: InstrumentId) {
+        if extract_condition_id(&instrument_id).is_ok_and(|condition_id| {
+            is_condition_closed(&self.closed_condition_ids, &condition_id)
+        }) {
+            return;
+        }
+
         {
             let mut pending = self
                 .pending_auto_loads
@@ -87,6 +102,7 @@ impl PolymarketDataClient {
         }
 
         let pending = self.pending_auto_loads.clone();
+        let closed_condition_ids = self.closed_condition_ids.clone();
         let scheduled = self.auto_load_scheduled.clone();
         let debounce_ms = self.config.auto_load_debounce_ms;
         let max_retries = self.config.auto_load_max_retries;
@@ -103,7 +119,6 @@ impl PolymarketDataClient {
         let ws_sub_mutex = self.ws_sub_mutex.clone();
         let ws_client = self.ws_client.handle();
         let data_sender = self.data_sender.clone();
-        let clock = self.clock;
         let cancellation = self.cancellation_token.clone();
         let order_books = self.order_books.clone();
         let last_quotes = self.last_quotes.clone();
@@ -170,11 +185,16 @@ impl PolymarketDataClient {
                     return;
                 }
 
-                // Gamma caps `condition_ids=` filters at ~100; chunk and merge.
-                let mut loaded: Vec<InstrumentAny> = Vec::new();
+                // Gamma caps `condition_ids=` filters at ~100; classify every
+                // condition independently before mutating runtime state.
+                let mut outcomes: AHashMap<String, AutoLoadOutcome> = condition_ids
+                    .iter()
+                    .cloned()
+                    .map(|condition_id| (condition_id, AutoLoadOutcome::Unknown))
+                    .collect();
                 let mut transient: AHashSet<String> = AHashSet::new();
+                let mut failed_condition_ids: AHashSet<String> = AHashSet::new();
                 let mut batch_returned_any = false;
-                let mut chunk_failed = false;
 
                 for chunk in condition_ids.chunks(GAMMA_CONDITION_IDS_BATCH_SIZE) {
                     let params = GetGammaMarketsParams {
@@ -182,44 +202,158 @@ impl PolymarketDataClient {
                         ..Default::default()
                     };
 
-                    match http
-                        .request_instruments_by_params_with_transient(params)
-                        .await
-                    {
+                    let normal_result = tokio::select! {
+                        result = http.request_instruments_by_params_with_transient(params) => result,
+                        () = cancellation.cancelled() => return,
+                    };
+
+                    if cancellation.is_cancelled() {
+                        return;
+                    }
+
+                    match normal_result {
                         Ok((insts, trans)) => {
                             batch_returned_any |= !insts.is_empty() || !trans.is_empty();
-                            loaded.extend(insts);
+                            let mut open_by_condition: AHashMap<String, Vec<InstrumentAny>> =
+                                AHashMap::new();
+                            let mut explicitly_closed = AHashSet::new();
+
+                            for instrument in insts {
+                                if let Ok(condition_id) = extract_condition_id(&instrument.id()) {
+                                    if market_closed(&instrument) == Some(true) {
+                                        explicitly_closed.insert(condition_id);
+                                    } else {
+                                        open_by_condition
+                                            .entry(condition_id)
+                                            .or_default()
+                                            .push(instrument);
+                                    }
+                                }
+                            }
+                            let classified_condition_ids: AHashSet<String> = open_by_condition
+                                .keys()
+                                .cloned()
+                                .chain(explicitly_closed.iter().cloned())
+                                .collect();
+                            let probe_condition_ids: Vec<String> = chunk
+                                .iter()
+                                .filter(|id| !classified_condition_ids.contains(*id))
+                                .cloned()
+                                .collect();
+
+                            for (condition_id, instruments) in open_by_condition {
+                                if !explicitly_closed.contains(&condition_id) {
+                                    outcomes.insert(
+                                        condition_id,
+                                        AutoLoadOutcome::Open(instruments),
+                                    );
+                                }
+                            }
+
+                            for condition_id in explicitly_closed {
+                                outcomes.insert(condition_id, AutoLoadOutcome::Closed);
+                            }
                             transient.extend(trans);
+
+                            if probe_condition_ids.is_empty() {
+                                continue;
+                            }
+
+                            let closed_result = tokio::select! {
+                                result = query_positive_closed_condition_ids(
+                                    &http,
+                                    &probe_condition_ids,
+                                ) => result,
+                                () = cancellation.cancelled() => return,
+                            };
+
+                            if cancellation.is_cancelled() {
+                                return;
+                            }
+
+                            match closed_result {
+                                Ok(closed_ids) => {
+                                    batch_returned_any |= !closed_ids.is_empty();
+                                    for condition_id in closed_ids {
+                                        outcomes.insert(condition_id, AutoLoadOutcome::Closed);
+                                    }
+                                }
+                                Err(e) => {
+                                    log::error!(
+                                        "Auto-load closed-market probe failed for {} condition_id(s): {e:?}",
+                                        probe_condition_ids.len(),
+                                    );
+                                    failed_condition_ids.extend(probe_condition_ids);
+                                }
+                            }
                         }
                         Err(e) => {
                             log::error!(
                                 "Auto-load batch failed for chunk of {} condition_id(s): {e:?}",
                                 chunk.len(),
                             );
-                            chunk_failed = true;
-                            break;
+                            failed_condition_ids.extend(chunk.iter().cloned());
                         }
                     }
                 }
 
-                // A chunk failure leaves the batch's state unknown; count it
-                // against the retry budget instead of dropping the subscription.
-                let next_batch: AHashSet<InstrumentId> = if chunk_failed {
-                    batch.clone()
-                } else {
-                    let mut retired_expired_ids = AHashSet::new();
+                if cancellation.is_cancelled() {
+                    return;
+                }
 
-                    for inst in loaded {
-                        if !filters.iter().all(|f| f.accept(&inst)) {
-                            log::debug!("Auto-loaded instrument {} filtered out", inst.id());
-                            continue;
+                for (condition_id, outcome) in &outcomes {
+                    match outcome {
+                        AutoLoadOutcome::Open(loaded) => {
+                            let closed = closed_condition_ids
+                                .lock()
+                                .expect("closed_condition_ids mutex poisoned");
+
+                            if cancellation.is_cancelled() || closed.contains(condition_id) {
+                                continue;
+                            }
+
+                            for instrument in loaded {
+                                if !filters.iter().all(|f| f.accept(instrument)) {
+                                    log::debug!(
+                                        "Auto-loaded instrument {} filtered out",
+                                        instrument.id()
+                                    );
+                                    continue;
+                                }
+
+                                cache_instrument(&instruments, &token_meta, instrument);
+                                let instrument_id = instrument.id();
+                                if let Err(e) =
+                                    data_sender.send(DataEvent::Instrument(instrument.clone()))
+                                {
+                                    log::error!(
+                                        "Failed to emit auto-loaded instrument {instrument_id}: {e}"
+                                    );
+                                }
+                            }
                         }
+                        AutoLoadOutcome::Closed => {
+                            {
+                                let mut closed = closed_condition_ids
+                                    .lock()
+                                    .expect("closed_condition_ids mutex poisoned");
 
-                        if is_instrument_expired(&inst, clock.get_time_ns()) {
-                            log::debug!("Skipping expired auto-loaded instrument {}", inst.id());
-                            retired_expired_ids.insert(inst.id());
-                            retire_local_instrument_state(
-                                inst.id(),
+                                if cancellation.is_cancelled() {
+                                    return;
+                                }
+
+                                closed.insert(condition_id.clone());
+                                publish_cached_condition_closed(
+                                    condition_id,
+                                    &instruments,
+                                    &data_sender,
+                                );
+                            }
+
+                            retire_closed_condition_state(
+                                condition_id,
+                                batch.iter().copied(),
+                                &closed_condition_ids,
                                 &instruments,
                                 &token_meta,
                                 &order_books,
@@ -233,41 +367,45 @@ impl PolymarketDataClient {
                                 &ws_open_tokens,
                                 &ws_sub_mutex,
                                 &ws_client,
+                                Some(&cancellation),
                             )
                             .await;
-                            continue;
                         }
+                        AutoLoadOutcome::Unknown => {}
+                    }
+                }
 
-                        cache_instrument(&instruments, &token_meta, &inst);
+                if cancellation.is_cancelled() {
+                    return;
+                }
 
-                        let instrument_id = inst.id();
-                        if let Err(e) = data_sender.send(DataEvent::Instrument(inst)) {
-                            log::error!(
-                                "Failed to emit auto-loaded instrument {instrument_id}: {e}"
-                            );
-                        }
+                // Snapshot loaded keys so the arc-swap Guard does not span
+                // the WS reconciliation awaits below.
+                let loaded_ids: AHashSet<InstrumentId> = {
+                    let cache = instruments.load();
+                    batch
+                        .iter()
+                        .filter(|id| cache.contains_key(id))
+                        .copied()
+                        .collect()
+                };
+                let mut next_batch: AHashSet<InstrumentId> = AHashSet::new();
+
+                for id in &batch {
+                    if cancellation.is_cancelled() {
+                        return;
                     }
 
-                    // Snapshot loaded keys so the arc-swap Guard does not span
-                    // the WS reconciliation awaits below.
-                    let loaded_ids: AHashSet<InstrumentId> = {
-                        let cache = instruments.load();
-                        batch
-                            .iter()
-                            .filter(|id| cache.contains_key(id))
-                            .copied()
-                            .collect()
+                    let condition_id = match extract_condition_id(id) {
+                        Ok(condition_id) => condition_id,
+                        Err(_) => continue,
                     };
-                    let mut next: AHashSet<InstrumentId> = AHashSet::new();
 
-                    for id in &batch {
-                        let cid = match extract_condition_id(id) {
-                            Ok(c) => c,
-                            Err(_) => continue,
-                        };
-
-                        if loaded_ids.contains(id) {
-                            if let Ok(token_id) = resolve_token_id_from(&instruments, *id) {
+                    match outcomes.get(&condition_id) {
+                        Some(AutoLoadOutcome::Open(_)) => {
+                            if loaded_ids.contains(id)
+                                && let Ok(token_id) = resolve_token_id_from(&instruments, *id)
+                            {
                                 sync_ws_subscription_async(
                                     *id,
                                     token_id,
@@ -280,21 +418,16 @@ impl PolymarketDataClient {
                                 )
                                 .await;
                             }
-                        } else if retired_expired_ids.contains(id) {
-                            // Expired instruments are terminal for live auto-load:
-                            // retire any residual runtime state and stop retrying.
-                        } else if transient.contains(&cid) {
-                            // CLOB still hydrating: retry within the budget.
-                            next.insert(*id);
-                        } else {
-                            // Absent from bulk response (same observable state as a
-                            // 404 in the single-market path): also transient.
-                            next.insert(*id);
+                        }
+                        Some(AutoLoadOutcome::Closed) => {
+                            // Terminal for live data; settlement metadata is
+                            // retained by `retire_local_instrument_state`.
+                        }
+                        Some(AutoLoadOutcome::Unknown) | None => {
+                            next_batch.insert(*id);
                         }
                     }
-
-                    next
-                };
+                }
 
                 if next_batch.is_empty() {
                     return;
@@ -308,15 +441,18 @@ impl PolymarketDataClient {
                     };
 
                     for id in &next_batch {
-                        let reason = if chunk_failed {
-                            "Gamma fetch failed"
-                        } else if extract_condition_id(id)
-                            .is_ok_and(|condition_id| transient.contains(&condition_id))
-                        {
-                            "no usable token_id (CLOB lifecycle race)"
-                        } else {
-                            absent_reason
-                        };
+                        let reason = extract_condition_id(id).map_or(
+                            "invalid condition_id",
+                            |condition_id| {
+                                if failed_condition_ids.contains(&condition_id) {
+                                    "Gamma fetch failed"
+                                } else if transient.contains(&condition_id) {
+                                    "no usable token_id (CLOB lifecycle race)"
+                                } else {
+                                    absent_reason
+                                }
+                            },
+                        );
 
                         log::error!(
                             "Cannot find instrument for {id}: {reason} after {max_retries} retries"
@@ -327,8 +463,11 @@ impl PolymarketDataClient {
 
                 let delay =
                     crate::common::retry::auto_load_retry_delay(attempt, base_secs, max_secs);
-                let kind = if chunk_failed {
-                    "chunk failure"
+                let kind = if next_batch.iter().any(|id| {
+                    extract_condition_id(id)
+                        .is_ok_and(|condition_id| failed_condition_ids.contains(&condition_id))
+                }) {
+                    "fetch failure or transient"
                 } else {
                     "transient"
                 };

--- a/crates/adapters/polymarket/src/data/dispatch.rs
+++ b/crates/adapters/polymarket/src/data/dispatch.rs
@@ -800,6 +800,7 @@ fn emit_quote_if_changed(ctx: &WsMessageContext, instrument_id: InstrumentId, qu
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::VecDeque,
         net::SocketAddr,
         num::NonZeroUsize,
         sync::atomic::{AtomicUsize, Ordering},
@@ -814,7 +815,7 @@ mod tests {
             ws::{Message as AxumWsMessage, WebSocket, WebSocketUpgrade},
         },
         http::StatusCode,
-        response::Json,
+        response::{IntoResponse, Json, Response},
         routing::get,
     };
     use futures_util::StreamExt;
@@ -1257,6 +1258,12 @@ mod tests {
             .expect("gamma market fixture json")
     }
 
+    fn gamma_market_future_closed_fixture_value() -> Value {
+        let mut value = gamma_market_recheck_fixture_value();
+        value["closed"] = Value::Bool(true);
+        value
+    }
+
     fn gamma_market_recheck_fixture_value() -> Value {
         let mut value = gamma_market_expired_fixture_value();
         let future_date = Offset::UTC
@@ -1283,13 +1290,57 @@ mod tests {
         value
     }
 
+    fn gamma_market_fixture_for(
+        condition_id: &str,
+        yes_token_id: &str,
+        no_token_id: &str,
+        closed: bool,
+    ) -> Value {
+        let mut value = gamma_market_recheck_fixture_value();
+        value["conditionId"] = Value::String(condition_id.to_string());
+        value["clobTokenIds"] = Value::String(
+            serde_json::to_string(&[yes_token_id, no_token_id]).expect("serialize token ids"),
+        );
+        value["closed"] = Value::Bool(closed);
+        value
+    }
+
     const TEST_CONDITION_ID: &str =
         "0x78443f961b9a65869dcb39359de9960165c7e5cbad0904eac7f29cd77872a63b";
     const TEST_TOKEN_ID_YES: &str =
         "104239898038807136052399800151408521467737075933964991162589336683346093173875";
+    const TEST_TOKEN_ID_NO: &str =
+        "71183960810705820955071415844881728181970340514894896943812046065452395013351";
 
     fn fixture_yes_instrument_id() -> InstrumentId {
         InstrumentId::from(format!("{TEST_CONDITION_ID}-{TEST_TOKEN_ID_YES}.POLYMARKET").as_str())
+    }
+
+    fn fixture_no_instrument_id() -> InstrumentId {
+        InstrumentId::from(format!("{TEST_CONDITION_ID}-{TEST_TOKEN_ID_NO}.POLYMARKET").as_str())
+    }
+
+    fn fixture_instrument_id(condition_id: &str, token_id: &str) -> InstrumentId {
+        InstrumentId::from(format!("{condition_id}-{token_id}.POLYMARKET").as_str())
+    }
+
+    fn instrument_from_gamma_fixture(value: Value) -> InstrumentAny {
+        instruments_from_gamma_fixture(value)
+            .into_iter()
+            .next()
+            .expect("fixture instrument")
+    }
+
+    fn instruments_from_gamma_fixture(value: Value) -> Vec<InstrumentAny> {
+        let market = serde_json::from_value(value).expect("gamma market fixture");
+        let definitions = crate::http::parse::parse_gamma_market(&market).expect("parse fixture");
+        definitions
+            .iter()
+            .map(|definition| {
+                crate::http::parse::create_instrument_from_def(definition, UnixNanos::default())
+                    .expect("create fixture instrument")
+            })
+            .collect()
     }
 
     #[derive(Clone, Copy, Debug)]
@@ -2105,24 +2156,55 @@ mod tests {
         addr
     }
 
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct ExpiredAutoLoadQuery {
+        condition_ids: Option<String>,
+        closed: Option<String>,
+    }
+
     #[derive(Clone)]
     struct ExpiredAutoLoadServerState {
-        requests: Arc<AtomicUsize>,
-        response: Value,
+        queries: Arc<StdMutex<Vec<ExpiredAutoLoadQuery>>>,
+        open_response: Value,
+        closed_response: Value,
+        market_payloads: Arc<tokio::sync::Mutex<Vec<Value>>>,
     }
 
     async fn handle_expired_auto_load_markets(
+        RawQuery(raw_query): RawQuery,
         State(state): State<ExpiredAutoLoadServerState>,
     ) -> Json<Value> {
-        state.requests.fetch_add(1, Ordering::SeqCst);
-        Json(state.response)
+        let condition_ids = query_param(raw_query.clone(), "condition_ids");
+        let closed = query_param(raw_query, "closed");
+        state
+            .queries
+            .lock()
+            .expect("expired auto-load queries mutex poisoned")
+            .push(ExpiredAutoLoadQuery {
+                condition_ids,
+                closed: closed.clone(),
+            });
+
+        if closed.as_deref() == Some("true") {
+            Json(state.closed_response)
+        } else {
+            Json(state.open_response)
+        }
     }
 
     async fn handle_expired_auto_load_markets_keyset(
+        raw_query: RawQuery,
         state: State<ExpiredAutoLoadServerState>,
     ) -> Json<Value> {
-        let Json(markets) = handle_expired_auto_load_markets(state).await;
+        let Json(markets) = handle_expired_auto_load_markets(raw_query, state).await;
         Json(serde_json::json!({"markets": markets}))
+    }
+
+    async fn handle_expired_auto_load_market_upgrade(
+        ws: WebSocketUpgrade,
+        State(state): State<ExpiredAutoLoadServerState>,
+    ) -> axum::response::Response {
+        ws.on_upgrade(move |socket| record_json_ws_payloads(socket, state.market_payloads))
     }
 
     async fn start_expired_auto_load_test_server(state: ExpiredAutoLoadServerState) -> SocketAddr {
@@ -2136,6 +2218,176 @@ mod tests {
                 "/markets/keyset",
                 get(handle_expired_auto_load_markets_keyset),
             )
+            .route("/ws/market", get(handle_expired_auto_load_market_upgrade))
+            .with_state(state);
+
+        tokio::spawn(async move { axum::serve(listener, router).await.expect("serve failed") });
+        addr
+    }
+
+    #[derive(Clone)]
+    struct ScriptedAutoLoadReply {
+        status: StatusCode,
+        body: Value,
+        delay: Duration,
+        release: Option<Arc<tokio::sync::Semaphore>>,
+    }
+
+    impl ScriptedAutoLoadReply {
+        fn ok(body: Value) -> Self {
+            Self {
+                status: StatusCode::OK,
+                body,
+                delay: Duration::ZERO,
+                release: None,
+            }
+        }
+
+        fn failed() -> Self {
+            Self {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                body: serde_json::json!({"error": "probe failed"}),
+                delay: Duration::ZERO,
+                release: None,
+            }
+        }
+
+        fn delayed(body: Value, delay: Duration) -> Self {
+            Self {
+                status: StatusCode::OK,
+                body,
+                delay,
+                release: None,
+            }
+        }
+
+        fn gated(body: Value, release: Arc<tokio::sync::Semaphore>) -> Self {
+            Self {
+                status: StatusCode::OK,
+                body,
+                delay: Duration::ZERO,
+                release: Some(release),
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct ScriptedAutoLoadServerState {
+        queries: Arc<StdMutex<Vec<ExpiredAutoLoadQuery>>>,
+        open_replies: Arc<StdMutex<VecDeque<ScriptedAutoLoadReply>>>,
+        closed_replies: Arc<StdMutex<VecDeque<ScriptedAutoLoadReply>>>,
+        market_payloads: Arc<tokio::sync::Mutex<Vec<Value>>>,
+        completed_replies: Arc<AtomicUsize>,
+    }
+
+    impl ScriptedAutoLoadServerState {
+        fn new(
+            open_replies: Vec<ScriptedAutoLoadReply>,
+            closed_replies: Vec<ScriptedAutoLoadReply>,
+        ) -> Self {
+            Self {
+                queries: Arc::new(StdMutex::new(Vec::new())),
+                open_replies: Arc::new(StdMutex::new(open_replies.into())),
+                closed_replies: Arc::new(StdMutex::new(closed_replies.into())),
+                market_payloads: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+                completed_replies: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    async fn next_scripted_auto_load_reply(
+        raw_query: Option<String>,
+        state: &ScriptedAutoLoadServerState,
+    ) -> ScriptedAutoLoadReply {
+        let condition_ids = query_param(raw_query.clone(), "condition_ids");
+        let closed = query_param(raw_query, "closed");
+        state
+            .queries
+            .lock()
+            .expect("scripted auto-load queries mutex poisoned")
+            .push(ExpiredAutoLoadQuery {
+                condition_ids,
+                closed: closed.clone(),
+            });
+
+        let replies = if closed.as_deref() == Some("true") {
+            &state.closed_replies
+        } else {
+            &state.open_replies
+        };
+        replies
+            .lock()
+            .expect("scripted auto-load replies mutex poisoned")
+            .pop_front()
+            .unwrap_or_else(|| ScriptedAutoLoadReply::ok(serde_json::json!([])))
+    }
+
+    async fn handle_scripted_auto_load_markets(
+        RawQuery(raw_query): RawQuery,
+        State(state): State<ScriptedAutoLoadServerState>,
+    ) -> Response {
+        let reply = next_scripted_auto_load_reply(raw_query, &state).await;
+
+        if !reply.delay.is_zero() {
+            tokio::time::sleep(reply.delay).await;
+        }
+
+        if let Some(release) = reply.release {
+            release
+                .acquire()
+                .await
+                .expect("scripted reply release")
+                .forget();
+        }
+        state.completed_replies.fetch_add(1, Ordering::SeqCst);
+
+        (reply.status, Json(reply.body)).into_response()
+    }
+
+    async fn handle_scripted_auto_load_markets_keyset(
+        RawQuery(raw_query): RawQuery,
+        State(state): State<ScriptedAutoLoadServerState>,
+    ) -> Response {
+        let reply = next_scripted_auto_load_reply(raw_query, &state).await;
+
+        if !reply.delay.is_zero() {
+            tokio::time::sleep(reply.delay).await;
+        }
+
+        if let Some(release) = reply.release {
+            release
+                .acquire()
+                .await
+                .expect("scripted reply release")
+                .forget();
+        }
+        state.completed_replies.fetch_add(1, Ordering::SeqCst);
+
+        let body = serde_json::json!({"markets": reply.body});
+        (reply.status, Json(body)).into_response()
+    }
+
+    async fn handle_scripted_auto_load_market_upgrade(
+        ws: WebSocketUpgrade,
+        State(state): State<ScriptedAutoLoadServerState>,
+    ) -> Response {
+        ws.on_upgrade(move |socket| record_json_ws_payloads(socket, state.market_payloads))
+    }
+
+    async fn start_scripted_auto_load_test_server(
+        state: ScriptedAutoLoadServerState,
+    ) -> SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind failed");
+        let addr = listener.local_addr().expect("local_addr");
+        let router = Router::new()
+            .route("/markets", get(handle_scripted_auto_load_markets))
+            .route(
+                "/markets/keyset",
+                get(handle_scripted_auto_load_markets_keyset),
+            )
+            .route("/ws/market", get(handle_scripted_auto_load_market_upgrade))
             .with_state(state);
 
         tokio::spawn(async move { axum::serve(listener, router).await.expect("serve failed") });
@@ -3268,13 +3520,24 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn auto_load_expired_instrument_retires_without_retrying() {
+    async fn auto_load_closed_future_instrument_retires_without_retrying() {
+        let filter_calls = Arc::new(AtomicUsize::new(0));
         let state = ExpiredAutoLoadServerState {
-            requests: Arc::new(AtomicUsize::new(0)),
-            response: serde_json::json!([gamma_market_expired_fixture_value()]),
+            queries: Arc::new(StdMutex::new(Vec::new())),
+            open_response: serde_json::json!([]),
+            closed_response: serde_json::json!([gamma_market_future_closed_fixture_value()]),
+            market_payloads: Arc::new(tokio::sync::Mutex::new(Vec::new())),
         };
         let addr = start_expired_auto_load_test_server(state.clone()).await;
-        let (mut client, _data_rx) = create_test_client(addr);
+        let (mut client, mut data_rx) = create_test_client(addr);
+        let filter_calls_clone = filter_calls.clone();
+        client.add_instrument_filter(Arc::new(crate::filters::PredicateFilter::new(
+            "count-calls",
+            move |_| {
+                filter_calls_clone.fetch_add(1, Ordering::SeqCst);
+                true
+            },
+        )));
         client.config.auto_load_debounce_ms = 0;
         client.config.auto_load_max_retries = 3;
         client.config.auto_load_retry_delay_initial_secs = 0.0;
@@ -3310,13 +3573,22 @@ mod tests {
         )
         .await;
 
-        let quiet_start = tokio::time::Instant::now();
-        while quiet_start.elapsed() < StdDuration::from_millis(100) {
-            assert_eq!(state.requests.load(Ordering::SeqCst), 1);
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-
-        assert_eq!(state.requests.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *state
+                .queries
+                .lock()
+                .expect("expired auto-load queries mutex poisoned"),
+            vec![
+                ExpiredAutoLoadQuery {
+                    condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                    closed: None,
+                },
+                ExpiredAutoLoadQuery {
+                    condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                    closed: Some("true".to_string()),
+                },
+            ],
+        );
         assert!(!client.active_quote_subs.contains(&instrument_id));
         assert!(
             !client
@@ -3324,6 +3596,1766 @@ mod tests {
                 .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
         );
         assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert_eq!(filter_calls.load(Ordering::SeqCst), 0);
+        assert!(data_rx.try_recv().is_err());
+        assert!(state.market_payloads.lock().await.is_empty());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn auto_load_closed_condition_retires_live_sibling_instrument() {
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([]))],
+            vec![ScriptedAutoLoadReply::delayed(
+                serde_json::json!([gamma_market_future_closed_fixture_value()]),
+                Duration::from_millis(200),
+            )],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let sibling = instruments_from_gamma_fixture(gamma_market_recheck_fixture_value())
+            .into_iter()
+            .find(|instrument| instrument.id() == fixture_no_instrument_id())
+            .expect("No sibling instrument");
+        let sibling_id = sibling.id();
+        cache_instrument(&client.instruments, &client.token_meta, &sibling);
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                sibling_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("cached sibling subscription");
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move { !state.market_payloads.lock().await.is_empty() }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+        client.active_delta_subs.insert(sibling_id);
+        client.active_trade_subs.insert(sibling_id);
+        client.pending_snapshot_after_tick_change.insert(sibling_id);
+        client
+            .order_books
+            .insert(sibling_id, OrderBook::new(sibling_id, BookType::L2_MBP));
+        client.last_quotes.insert(
+            sibling_id,
+            QuoteTick::new(
+                sibling_id,
+                Price::from("0.49"),
+                Price::from("0.51"),
+                Quantity::from("1"),
+                Quantity::from("1"),
+                UnixNanos::default(),
+                UnixNanos::default(),
+            ),
+        );
+
+        let requested_id = fixture_yes_instrument_id();
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                requested_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("missing sibling subscription should queue auto-load");
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        >= 2
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+        client
+            .pending_auto_loads
+            .lock()
+            .expect("pending_auto_loads mutex poisoned")
+            .insert(sibling_id);
+
+        wait_until_async(
+            || {
+                let client = &client;
+                async move {
+                    !client.active_quote_subs.contains(&requested_id)
+                        && !client.active_quote_subs.contains(&sibling_id)
+                        && !client.instruments.load().contains_key(&sibling_id)
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert!(!client.active_quote_subs.contains(&sibling_id));
+        assert!(!client.active_delta_subs.contains(&sibling_id));
+        assert!(!client.active_trade_subs.contains(&sibling_id));
+        assert!(!client.instruments.load().contains_key(&sibling_id));
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_NO))
+        );
+        assert!(!client.order_books.contains_key(&sibling_id));
+        assert!(!client.last_quotes.contains_key(&sibling_id));
+        assert!(
+            !client
+                .pending_snapshot_after_tick_change
+                .contains(&sibling_id)
+        );
+        assert!(
+            !client
+                .pending_auto_loads
+                .lock()
+                .expect("pending_auto_loads mutex poisoned")
+                .contains(&sibling_id)
+        );
+        assert!(
+            !client
+                .ws_open_tokens
+                .contains(&Ustr::from(TEST_TOKEN_ID_NO))
+        );
+
+        let query_count = state
+            .queries
+            .lock()
+            .expect("scripted auto-load queries mutex poisoned")
+            .len();
+        let payload_count = state.market_payloads.lock().await.len();
+
+        for instrument_id in [requested_id, sibling_id] {
+            let _ = client.subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ));
+        }
+        // Quiet period: terminal resubscriptions must not enqueue a later auto-load or WS payload.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(
+            state
+                .queries
+                .lock()
+                .expect("scripted auto-load queries mutex poisoned")
+                .len(),
+            query_count,
+        );
+        assert_eq!(state.market_payloads.lock().await.len(), payload_count);
+        assert!(!client.active_quote_subs.contains(&requested_id));
+        assert!(!client.active_quote_subs.contains(&sibling_id));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn terminal_closure_cannot_race_delta_subscription_into_recreating_order_book() {
+        let addr = start_mock_server(TestServerState::default()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.compute_effective_deltas = true;
+
+        let instrument = instrument_from_gamma_fixture(gamma_market_recheck_fixture_value());
+        let instrument_id = instrument.id();
+        cache_instrument(&client.instruments, &client.token_meta, &instrument);
+        client.ws_open_tokens.insert(Ustr::from(TEST_TOKEN_ID_YES));
+
+        let closed_condition_ids = client.closed_condition_ids.clone();
+        let closed_condition_ids_observer = closed_condition_ids.clone();
+        let instruments = client.instruments.clone();
+        let token_meta = client.token_meta.clone();
+        let order_books = client.order_books.clone();
+        let last_quotes = client.last_quotes.clone();
+        let active_quote_subs = client.active_quote_subs.clone();
+        let active_delta_subs = client.active_delta_subs.clone();
+        let active_delta_subs_observer = active_delta_subs.clone();
+        let active_trade_subs = client.active_trade_subs.clone();
+        let resolve_poll_watchlist = client.resolve_poll_watchlist.clone();
+        let pending_snapshot_after_tick_change = client.pending_snapshot_after_tick_change.clone();
+        let pending_auto_loads = client.pending_auto_loads.clone();
+        let ws_open_tokens = client.ws_open_tokens.clone();
+        let ws_sub_mutex = client.ws_sub_mutex.clone();
+        let ws = client.ws_client.handle();
+
+        // Reproduce the synchronous subscription split exactly: intent is inserted first, then a
+        // concurrent closure is paused after retiring that intent but before local book cleanup.
+        let ws_guard = ws_sub_mutex.clone().lock_owned().await;
+        client.active_delta_subs.insert(instrument_id);
+
+        let closure_thread = std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("closure test runtime")
+                .block_on(crate::data::runtime::retire_closed_condition_state(
+                    TEST_CONDITION_ID,
+                    [instrument_id],
+                    &closed_condition_ids,
+                    &instruments,
+                    &token_meta,
+                    &order_books,
+                    &last_quotes,
+                    &active_quote_subs,
+                    &active_delta_subs,
+                    &active_trade_subs,
+                    &resolve_poll_watchlist,
+                    &pending_snapshot_after_tick_change,
+                    &pending_auto_loads,
+                    &ws_open_tokens,
+                    &ws_sub_mutex,
+                    &ws,
+                    None,
+                ));
+        });
+
+        let deadline = std::time::Instant::now() + StdDuration::from_secs(3);
+
+        while active_delta_subs_observer.contains(&instrument_id)
+            || !crate::data::runtime::is_condition_closed(
+                &closed_condition_ids_observer,
+                TEST_CONDITION_ID,
+            )
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "closure did not retire delta intent before timeout"
+            );
+            std::thread::yield_now();
+        }
+
+        assert!(!client.add_delta_subscription_intent(instrument_id));
+        let recreated_order_book = client.order_books.contains_key(&instrument_id);
+        drop(ws_guard);
+        closure_thread.join().expect("closure thread");
+
+        assert!(!recreated_order_book);
+        assert!(!client.active_delta_subs.contains(&instrument_id));
+        assert!(!client.order_books.contains_key(&instrument_id));
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(
+            !client
+                .ws_open_tokens
+                .contains(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn auto_load_normal_response_explicit_closed_is_terminal() {
+        let filter_calls = Arc::new(AtomicUsize::new(0));
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([
+                gamma_market_future_closed_fixture_value()
+            ]))],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, mut data_rx) = create_test_client(addr);
+        let filter_calls_clone = filter_calls.clone();
+        client.add_instrument_filter(Arc::new(crate::filters::PredicateFilter::new(
+            "count-calls",
+            move |_| {
+                filter_calls_clone.fetch_add(1, Ordering::SeqCst);
+                true
+            },
+        )));
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 3;
+        client.config.auto_load_retry_delay_initial_secs = 0.0;
+        client.config.auto_load_retry_delay_max_secs = 0.0;
+
+        let instrument_id = fixture_yes_instrument_id();
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("missing closed instrument subscription should queue auto-load");
+
+        wait_until_async(
+            || {
+                let client = &client;
+                async move { !client.active_quote_subs.contains(&instrument_id) }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert_eq!(
+            state
+                .queries
+                .lock()
+                .expect("scripted auto-load queries mutex poisoned")
+                .as_slice(),
+            &[ExpiredAutoLoadQuery {
+                condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                closed: None,
+            }],
+        );
+        assert_eq!(filter_calls.load(Ordering::SeqCst), 0);
+        assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(client.ws_open_tokens.is_empty());
+        assert!(state.market_payloads.lock().await.is_empty());
+        assert!(data_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn reset_isolates_delayed_auto_load_generation() {
+        let old_reply_release = Arc::new(tokio::sync::Semaphore::new(0));
+        let state = ScriptedAutoLoadServerState::new(
+            vec![
+                ScriptedAutoLoadReply::gated(
+                    serde_json::json!([gamma_market_future_closed_fixture_value()]),
+                    old_reply_release.clone(),
+                ),
+                ScriptedAutoLoadReply::ok(serde_json::json!(
+                    [gamma_market_recheck_fixture_value()]
+                )),
+            ],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, mut data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let instrument_id = fixture_yes_instrument_id();
+        let subscribe = |client: &mut PolymarketDataClient| {
+            client.subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+        };
+        subscribe(&mut client).expect("old-generation subscription");
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        == 1
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        client.reset_client();
+        subscribe(&mut client).expect("new-generation subscription");
+        wait_until_async(
+            || {
+                let client = &client;
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        == 2
+                        && client.instruments.load().contains_key(&instrument_id)
+                        && client.active_quote_subs.contains(&instrument_id)
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        while data_rx.try_recv().is_ok() {}
+
+        old_reply_release.add_permits(1);
+        // Quiet period: cancellation may drop the old HTTP request before the gated server handler
+        // completes, and the detached task has no completion handle. Allow any stale mutation or
+        // publication to become observable before asserting isolation.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(
+            !client
+                .closed_condition_ids
+                .lock()
+                .expect("closed_condition_ids mutex poisoned")
+                .contains(TEST_CONDITION_ID)
+        );
+        assert!(client.active_quote_subs.contains(&instrument_id));
+        assert!(client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(
+            !client
+                .pending_auto_loads
+                .lock()
+                .expect("pending_auto_loads mutex poisoned")
+                .contains(&instrument_id)
+        );
+        assert!(data_rx.try_recv().is_err());
+        assert_eq!(state.completed_replies.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            state
+                .queries
+                .lock()
+                .expect("scripted auto-load queries mutex poisoned")
+                .len(),
+            2,
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn reset_isolates_closed_application_after_http_completion() {
+        let reply_release = Arc::new(tokio::sync::Semaphore::new(0));
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::gated(
+                serde_json::json!([gamma_market_future_closed_fixture_value()]),
+                reply_release.clone(),
+            )],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let instrument_id = fixture_yes_instrument_id();
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("old-generation subscription");
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        == 1
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        let old_pending = client.pending_auto_loads.clone();
+        let (pending_locked_tx, pending_locked_rx) = std::sync::mpsc::sync_channel(1);
+        let (pending_release_tx, pending_release_rx) = std::sync::mpsc::sync_channel(1);
+        let pending_lock_thread = std::thread::spawn(move || {
+            let _guard = old_pending
+                .lock()
+                .expect("pending_auto_loads mutex poisoned");
+            pending_locked_tx
+                .send(())
+                .expect("signal pending auto-load gate");
+            pending_release_rx
+                .recv()
+                .expect("release pending auto-load gate");
+        });
+        pending_locked_rx
+            .recv_timeout(StdDuration::from_secs(3))
+            .expect("pending auto-load gate");
+        let old_closed_condition_ids = client.closed_condition_ids.clone();
+        reply_release.add_permits(1);
+        wait_until_async(
+            || {
+                let closed_condition_ids = old_closed_condition_ids.clone();
+                async move {
+                    closed_condition_ids
+                        .lock()
+                        .expect("closed_condition_ids mutex poisoned")
+                        .contains(TEST_CONDITION_ID)
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        client.reset_client();
+        let new_instrument = instrument_from_gamma_fixture(gamma_market_recheck_fixture_value());
+        cache_instrument(&client.instruments, &client.token_meta, &new_instrument);
+        client.active_quote_subs.insert(instrument_id);
+        pending_release_tx
+            .send(())
+            .expect("release pending auto-load gate");
+        pending_lock_thread
+            .join()
+            .expect("pending auto-load gate thread");
+        // Quiet period: the detached old-generation task has no completion handle. Give its
+        // cancellation branch time to run before checking that no old cache mutation crossed reset.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(client.active_quote_subs.contains(&instrument_id));
+        assert!(client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn cancellation_drops_delayed_closure_refresh_before_mutation() {
+        let reply_release = Arc::new(tokio::sync::Semaphore::new(0));
+        let mut closed_market = gamma_market_expired_fixture_value();
+        closed_market["closed"] = Value::Bool(true);
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::gated(
+                serde_json::json!([closed_market]),
+                reply_release.clone(),
+            )],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, mut data_rx) = create_test_client(addr);
+        client.config.resolve_poll_interval_secs = 1;
+
+        let mut instrument = instrument_from_gamma_fixture(gamma_market_expired_fixture_value());
+        if let InstrumentAny::BinaryOption(binary) = &mut instrument {
+            binary.expiration_ns = UnixNanos::from(1);
+            crate::filters::set_market_closed(binary, false);
+        }
+        let instrument_id = instrument.id();
+        client.instruments.insert(instrument_id, instrument);
+        client.spawn_resolve_poll_task();
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        == 1
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        let closed_condition_ids = client.closed_condition_ids.clone();
+        let (locked_tx, locked_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let lock_thread = std::thread::spawn(move || {
+            let _guard = closed_condition_ids
+                .lock()
+                .expect("closed_condition_ids mutex poisoned");
+            locked_tx.send(()).expect("signal closure application gate");
+            release_rx.recv().expect("release closure application gate");
+        });
+        locked_rx
+            .recv_timeout(StdDuration::from_secs(3))
+            .expect("closure application gate");
+
+        reply_release.add_permits(1);
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move { state.completed_replies.load(Ordering::SeqCst) == 1 }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        client.stop_client();
+        release_tx
+            .send(())
+            .expect("release closure application gate");
+        lock_thread.join().expect("closure application gate thread");
+        // Quiet period: cancellation after HTTP completion must still prevent positive closure
+        // evidence or publication from crossing the application boundary.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let cached = client
+            .instruments
+            .get_cloned(&instrument_id)
+            .expect("cached instrument");
+        assert_eq!(crate::filters::market_closed(&cached), Some(false));
+        assert!(
+            !client
+                .closed_condition_ids
+                .lock()
+                .expect("closed_condition_ids mutex poisoned")
+                .contains(TEST_CONDITION_ID)
+        );
+        assert!(data_rx.try_recv().is_err());
+        client.reset_client();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn auto_load_transient_closed_market_uses_positive_closure_probe() {
+        let mut closed_unusable = gamma_market_future_closed_fixture_value();
+        closed_unusable["clobTokenIds"] = Value::String("[]".to_string());
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([
+                closed_unusable.clone()
+            ]))],
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([
+                closed_unusable
+            ]))],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, mut data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let instrument_id = fixture_yes_instrument_id();
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("unusable closed market subscription should queue auto-load");
+
+        wait_until_async(
+            || {
+                let client = &client;
+                async move { !client.active_quote_subs.contains(&instrument_id) }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert_eq!(
+            state
+                .queries
+                .lock()
+                .expect("scripted auto-load queries mutex poisoned")
+                .as_slice(),
+            &[
+                ExpiredAutoLoadQuery {
+                    condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                    closed: None,
+                },
+                ExpiredAutoLoadQuery {
+                    condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                    closed: Some("true".to_string()),
+                },
+            ],
+        );
+        assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(client.ws_open_tokens.is_empty());
+        assert!(state.market_payloads.lock().await.is_empty());
+        assert!(data_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn closure_refresh_registers_shared_terminal_condition() {
+        let mut closed_market = gamma_market_expired_fixture_value();
+        closed_market["closed"] = Value::Bool(true);
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([
+                closed_market
+            ]))],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state).await;
+        let (client, _data_rx) = create_test_client(addr);
+        let mut instrument = instrument_from_gamma_fixture(gamma_market_expired_fixture_value());
+        if let InstrumentAny::BinaryOption(binary) = &mut instrument {
+            binary.expiration_ns = UnixNanos::from(1);
+            crate::filters::set_market_closed(binary, false);
+        }
+        client.instruments.insert(instrument.id(), instrument);
+
+        let updated = crate::data::instruments::refresh_expired_market_closure(
+            client.provider.http_client(),
+            &client.instruments,
+            &client.data_sender,
+            UnixNanos::from(u64::MAX),
+            &client.closed_condition_ids,
+            None,
+        )
+        .await
+        .expect("closure refresh");
+        assert_eq!(updated, 1);
+
+        assert!(
+            client
+                .closed_condition_ids
+                .lock()
+                .expect("closed_condition_ids mutex poisoned")
+                .contains(TEST_CONDITION_ID)
+        );
+    }
+
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    #[tokio::test]
+    async fn closure_refresh_closed_wins_stale_auto_load_open(#[case] open_completes_last: bool) {
+        let open_reply = if open_completes_last {
+            ScriptedAutoLoadReply::delayed(
+                serde_json::json!([gamma_market_expired_fixture_value()]),
+                Duration::from_millis(200),
+            )
+        } else {
+            ScriptedAutoLoadReply::ok(serde_json::json!([gamma_market_expired_fixture_value()]))
+        };
+        let mut closed_market = gamma_market_expired_fixture_value();
+        closed_market["closed"] = Value::Bool(true);
+        let state = ScriptedAutoLoadServerState::new(
+            vec![
+                open_reply,
+                ScriptedAutoLoadReply::ok(serde_json::json!([closed_market])),
+            ],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, mut data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let mut carried = instrument_from_gamma_fixture(gamma_market_expired_fixture_value());
+        if let InstrumentAny::BinaryOption(binary) = &mut carried {
+            binary.expiration_ns = UnixNanos::from(1);
+            crate::filters::set_market_closed(binary, false);
+        }
+        let instrument_id = carried.id();
+        client.instruments.insert(instrument_id, carried);
+        client.active_quote_subs.insert(instrument_id);
+        client.queue_pending_load(instrument_id);
+
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    !state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .is_empty()
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        if !open_completes_last {
+            wait_until_async(
+                || {
+                    let client = &client;
+                    async move {
+                        client
+                            .token_meta
+                            .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+                    }
+                },
+                StdDuration::from_secs(3),
+            )
+            .await;
+
+            while data_rx.try_recv().is_ok() {}
+        }
+
+        crate::data::instruments::refresh_expired_market_closure(
+            client.provider.http_client(),
+            &client.instruments,
+            &client.data_sender,
+            UnixNanos::from(u64::MAX),
+            &client.closed_condition_ids,
+            None,
+        )
+        .await
+        .expect("closure refresh");
+        crate::data::runtime::retire_closed_condition_state(
+            TEST_CONDITION_ID,
+            [instrument_id],
+            &client.closed_condition_ids,
+            &client.instruments,
+            &client.token_meta,
+            &client.order_books,
+            &client.last_quotes,
+            &client.active_quote_subs,
+            &client.active_delta_subs,
+            &client.active_trade_subs,
+            &client.resolve_poll_watchlist,
+            &client.pending_snapshot_after_tick_change,
+            &client.pending_auto_loads,
+            &client.ws_open_tokens,
+            &client.ws_sub_mutex,
+            &client.ws_client.handle(),
+            None,
+        )
+        .await;
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move { state.completed_replies.load(Ordering::SeqCst) == 2 }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert!(
+            client
+                .closed_condition_ids
+                .lock()
+                .expect("closed_condition_ids mutex poisoned")
+                .contains(TEST_CONDITION_ID)
+        );
+        assert!(!client.active_quote_subs.contains(&instrument_id));
+        assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(
+            !client
+                .ws_open_tokens
+                .contains(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+
+        while let Ok(event) = data_rx.try_recv() {
+            if let DataEvent::Instrument(instrument) = event {
+                assert_ne!(crate::filters::market_closed(&instrument), Some(false));
+            }
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn auto_load_expired_open_instrument_is_cached_and_subscribed() {
+        let filter_calls = Arc::new(AtomicUsize::new(0));
+        let state = ExpiredAutoLoadServerState {
+            queries: Arc::new(StdMutex::new(Vec::new())),
+            open_response: serde_json::json!([gamma_market_expired_fixture_value()]),
+            closed_response: serde_json::json!([]),
+            market_payloads: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        };
+        let addr = start_expired_auto_load_test_server(state.clone()).await;
+        let (mut client, mut data_rx) = create_test_client(addr);
+        let filter_calls_clone = filter_calls.clone();
+        client.add_instrument_filter(Arc::new(crate::filters::PredicateFilter::new(
+            "count-calls",
+            move |_| {
+                filter_calls_clone.fetch_add(1, Ordering::SeqCst);
+                true
+            },
+        )));
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 3;
+        client.config.auto_load_retry_delay_initial_secs = 0.0;
+        client.config.auto_load_retry_delay_max_secs = 0.0;
+
+        let instrument_id = fixture_yes_instrument_id();
+        let auto_load_scheduled = client.auto_load_scheduled.clone();
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("subscribe_quotes should queue auto-load");
+
+        let emitted_instrument = tokio::time::timeout(StdDuration::from_secs(3), async {
+            loop {
+                match data_rx.recv().await {
+                    Some(DataEvent::Instrument(instrument)) if instrument.id() == instrument_id => {
+                        return instrument;
+                    }
+                    Some(_) => {}
+                    None => panic!("data event channel closed before instrument publication"),
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for instrument publication");
+
+        wait_until_async(
+            || {
+                let state = state.clone();
+                let auto_load_scheduled = auto_load_scheduled.clone();
+                async move {
+                    !state.market_payloads.lock().await.is_empty()
+                        && !auto_load_scheduled.load(Ordering::Acquire)
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert_eq!(
+            *state
+                .queries
+                .lock()
+                .expect("expired auto-load queries mutex poisoned"),
+            vec![ExpiredAutoLoadQuery {
+                condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                closed: None,
+            }],
+        );
+        assert!(client.active_quote_subs.contains(&instrument_id));
+        assert!(client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert_eq!(emitted_instrument.raw_symbol().as_str(), TEST_TOKEN_ID_YES);
+        assert_eq!(filter_calls.load(Ordering::SeqCst), 2);
+        assert!(
+            !client
+                .pending_auto_loads
+                .lock()
+                .expect("pending_auto_loads mutex poisoned")
+                .contains(&instrument_id)
+        );
+
+        let payloads = state.market_payloads.lock().await.clone();
+        assert_eq!(
+            payloads,
+            vec![serde_json::json!({
+                "assets_ids": [TEST_TOKEN_ID_YES],
+                "type": "market",
+                "initial_dump": true,
+            })],
+        );
+
+        client
+            .ws_client
+            .disconnect()
+            .await
+            .expect("disconnect failed");
+    }
+
+    #[rstest]
+    #[case::past_end(true, true)]
+    #[case::future_end(false, true)]
+    #[case::not_accepting_orders(false, false)]
+    #[tokio::test]
+    async fn auto_load_open_outcome_is_independent_of_end_date_and_accepting_orders(
+        #[case] past_end: bool,
+        #[case] accepting_orders: bool,
+    ) {
+        let mut market = if past_end {
+            gamma_market_expired_fixture_value()
+        } else {
+            gamma_market_recheck_fixture_value()
+        };
+        market["acceptingOrders"] = Value::Bool(accepting_orders);
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([market]))],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, mut data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let instrument_id = fixture_yes_instrument_id();
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("missing open instrument subscription should queue auto-load");
+
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move { !state.market_payloads.lock().await.is_empty() }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert_eq!(
+            state
+                .queries
+                .lock()
+                .expect("scripted auto-load queries mutex poisoned")
+                .as_slice(),
+            &[ExpiredAutoLoadQuery {
+                condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                closed: None,
+            }],
+        );
+        assert!(client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(client.active_quote_subs.contains(&instrument_id));
+        assert_eq!(state.market_payloads.lock().await.len(), 1);
+
+        let mut published_requested = false;
+        while let Ok(DataEvent::Instrument(instrument)) = data_rx.try_recv() {
+            published_requested |= instrument.id() == instrument_id;
+        }
+        assert!(published_requested);
+    }
+
+    #[rstest]
+    #[case::absent(false)]
+    #[case::unusable_tokens(true)]
+    #[tokio::test]
+    async fn auto_load_unclassifiable_condition_remains_unknown_through_retry_budget(
+        #[case] unusable_tokens: bool,
+    ) {
+        let normal_response = if unusable_tokens {
+            let mut market = gamma_market_recheck_fixture_value();
+            market["clobTokenIds"] = Value::String("[]".to_string());
+            serde_json::json!([market])
+        } else {
+            serde_json::json!([])
+        };
+        let state = ScriptedAutoLoadServerState::new(
+            vec![
+                ScriptedAutoLoadReply::ok(normal_response.clone()),
+                ScriptedAutoLoadReply::ok(normal_response.clone()),
+                ScriptedAutoLoadReply::ok(normal_response),
+            ],
+            vec![
+                ScriptedAutoLoadReply::ok(serde_json::json!([])),
+                ScriptedAutoLoadReply::ok(serde_json::json!([])),
+                ScriptedAutoLoadReply::ok(serde_json::json!([])),
+            ],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 2;
+        client.config.auto_load_retry_delay_initial_secs = 0.0;
+        client.config.auto_load_retry_delay_max_secs = 0.0;
+        let instrument_id = fixture_yes_instrument_id();
+
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("subscribe_quotes should queue auto-load");
+
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        >= 6
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        let queries = state
+            .queries
+            .lock()
+            .expect("scripted auto-load queries mutex poisoned")
+            .clone();
+        assert_eq!(queries.len(), 6);
+        for (index, query) in queries.iter().enumerate() {
+            assert_eq!(query.condition_ids.as_deref(), Some(TEST_CONDITION_ID));
+            assert_eq!(query.closed.as_deref(), (index % 2 == 1).then_some("true"));
+        }
+        assert!(client.active_quote_subs.contains(&instrument_id));
+        assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(state.market_payloads.lock().await.is_empty());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn auto_load_applies_open_closed_and_unknown_per_condition() {
+        const OPEN_CONDITION: &str =
+            "0x1111111111111111111111111111111111111111111111111111111111111111";
+        const CLOSED_CONDITION: &str =
+            "0x2222222222222222222222222222222222222222222222222222222222222222";
+        const UNKNOWN_CONDITION: &str =
+            "0x3333333333333333333333333333333333333333333333333333333333333333";
+        const OPEN_TOKEN: &str =
+            "11111111111111111111111111111111111111111111111111111111111111111";
+        const CLOSED_TOKEN: &str =
+            "22222222222222222222222222222222222222222222222222222222222222222";
+        const UNKNOWN_TOKEN: &str =
+            "33333333333333333333333333333333333333333333333333333333333333333";
+
+        let open_market = gamma_market_fixture_for(
+            OPEN_CONDITION,
+            OPEN_TOKEN,
+            "11111111111111111111111111111111111111111111111111111111111111112",
+            false,
+        );
+        let closed_market = gamma_market_fixture_for(
+            CLOSED_CONDITION,
+            CLOSED_TOKEN,
+            "22222222222222222222222222222222222222222222222222222222222222223",
+            true,
+        );
+        let state = ScriptedAutoLoadServerState::new(
+            vec![
+                ScriptedAutoLoadReply::ok(serde_json::json!([open_market])),
+                ScriptedAutoLoadReply::ok(serde_json::json!([])),
+            ],
+            vec![
+                ScriptedAutoLoadReply::ok(serde_json::json!([closed_market])),
+                ScriptedAutoLoadReply::ok(serde_json::json!([])),
+            ],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 1;
+        client.config.auto_load_retry_delay_initial_secs = 0.0;
+        client.config.auto_load_retry_delay_max_secs = 0.0;
+
+        let open_id = fixture_instrument_id(OPEN_CONDITION, OPEN_TOKEN);
+        let closed_id = fixture_instrument_id(CLOSED_CONDITION, CLOSED_TOKEN);
+        let unknown_id = fixture_instrument_id(UNKNOWN_CONDITION, UNKNOWN_TOKEN);
+        for instrument_id in [open_id, closed_id, unknown_id] {
+            client
+                .subscribe_quotes(SubscribeQuotes::new(
+                    instrument_id,
+                    Some(client.client_id),
+                    Some(*POLYMARKET_VENUE),
+                    UUID4::new(),
+                    UnixNanos::default(),
+                    None,
+                    None,
+                ))
+                .expect("subscribe_quotes should queue auto-load");
+        }
+
+        wait_until_async(
+            || {
+                let client = &client;
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        == 4
+                        && client.instruments.load().contains_key(&open_id)
+                        && client
+                            .closed_condition_ids
+                            .lock()
+                            .expect("closed_condition_ids mutex poisoned")
+                            .contains(CLOSED_CONDITION)
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        let queries = state
+            .queries
+            .lock()
+            .expect("scripted auto-load queries mutex poisoned")
+            .clone();
+        assert_eq!(queries.len(), 4);
+        assert_eq!(queries[2].condition_ids.as_deref(), Some(UNKNOWN_CONDITION));
+        assert_eq!(queries[2].closed, None);
+        assert_eq!(queries[3].condition_ids.as_deref(), Some(UNKNOWN_CONDITION));
+        assert_eq!(queries[3].closed.as_deref(), Some("true"));
+
+        assert!(client.active_quote_subs.contains(&open_id));
+        assert!(client.instruments.load().contains_key(&open_id));
+        assert!(client.token_meta.contains_key(&Ustr::from(OPEN_TOKEN)));
+
+        assert!(!client.active_quote_subs.contains(&closed_id));
+        assert!(!client.instruments.load().contains_key(&closed_id));
+        assert!(!client.token_meta.contains_key(&Ustr::from(CLOSED_TOKEN)));
+
+        assert!(client.active_quote_subs.contains(&unknown_id));
+        assert!(!client.instruments.load().contains_key(&unknown_id));
+        assert!(!client.token_meta.contains_key(&Ustr::from(UNKNOWN_TOKEN)));
+
+        client
+            .ws_client
+            .disconnect()
+            .await
+            .expect("disconnect failed");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn auto_load_closed_probe_failure_preserves_open_condition() {
+        const OPEN_CONDITION: &str =
+            "0x4444444444444444444444444444444444444444444444444444444444444444";
+        const UNKNOWN_CONDITION: &str =
+            "0x5555555555555555555555555555555555555555555555555555555555555555";
+        const OPEN_TOKEN: &str =
+            "44444444444444444444444444444444444444444444444444444444444444444";
+        const UNKNOWN_TOKEN: &str =
+            "55555555555555555555555555555555555555555555555555555555555555555";
+
+        let open_market = gamma_market_fixture_for(
+            OPEN_CONDITION,
+            OPEN_TOKEN,
+            "44444444444444444444444444444444444444444444444444444444444444446",
+            false,
+        );
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([open_market]))],
+            vec![ScriptedAutoLoadReply::failed()],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let open_id = fixture_instrument_id(OPEN_CONDITION, OPEN_TOKEN);
+        let unknown_id = fixture_instrument_id(UNKNOWN_CONDITION, UNKNOWN_TOKEN);
+        for instrument_id in [open_id, unknown_id] {
+            client
+                .subscribe_quotes(SubscribeQuotes::new(
+                    instrument_id,
+                    Some(client.client_id),
+                    Some(*POLYMARKET_VENUE),
+                    UUID4::new(),
+                    UnixNanos::default(),
+                    None,
+                    None,
+                ))
+                .expect("subscribe_quotes should queue auto-load");
+        }
+
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        >= 2
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+        wait_until_async(
+            || {
+                let client = &client;
+                async move { client.instruments.load().contains_key(&open_id) }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert!(client.active_quote_subs.contains(&open_id));
+        assert!(client.instruments.load().contains_key(&open_id));
+        assert!(client.token_meta.contains_key(&Ustr::from(OPEN_TOKEN)));
+        assert!(client.active_quote_subs.contains(&unknown_id));
+        assert!(!client.instruments.load().contains_key(&unknown_id));
+        assert!(!client.token_meta.contains_key(&Ustr::from(UNKNOWN_TOKEN)));
+
+        client
+            .ws_client
+            .disconnect()
+            .await
+            .expect("disconnect failed");
+    }
+
+    #[rstest]
+    #[case::stale_open_completes_last(true)]
+    #[case::closed_completes_last(false)]
+    #[tokio::test]
+    async fn auto_load_closed_wins_concurrent_completion_order(#[case] open_completes_last: bool) {
+        const CONDITION: &str =
+            "0x6666666666666666666666666666666666666666666666666666666666666666";
+        const TOKEN: &str = "66666666666666666666666666666666666666666666666666666666666666666";
+        let open_market = gamma_market_fixture_for(
+            CONDITION,
+            TOKEN,
+            "66666666666666666666666666666666666666666666666666666666666666667",
+            false,
+        );
+        let closed_market = gamma_market_fixture_for(
+            CONDITION,
+            TOKEN,
+            "66666666666666666666666666666666666666666666666666666666666666667",
+            true,
+        );
+        let delay = Duration::from_millis(250);
+        let (open_replies, closed_replies, queries_before_second_load) = if open_completes_last {
+            (
+                vec![
+                    ScriptedAutoLoadReply::delayed(serde_json::json!([open_market]), delay),
+                    ScriptedAutoLoadReply::ok(serde_json::json!([])),
+                ],
+                vec![ScriptedAutoLoadReply::ok(serde_json::json!([
+                    closed_market
+                ]))],
+                1,
+            )
+        } else {
+            (
+                vec![
+                    ScriptedAutoLoadReply::ok(serde_json::json!([])),
+                    ScriptedAutoLoadReply::ok(serde_json::json!([open_market])),
+                ],
+                vec![ScriptedAutoLoadReply::delayed(
+                    serde_json::json!([closed_market]),
+                    delay,
+                )],
+                2,
+            )
+        };
+        let state = ScriptedAutoLoadServerState::new(open_replies, closed_replies);
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, mut data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+        let instrument_id = fixture_instrument_id(CONDITION, TOKEN);
+
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("subscribe_quotes should queue auto-load");
+
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        >= queries_before_second_load
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+        client.queue_pending_load(instrument_id);
+
+        wait_until_async(
+            || {
+                let client = &client;
+                async move {
+                    client
+                        .closed_condition_ids
+                        .lock()
+                        .expect("closed_condition_ids mutex poisoned")
+                        .contains(CONDITION)
+                        && !client.active_quote_subs.contains(&instrument_id)
+                        && !client.instruments.load().contains_key(&instrument_id)
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert!(!client.active_quote_subs.contains(&instrument_id));
+        assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert!(!client.token_meta.contains_key(&Ustr::from(TOKEN)));
+        assert!(!client.ws_open_tokens.contains(&Ustr::from(TOKEN)));
+        let payloads = state.market_payloads.lock().await.clone();
+        if open_completes_last {
+            assert!(payloads.is_empty());
+        }
+
+        let published = std::iter::from_fn(|| data_rx.try_recv().ok())
+            .filter_map(|event| match event {
+                DataEvent::Instrument(instrument) if instrument.id() == instrument_id => {
+                    Some(crate::filters::market_closed(&instrument))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        if open_completes_last {
+            assert!(published.is_empty());
+        } else {
+            assert_eq!(published, vec![Some(false), Some(true)]);
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn remembered_closed_condition_rejects_later_subscription() {
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([]))],
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([
+                gamma_market_future_closed_fixture_value()
+            ]))],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+        let instrument_id = fixture_yes_instrument_id();
+
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("initial subscription should queue auto-load");
+
+        wait_until_async(
+            || {
+                let client = &client;
+                async move {
+                    !client.active_quote_subs.contains(&instrument_id)
+                        && !client.instruments.load().contains_key(&instrument_id)
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+        let query_count = state
+            .queries
+            .lock()
+            .expect("scripted auto-load queries mutex poisoned")
+            .len();
+
+        let _ = client.subscribe_quotes(SubscribeQuotes::new(
+            instrument_id,
+            Some(client.client_id),
+            Some(*POLYMARKET_VENUE),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        ));
+        // Quiet period: a terminal resubscription must not enqueue a delayed auto-load.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(
+            state
+                .queries
+                .lock()
+                .expect("scripted auto-load queries mutex poisoned")
+                .len(),
+            query_count,
+        );
+        assert!(!client.active_quote_subs.contains(&instrument_id));
+        assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert!(state.market_payloads.lock().await.is_empty());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn closed_watchlisted_metadata_stays_retired_on_resubscribe() {
+        let closed_market = gamma_market_future_closed_fixture_value();
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([]))],
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([
+                closed_market.clone()
+            ]))],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let instruments = instruments_from_gamma_fixture(closed_market);
+        let instrument = instruments
+            .iter()
+            .find(|instrument| instrument.id() == fixture_yes_instrument_id())
+            .expect("Yes instrument");
+        let sibling = instruments
+            .iter()
+            .find(|instrument| instrument.id() == fixture_no_instrument_id())
+            .expect("No instrument");
+        let instrument_id = instrument.id();
+        let sibling_id = sibling.id();
+
+        for (instrument, position_id) in [
+            (instrument, "P-CLOSED-WATCH-YES"),
+            (sibling, "P-CLOSED-WATCH-NO"),
+        ] {
+            cache_instrument(&client.instruments, &client.token_meta, instrument);
+            upsert_resolve_watch_entry_from_instrument(
+                &client.resolve_poll_watchlist,
+                instrument,
+                PositionId::new(position_id),
+            );
+        }
+        client.active_quote_subs.insert(instrument_id);
+        client.active_quote_subs.insert(sibling_id);
+        client.active_delta_subs.insert(sibling_id);
+        client.active_trade_subs.insert(sibling_id);
+        client.queue_pending_load(instrument_id);
+
+        wait_until_async(
+            || {
+                let client = &client;
+                async move {
+                    !client.active_quote_subs.contains(&instrument_id)
+                        && !client.active_quote_subs.contains(&sibling_id)
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert!(client.instruments.load().contains_key(&instrument_id));
+        assert!(client.instruments.load().contains_key(&sibling_id));
+        assert!(
+            client
+                .resolve_poll_watchlist
+                .contains_key(&TEST_CONDITION_ID.to_string())
+        );
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_NO))
+        );
+        assert!(!client.active_delta_subs.contains(&sibling_id));
+        assert!(!client.active_trade_subs.contains(&sibling_id));
+
+        let query_count = state
+            .queries
+            .lock()
+            .expect("scripted auto-load queries mutex poisoned")
+            .len();
+
+        for instrument_id in [instrument_id, sibling_id] {
+            let _ = client.subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ));
+        }
+        // Quiet period: retained settlement metadata must not trigger a delayed live reload.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(
+            state
+                .queries
+                .lock()
+                .expect("scripted auto-load queries mutex poisoned")
+                .len(),
+            query_count,
+        );
+        assert!(client.instruments.load().contains_key(&instrument_id));
+        assert!(client.instruments.load().contains_key(&sibling_id));
+        assert!(!client.active_quote_subs.contains(&instrument_id));
+        assert!(!client.active_quote_subs.contains(&sibling_id));
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
+        );
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_NO))
+        );
+        assert!(state.market_payloads.lock().await.is_empty());
+    }
+
+    #[rstest]
+    #[case::closed_probe_failure(false)]
+    #[case::normal_query_failure(true)]
+    #[tokio::test]
+    async fn auto_load_successful_chunks_survive_failed_chunk(#[case] normal_query_failure: bool) {
+        const FIRST_CONDITION: &str =
+            "0x0000000000000000000000000000000000000000000000000000000000000001";
+        const LAST_CONDITION: &str =
+            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        const FIRST_TOKEN: &str =
+            "77777777777777777777777777777777777777777777777777777777777777777";
+        const LAST_TOKEN: &str =
+            "88888888888888888888888888888888888888888888888888888888888888888";
+        let first_market = gamma_market_fixture_for(
+            FIRST_CONDITION,
+            FIRST_TOKEN,
+            "77777777777777777777777777777777777777777777777777777777777777778",
+            false,
+        );
+        let last_market = gamma_market_fixture_for(
+            LAST_CONDITION,
+            LAST_TOKEN,
+            "88888888888888888888888888888888888888888888888888888888888888889",
+            false,
+        );
+        let state = if normal_query_failure {
+            ScriptedAutoLoadServerState::new(
+                vec![
+                    ScriptedAutoLoadReply::ok(serde_json::json!([first_market])),
+                    ScriptedAutoLoadReply::failed(),
+                ],
+                vec![ScriptedAutoLoadReply::ok(serde_json::json!([]))],
+            )
+        } else {
+            ScriptedAutoLoadServerState::new(
+                vec![
+                    ScriptedAutoLoadReply::ok(serde_json::json!([first_market])),
+                    ScriptedAutoLoadReply::ok(serde_json::json!([last_market])),
+                ],
+                vec![
+                    ScriptedAutoLoadReply::failed(),
+                    ScriptedAutoLoadReply::ok(serde_json::json!([])),
+                ],
+            )
+        };
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 0;
+
+        let first_id = fixture_instrument_id(FIRST_CONDITION, FIRST_TOKEN);
+        let last_id = fixture_instrument_id(LAST_CONDITION, LAST_TOKEN);
+        let mut instrument_ids = vec![first_id, last_id];
+
+        for index in 2..=100 {
+            let condition_id = format!("0x{index:064x}");
+            let token_id = (9_000_000_u64 + index).to_string();
+            instrument_ids.push(fixture_instrument_id(&condition_id, &token_id));
+        }
+
+        for instrument_id in instrument_ids {
+            client
+                .subscribe_quotes(SubscribeQuotes::new(
+                    instrument_id,
+                    Some(client.client_id),
+                    Some(*POLYMARKET_VENUE),
+                    UUID4::new(),
+                    UnixNanos::default(),
+                    None,
+                    None,
+                ))
+                .expect("subscribe_quotes should queue auto-load");
+        }
+
+        wait_until_async(
+            || {
+                let client = &client;
+                async move {
+                    client.instruments.load().contains_key(&first_id)
+                        && client.active_quote_subs.contains(&first_id)
+                        && client.active_quote_subs.contains(&last_id)
+                        && (normal_query_failure
+                            || client.instruments.load().contains_key(&last_id))
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert!(client.instruments.load().contains_key(&first_id));
+        assert!(client.active_quote_subs.contains(&first_id));
+        assert!(client.active_quote_subs.contains(&last_id));
+        assert_eq!(
+            client.instruments.load().contains_key(&last_id),
+            !normal_query_failure
+        );
+
+        client
+            .ws_client
+            .disconnect()
+            .await
+            .expect("disconnect failed");
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/data/dispatch.rs
+++ b/crates/adapters/polymarket/src/data/dispatch.rs
@@ -35,7 +35,7 @@
 
 use std::sync::{Arc, Mutex as StdMutex};
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use dashmap::{DashMap, mapref::entry::Entry};
 use nautilus_common::{live::get_runtime, messages::DataEvent};
 use nautilus_core::{AtomicMap, AtomicSet, time::AtomicTime};
@@ -52,7 +52,7 @@ use ustr::Ustr;
 use super::{
     NEW_MARKET_EMPTY_RECHECK_DELAY, NEW_MARKET_EMPTY_RECHECK_MAX_ATTEMPTS,
     effective_deltas::apply_snapshot_and_diff,
-    instruments::{TokenMeta, cache_instrument_if_active},
+    instruments::{TokenMeta, apply_live_instrument},
 };
 use crate::{
     filters::InstrumentFilter,
@@ -102,6 +102,7 @@ pub(super) struct WsMessageContext {
     pub(super) active_quote_subs: Arc<AtomicSet<InstrumentId>>,
     pub(super) active_delta_subs: Arc<AtomicSet<InstrumentId>>,
     pub(super) active_trade_subs: Arc<AtomicSet<InstrumentId>>,
+    pub(super) closed_condition_ids: Arc<StdMutex<AHashSet<String>>>,
     pub(super) resolve_poll_watchlist: Arc<AtomicMap<String, ResolveWatchEntry>>,
     pub(super) resolve_watch_apply_mutex: Arc<StdMutex<()>>,
     pub(super) pending_snapshot_after_tick_change: Arc<AtomicSet<InstrumentId>>,
@@ -113,6 +114,20 @@ pub(super) struct WsMessageContext {
     pub(super) drop_quotes_missing_side: bool,
     pub(super) compute_effective_deltas: bool,
     pub(super) cancellation_token: CancellationToken,
+}
+
+fn lock_live_condition<'a>(
+    ctx: &'a WsMessageContext,
+    instrument_id: InstrumentId,
+) -> Option<std::sync::MutexGuard<'a, AHashSet<String>>> {
+    let terminal_conditions = ctx
+        .closed_condition_ids
+        .lock()
+        .expect("closed_condition_ids mutex poisoned");
+    let is_terminal = crate::providers::extract_condition_id(&instrument_id)
+        .is_ok_and(|condition_id| terminal_conditions.contains(&condition_id));
+
+    (!is_terminal).then_some(terminal_conditions)
 }
 
 impl WsMessageContext {
@@ -190,6 +205,9 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                 }
             };
             let instrument_id = meta.instrument_id;
+            let Some(_terminal_guard) = lock_live_condition(ctx, instrument_id) else {
+                return;
+            };
 
             if let Err(e) =
                 verify_book_snapshot_hash(&snap, meta.min_order_size.as_deref(), meta.neg_risk)
@@ -333,6 +351,9 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
 
             for (group_index, meta, change) in resolved {
                 let instrument_id = meta.instrument_id;
+                let Some(_terminal_guard) = lock_live_condition(ctx, instrument_id) else {
+                    continue;
+                };
                 let changes = std::mem::take(&mut groups[group_index].1);
 
                 if !changes.is_empty() && ctx.active_delta_subs.contains(&instrument_id) {
@@ -425,6 +446,9 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                 }
             };
             let instrument_id = meta.instrument_id;
+            let Some(_terminal_guard) = lock_live_condition(ctx, instrument_id) else {
+                return;
+            };
 
             if ctx.active_trade_subs.contains(&instrument_id) {
                 let ts_init = ctx.clock.get_time_ns();
@@ -457,6 +481,9 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                     log::error!("No instrument for token_id {token_id}");
                     return;
                 }
+            };
+            let Some(_terminal_guard) = lock_live_condition(ctx, meta.instrument_id) else {
+                return;
             };
 
             let tick_size: rust_decimal::Decimal = match change.new_tick_size.parse() {
@@ -586,6 +613,7 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
             let filters = ctx.filters.clone();
             let token_meta = ctx.token_meta.clone();
             let instruments = ctx.instruments.clone();
+            let closed_condition_ids = ctx.closed_condition_ids.clone();
             let data_sender = ctx.data_sender.clone();
             let clock = ctx.clock;
             let cancellation = ctx.cancellation_token.clone();
@@ -694,11 +722,9 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                                 continue;
                             }
 
-                            if !cache_instrument_if_active(
-                                clock.get_time_ns(),
-                                &instruments,
-                                &token_meta,
+                            if crate::data::runtime::is_instrument_expired(
                                 &inst,
+                                clock.get_time_ns(),
                             ) {
                                 log::debug!(
                                     "Skipping expired new market instrument {} during cache update",
@@ -708,36 +734,48 @@ fn handle_market_message(message: MarketWsMessage, ctx: &WsMessageContext) {
                             }
 
                             let instrument_id = inst.id();
-                            if let Err(e) = data_sender.send(DataEvent::Instrument(inst)) {
-                                log::error!(
-                                    "Failed to emit new market instrument {instrument_id}: {e}"
-                                );
-                            }
+                            apply_live_instrument(
+                                &closed_condition_ids,
+                                &instruments,
+                                &token_meta,
+                                &inst,
+                                |instrument| {
+                                    if let Err(e) = data_sender
+                                        .send(DataEvent::Instrument(instrument.clone()))
+                                    {
+                                        log::error!(
+                                            "Failed to emit new market instrument {instrument_id}: {e}"
+                                        );
+                                    }
 
-                            // Emit instrument status based on WS active flag
-                            let ts_now = clock.get_time_ns();
-                            let action = if active {
-                                MarketStatusAction::Trading
-                            } else {
-                                MarketStatusAction::PreOpen
-                            };
-                            let status = InstrumentStatus::new(
-                                instrument_id,
-                                action,
-                                ts_now,
-                                ts_now,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
+                                    // Emit instrument status based on WS active flag
+                                    let ts_now = clock.get_time_ns();
+                                    let action = if active {
+                                        MarketStatusAction::Trading
+                                    } else {
+                                        MarketStatusAction::PreOpen
+                                    };
+                                    let status = InstrumentStatus::new(
+                                        instrument_id,
+                                        action,
+                                        ts_now,
+                                        ts_now,
+                                        None,
+                                        None,
+                                        None,
+                                        None,
+                                        None,
+                                    );
+
+                                    if let Err(e) =
+                                        data_sender.send(DataEvent::InstrumentStatus(status))
+                                    {
+                                        log::error!(
+                                            "Failed to emit instrument status for {instrument_id}: {e}"
+                                        );
+                                    }
+                                },
                             );
-
-                            if let Err(e) = data_sender.send(DataEvent::InstrumentStatus(status)) {
-                                log::error!(
-                                    "Failed to emit instrument status for {instrument_id}: {e}"
-                                );
-                            }
                         }
                     }
                     Err(e) => log::warn!(
@@ -826,8 +864,8 @@ mod tests {
         messages::{
             DataResponse,
             data::{
-                RequestBookSnapshot, RequestCustomData, RequestTrades, SubscribeBookDeltas,
-                SubscribeQuotes,
+                RequestBookSnapshot, RequestCustomData, RequestInstrument, RequestTrades,
+                SubscribeBookDeltas, SubscribeQuotes,
             },
         },
         testing::wait_until_async,
@@ -1035,6 +1073,7 @@ mod tests {
             active_quote_subs: Arc::new(AtomicSet::new()),
             active_delta_subs: Arc::new(AtomicSet::new()),
             active_trade_subs: Arc::new(AtomicSet::new()),
+            closed_condition_ids: Arc::new(StdMutex::new(AHashSet::new())),
             resolve_poll_watchlist: Arc::new(AtomicMap::new()),
             resolve_watch_apply_mutex: Arc::new(StdMutex::new(())),
             pending_snapshot_after_tick_change: Arc::new(AtomicSet::new()),
@@ -1191,6 +1230,7 @@ mod tests {
             active_quote_subs: client.active_quote_subs.clone(),
             active_delta_subs: client.active_delta_subs.clone(),
             active_trade_subs: client.active_trade_subs.clone(),
+            closed_condition_ids: client.closed_condition_ids.clone(),
             resolve_poll_watchlist: client.resolve_poll_watchlist.clone(),
             resolve_watch_apply_mutex: client.resolve_watch_apply_mutex.clone(),
             pending_snapshot_after_tick_change: client.pending_snapshot_after_tick_change.clone(),
@@ -1554,6 +1594,162 @@ mod tests {
         assert!(
             emitted_instrument,
             "expected emitted DataEvent::Instrument after successful recheck"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn new_market_does_not_restore_terminal_condition_live_state() {
+        let market = gamma_market_recheck_fixture_value();
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([market]))],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (client, mut data_rx) = create_test_client(addr);
+        let mut ctx = make_client_ws_ctx(&client);
+        ctx.subscribe_new_markets = true;
+        crate::data::runtime::register_closed_condition(
+            &client.closed_condition_ids,
+            TEST_CONDITION_ID,
+        );
+
+        handle_market_message(
+            make_new_market_with_condition("terminal-condition", TEST_CONDITION_ID, true),
+            &ctx,
+        );
+
+        wait_until_async(
+            || {
+                let state = state.clone();
+                let ctx = &ctx;
+                async move {
+                    !state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .is_empty()
+                        && ctx.new_market_inflight_keys.is_empty()
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert!(ctx.instruments.load().is_empty());
+        assert!(ctx.token_meta.is_empty());
+        assert!(data_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn terminal_condition_drops_queued_market_data_dispatch() {
+        let state = ScriptedAutoLoadServerState::new(vec![], vec![]);
+        let addr = start_scripted_auto_load_test_server(state).await;
+        let (client, mut data_rx) = create_test_client(addr);
+        let instrument = instrument_from_gamma_fixture(gamma_market_recheck_fixture_value());
+        let instrument_id = instrument.id();
+        cache_instrument(&client.instruments, &client.token_meta, &instrument);
+        client.active_delta_subs.insert(instrument_id);
+        crate::data::runtime::register_closed_condition(
+            &client.closed_condition_ids,
+            TEST_CONDITION_ID,
+        );
+        let ctx = make_client_ws_ctx(&client);
+
+        handle_market_message(
+            make_price_change(
+                TEST_CONDITION_ID,
+                instrument.raw_symbol().as_str(),
+                "0.45",
+                "20",
+            ),
+            &ctx,
+        );
+
+        assert!(ctx.order_books.is_empty());
+        assert!(data_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn queued_reconciliation_cannot_subscribe_terminal_condition() {
+        let state = ScriptedAutoLoadServerState::new(vec![], vec![]);
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (client, _data_rx) = create_test_client(addr);
+        let instrument = instrument_from_gamma_fixture(gamma_market_recheck_fixture_value());
+        let instrument_id = instrument.id();
+        let token_id = Ustr::from(instrument.raw_symbol().as_str());
+        cache_instrument(&client.instruments, &client.token_meta, &instrument);
+        client.active_quote_subs.insert(instrument_id);
+
+        let guard = client.ws_sub_mutex.lock().await;
+        client.sync_ws_subscription(instrument_id);
+        crate::data::runtime::register_closed_condition(
+            &client.closed_condition_ids,
+            TEST_CONDITION_ID,
+        );
+        drop(guard);
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(!client.ws_open_tokens.contains(&token_id));
+        assert!(state.market_payloads.lock().await.is_empty());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn instrument_request_does_not_restore_terminal_condition_live_state() {
+        let market = gamma_market_recheck_fixture_value();
+        let state = ScriptedAutoLoadServerState::new(
+            vec![ScriptedAutoLoadReply::ok(serde_json::json!([market]))],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state).await;
+        let (client, mut data_rx) = create_test_client(addr);
+        crate::data::runtime::register_closed_condition(
+            &client.closed_condition_ids,
+            TEST_CONDITION_ID,
+        );
+        let instrument_id = fixture_yes_instrument_id();
+
+        client
+            .request_instrument(RequestInstrument::new(
+                instrument_id,
+                None,
+                None,
+                Some(client.client_id),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+            ))
+            .expect("instrument request should start");
+
+        let events = tokio::time::timeout(StdDuration::from_secs(3), async {
+            let mut events = Vec::new();
+
+            loop {
+                let event = data_rx.recv().await.expect("data event channel closed");
+                let is_response = matches!(event, DataEvent::Response(DataResponse::Instrument(_)));
+                events.push(event);
+                if is_response {
+                    return events;
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for instrument response");
+
+        assert!(
+            events
+                .iter()
+                .all(|event| !matches!(event, DataEvent::Instrument(_)))
+        );
+        assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert!(
+            !client
+                .token_meta
+                .contains_key(&Ustr::from(TEST_TOKEN_ID_YES))
         );
     }
 
@@ -3798,9 +3994,9 @@ mod tests {
         let ws_sub_mutex = client.ws_sub_mutex.clone();
         let ws = client.ws_client.handle();
 
-        // Reproduce the synchronous subscription split exactly: intent is inserted first, then a
-        // concurrent closure is paused after retiring that intent but before local book cleanup.
-        let ws_guard = ws_sub_mutex.clone().lock_owned().await;
+        // Start with delta intent present, then race a second intent insertion after terminal
+        // registration. Closure must remove the first and reject the second without recreating
+        // its effective-delta book.
         client.active_delta_subs.insert(instrument_id);
 
         let closure_thread = std::thread::spawn(move || {
@@ -3846,7 +4042,6 @@ mod tests {
 
         assert!(!client.add_delta_subscription_intent(instrument_id));
         let recreated_order_book = client.order_books.contains_key(&instrument_id);
-        drop(ws_guard);
         closure_thread.join().expect("closure thread");
 
         assert!(!recreated_order_book);
@@ -4330,6 +4525,7 @@ mod tests {
             &client.data_sender,
             UnixNanos::from(u64::MAX),
             &client.closed_condition_ids,
+            &client.ws_sub_mutex,
             None,
         )
         .await
@@ -4420,6 +4616,7 @@ mod tests {
             &client.data_sender,
             UnixNanos::from(u64::MAX),
             &client.closed_condition_ids,
+            &client.ws_sub_mutex,
             None,
         )
         .await
@@ -4661,6 +4858,82 @@ mod tests {
             published_requested |= instrument.id() == instrument_id;
         }
         assert!(published_requested);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn auto_load_open_condition_retries_when_requested_token_is_missing() {
+        const MISSING_TOKEN: &str =
+            "99999999999999999999999999999999999999999999999999999999999999999";
+        let market = gamma_market_recheck_fixture_value();
+        let state = ScriptedAutoLoadServerState::new(
+            vec![
+                ScriptedAutoLoadReply::ok(serde_json::json!([market.clone()])),
+                ScriptedAutoLoadReply::ok(serde_json::json!([market.clone()])),
+                ScriptedAutoLoadReply::ok(serde_json::json!([market])),
+            ],
+            vec![],
+        );
+        let addr = start_scripted_auto_load_test_server(state.clone()).await;
+        let (mut client, _data_rx) = create_test_client(addr);
+        client.config.auto_load_debounce_ms = 0;
+        client.config.auto_load_max_retries = 2;
+        client.config.auto_load_retry_delay_initial_secs = 0.0;
+        client.config.auto_load_retry_delay_max_secs = 0.0;
+
+        let instrument_id = fixture_instrument_id(TEST_CONDITION_ID, MISSING_TOKEN);
+        client
+            .subscribe_quotes(SubscribeQuotes::new(
+                instrument_id,
+                Some(client.client_id),
+                Some(*POLYMARKET_VENUE),
+                UUID4::new(),
+                UnixNanos::default(),
+                None,
+                None,
+            ))
+            .expect("missing token subscription should queue auto-load");
+
+        wait_until_async(
+            || {
+                let state = state.clone();
+                async move {
+                    state
+                        .queries
+                        .lock()
+                        .expect("scripted auto-load queries mutex poisoned")
+                        .len()
+                        >= 3
+                }
+            },
+            StdDuration::from_secs(3),
+        )
+        .await;
+
+        assert_eq!(
+            state
+                .queries
+                .lock()
+                .expect("scripted auto-load queries mutex poisoned")
+                .as_slice(),
+            &[
+                ExpiredAutoLoadQuery {
+                    condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                    closed: None,
+                },
+                ExpiredAutoLoadQuery {
+                    condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                    closed: None,
+                },
+                ExpiredAutoLoadQuery {
+                    condition_ids: Some(TEST_CONDITION_ID.to_string()),
+                    closed: None,
+                },
+            ],
+        );
+        assert!(client.active_quote_subs.contains(&instrument_id));
+        assert!(!client.instruments.load().contains_key(&instrument_id));
+        assert!(!client.ws_open_tokens.contains(&Ustr::from(MISSING_TOKEN)));
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/data/instruments.rs
+++ b/crates/adapters/polymarket/src/data/instruments.rs
@@ -45,11 +45,7 @@ pub(crate) struct TokenMeta {
     pub(crate) neg_risk: Option<bool>,
 }
 
-// Inserts `instrument` into the live instrument cache and updates the
-// `token_meta` routing index in one step. Every path that populates the live
-// cache must go through here so WS messages can always resolve token_id back
-// to an InstrumentId.
-pub(crate) fn cache_instrument(
+fn cache_instrument_unchecked(
     instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
     token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
     instrument: &InstrumentAny,
@@ -60,6 +56,39 @@ pub(crate) fn cache_instrument(
         TokenMeta::from_instrument(instrument),
     );
     instruments.insert(instrument_id, instrument.clone());
+}
+
+// Applies one instrument to live cache, routing, and publication state while
+// terminal closure is excluded by the shared condition boundary.
+pub(crate) fn apply_live_instrument(
+    closed_condition_ids: &Arc<std::sync::Mutex<AHashSet<String>>>,
+    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+    token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
+    instrument: &InstrumentAny,
+    apply: impl FnOnce(&InstrumentAny),
+) -> bool {
+    let terminal_conditions = closed_condition_ids
+        .lock()
+        .expect("closed_condition_ids mutex poisoned");
+    let is_terminal = extract_condition_id(&instrument.id())
+        .is_ok_and(|condition_id| terminal_conditions.contains(&condition_id));
+
+    if is_terminal {
+        return false;
+    }
+
+    cache_instrument_unchecked(instruments, token_meta, instrument);
+    apply(instrument);
+    true
+}
+
+#[cfg(test)]
+pub(crate) fn cache_instrument(
+    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+    token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
+    instrument: &InstrumentAny,
+) {
+    cache_instrument_unchecked(instruments, token_meta, instrument);
 }
 
 pub(super) fn publish_cached_condition_closed(
@@ -120,6 +149,7 @@ impl TokenMeta {
 
 pub(super) fn cache_instrument_if_active(
     now_ns: UnixNanos,
+    closed_condition_ids: &Arc<std::sync::Mutex<AHashSet<String>>>,
     instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
     token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
     instrument: &InstrumentAny,
@@ -128,11 +158,17 @@ pub(super) fn cache_instrument_if_active(
         return false;
     }
 
-    cache_instrument(instruments, token_meta, instrument);
-    true
+    apply_live_instrument(
+        closed_condition_ids,
+        instruments,
+        token_meta,
+        instrument,
+        |_| {},
+    )
 }
 
 pub(super) fn cache_and_publish_instruments(
+    closed_condition_ids: &Arc<std::sync::Mutex<AHashSet<String>>>,
     instruments_cache: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
     token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
     data_sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
@@ -142,7 +178,7 @@ pub(super) fn cache_and_publish_instruments(
     let mut total = 0;
 
     for instrument in instruments {
-        if !cache_instrument_if_active(now_ns, instruments_cache, token_meta, &instrument) {
+        if is_instrument_expired(&instrument, now_ns) {
             log::debug!(
                 "Skipping expired instrument {} during live cache publish",
                 instrument.id()
@@ -151,20 +187,34 @@ pub(super) fn cache_and_publish_instruments(
         }
 
         let instrument_id = instrument.id();
-        total += 1;
 
-        if let Err(e) = data_sender.send(DataEvent::Instrument(instrument)) {
-            log::warn!("Failed to publish instrument {instrument_id}: {e}");
+        if apply_live_instrument(
+            closed_condition_ids,
+            instruments_cache,
+            token_meta,
+            &instrument,
+            |instrument| {
+                if let Err(e) = data_sender.send(DataEvent::Instrument(instrument.clone())) {
+                    log::warn!("Failed to publish instrument {instrument_id}: {e}");
+                }
+            },
+        ) {
+            total += 1;
         }
     }
 
     total
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "shared adapter state is held in Arcs"
+)]
 pub(super) async fn refresh_scoped_instruments(
     http_client: PolymarketGammaHttpClient,
     instrument_config: Option<crate::config::PolymarketInstrumentProviderConfig>,
     filters: Vec<Arc<dyn InstrumentFilter>>,
+    closed_condition_ids: &Arc<std::sync::Mutex<AHashSet<String>>>,
     instruments_cache: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
     token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
     data_sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
@@ -178,6 +228,7 @@ pub(super) async fn refresh_scoped_instruments(
             .await?;
 
     Ok(cache_and_publish_instruments(
+        closed_condition_ids,
         instruments_cache,
         token_meta,
         data_sender,
@@ -257,6 +308,7 @@ pub(super) async fn refresh_expired_market_closure(
     sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
     now_ns: UnixNanos,
     closed_condition_ids: &Arc<std::sync::Mutex<AHashSet<String>>>,
+    ws_sub_mutex: &Arc<tokio::sync::Mutex<()>>,
     cancellation: Option<&CancellationToken>,
 ) -> anyhow::Result<usize> {
     let mut carried: AHashMap<String, Vec<InstrumentId>> = AHashMap::new();
@@ -299,7 +351,20 @@ pub(super) async fn refresh_expired_market_closure(
 
     // Serialize terminal application with reset. If reset wins the boundary, this old generation
     // must not mutate or publish from the cache it captured before the request.
-    let mut terminal_conditions = closed_condition_ids
+    for condition_id in &closed_ids {
+        if !crate::data::runtime::register_closed_condition_for_live_data(
+            closed_condition_ids,
+            ws_sub_mutex,
+            condition_id,
+            cancellation,
+        )
+        .await
+        {
+            return Ok(0);
+        }
+    }
+
+    let terminal_conditions = closed_condition_ids
         .lock()
         .expect("closed_condition_ids mutex poisoned");
 
@@ -307,9 +372,9 @@ pub(super) async fn refresh_expired_market_closure(
         return Ok(0);
     }
 
-    // Positive Gamma closure evidence is terminal and must become visible before cache mutation.
+    // Positive Gamma closure evidence is terminal before cache mutation.
     for condition_id in &closed_ids {
-        terminal_conditions.insert(condition_id.clone());
+        debug_assert!(terminal_conditions.contains(condition_id));
     }
     let mut updated = Vec::new();
 
@@ -355,6 +420,7 @@ impl PolymarketDataClient {
         self.provider.initialize(false).await?;
 
         let total = cache_and_publish_instruments(
+            &self.closed_condition_ids,
             &self.instruments,
             &self.token_meta,
             &self.data_sender,
@@ -392,6 +458,7 @@ impl PolymarketDataClient {
         let instrument_config = self.config.instrument_config.clone();
         let instruments_cache = self.instruments.clone();
         let token_meta = self.token_meta.clone();
+        let closed_condition_ids = self.closed_condition_ids.clone();
         let data_sender = self.data_sender.clone();
         let clock = self.clock;
 
@@ -411,6 +478,7 @@ impl PolymarketDataClient {
                     http_client.clone(),
                     instrument_config.clone(),
                     filters.clone(),
+                    &closed_condition_ids,
                     &instruments_cache,
                     &token_meta,
                     &data_sender,
@@ -672,6 +740,31 @@ mod tests {
         }
     }
 
+    #[rstest]
+    fn cache_and_publish_skips_terminal_condition() {
+        let instruments = Arc::new(AtomicMap::new());
+        let token_meta = Arc::new(DashMap::new());
+        let closed_condition_ids =
+            Arc::new(StdMutex::new(AHashSet::from_iter(["terminal".to_string()])));
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let instrument =
+            stub_instrument("terminal-token", Price::from("0.01"), Quantity::from("0.1"));
+
+        let total = cache_and_publish_instruments(
+            &closed_condition_ids,
+            &instruments,
+            &token_meta,
+            &tx,
+            UnixNanos::default(),
+            vec![instrument],
+        );
+
+        assert_eq!(total, 0);
+        assert!(instruments.load().is_empty());
+        assert!(token_meta.is_empty());
+        assert!(rx.try_recv().is_err());
+    }
+
     fn past_end_open_market() -> serde_json::Value {
         serde_json::from_str(include_str!(
             "../../test_data/gamma_market_past_end_date_open.json"
@@ -754,12 +847,14 @@ mod tests {
         .unwrap();
 
         let closed_condition_ids = Arc::new(StdMutex::new(AHashSet::new()));
+        let ws_sub_mutex = Arc::new(tokio::sync::Mutex::new(()));
         let result = refresh_expired_market_closure(
             &client,
             &instruments,
             &tx,
             UnixNanos::from(u64::MAX),
             &closed_condition_ids,
+            &ws_sub_mutex,
             None,
         )
         .await;
@@ -845,12 +940,14 @@ mod tests {
         .unwrap();
 
         let closed_condition_ids = Arc::new(StdMutex::new(AHashSet::new()));
+        let ws_sub_mutex = Arc::new(tokio::sync::Mutex::new(()));
         let result = refresh_expired_market_closure(
             &client,
             &instruments,
             &tx,
             UnixNanos::from(u64::MAX),
             &closed_condition_ids,
+            &ws_sub_mutex,
             None,
         )
         .await;

--- a/crates/adapters/polymarket/src/data/instruments.rs
+++ b/crates/adapters/polymarket/src/data/instruments.rs
@@ -23,6 +23,7 @@ use nautilus_model::{
     identifiers::InstrumentId,
     instruments::{Instrument, InstrumentAny},
 };
+use tokio_util::sync::CancellationToken;
 use ustr::Ustr;
 
 use super::{PolymarketDataClient, runtime::is_instrument_expired};
@@ -59,6 +60,43 @@ pub(crate) fn cache_instrument(
         TokenMeta::from_instrument(instrument),
     );
     instruments.insert(instrument_id, instrument.clone());
+}
+
+pub(super) fn publish_cached_condition_closed(
+    condition_id: &str,
+    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+    data_sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
+) -> usize {
+    let mut updated = Vec::new();
+
+    instruments.rcu(|map| {
+        updated.clear();
+
+        for (instrument_id, instrument) in map.iter_mut() {
+            if !extract_condition_id(instrument_id).is_ok_and(|candidate| candidate == condition_id)
+            {
+                continue;
+            }
+
+            if let InstrumentAny::BinaryOption(binary) = instrument
+                && binary_market_closed(binary) != Some(true)
+            {
+                set_market_closed(binary, true);
+                updated.push(InstrumentAny::BinaryOption(binary.clone()));
+            }
+        }
+    });
+
+    for instrument in &updated {
+        let instrument_id = instrument.id();
+        if let Some(latest) = instruments.get_cloned(&instrument_id)
+            && let Err(e) = data_sender.send(DataEvent::Instrument(latest))
+        {
+            log::warn!("Failed to publish market closure update for {instrument_id}: {e}");
+        }
+    }
+
+    updated.len()
 }
 
 impl TokenMeta {
@@ -148,6 +186,32 @@ pub(super) async fn refresh_scoped_instruments(
     ))
 }
 
+// Queries Gamma's positive `closed=true` path and returns only conditions it confirms closed.
+pub(super) async fn query_positive_closed_condition_ids(
+    http: &PolymarketGammaHttpClient,
+    condition_ids: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let requested = condition_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<AHashSet<_>>();
+    let markets = http
+        .request_markets_by_params(GetGammaMarketsParams {
+            condition_ids: Some(condition_ids.to_vec()),
+            closed: Some(true),
+            ..Default::default()
+        })
+        .await?;
+
+    Ok(markets
+        .into_iter()
+        .filter(|market| {
+            market.closed == Some(true) && requested.contains(market.condition_id.as_str())
+        })
+        .map(|market| market.condition_id)
+        .collect())
+}
+
 // Returns the condition IDs Gamma positively reports as `closed=true`.
 //
 // Condition IDs the unfiltered lookup does not return are re-queried with `closed=true`, so a
@@ -182,19 +246,7 @@ async fn probe_closed_condition_ids(
         return Ok(closed_ids);
     }
 
-    let closed = http
-        .request_markets_by_params(GetGammaMarketsParams {
-            condition_ids: Some(missing),
-            closed: Some(true),
-            ..Default::default()
-        })
-        .await?;
-    closed_ids.extend(
-        closed
-            .into_iter()
-            .filter(|market| market.closed == Some(true))
-            .map(|market| market.condition_id),
-    );
+    closed_ids.extend(query_positive_closed_condition_ids(http, &missing).await?);
 
     Ok(closed_ids)
 }
@@ -204,6 +256,8 @@ pub(super) async fn refresh_expired_market_closure(
     cache: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
     sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>,
     now_ns: UnixNanos,
+    closed_condition_ids: &Arc<std::sync::Mutex<AHashSet<String>>>,
+    cancellation: Option<&CancellationToken>,
 ) -> anyhow::Result<usize> {
     let mut carried: AHashMap<String, Vec<InstrumentId>> = AHashMap::new();
 
@@ -242,6 +296,21 @@ pub(super) async fn refresh_expired_market_closure(
         .flatten()
         .copied()
         .collect::<Vec<_>>();
+
+    // Serialize terminal application with reset. If reset wins the boundary, this old generation
+    // must not mutate or publish from the cache it captured before the request.
+    let mut terminal_conditions = closed_condition_ids
+        .lock()
+        .expect("closed_condition_ids mutex poisoned");
+
+    if cancellation.is_some_and(CancellationToken::is_cancelled) {
+        return Ok(0);
+    }
+
+    // Positive Gamma closure evidence is terminal and must become visible before cache mutation.
+    for condition_id in &closed_ids {
+        terminal_conditions.insert(condition_id.clone());
+    }
     let mut updated = Vec::new();
 
     // Compose against the latest cached value, so a concurrent tick size change is not discarded.
@@ -373,7 +442,10 @@ impl PolymarketDataClient {
 mod tests {
     use std::{
         net::SocketAddr,
-        sync::atomic::{AtomicUsize, Ordering},
+        sync::{
+            Mutex as StdMutex,
+            atomic::{AtomicUsize, Ordering},
+        },
     };
 
     use axum::{
@@ -681,9 +753,16 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            refresh_expired_market_closure(&client, &instruments, &tx, UnixNanos::from(u64::MAX))
-                .await;
+        let closed_condition_ids = Arc::new(StdMutex::new(AHashSet::new()));
+        let result = refresh_expired_market_closure(
+            &client,
+            &instruments,
+            &tx,
+            UnixNanos::from(u64::MAX),
+            &closed_condition_ids,
+            None,
+        )
+        .await;
 
         if fail {
             assert!(result.is_err());
@@ -765,9 +844,16 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            refresh_expired_market_closure(&client, &instruments, &tx, UnixNanos::from(u64::MAX))
-                .await;
+        let closed_condition_ids = Arc::new(StdMutex::new(AHashSet::new()));
+        let result = refresh_expired_market_closure(
+            &client,
+            &instruments,
+            &tx,
+            UnixNanos::from(u64::MAX),
+            &closed_condition_ids,
+            None,
+        )
+        .await;
 
         assert!(result.is_err());
 
@@ -778,5 +864,12 @@ mod tests {
             .count();
 
         assert_eq!(closed, GAMMA_CONDITION_IDS_BATCH_SIZE);
+        assert_eq!(
+            closed_condition_ids
+                .lock()
+                .expect("closed_condition_ids mutex poisoned")
+                .len(),
+            GAMMA_CONDITION_IDS_BATCH_SIZE,
+        );
     }
 }

--- a/crates/adapters/polymarket/src/data/lifecycle.rs
+++ b/crates/adapters/polymarket/src/data/lifecycle.rs
@@ -15,20 +15,23 @@
 
 use std::time::Duration;
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use dashmap::DashMap;
 use nautilus_common::{
     live::get_runtime,
     msgbus::{self, TypedHandler},
 };
-use nautilus_core::AtomicSet;
+use nautilus_core::{AtomicMap, AtomicSet};
 use nautilus_model::events::PositionEvent;
 
 use super::{
     PolymarketDataClient,
     dispatch::{WsMessageContext, handle_ws_message},
     instruments::refresh_expired_market_closure,
-    runtime::{retire_expired_local_instruments, seed_token_meta_from_live_instruments},
+    runtime::{
+        retire_closed_condition_state, retire_expired_local_instruments,
+        seed_token_meta_from_live_instruments,
+    },
 };
 use crate::{
     data_types::register_polymarket_custom_data,
@@ -150,6 +153,7 @@ impl PolymarketDataClient {
         let ws = self.ws_client.handle();
         let closure_client = gamma_client.clone();
         let closure_sender = self.data_sender.clone();
+        let closed_condition_ids = self.closed_condition_ids.clone();
 
         let ctx = WsMessageContext {
             clock: self.clock,
@@ -199,10 +203,54 @@ impl PolymarketDataClient {
 
                         // Runs on every tick so retirement never trails closure by more than one
                         // cycle. Without an expired instrument reported open, no request is sent.
-                        if let Err(e) = refresh_expired_market_closure(
-                            &closure_client, &instruments, &closure_sender, now_ns,
-                        ).await {
+                        let refresh_result = tokio::select! {
+                            result = refresh_expired_market_closure(
+                                &closure_client,
+                                &instruments,
+                                &closure_sender,
+                                now_ns,
+                                &closed_condition_ids,
+                                Some(&cancellation),
+                            ) => result,
+                            () = cancellation.cancelled() => break,
+                        };
+
+                        if let Err(e) = refresh_result {
                             log::warn!("Failed to refresh Polymarket market closure state: {e}");
+                        }
+
+                        if cancellation.is_cancelled() {
+                            break;
+                        }
+
+                        let terminal_conditions = closed_condition_ids
+                            .lock()
+                            .expect("closed_condition_ids mutex poisoned")
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>();
+
+                        for condition_id in terminal_conditions {
+                            retire_closed_condition_state(
+                                &condition_id,
+                                std::iter::empty(),
+                                &closed_condition_ids,
+                                &instruments,
+                                &token_meta,
+                                &order_books,
+                                &last_quotes,
+                                &active_quote_subs,
+                                &active_delta_subs,
+                                &active_trade_subs,
+                                &watchlist,
+                                &pending_snapshot_after_tick_change,
+                                &pending_auto_loads,
+                                &ws_open_tokens,
+                                &ws_sub_mutex,
+                                &ws,
+                                Some(&cancellation),
+                            )
+                            .await;
                         }
 
                         retire_expired_local_instruments(
@@ -329,10 +377,15 @@ impl PolymarketDataClient {
             handle.abort();
         }
 
-        self.instruments.store(AHashMap::new());
-        self.token_meta.clear();
-        self.order_books.clear();
-        self.last_quotes.clear();
+        let old_closed_condition_ids = self.closed_condition_ids.clone();
+        let _generation_guard = old_closed_condition_ids
+            .lock()
+            .expect("closed_condition_ids mutex poisoned");
+
+        self.instruments = std::sync::Arc::new(AtomicMap::new());
+        self.token_meta = std::sync::Arc::new(DashMap::new());
+        self.order_books = std::sync::Arc::new(DashMap::new());
+        self.last_quotes = std::sync::Arc::new(DashMap::new());
 
         self.active_quote_subs = std::sync::Arc::new(AtomicSet::new());
         self.active_delta_subs = std::sync::Arc::new(AtomicSet::new());
@@ -349,12 +402,9 @@ impl PolymarketDataClient {
             self.rtds_socket_control.clone(),
         );
 
-        self.pending_auto_loads
-            .lock()
-            .expect("pending_auto_loads mutex poisoned")
-            .clear();
-        self.auto_load_scheduled
-            .store(false, std::sync::atomic::Ordering::Release);
+        self.pending_auto_loads = std::sync::Arc::new(std::sync::Mutex::new(AHashSet::new()));
+        self.closed_condition_ids = std::sync::Arc::new(std::sync::Mutex::new(AHashSet::new()));
+        self.auto_load_scheduled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         self.cancellation_token = tokio_util::sync::CancellationToken::new();
     }

--- a/crates/adapters/polymarket/src/data/lifecycle.rs
+++ b/crates/adapters/polymarket/src/data/lifecycle.rs
@@ -73,6 +73,7 @@ impl PolymarketDataClient {
 
         seed_token_meta_from_live_instruments(
             self.clock.get_time_ns(),
+            &self.closed_condition_ids,
             &self.instruments,
             &self.token_meta,
         );
@@ -90,6 +91,7 @@ impl PolymarketDataClient {
             active_quote_subs: self.active_quote_subs.clone(),
             active_delta_subs: self.active_delta_subs.clone(),
             active_trade_subs: self.active_trade_subs.clone(),
+            closed_condition_ids: self.closed_condition_ids.clone(),
             resolve_poll_watchlist: self.resolve_poll_watchlist.clone(),
             resolve_watch_apply_mutex: self.resolve_watch_apply_mutex.clone(),
             pending_snapshot_after_tick_change: self.pending_snapshot_after_tick_change.clone(),
@@ -168,6 +170,7 @@ impl PolymarketDataClient {
             active_quote_subs: self.active_quote_subs.clone(),
             active_delta_subs: self.active_delta_subs.clone(),
             active_trade_subs: self.active_trade_subs.clone(),
+            closed_condition_ids: self.closed_condition_ids.clone(),
             resolve_poll_watchlist: self.resolve_poll_watchlist.clone(),
             resolve_watch_apply_mutex: self.resolve_watch_apply_mutex.clone(),
             pending_snapshot_after_tick_change: self.pending_snapshot_after_tick_change.clone(),
@@ -210,6 +213,7 @@ impl PolymarketDataClient {
                                 &closure_sender,
                                 now_ns,
                                 &closed_condition_ids,
+                                &ws_sub_mutex,
                                 Some(&cancellation),
                             ) => result,
                             () = cancellation.cancelled() => break,
@@ -1308,6 +1312,42 @@ mod tests {
                 "message-handler startup #{startup} must not re-seed token_meta for retained expired instruments",
             );
         }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn spawn_message_handler_does_not_reseed_terminal_condition_routing() {
+        let mut client = make_client_for_reset_test();
+        let expiration_ns = UnixNanos::from(
+            client
+                .clock
+                .get_time_ns()
+                .as_u64()
+                .saturating_add(1_000_000_000),
+        );
+        let inst = seed_instrument(
+            &client,
+            "0xCOND-TERMINAL-0xTOKEN_TERMINAL",
+            "0xCOND-TERMINAL",
+            expiration_ns,
+        );
+        let token_id = Ustr::from(inst.raw_symbol().as_str());
+
+        crate::data::runtime::register_closed_condition(
+            &client.closed_condition_ids,
+            "0xCOND-TERMINAL",
+        );
+        client.token_meta.clear();
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<PolymarketWsMessage>();
+        drop(tx);
+        client.spawn_message_handler(rx);
+        client
+            .await_tasks_with_timeout(tokio::time::Duration::from_secs(1))
+            .await;
+
+        assert!(client.instruments.load().contains_key(&inst.id()));
+        assert!(!client.token_meta.contains_key(&token_id));
     }
 
     // Matches EXPIRED_ENGINE_SWEEP_INTERVAL_NS in crates/adapters/sandbox/src/execution.rs.

--- a/crates/adapters/polymarket/src/data/mod.rs
+++ b/crates/adapters/polymarket/src/data/mod.rs
@@ -74,7 +74,7 @@ use self::{
         request_trades,
     },
     runtime::is_instrument_expired_and_not_reported_open,
-    subscriptions::{resolve_token_id_from, sync_ws_subscription_async},
+    subscriptions::{resolve_token_id_from, sync_ws_subscription_with_terminal_async},
 };
 use crate::{
     common::{
@@ -402,16 +402,18 @@ impl PolymarketDataClient {
         let active_quote_subs = self.active_quote_subs.clone();
         let active_delta_subs = self.active_delta_subs.clone();
         let active_trade_subs = self.active_trade_subs.clone();
+        let closed_condition_ids = self.closed_condition_ids.clone();
         let ws_open_tokens = self.ws_open_tokens.clone();
         let ws_sub_mutex = self.ws_sub_mutex.clone();
         let ws = self.ws_client.handle();
 
-        get_runtime().spawn(sync_ws_subscription_async(
+        get_runtime().spawn(sync_ws_subscription_with_terminal_async(
             instrument_id,
             token_id_str,
             active_quote_subs,
             active_delta_subs,
             active_trade_subs,
+            closed_condition_ids,
             ws_open_tokens,
             ws_sub_mutex,
             ws,

--- a/crates/adapters/polymarket/src/data/mod.rs
+++ b/crates/adapters/polymarket/src/data/mod.rs
@@ -137,6 +137,7 @@ pub struct PolymarketDataClient {
     ws_sub_mutex: Arc<tokio::sync::Mutex<()>>,
     pending_auto_loads: Arc<StdMutex<AHashSet<InstrumentId>>>,
     auto_load_scheduled: Arc<AtomicBool>,
+    closed_condition_ids: Arc<StdMutex<AHashSet<String>>>,
     position_event_handler: Option<TypedHandler<PositionEvent>>,
     rtds_feed: PolymarketRtdsFeed,
     socket_registry: SocketReconnectRegistry,
@@ -239,6 +240,7 @@ impl PolymarketDataClient {
             ws_sub_mutex: Arc::new(tokio::sync::Mutex::new(())),
             pending_auto_loads: Arc::new(StdMutex::new(AHashSet::new())),
             auto_load_scheduled: Arc::new(AtomicBool::new(false)),
+            closed_condition_ids: Arc::new(StdMutex::new(AHashSet::new())),
             position_event_handler: None,
             rtds_feed: PolymarketRtdsFeed::new_with_proxy_and_socket_control(
                 rtds_url,
@@ -340,6 +342,52 @@ impl PolymarketDataClient {
         }
 
         Ok(instrument)
+    }
+
+    fn add_live_subscription_intent(
+        &self,
+        instrument_id: InstrumentId,
+        subscriptions: &Arc<AtomicSet<InstrumentId>>,
+    ) -> bool {
+        self.add_live_subscription_intent_with_state(instrument_id, subscriptions, || {})
+    }
+
+    fn add_delta_subscription_intent(&self, instrument_id: InstrumentId) -> bool {
+        self.add_live_subscription_intent_with_state(instrument_id, &self.active_delta_subs, || {
+            if self.config.compute_effective_deltas {
+                self.order_books
+                    .entry(instrument_id)
+                    .or_insert_with(|| OrderBook::new(instrument_id, BookType::L2_MBP));
+            }
+        })
+    }
+
+    fn add_live_subscription_intent_with_state(
+        &self,
+        instrument_id: InstrumentId,
+        subscriptions: &Arc<AtomicSet<InstrumentId>>,
+        initialize_state: impl FnOnce(),
+    ) -> bool {
+        let Ok(condition_id) = crate::providers::extract_condition_id(&instrument_id) else {
+            subscriptions.insert(instrument_id);
+            initialize_state();
+            return true;
+        };
+        let closed = self
+            .closed_condition_ids
+            .lock()
+            .expect("closed_condition_ids mutex poisoned");
+
+        if closed.contains(&condition_id) {
+            log::debug!(
+                "Ignoring live subscription for terminally closed Polymarket condition {condition_id}"
+            );
+            return false;
+        }
+
+        subscriptions.insert(instrument_id);
+        initialize_state();
+        true
     }
 
     // Spawns an async task that reconciles the WS subscription for
@@ -512,12 +560,8 @@ impl DataClient for PolymarketDataClient {
         }
 
         // Mark intent before routing so unsubscribe can race-safely clear it.
-        self.active_delta_subs.insert(instrument_id);
-
-        if self.config.compute_effective_deltas {
-            self.order_books
-                .entry(instrument_id)
-                .or_insert_with(|| OrderBook::new(instrument_id, BookType::L2_MBP));
+        if !self.add_delta_subscription_intent(instrument_id) {
+            return Ok(());
         }
 
         if !cached {
@@ -546,7 +590,9 @@ impl DataClient for PolymarketDataClient {
             );
         }
 
-        self.active_quote_subs.insert(instrument_id);
+        if !self.add_live_subscription_intent(instrument_id, &self.active_quote_subs) {
+            return Ok(());
+        }
 
         if !cached {
             self.queue_pending_load(instrument_id);
@@ -568,7 +614,9 @@ impl DataClient for PolymarketDataClient {
             );
         }
 
-        self.active_trade_subs.insert(instrument_id);
+        if !self.add_live_subscription_intent(instrument_id, &self.active_trade_subs) {
+            return Ok(());
+        }
 
         if !cached {
             self.queue_pending_load(instrument_id);

--- a/crates/adapters/polymarket/src/data/requests.rs
+++ b/crates/adapters/polymarket/src/data/requests.rs
@@ -31,7 +31,9 @@ use nautilus_core::datetime::datetime_to_unix_nanos;
 use nautilus_model::{data::CustomData, instruments::Instrument};
 
 use super::{
-    PolymarketDataClient, dispatch::WsMessageContext, instruments::cache_instrument_if_active,
+    PolymarketDataClient,
+    dispatch::WsMessageContext,
+    instruments::{apply_live_instrument, cache_instrument_if_active},
 };
 use crate::{
     common::consts::POLYMARKET_VENUE,
@@ -85,6 +87,7 @@ pub(super) fn request_data(client: &PolymarketDataClient, request: RequestCustom
         active_quote_subs: client.active_quote_subs.clone(),
         active_delta_subs: client.active_delta_subs.clone(),
         active_trade_subs: client.active_trade_subs.clone(),
+        closed_condition_ids: client.closed_condition_ids.clone(),
         resolve_poll_watchlist: client.resolve_poll_watchlist.clone(),
         resolve_watch_apply_mutex: client.resolve_watch_apply_mutex.clone(),
         pending_snapshot_after_tick_change: client.pending_snapshot_after_tick_change.clone(),
@@ -208,6 +211,7 @@ pub(super) fn request_instruments(client: &PolymarketDataClient, request: Reques
     let instrument_config = client.provider.config().clone();
     let instruments_cache = client.instruments.clone();
     let token_meta = client.token_meta.clone();
+    let closed_condition_ids = client.closed_condition_ids.clone();
     let request_id = request.request_id;
     let client_id = request.client_id.unwrap_or(client.client_id);
     let venue = *POLYMARKET_VENUE;
@@ -236,6 +240,7 @@ pub(super) fn request_instruments(client: &PolymarketDataClient, request: Reques
         for instrument in &instruments {
             if !cache_instrument_if_active(
                 clock.get_time_ns(),
+                &closed_condition_ids,
                 &instruments_cache,
                 &token_meta,
                 instrument,
@@ -270,6 +275,7 @@ pub(super) fn request_instrument(client: &PolymarketDataClient, request: Request
     let sender = client.data_sender.clone();
     let instruments_cache = client.instruments.clone();
     let token_meta = client.token_meta.clone();
+    let closed_condition_ids = client.closed_condition_ids.clone();
     let client_id = request.client_id.unwrap_or(client.client_id);
     let request_id = request.request_id;
     let start = request.start;
@@ -300,16 +306,25 @@ pub(super) fn request_instrument(client: &PolymarketDataClient, request: Request
         };
 
         if let Some(inst) = instrument {
-            if cache_instrument_if_active(clock.get_time_ns(), &instruments_cache, &token_meta, &inst)
-            {
-                // Publish onto the data bus so other clients (e.g. the exec
-                // client's token map) can update from the same fetch.
-                if let Err(e) = sender.send(DataEvent::Instrument(inst.clone())) {
-                    log::warn!("Failed to publish instrument {instrument_id}: {e}");
-                }
-            } else {
+            if crate::data::runtime::is_instrument_expired(&inst, clock.get_time_ns()) {
                 log::debug!(
                     "Skipping expired instrument {instrument_id} during request_instrument cache update"
+                );
+            } else {
+                apply_live_instrument(
+                    &closed_condition_ids,
+                    &instruments_cache,
+                    &token_meta,
+                    &inst,
+                    |instrument| {
+                        // Publish onto the data bus so other clients (e.g. the exec
+                        // client's token map) can update from the same fetch.
+                        if let Err(e) =
+                            sender.send(DataEvent::Instrument(instrument.clone()))
+                        {
+                            log::warn!("Failed to publish instrument {instrument_id}: {e}");
+                        }
+                    },
                 );
             }
 

--- a/crates/adapters/polymarket/src/data/runtime.rs
+++ b/crates/adapters/polymarket/src/data/runtime.rs
@@ -45,6 +45,7 @@ pub(crate) fn is_condition_closed(
         .contains(condition_id)
 }
 
+#[cfg(test)]
 pub(crate) fn register_closed_condition(
     closed_condition_ids: &Arc<StdMutex<AHashSet<String>>>,
     condition_id: &str,
@@ -53,6 +54,32 @@ pub(crate) fn register_closed_condition(
         .lock()
         .expect("closed_condition_ids mutex poisoned")
         .insert(condition_id.to_string());
+}
+
+pub(crate) async fn register_closed_condition_for_live_data(
+    closed_condition_ids: &Arc<StdMutex<AHashSet<String>>>,
+    ws_sub_mutex: &Arc<tokio::sync::Mutex<()>>,
+    condition_id: &str,
+    cancellation: Option<&CancellationToken>,
+) -> bool {
+    let _reconcile_guard = if let Some(cancellation) = cancellation {
+        tokio::select! {
+            guard = ws_sub_mutex.lock() => guard,
+            () = cancellation.cancelled() => return false,
+        }
+    } else {
+        ws_sub_mutex.lock().await
+    };
+    let mut terminal_conditions = closed_condition_ids
+        .lock()
+        .expect("closed_condition_ids mutex poisoned");
+
+    if cancellation.is_some_and(CancellationToken::is_cancelled) {
+        return false;
+    }
+
+    terminal_conditions.insert(condition_id.to_string());
+    true
 }
 
 pub(crate) fn is_instrument_expired(instrument: &InstrumentAny, now_ns: UnixNanos) -> bool {
@@ -68,6 +95,7 @@ pub(crate) fn is_instrument_expired_and_not_reported_open(
 
 pub(crate) fn seed_token_meta_from_live_instruments(
     now_ns: UnixNanos,
+    closed_condition_ids: &Arc<StdMutex<AHashSet<String>>>,
     instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
     token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
 ) {
@@ -75,6 +103,16 @@ pub(crate) fn seed_token_meta_from_live_instruments(
 
     for instrument in loaded.values() {
         if is_instrument_expired_and_not_reported_open(instrument, now_ns) {
+            continue;
+        }
+
+        let terminal_conditions = closed_condition_ids
+            .lock()
+            .expect("closed_condition_ids mutex poisoned");
+
+        if extract_condition_id(&instrument.id())
+            .is_ok_and(|condition_id| terminal_conditions.contains(&condition_id))
+        {
             continue;
         }
 
@@ -228,7 +266,16 @@ pub(crate) async fn retire_closed_condition_state(
 
     // The terminal marker must be visible before state is inspected or any asynchronous
     // WebSocket reconciliation begins.
-    register_closed_condition(closed_condition_ids, condition_id);
+    if !register_closed_condition_for_live_data(
+        closed_condition_ids,
+        ws_sub_mutex,
+        condition_id,
+        cancellation,
+    )
+    .await
+    {
+        return;
+    }
 
     let matches_condition = |instrument_id: &InstrumentId| {
         extract_condition_id(instrument_id).is_ok_and(|candidate| candidate == condition_id)

--- a/crates/adapters/polymarket/src/data/runtime.rs
+++ b/crates/adapters/polymarket/src/data/runtime.rs
@@ -26,13 +26,34 @@ use nautilus_model::{
     instruments::{Instrument, InstrumentAny},
     orderbook::OrderBook,
 };
+use tokio_util::sync::CancellationToken;
 use ustr::Ustr;
 
 use super::{
     instruments::TokenMeta,
     subscriptions::{resolve_token_id_from, sync_ws_subscription_async},
 };
-use crate::resolve::ResolveWatchEntry;
+use crate::{providers::extract_condition_id, resolve::ResolveWatchEntry};
+
+pub(crate) fn is_condition_closed(
+    closed_condition_ids: &Arc<StdMutex<AHashSet<String>>>,
+    condition_id: &str,
+) -> bool {
+    closed_condition_ids
+        .lock()
+        .expect("closed_condition_ids mutex poisoned")
+        .contains(condition_id)
+}
+
+pub(crate) fn register_closed_condition(
+    closed_condition_ids: &Arc<StdMutex<AHashSet<String>>>,
+    condition_id: &str,
+) {
+    closed_condition_ids
+        .lock()
+        .expect("closed_condition_ids mutex poisoned")
+        .insert(condition_id.to_string());
+}
 
 pub(crate) fn is_instrument_expired(instrument: &InstrumentAny, now_ns: UnixNanos) -> bool {
     crate::filters::is_expired(instrument, now_ns)
@@ -175,6 +196,125 @@ pub(crate) async fn retire_local_instrument_state(
     let keep_local_metadata = is_watchlisted_instrument(resolve_poll_watchlist, instrument_id);
     if !keep_local_metadata {
         instruments.remove(&instrument_id);
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "shared adapter state is held in Arcs"
+)]
+pub(crate) async fn retire_closed_condition_state(
+    condition_id: &str,
+    seed_ids: impl IntoIterator<Item = InstrumentId>,
+    closed_condition_ids: &Arc<StdMutex<AHashSet<String>>>,
+    instruments: &Arc<AtomicMap<InstrumentId, InstrumentAny>>,
+    token_meta: &Arc<DashMap<Ustr, TokenMeta>>,
+    order_books: &Arc<DashMap<InstrumentId, OrderBook>>,
+    last_quotes: &Arc<DashMap<InstrumentId, QuoteTick>>,
+    active_quote_subs: &Arc<AtomicSet<InstrumentId>>,
+    active_delta_subs: &Arc<AtomicSet<InstrumentId>>,
+    active_trade_subs: &Arc<AtomicSet<InstrumentId>>,
+    resolve_poll_watchlist: &Arc<AtomicMap<String, ResolveWatchEntry>>,
+    pending_snapshot_after_tick_change: &Arc<AtomicSet<InstrumentId>>,
+    pending_auto_loads: &Arc<StdMutex<AHashSet<InstrumentId>>>,
+    ws_open_tokens: &Arc<AtomicSet<Ustr>>,
+    ws_sub_mutex: &Arc<tokio::sync::Mutex<()>>,
+    ws: &crate::websocket::pool::PolymarketMarketPoolHandle,
+    cancellation: Option<&CancellationToken>,
+) {
+    if cancellation.is_some_and(CancellationToken::is_cancelled) {
+        return;
+    }
+
+    // The terminal marker must be visible before state is inspected or any asynchronous
+    // WebSocket reconciliation begins.
+    register_closed_condition(closed_condition_ids, condition_id);
+
+    let matches_condition = |instrument_id: &InstrumentId| {
+        extract_condition_id(instrument_id).is_ok_and(|candidate| candidate == condition_id)
+    };
+    let mut retiring_ids = seed_ids
+        .into_iter()
+        .filter(matches_condition)
+        .collect::<AHashSet<_>>();
+
+    retiring_ids.extend(
+        instruments
+            .load()
+            .keys()
+            .filter(|id| matches_condition(id))
+            .copied(),
+    );
+
+    for subscriptions in [active_quote_subs, active_delta_subs, active_trade_subs] {
+        retiring_ids.extend(
+            subscriptions
+                .load()
+                .iter()
+                .filter(|id| matches_condition(id))
+                .copied(),
+        );
+    }
+    retiring_ids.extend(
+        pending_snapshot_after_tick_change
+            .load()
+            .iter()
+            .filter(|id| matches_condition(id))
+            .copied(),
+    );
+    retiring_ids.extend(
+        pending_auto_loads
+            .lock()
+            .expect("pending_auto_loads mutex poisoned")
+            .iter()
+            .filter(|id| matches_condition(id))
+            .copied(),
+    );
+    retiring_ids.extend(
+        token_meta
+            .iter()
+            .map(|entry| entry.value().instrument_id)
+            .filter(matches_condition),
+    );
+    retiring_ids.extend(
+        order_books
+            .iter()
+            .map(|entry| *entry.key())
+            .filter(matches_condition),
+    );
+    retiring_ids.extend(
+        last_quotes
+            .iter()
+            .map(|entry| *entry.key())
+            .filter(matches_condition),
+    );
+
+    for instrument_id in retiring_ids {
+        let retirement = retire_local_instrument_state(
+            instrument_id,
+            instruments,
+            token_meta,
+            order_books,
+            last_quotes,
+            active_quote_subs,
+            active_delta_subs,
+            active_trade_subs,
+            resolve_poll_watchlist,
+            pending_snapshot_after_tick_change,
+            pending_auto_loads,
+            ws_open_tokens,
+            ws_sub_mutex,
+            ws,
+        );
+
+        if let Some(cancellation) = cancellation {
+            tokio::select! {
+                () = cancellation.cancelled() => return,
+                () = retirement => {}
+            }
+        } else {
+            retirement.await;
+        }
     }
 }
 

--- a/crates/adapters/polymarket/src/data/subscriptions.rs
+++ b/crates/adapters/polymarket/src/data/subscriptions.rs
@@ -13,8 +13,9 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 
+use ahash::AHashSet;
 use nautilus_common::cache::InstrumentLookupError;
 use nautilus_core::{AtomicMap, AtomicSet};
 use nautilus_model::{
@@ -52,12 +53,79 @@ pub(crate) async fn sync_ws_subscription_async(
     ws_sub_mutex: Arc<tokio::sync::Mutex<()>>,
     ws: crate::websocket::pool::PolymarketMarketPoolHandle,
 ) {
+    sync_ws_subscription_inner(
+        instrument_id,
+        token_id_str,
+        active_quote_subs,
+        active_delta_subs,
+        active_trade_subs,
+        None,
+        ws_open_tokens,
+        ws_sub_mutex,
+        ws,
+    )
+    .await;
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "shared state comes in as Arc refs"
+)]
+pub(crate) async fn sync_ws_subscription_with_terminal_async(
+    instrument_id: InstrumentId,
+    token_id_str: String,
+    active_quote_subs: Arc<AtomicSet<InstrumentId>>,
+    active_delta_subs: Arc<AtomicSet<InstrumentId>>,
+    active_trade_subs: Arc<AtomicSet<InstrumentId>>,
+    closed_condition_ids: Arc<StdMutex<AHashSet<String>>>,
+    ws_open_tokens: Arc<AtomicSet<Ustr>>,
+    ws_sub_mutex: Arc<tokio::sync::Mutex<()>>,
+    ws: crate::websocket::pool::PolymarketMarketPoolHandle,
+) {
+    sync_ws_subscription_inner(
+        instrument_id,
+        token_id_str,
+        active_quote_subs,
+        active_delta_subs,
+        active_trade_subs,
+        Some(closed_condition_ids),
+        ws_open_tokens,
+        ws_sub_mutex,
+        ws,
+    )
+    .await;
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "shared state comes in as Arc refs"
+)]
+async fn sync_ws_subscription_inner(
+    instrument_id: InstrumentId,
+    token_id_str: String,
+    active_quote_subs: Arc<AtomicSet<InstrumentId>>,
+    active_delta_subs: Arc<AtomicSet<InstrumentId>>,
+    active_trade_subs: Arc<AtomicSet<InstrumentId>>,
+    closed_condition_ids: Option<Arc<StdMutex<AHashSet<String>>>>,
+    ws_open_tokens: Arc<AtomicSet<Ustr>>,
+    ws_sub_mutex: Arc<tokio::sync::Mutex<()>>,
+    ws: crate::websocket::pool::PolymarketMarketPoolHandle,
+) {
     let token_id = Ustr::from(token_id_str.as_str());
     let _guard = ws_sub_mutex.lock().await;
 
-    let wants_subscribe = active_quote_subs.contains(&instrument_id)
-        || active_delta_subs.contains(&instrument_id)
-        || active_trade_subs.contains(&instrument_id);
+    let is_terminal = closed_condition_ids.is_some_and(|closed_condition_ids| {
+        crate::providers::extract_condition_id(&instrument_id).is_ok_and(|condition_id| {
+            closed_condition_ids
+                .lock()
+                .expect("closed_condition_ids mutex poisoned")
+                .contains(&condition_id)
+        })
+    });
+    let wants_subscribe = !is_terminal
+        && (active_quote_subs.contains(&instrument_id)
+            || active_delta_subs.contains(&instrument_id)
+            || active_trade_subs.contains(&instrument_id));
     let is_open = ws_open_tokens.contains(&token_id);
 
     if wants_subscribe && !is_open {


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue
- [x] I have read and followed CONTRIBUTING.md and AI_POLICY.md
- [x] I understand and can explain every submitted change
- [x] This change is complete and locally validated
- [x] I ran `make format`, then `make pre-commit` locally
- [x] I ran the relevant tests
- [x] I have not modified `RELEASES.md`

## Summary

Polymarket’s normal Gamma lookup can omit a closed market or return it without enough usable token information to classify it. When no classifiable instrument is returned for a condition, the auto-load path performs a positive Gamma `closed=true` lookup before deciding whether the condition is `Closed` or remains `Unknown`.

This change gives each auto-loaded condition one of three lifecycle outcomes:

- `Open`: apply the normal filters, then cache, publish, and subscribe;
- `Closed`: retire live subscriptions and runtime state, preserve any watchlisted metadata needed for pending settlement, and stop retrying;
- `Unknown`: preserve subscription intent and retry without overriding a known state.

A positive Gamma `closed=true` result is the terminal signal for live data. Closed conditions are classified separately and never pass through the normal filtering or live publication path. Once closure is confirmed, stale concurrent `Open` results and later subscription attempts cannot reopen the condition.

Gamma `endDate` remains instrument metadata and is not proof of closure. `market_resolved` remains separate settlement evidence.

Successful conditions are applied independently, so an absent condition or failed closure probe does not discard successful results from the same batch.


## Related issues/PRs

Related to #4689  
Follow-up to #4706
Lifecycle contract discussed in #4722

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details

None.

## Documentation

No documentation changes.

## Testing

Added regression coverage for:

- open conditions being cached, published, and subscribed with one Gamma request;
- absent conditions receiving the additional `closed=true` lookup;
- positive closure evidence retiring condition-wide live state without retrying;
- closed lookup results bypassing filters and live publication;
- unknown and failed probes preserving subscription intent;
- successful conditions surviving failures elsewhere in the same request;
- terminal closure winning over stale `Open` results in either completion order;
- sibling outcomes for a closed condition being retired together;
- watchlisted metadata being retained while live state is removed;
- later subscriptions being unable to reopen a confirmed-closed condition;
- auto-load and periodic closure refresh sharing the same terminal state.

Validation completed:

- `cargo test -p nautilus-polymarket --lib --tests`
- `cargo clippy -p nautilus-polymarket --lib --tests -- -D warnings`
- `make format`
- `make pre-commit`
- `git diff --check`