### PR TITLE
Fix OKX query order routing

### DIFF
--- a/crates/adapters/okx/src/execution.rs
+++ b/crates/adapters/okx/src/execution.rs
@@ -1257,47 +1257,85 @@ impl ExecutionClient for OKXExecutionClient {
         let instrument_id = cmd.instrument_id;
         let client_order_id = cmd.client_order_id;
         let venue_order_id = cmd.venue_order_id;
-        let should_query_algo = !is_spread_instrument(instrument_id)
-            && supports_algo_orders(okx_instrument_type_from_symbol(
-                instrument_id.symbol.as_str(),
-            ));
+        let order_state = {
+            let cache = self.core.cache();
+            cache
+                .order(&client_order_id)
+                .map(|order| (order.order_type(), order.is_triggered()))
+        };
+        let route = query_order_route(instrument_id, order_state.map(|state| state.0));
+        let algo_id = order_state
+            .filter(|(order_type, is_triggered)| {
+                OKX_CONDITIONAL_ORDER_TYPES.contains(order_type) && *is_triggered == Some(false)
+            })
+            .and_then(|_| {
+                venue_order_id
+                    .as_ref()
+                    .map(|venue_order_id| venue_order_id.as_str().to_string())
+            });
 
         self.spawn_task("query_order", async move {
-            let mut reports = match http_client
-                .request_order_status_reports(
-                    account_id,
-                    None,
-                    Some(instrument_id),
-                    None,
-                    None,
-                    false,
-                    None,
-                )
-                .await
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    log::error!("OKX query_order failed to fetch orders: {e}");
-                    Vec::new()
-                }
-            };
+            let mut reports = Vec::with_capacity(1);
+            let mut query_algo = route == QueryOrderRoute::Algo;
 
-            // Merge algo orders (stop, OCO, TP/SL, trailing) so query_order can
-            // resolve conditional orders as well.
-            if should_query_algo {
+            match route {
+                QueryOrderRoute::Spread => {
+                    match http_client
+                        .request_order_status_reports(
+                            account_id,
+                            None,
+                            Some(instrument_id),
+                            None,
+                            None,
+                            false,
+                            None,
+                        )
+                        .await
+                    {
+                        Ok(spread_reports) => reports.extend(spread_reports),
+                        Err(e) => {
+                            log::error!("OKX query_order failed to fetch spread order: {e}");
+                        }
+                    }
+                }
+                QueryOrderRoute::Regular | QueryOrderRoute::RegularThenAlgo => {
+                    match http_client
+                        .request_order_status_report(
+                            account_id,
+                            instrument_id,
+                            client_order_id,
+                        )
+                        .await
+                    {
+                        Ok(Some(report)) => reports.push(report),
+                        Ok(None) => {
+                            query_algo = route == QueryOrderRoute::RegularThenAlgo;
+                        }
+                        Err(e) => {
+                            log::error!("OKX query_order failed to fetch regular order: {e}");
+                        }
+                    }
+                }
+                QueryOrderRoute::Algo => {}
+            }
+
+            // Known conditional orders route directly to the algo endpoint. For
+            // an uncached order, only fall back when the regular detail lookup
+            // has no match (including OKX 51603).
+            if query_algo {
                 match http_client
                     .request_algo_order_status_reports(
                         account_id,
                         None,
                         Some(instrument_id),
-                        None,
+                        algo_id,
                         Some(client_order_id),
                         None,
-                        None,
+                        Some(1),
                     )
                     .await
                 {
-                    Ok(algo) => merge_order_status_reports(&mut reports, algo),
+                    Ok(algo_reports) => merge_order_status_reports(&mut reports, algo_reports),
                     Err(e) => {
                         log::warn!("OKX query_order algo lookup failed for {instrument_id}: {e}");
                     }
@@ -2364,6 +2402,14 @@ enum OrderCommandRoute {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QueryOrderRoute {
+    Regular,
+    Algo,
+    RegularThenAlgo,
+    Spread,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CancelAllOrdersRoute {
     BatchWs,
     MassCancelHttp,
@@ -2483,6 +2529,27 @@ fn order_routing_instrument_types(
     routing_types
 }
 
+fn query_order_route(
+    instrument_id: InstrumentId,
+    order_type: Option<OrderType>,
+) -> QueryOrderRoute {
+    if is_spread_instrument(instrument_id) {
+        return QueryOrderRoute::Spread;
+    }
+
+    let supports_algo = supports_algo_orders(okx_instrument_type_from_symbol(
+        instrument_id.symbol.as_str(),
+    ));
+
+    match order_type {
+        Some(order_type) if supports_algo && OKX_CONDITIONAL_ORDER_TYPES.contains(&order_type) => {
+            QueryOrderRoute::Algo
+        }
+        None if supports_algo => QueryOrderRoute::RegularThenAlgo,
+        _ => QueryOrderRoute::Regular,
+    }
+}
+
 fn is_spread_instrument(instrument_id: InstrumentId) -> bool {
     is_okx_spread_symbol(instrument_id.symbol.as_str())
 }
@@ -2516,10 +2583,10 @@ fn merge_order_status_reports(
 //      still valid; OKX rotates venue_order_id once an algo order triggers).
 //
 // Triggered-algo recovery is handled by the algo endpoint in the caller,
-// which queries by algo_cl_ord_id and returns the parent's algo record
-// directly. `linked_order_ids` is deliberately not consulted here because
-// it is also populated with attached TP/SL child ids on the parent order,
-// which would otherwise let a query for a child match the parent's report.
+// which queries by `algo_id` when it is known to be stable and otherwise by
+// `algo_cl_ord_id`. `linked_order_ids` is deliberately not consulted here
+// because it is also populated with attached TP/SL child ids on the parent
+// order, which would otherwise let a query for a child match the parent report.
 fn select_query_order_report(
     reports: Vec<OrderStatusReport>,
     client_order_id: ClientOrderId,
@@ -2554,6 +2621,37 @@ mod tests {
     use serde_json::Value;
 
     use super::*;
+
+    #[rstest]
+    #[case(OrderType::Market, QueryOrderRoute::Regular)]
+    #[case(OrderType::Limit, QueryOrderRoute::Regular)]
+    #[case(OrderType::StopMarket, QueryOrderRoute::Algo)]
+    #[case(OrderType::TrailingStopMarket, QueryOrderRoute::Algo)]
+    fn test_query_order_route_for_known_order_type(
+        #[case] order_type: OrderType,
+        #[case] expected: QueryOrderRoute,
+    ) {
+        assert_eq!(
+            query_order_route(InstrumentId::from("BTC-USDT.OKX"), Some(order_type)),
+            expected
+        );
+    }
+
+    #[rstest]
+    fn test_query_order_route_for_unknown_order_type() {
+        assert_eq!(
+            query_order_route(InstrumentId::from("BTC-USDT.OKX"), None),
+            QueryOrderRoute::RegularThenAlgo,
+        );
+    }
+
+    #[rstest]
+    fn test_query_order_route_for_spread() {
+        assert_eq!(
+            query_order_route(InstrumentId::from("ETH-USD-SWAP_ETH-USD-231229.OKX"), None,),
+            QueryOrderRoute::Spread,
+        );
+    }
 
     fn build_config(
         margin_mode: Option<OKXMarginMode>,

--- a/crates/adapters/okx/src/execution.rs
+++ b/crates/adapters/okx/src/execution.rs
@@ -47,7 +47,9 @@ use nautilus_live::{
 };
 use nautilus_model::{
     accounts::AccountAny,
-    enums::{AccountType, OmsType, OrderSide, OrderType, TimeInForce, TrailingOffsetType},
+    enums::{
+        AccountType, OmsType, OrderSide, OrderStatus, OrderType, TimeInForce, TrailingOffsetType,
+    },
     events::OrderDeniedReason,
     identifiers::{
         AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId, Venue, VenueOrderId,
@@ -1259,43 +1261,27 @@ impl ExecutionClient for OKXExecutionClient {
         let venue_order_id = cmd.venue_order_id;
         let order_state = {
             let cache = self.core.cache();
-            cache.order(&client_order_id).map(|order| {
-                let order_type = order.order_type();
-                let is_conditional = OKX_CONDITIONAL_ORDER_TYPES.contains(&order_type);
-                let has_regular_child = is_conditional && order.venue_order_ids().len() > 1;
-
-                CachedQueryOrderState {
-                    order_type,
-                    is_triggered: order.is_triggered(),
-                    has_regular_child,
+            cache
+                .order(&client_order_id)
+                .map(|order| CachedQueryOrderState {
+                    order_type: order.order_type(),
                     venue_order_id: order.venue_order_id(),
-                }
-            })
+                })
         };
+        let cached_venue_order_id = order_state.and_then(|state| state.venue_order_id);
+        let regular_venue_order_id = order_state.and_then(|state| {
+            if OKX_CONDITIONAL_ORDER_TYPES.contains(&state.order_type) {
+                state.venue_order_id.or(venue_order_id)
+            } else {
+                state.venue_order_id
+            }
+        });
+        let selection_venue_order_id = cached_venue_order_id.or(venue_order_id);
         let route = query_order_route(
             instrument_id,
             order_state.map(|state| state.order_type),
-            order_state.is_some_and(|state| state.has_regular_child),
+            regular_venue_order_id.is_some(),
         );
-        let regular_venue_order_id = order_state
-            .filter(|state| {
-                state.has_regular_child
-                    || state.venue_order_id.is_some_and(|venue_order_id| {
-                        venue_order_id.as_str() == client_order_id.as_str()
-                    })
-            })
-            .and_then(|state| state.venue_order_id);
-        let algo_id = order_state
-            .filter(|state| {
-                OKX_CONDITIONAL_ORDER_TYPES.contains(&state.order_type)
-                    && !state.has_regular_child
-                    && state.is_triggered == Some(false)
-            })
-            .and_then(|_| {
-                venue_order_id
-                    .as_ref()
-                    .map(|venue_order_id| venue_order_id.as_str().to_string())
-            });
         self.spawn_task("query_order", async move {
             let mut reports = Vec::with_capacity(1);
             let mut query_algo = matches!(
@@ -1323,9 +1309,7 @@ impl ExecutionClient for OKXExecutionClient {
                         }
                     }
                 }
-                QueryOrderRoute::Regular
-                | QueryOrderRoute::RegularThenAlgo
-                | QueryOrderRoute::RegularAndAlgo => {
+                QueryOrderRoute::Regular | QueryOrderRoute::RegularThenAlgo => {
                     let result = if let Some(venue_order_id) = regular_venue_order_id {
                         http_client
                             .request_order_status_report_by_venue_order_id(
@@ -1354,37 +1338,88 @@ impl ExecutionClient for OKXExecutionClient {
                         }
                     }
                 }
-                QueryOrderRoute::Algo => {}
+                QueryOrderRoute::Algo | QueryOrderRoute::RegularAndAlgo => {}
             }
 
-            // Known conditional orders query the algo endpoint. Once a regular
-            // child is cached, query both endpoints so a missed child event can
-            // supersede the parent algo state. For an uncached order, only fall
-            // back when the regular detail lookup has no match (including 51603).
+            // Known conditional orders query the algo endpoint by client ID. If
+            // the parent has triggered, query its single latest regular child so
+            // a missed child event can supersede the parent state. For an
+            // uncached order, only fall back after the regular lookup has no match.
             if query_algo {
+                let mut regular_child_venue_order_id = None;
+
                 match http_client
                     .request_algo_order_status_reports(
                         account_id,
                         None,
                         Some(instrument_id),
-                        algo_id,
+                        None,
                         Some(client_order_id),
                         None,
                         Some(1),
                     )
                     .await
                 {
-                    Ok(algo_reports) => merge_order_status_reports(&mut reports, algo_reports),
+                    Ok(algo_reports) => {
+                        if route == QueryOrderRoute::RegularAndAlgo {
+                            regular_child_venue_order_id = algo_reports
+                                .iter()
+                                .find(|report| {
+                                    matches!(
+                                        report.order_status,
+                                        OrderStatus::Triggered | OrderStatus::Filled
+                                    )
+                                })
+                                .map(|report| report.venue_order_id)
+                                .or_else(|| {
+                                    regular_venue_order_id.filter(|venue_order_id| {
+                                        algo_reports.first().is_none_or(|report| {
+                                            report.venue_order_id != *venue_order_id
+                                        })
+                                    })
+                                });
+                        }
+
+                        merge_order_status_reports(&mut reports, algo_reports);
+                    }
                     Err(e) => {
+                        if route == QueryOrderRoute::RegularAndAlgo {
+                            regular_child_venue_order_id = regular_venue_order_id;
+                        }
+
                         log::warn!("OKX query_order algo lookup failed for {instrument_id}: {e}");
+                    }
+                }
+
+                if let Some(child_venue_order_id) = regular_child_venue_order_id {
+                    match http_client
+                        .request_order_status_report_by_venue_order_id(
+                            account_id,
+                            instrument_id,
+                            child_venue_order_id,
+                        )
+                        .await
+                    {
+                        Ok(Some(child_report)) => {
+                            merge_order_status_reports(&mut reports, vec![child_report]);
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            log::error!(
+                                "OKX query_order failed to fetch regular child order: {e}"
+                            );
+                        }
                     }
                 }
             }
 
-            let Some(report) = select_query_order_report(reports, client_order_id, venue_order_id)
-            else {
+            let Some(report) = select_query_order_report(
+                reports,
+                client_order_id,
+                selection_venue_order_id,
+            ) else {
                 log::warn!(
-                    "OKX query_order found no order for client_order_id={client_order_id}, venue_order_id={venue_order_id:?}",
+                    "OKX query_order found no order for client_order_id={client_order_id}, venue_order_id={selection_venue_order_id:?}",
                 );
                 return Ok(());
             };
@@ -2452,8 +2487,6 @@ enum QueryOrderRoute {
 #[derive(Debug, Clone, Copy)]
 struct CachedQueryOrderState {
     order_type: OrderType,
-    is_triggered: Option<bool>,
-    has_regular_child: bool,
     venue_order_id: Option<VenueOrderId>,
 }
 
@@ -2580,7 +2613,7 @@ fn order_routing_instrument_types(
 fn query_order_route(
     instrument_id: InstrumentId,
     order_type: Option<OrderType>,
-    has_regular_child: bool,
+    has_cached_venue_order_id: bool,
 ) -> QueryOrderRoute {
     if is_spread_instrument(instrument_id) {
         return QueryOrderRoute::Spread;
@@ -2594,7 +2627,7 @@ fn query_order_route(
         Some(order_type)
             if supports_algo
                 && OKX_CONDITIONAL_ORDER_TYPES.contains(&order_type)
-                && has_regular_child =>
+                && has_cached_venue_order_id =>
         {
             QueryOrderRoute::RegularAndAlgo
         }
@@ -2703,7 +2736,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_query_order_route_for_conditional_order_with_known_regular_child() {
+    fn test_query_order_route_for_conditional_order_with_cached_venue_id() {
         assert_eq!(
             query_order_route(
                 InstrumentId::from("BTC-USDT.OKX"),

--- a/crates/adapters/okx/src/execution.rs
+++ b/crates/adapters/okx/src/execution.rs
@@ -1259,24 +1259,49 @@ impl ExecutionClient for OKXExecutionClient {
         let venue_order_id = cmd.venue_order_id;
         let order_state = {
             let cache = self.core.cache();
-            cache
-                .order(&client_order_id)
-                .map(|order| (order.order_type(), order.is_triggered()))
+            cache.order(&client_order_id).map(|order| {
+                let order_type = order.order_type();
+                let is_conditional = OKX_CONDITIONAL_ORDER_TYPES.contains(&order_type);
+                let has_regular_child = is_conditional && order.venue_order_ids().len() > 1;
+
+                CachedQueryOrderState {
+                    order_type,
+                    is_triggered: order.is_triggered(),
+                    has_regular_child,
+                    venue_order_id: order.venue_order_id(),
+                }
+            })
         };
-        let route = query_order_route(instrument_id, order_state.map(|state| state.0));
+        let route = query_order_route(
+            instrument_id,
+            order_state.map(|state| state.order_type),
+            order_state.is_some_and(|state| state.has_regular_child),
+        );
+        let regular_venue_order_id = order_state
+            .filter(|state| {
+                state.has_regular_child
+                    || state.venue_order_id.is_some_and(|venue_order_id| {
+                        venue_order_id.as_str() == client_order_id.as_str()
+                    })
+            })
+            .and_then(|state| state.venue_order_id);
         let algo_id = order_state
-            .filter(|(order_type, is_triggered)| {
-                OKX_CONDITIONAL_ORDER_TYPES.contains(order_type) && *is_triggered == Some(false)
+            .filter(|state| {
+                OKX_CONDITIONAL_ORDER_TYPES.contains(&state.order_type)
+                    && !state.has_regular_child
+                    && state.is_triggered == Some(false)
             })
             .and_then(|_| {
                 venue_order_id
                     .as_ref()
                     .map(|venue_order_id| venue_order_id.as_str().to_string())
             });
-
         self.spawn_task("query_order", async move {
             let mut reports = Vec::with_capacity(1);
-            let mut query_algo = route == QueryOrderRoute::Algo;
+            let mut query_algo = matches!(
+                route,
+                QueryOrderRoute::Algo | QueryOrderRoute::RegularAndAlgo
+            );
 
             match route {
                 QueryOrderRoute::Spread => {
@@ -1298,18 +1323,31 @@ impl ExecutionClient for OKXExecutionClient {
                         }
                     }
                 }
-                QueryOrderRoute::Regular | QueryOrderRoute::RegularThenAlgo => {
-                    match http_client
-                        .request_order_status_report(
-                            account_id,
-                            instrument_id,
-                            client_order_id,
-                        )
-                        .await
-                    {
+                QueryOrderRoute::Regular
+                | QueryOrderRoute::RegularThenAlgo
+                | QueryOrderRoute::RegularAndAlgo => {
+                    let result = if let Some(venue_order_id) = regular_venue_order_id {
+                        http_client
+                            .request_order_status_report_by_venue_order_id(
+                                account_id,
+                                instrument_id,
+                                venue_order_id,
+                            )
+                            .await
+                    } else {
+                        http_client
+                            .request_order_status_report(
+                                account_id,
+                                instrument_id,
+                                client_order_id,
+                            )
+                            .await
+                    };
+
+                    match result {
                         Ok(Some(report)) => reports.push(report),
                         Ok(None) => {
-                            query_algo = route == QueryOrderRoute::RegularThenAlgo;
+                            query_algo |= route == QueryOrderRoute::RegularThenAlgo;
                         }
                         Err(e) => {
                             log::error!("OKX query_order failed to fetch regular order: {e}");
@@ -1319,9 +1357,10 @@ impl ExecutionClient for OKXExecutionClient {
                 QueryOrderRoute::Algo => {}
             }
 
-            // Known conditional orders route directly to the algo endpoint. For
-            // an uncached order, only fall back when the regular detail lookup
-            // has no match (including OKX 51603).
+            // Known conditional orders query the algo endpoint. Once a regular
+            // child is cached, query both endpoints so a missed child event can
+            // supersede the parent algo state. For an uncached order, only fall
+            // back when the regular detail lookup has no match (including 51603).
             if query_algo {
                 match http_client
                     .request_algo_order_status_reports(
@@ -2406,7 +2445,16 @@ enum QueryOrderRoute {
     Regular,
     Algo,
     RegularThenAlgo,
+    RegularAndAlgo,
     Spread,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CachedQueryOrderState {
+    order_type: OrderType,
+    is_triggered: Option<bool>,
+    has_regular_child: bool,
+    venue_order_id: Option<VenueOrderId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2532,6 +2580,7 @@ fn order_routing_instrument_types(
 fn query_order_route(
     instrument_id: InstrumentId,
     order_type: Option<OrderType>,
+    has_regular_child: bool,
 ) -> QueryOrderRoute {
     if is_spread_instrument(instrument_id) {
         return QueryOrderRoute::Spread;
@@ -2542,6 +2591,13 @@ fn query_order_route(
     ));
 
     match order_type {
+        Some(order_type)
+            if supports_algo
+                && OKX_CONDITIONAL_ORDER_TYPES.contains(&order_type)
+                && has_regular_child =>
+        {
+            QueryOrderRoute::RegularAndAlgo
+        }
         Some(order_type) if supports_algo && OKX_CONDITIONAL_ORDER_TYPES.contains(&order_type) => {
             QueryOrderRoute::Algo
         }
@@ -2582,9 +2638,8 @@ fn merge_order_status_reports(
 //   2. Exact `venue_order_id` match (rare: only when the cached vid is
 //      still valid; OKX rotates venue_order_id once an algo order triggers).
 //
-// Triggered-algo recovery is handled by the algo endpoint in the caller,
-// which queries by `algo_id` when it is known to be stable and otherwise by
-// `algo_cl_ord_id`. `linked_order_ids` is deliberately not consulted here
+// Triggered-algo recovery queries the regular child by `ord_id` and the algo
+// parent by `algo_cl_ord_id`. `linked_order_ids` is deliberately not consulted here
 // because it is also populated with attached TP/SL child ids on the parent
 // order, which would otherwise let a query for a child match the parent report.
 fn select_query_order_report(
@@ -2592,23 +2647,33 @@ fn select_query_order_report(
     client_order_id: ClientOrderId,
     venue_order_id: Option<VenueOrderId>,
 ) -> Option<OrderStatusReport> {
+    let mut by_client_id: Option<OrderStatusReport> = None;
     let mut by_vid: Option<OrderStatusReport> = None;
 
     for report in reports {
         if report.client_order_id == Some(client_order_id) {
-            return Some(report);
+            if by_client_id
+                .as_ref()
+                .is_none_or(|current| is_order_status_report_more_advanced(&report, current))
+            {
+                by_client_id = Some(report);
+            }
+
+            continue;
         }
 
-        if by_vid.is_none()
-            && venue_order_id
+        if venue_order_id
+            .as_ref()
+            .is_some_and(|vid| report.venue_order_id.as_str() == vid.as_str())
+            && by_vid
                 .as_ref()
-                .is_some_and(|vid| report.venue_order_id.as_str() == vid.as_str())
+                .is_none_or(|current| is_order_status_report_more_advanced(&report, current))
         {
             by_vid = Some(report);
         }
     }
 
-    by_vid
+    by_client_id.or(by_vid)
 }
 
 #[cfg(test)]
@@ -2632,15 +2697,27 @@ mod tests {
         #[case] expected: QueryOrderRoute,
     ) {
         assert_eq!(
-            query_order_route(InstrumentId::from("BTC-USDT.OKX"), Some(order_type)),
+            query_order_route(InstrumentId::from("BTC-USDT.OKX"), Some(order_type), false,),
             expected
+        );
+    }
+
+    #[rstest]
+    fn test_query_order_route_for_conditional_order_with_known_regular_child() {
+        assert_eq!(
+            query_order_route(
+                InstrumentId::from("BTC-USDT.OKX"),
+                Some(OrderType::StopMarket),
+                true,
+            ),
+            QueryOrderRoute::RegularAndAlgo,
         );
     }
 
     #[rstest]
     fn test_query_order_route_for_unknown_order_type() {
         assert_eq!(
-            query_order_route(InstrumentId::from("BTC-USDT.OKX"), None),
+            query_order_route(InstrumentId::from("BTC-USDT.OKX"), None, false),
             QueryOrderRoute::RegularThenAlgo,
         );
     }
@@ -2648,7 +2725,11 @@ mod tests {
     #[rstest]
     fn test_query_order_route_for_spread() {
         assert_eq!(
-            query_order_route(InstrumentId::from("ETH-USD-SWAP_ETH-USD-231229.OKX"), None,),
+            query_order_route(
+                InstrumentId::from("ETH-USD-SWAP_ETH-USD-231229.OKX"),
+                None,
+                false,
+            ),
             QueryOrderRoute::Spread,
         );
     }
@@ -2997,6 +3078,68 @@ mod tests {
             selected.and_then(|r| r.client_order_id),
             Some(ClientOrderId::from("O-001"))
         );
+    }
+
+    #[rstest]
+    #[case(
+        OrderStatus::Accepted,
+        Quantity::zero(0),
+        OrderStatus::Triggered,
+        Quantity::zero(0),
+        OrderStatus::Triggered
+    )]
+    #[case(
+        OrderStatus::Triggered,
+        Quantity::zero(0),
+        OrderStatus::PartiallyFilled,
+        Quantity::new(0.5, 1),
+        OrderStatus::PartiallyFilled
+    )]
+    #[case(
+        OrderStatus::PartiallyFilled,
+        Quantity::new(0.5, 1),
+        OrderStatus::Filled,
+        Quantity::new(1.0, 0),
+        OrderStatus::Filled
+    )]
+    #[case(
+        OrderStatus::Triggered,
+        Quantity::zero(0),
+        OrderStatus::Canceled,
+        Quantity::zero(0),
+        OrderStatus::Canceled
+    )]
+    #[case(
+        OrderStatus::Triggered,
+        Quantity::zero(0),
+        OrderStatus::Rejected,
+        Quantity::zero(0),
+        OrderStatus::Rejected
+    )]
+    fn test_select_query_order_report_chooses_most_advanced_client_match_regardless_of_order(
+        #[case] first_status: OrderStatus,
+        #[case] first_filled_qty: Quantity,
+        #[case] second_status: OrderStatus,
+        #[case] second_filled_qty: Quantity,
+        #[case] expected_status: OrderStatus,
+    ) {
+        let mut first = make_query_order_report(Some("O-001"), "V-PARENT");
+        first.order_status = first_status;
+        first.filled_qty = first_filled_qty;
+        let mut second = make_query_order_report(Some("O-001"), "V-CHILD");
+        second.order_status = second_status;
+        second.filled_qty = second_filled_qty;
+
+        for reports in [vec![first.clone(), second.clone()], vec![second, first]] {
+            let selected = select_query_order_report(
+                reports,
+                ClientOrderId::from("O-001"),
+                Some(VenueOrderId::from("V-PARENT")),
+            )
+            .unwrap();
+
+            assert_eq!(selected.order_status, expected_status);
+        }
     }
 
     #[rstest]

--- a/crates/adapters/okx/src/http/client.rs
+++ b/crates/adapters/okx/src/http/client.rs
@@ -102,13 +102,13 @@ use super::{
         GetInstrumentsParams, GetInstrumentsParamsBuilder, GetMarkPriceParams,
         GetMarkPriceParamsBuilder, GetOptionSummaryParams, GetOrderBookParams,
         GetOrderHistoryParams, GetOrderHistoryParamsBuilder, GetOrderListParams,
-        GetOrderListParamsBuilder, GetPositionTiersParams, GetPositionsHistoryParams,
-        GetPositionsParams, GetPositionsParamsBuilder, GetPriceLimitParams,
-        GetPriceLimitParamsBuilder, GetRpiOrderBookParams, GetSpreadOrderParams,
-        GetSpreadOrdersParams, GetSpreadOrdersParamsBuilder, GetSpreadTradesParams,
-        GetSpreadTradesParamsBuilder, GetSpreadsParams, GetTradeFeeParams, GetTradesParams,
-        GetTradesParamsBuilder, GetTransactionDetailsParams, GetTransactionDetailsParamsBuilder,
-        SetPositionModeParams, SetPositionModeParamsBuilder,
+        GetOrderListParamsBuilder, GetOrderParams, GetOrderParamsBuilder, GetPositionTiersParams,
+        GetPositionsHistoryParams, GetPositionsParams, GetPositionsParamsBuilder,
+        GetPriceLimitParams, GetPriceLimitParamsBuilder, GetRpiOrderBookParams,
+        GetSpreadOrderParams, GetSpreadOrdersParams, GetSpreadOrdersParamsBuilder,
+        GetSpreadTradesParams, GetSpreadTradesParamsBuilder, GetSpreadsParams, GetTradeFeeParams,
+        GetTradesParams, GetTradesParamsBuilder, GetTransactionDetailsParams,
+        GetTransactionDetailsParamsBuilder, SetPositionModeParams, SetPositionModeParamsBuilder,
     },
 };
 use crate::{
@@ -136,10 +136,7 @@ use crate::{
             parse_trade_tick, prefer_rpi_response_fields,
         },
     },
-    http::{
-        models::{OKXCandlestick, OKXTrade},
-        query::GetOrderParams,
-    },
+    http::models::{OKXCandlestick, OKXTrade},
     websocket::{messages::OKXAlgoOrderMsg, parse::parse_algo_order_status_report},
 };
 
@@ -4111,6 +4108,47 @@ impl OKXHttpClient {
         Ok(reports)
     }
 
+    /// Requests a regular order status report by client order identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the report cannot be parsed.
+    pub async fn request_order_status_report(
+        &self,
+        account_id: AccountId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+    ) -> anyhow::Result<Option<OrderStatusReport>> {
+        let instrument = self.instrument_from_cache(instrument_id.symbol.inner())?;
+        let mut params_builder = GetOrderParamsBuilder::default();
+        params_builder
+            .inst_id(instrument_id.symbol.inner().to_string())
+            .cl_ord_id(client_order_id.as_str().to_string());
+
+        let params = params_builder
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to build order detail params: {e}"))?;
+        let orders = match self.inner.get_order(params).await {
+            Ok(orders) => orders,
+            Err(e) if e.is_order_not_found() => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+        let Some(order) = orders.into_iter().next() else {
+            return Ok(None);
+        };
+        let ts_init = self.generate_ts_init();
+        let report = parse_order_status_report(
+            &order,
+            account_id,
+            instrument.id(),
+            instrument.price_precision(),
+            instrument.size_precision(),
+            ts_init,
+        )?;
+
+        Ok(Some(report))
+    }
+
     /// Requests spread order status reports for the given parameters.
     ///
     /// # Errors
@@ -6191,7 +6229,11 @@ impl OKXHttpClient {
             let params = params_builder
                 .build()
                 .map_err(|e| anyhow::anyhow!(format!("Failed to build algo order params: {e}")))?;
-            let mut orders = self.inner.get_algo_order(params).await?;
+            let mut orders = match self.inner.get_algo_order(params).await {
+                Ok(orders) => orders,
+                Err(e) if e.is_order_not_found() => return Ok(reports),
+                Err(e) => return Err(e.into()),
+            };
 
             if let Some(state) = state {
                 orders.retain(|order| order.state == state);

--- a/crates/adapters/okx/src/http/client.rs
+++ b/crates/adapters/okx/src/http/client.rs
@@ -4119,11 +4119,52 @@ impl OKXHttpClient {
         instrument_id: InstrumentId,
         client_order_id: ClientOrderId,
     ) -> anyhow::Result<Option<OrderStatusReport>> {
+        self.request_order_status_report_by_identifier(
+            account_id,
+            instrument_id,
+            Some(client_order_id),
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn request_order_status_report_by_venue_order_id(
+        &self,
+        account_id: AccountId,
+        instrument_id: InstrumentId,
+        venue_order_id: VenueOrderId,
+    ) -> anyhow::Result<Option<OrderStatusReport>> {
+        self.request_order_status_report_by_identifier(
+            account_id,
+            instrument_id,
+            None,
+            Some(venue_order_id),
+        )
+        .await
+    }
+
+    async fn request_order_status_report_by_identifier(
+        &self,
+        account_id: AccountId,
+        instrument_id: InstrumentId,
+        client_order_id: Option<ClientOrderId>,
+        venue_order_id: Option<VenueOrderId>,
+    ) -> anyhow::Result<Option<OrderStatusReport>> {
         let instrument = self.instrument_from_cache(instrument_id.symbol.inner())?;
         let mut params_builder = GetOrderParamsBuilder::default();
-        params_builder
-            .inst_id(instrument_id.symbol.inner().to_string())
-            .cl_ord_id(client_order_id.as_str().to_string());
+        params_builder.inst_id(instrument_id.symbol.inner().to_string());
+
+        match (client_order_id, venue_order_id) {
+            (Some(client_order_id), None) => {
+                params_builder.cl_ord_id(client_order_id.as_str().to_string());
+            }
+            (None, Some(venue_order_id)) => {
+                params_builder.ord_id(venue_order_id.as_str().to_string());
+            }
+            _ => anyhow::bail!(
+                "Exactly one of client_order_id or venue_order_id is required for an order detail request"
+            ),
+        }
 
         let params = params_builder
             .build()

--- a/crates/adapters/okx/src/http/client.rs
+++ b/crates/adapters/okx/src/http/client.rs
@@ -88,7 +88,7 @@ use super::{
         OKXCancelAllSpreadOrdersRequest, OKXCancelOrderRequest, OKXCancelOrderResponse,
         OKXCancelSpreadOrderRequest, OKXEventContractEvent, OKXEventContractMarket,
         OKXEventContractSeries, OKXFeeRate, OKXFundingRateHistory, OKXIndexTicker, OKXMarkPrice,
-        OKXOptionSummary, OKXOrderAlgo, OKXOrderBookSnapshot, OKXOrderHistory,
+        OKXOptionSummary, OKXOrderAlgo, OKXOrderAlgoDetails, OKXOrderBookSnapshot, OKXOrderHistory,
         OKXPlaceAlgoOrderRequest, OKXPlaceAlgoOrderResponse, OKXPlaceOrderRequest,
         OKXPlaceOrderResponse, OKXPlaceSpreadOrderRequest, OKXPosition, OKXPositionHistory,
         OKXPositionTier, OKXPriceLimit, OKXRpiOrderBookSnapshot, OKXServerTime, OKXSpread,
@@ -1604,6 +1604,18 @@ impl OKXRawHttpClient {
         &self,
         params: GetAlgoOrderParams,
     ) -> Result<Vec<OKXOrderAlgo>, OKXHttpError> {
+        self.get_algo_order_details(params).await.map(|details| {
+            details
+                .into_iter()
+                .map(OKXOrderAlgoDetails::into_order)
+                .collect()
+        })
+    }
+
+    async fn get_algo_order_details(
+        &self,
+        params: GetAlgoOrderParams,
+    ) -> Result<Vec<OKXOrderAlgoDetails>, OKXHttpError> {
         self.send_request(
             Method::GET,
             "/api/v5/trade/order-algo",
@@ -6270,15 +6282,20 @@ impl OKXHttpClient {
             let params = params_builder
                 .build()
                 .map_err(|e| anyhow::anyhow!(format!("Failed to build algo order params: {e}")))?;
-            let mut orders = match self.inner.get_algo_order(params).await {
-                Ok(orders) => orders,
+            let mut details = match self.inner.get_algo_order_details(params).await {
+                Ok(details) => details,
                 Err(e) if e.is_order_not_found() => return Ok(reports),
                 Err(e) => return Err(e.into()),
             };
 
             if let Some(state) = state {
-                orders.retain(|order| order.state == state);
+                details.retain(|detail| detail.order.state == state);
             }
+
+            let orders: Vec<_> = details
+                .into_iter()
+                .map(OKXOrderAlgoDetails::into_order)
+                .collect();
 
             self.collect_algo_reports(
                 account_id,

--- a/crates/adapters/okx/src/http/error.rs
+++ b/crates/adapters/okx/src/http/error.rs
@@ -108,6 +108,15 @@ impl From<serde_json::Error> for OKXHttpError {
 }
 
 impl OKXHttpError {
+    /// Returns whether OKX reported that the requested order does not exist.
+    #[must_use]
+    pub fn is_order_not_found(&self) -> bool {
+        matches!(
+            self,
+            Self::OkxError { error_code, .. } if error_code == "51603"
+        )
+    }
+
     /// Returns whether this error is retryable.
     #[must_use]
     pub fn is_retryable(&self) -> bool {
@@ -142,5 +151,19 @@ mod tests {
     #[case(OKXHttpError::Canceled("shutdown".to_string()), false)]
     fn test_is_retryable(#[case] error: OKXHttpError, #[case] expected: bool) {
         assert_eq!(error.is_retryable(), expected);
+    }
+
+    #[rstest]
+    #[case(OKXHttpError::OkxError {
+        error_code: "51603".to_string(),
+        message: "Order does not exist".to_string(),
+    }, true)]
+    #[case(OKXHttpError::OkxError {
+        error_code: "51000".to_string(),
+        message: "Parameter error".to_string(),
+    }, false)]
+    #[case(OKXHttpError::ValidationError("bad".to_string()), false)]
+    fn test_is_order_not_found(#[case] error: OKXHttpError, #[case] expected: bool) {
+        assert_eq!(error.is_order_not_found(), expected);
     }
 }

--- a/crates/adapters/okx/src/http/models.rs
+++ b/crates/adapters/okx/src/http/models.rs
@@ -1134,9 +1134,15 @@ pub struct OKXOrderAlgo {
     /// Client order ID (empty until triggered).
     #[serde(default)]
     pub cl_ord_id: String,
-    /// Venue order ID (empty until triggered).
+    /// Latest regular order ID (deprecated by OKX; empty until triggered).
     #[serde(default)]
     pub ord_id: String,
+    /// Regular order IDs created after the algo order triggers.
+    #[serde(default)]
+    pub ord_id_list: Vec<String>,
+    /// Child algo order IDs created for split take-profit orders.
+    #[serde(default)]
+    pub sub_algo_id_list: Vec<String>,
     /// Instrument ID, e.g. `ETH-USDT-SWAP`.
     pub inst_id: Ustr,
     /// Instrument type.
@@ -1586,6 +1592,30 @@ mod tests {
     use serde_json;
 
     use super::*;
+
+    #[rstest]
+    fn test_algo_order_deserializes_current_child_identifier_lists() {
+        let order: OKXOrderAlgo = serde_json::from_value(serde_json::json!({
+            "algoId": "123",
+            "algoClOrdId": "algo-client-1",
+            "ordId": "456",
+            "ordIdList": ["456", "457"],
+            "subAlgoIdList": ["789"],
+            "instId": "ETH-USDT-SWAP",
+            "instType": "SWAP",
+            "ordType": "conditional",
+            "state": "effective",
+            "side": "sell",
+            "posSide": "net",
+            "tdMode": "cross",
+            "cTime": "1700000000000",
+            "uTime": "1700000001000"
+        }))
+        .unwrap();
+
+        assert_eq!(order.ord_id_list, ["456", "457"]);
+        assert_eq!(order.sub_algo_id_list, ["789"]);
+    }
 
     #[rstest]
     fn test_algo_order_request_serialization() {

--- a/crates/adapters/okx/src/http/models.rs
+++ b/crates/adapters/okx/src/http/models.rs
@@ -1137,12 +1137,6 @@ pub struct OKXOrderAlgo {
     /// Latest regular order ID (deprecated by OKX; empty until triggered).
     #[serde(default)]
     pub ord_id: String,
-    /// Regular order IDs created after the algo order triggers.
-    #[serde(default)]
-    pub ord_id_list: Vec<String>,
-    /// Child algo order IDs created for split take-profit orders.
-    #[serde(default)]
-    pub sub_algo_id_list: Vec<String>,
     /// Instrument ID, e.g. `ETH-USDT-SWAP`.
     pub inst_id: Ustr,
     /// Instrument type.
@@ -1226,6 +1220,32 @@ pub struct OKXOrderAlgo {
     /// Activation price for trailing stop.
     #[serde(default)]
     pub active_px: String,
+}
+
+/// Internal response shape for current algo order detail identifiers.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OKXOrderAlgoDetails {
+    #[serde(flatten)]
+    pub order: OKXOrderAlgo,
+    /// Regular order IDs created after the algo order triggers.
+    #[serde(default)]
+    pub ord_id_list: Vec<String>,
+    /// Child algo order IDs created for split take-profit orders.
+    #[serde(default)]
+    pub sub_algo_id_list: Vec<String>,
+}
+
+impl OKXOrderAlgoDetails {
+    pub(crate) fn into_order(self) -> OKXOrderAlgo {
+        let Self {
+            order,
+            ord_id_list,
+            sub_algo_id_list,
+        } = self;
+        drop((ord_id_list, sub_algo_id_list));
+        order
+    }
 }
 
 /// Represents a transaction detail (fill) from `GET /api/v5/trade/fills`.
@@ -1595,7 +1615,7 @@ mod tests {
 
     #[rstest]
     fn test_algo_order_deserializes_current_child_identifier_lists() {
-        let order: OKXOrderAlgo = serde_json::from_value(serde_json::json!({
+        let details: OKXOrderAlgoDetails = serde_json::from_value(serde_json::json!({
             "algoId": "123",
             "algoClOrdId": "algo-client-1",
             "ordId": "456",
@@ -1613,8 +1633,9 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(order.ord_id_list, ["456", "457"]);
-        assert_eq!(order.sub_algo_id_list, ["789"]);
+        assert_eq!(details.order.ord_id, "456");
+        assert_eq!(details.ord_id_list, ["456", "457"]);
+        assert_eq!(details.sub_algo_id_list, ["789"]);
     }
 
     #[rstest]

--- a/crates/adapters/okx/src/http/query.rs
+++ b/crates/adapters/okx/src/http/query.rs
@@ -33,7 +33,7 @@ use serde::{self, Deserialize, Serialize};
 use crate::{
     common::enums::{
         OKXAlgoOrderStatus, OKXAlgoOrderType, OKXInstrumentType, OKXOrderStatus, OKXOrderType,
-        OKXPositionMode, OKXPositionSide, OKXTradeMode,
+        OKXPositionMode, OKXTradeMode,
     },
     http::error::BuildError,
 };
@@ -703,8 +703,6 @@ pub struct GetPositionsHistoryParams {
 #[builder(setter(into, strip_option))]
 #[serde(rename_all = "camelCase")]
 pub struct GetOrderParams {
-    /// Instrument type: SPOT, MARGIN, SWAP, FUTURES, OPTION.
-    pub inst_type: OKXInstrumentType,
     /// Instrument ID, e.g. "BTC-USDT".
     pub inst_id: String,
     /// Exchange-assigned order ID (optional if client order ID is provided).
@@ -713,9 +711,6 @@ pub struct GetOrderParams {
     /// User-assigned client order ID (optional if order ID is provided).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cl_ord_id: Option<String>,
-    /// Position side (optional).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pos_side: Option<OKXPositionSide>,
 }
 
 /// Parameters for the GET /api/v5/account/trade-fee endpoint.

--- a/crates/adapters/okx/src/http/query.rs
+++ b/crates/adapters/okx/src/http/query.rs
@@ -33,7 +33,7 @@ use serde::{self, Deserialize, Serialize};
 use crate::{
     common::enums::{
         OKXAlgoOrderStatus, OKXAlgoOrderType, OKXInstrumentType, OKXOrderStatus, OKXOrderType,
-        OKXPositionMode, OKXTradeMode,
+        OKXPositionMode, OKXPositionSide, OKXTradeMode,
     },
     http::error::BuildError,
 };
@@ -703,6 +703,9 @@ pub struct GetPositionsHistoryParams {
 #[builder(setter(into, strip_option))]
 #[serde(rename_all = "camelCase")]
 pub struct GetOrderParams {
+    /// Instrument type retained for API compatibility; not accepted by this endpoint.
+    #[serde(skip_serializing)]
+    pub inst_type: OKXInstrumentType,
     /// Instrument ID, e.g. "BTC-USDT".
     pub inst_id: String,
     /// Exchange-assigned order ID (optional if client order ID is provided).
@@ -711,6 +714,9 @@ pub struct GetOrderParams {
     /// User-assigned client order ID (optional if order ID is provided).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cl_ord_id: Option<String>,
+    /// Position side retained for API compatibility; not accepted by this endpoint.
+    #[serde(skip_serializing)]
+    pub pos_side: Option<OKXPositionSide>,
 }
 
 /// Parameters for the GET /api/v5/account/trade-fee endpoint.

--- a/crates/adapters/okx/tests/exec_client.rs
+++ b/crates/adapters/okx/tests/exec_client.rs
@@ -2357,10 +2357,18 @@ fn regular_order_detail_response(params: &HashMap<String, String>) -> serde_json
         .expect("expected clOrdId or ordId query parameter");
     let (algo_client_order_id, client_order_id, venue_order_id, order_type, state, price) =
         match query_id {
-            "OQUERYREGULAR1" => (
+            "regular-venue-id" => (
                 "",
                 "OQUERYREGULAR1",
                 "regular-venue-id",
+                "limit",
+                "live",
+                "2000.00",
+            ),
+            "OQUERYREGULAR1" => (
+                "",
+                "OQUERYREGULAR1",
+                "reused-regular-venue-id",
                 "limit",
                 "live",
                 "2000.00",
@@ -2380,6 +2388,22 @@ fn regular_order_detail_response(params: &HashMap<String, String>) -> serde_json
                 "limit",
                 "filled",
                 "900.00",
+            ),
+            "missed-child-venue-id" => (
+                "OQUERYMISSEDCHILD1",
+                "",
+                "missed-child-venue-id",
+                "limit",
+                "filled",
+                "850.00",
+            ),
+            "single-child-venue-id" => (
+                "OQUERYSINGLECHILD1",
+                "",
+                "single-child-venue-id",
+                "limit",
+                "filled",
+                "800.00",
             ),
             "external-venue-id" => ("", "", "external-venue-id", "limit", "live", "2000.00"),
             other => panic!("unexpected regular order detail query: {other}"),
@@ -2419,6 +2443,11 @@ fn algo_order_detail_response(params: &HashMap<String, String>) -> serde_json::V
     order["instId"] = json!("ETH-USDT-SWAP");
 
     match params.get("algoClOrdId").map(String::as_str) {
+        Some("OQUERYALGO1") => {
+            order["algoId"] = json!("algo-venue-id");
+            order["ordId"] = json!("");
+            order["state"] = json!("live");
+        }
         Some("OQUERYMARKETCHILD1") => {
             order["algoId"] = json!("parent-market-algo-id");
             order["ordId"] = json!("market-child-venue-id");
@@ -2427,7 +2456,22 @@ fn algo_order_detail_response(params: &HashMap<String, String>) -> serde_json::V
         Some("OQUERYTRIGGERED1") => {
             order["algoId"] = json!("parent-algo-id");
             order["ordId"] = json!("triggered-child-venue-id");
+            order["ordIdList"] = json!(["triggered-child-venue-id"]);
             order["slOrdPx"] = json!("900.00");
+            order["state"] = json!("effective");
+        }
+        Some("OQUERYMISSEDCHILD1") => {
+            order["algoId"] = json!("parent-missed-algo-id");
+            order["ordId"] = json!("missed-child-venue-id");
+            order["ordIdList"] = json!(["missed-child-venue-id"]);
+            order["slOrdPx"] = json!("850.00");
+            order["state"] = json!("effective");
+        }
+        Some("OQUERYSINGLECHILD1") => {
+            order["algoId"] = json!("parent-single-algo-id");
+            order["ordId"] = json!("single-child-venue-id");
+            order["ordIdList"] = json!(["single-child-venue-id"]);
+            order["slOrdPx"] = json!("800.00");
             order["state"] = json!("effective");
         }
         _ => {}
@@ -2467,7 +2511,7 @@ async fn start_exec_query_order_test_server(state: Arc<QueryOrderRouteState>) ->
                         .await
                         .push(format!("regular:{query_id}"));
 
-                    if query_id == "OQUERYUNKNOWN1" {
+                    if matches!(query_id.as_str(), "OQUERYUNKNOWN1" | "algo-venue-id") {
                         state.regular_queries.lock().await.push(params);
                         return Json(json!({
                             "code": "51603",
@@ -3002,11 +3046,17 @@ async fn test_margin_only_restart_recovers_spot_fill_reports() {
 
 #[rstest]
 #[tokio::test]
-async fn test_query_order_routes_regular_untriggered_and_unknown_orders() {
+async fn test_query_order_routes_cached_regular_pretrigger_algo_and_unknown_orders() {
     let (client, mut rx, cache, state) = create_query_order_test_client().await;
 
     let regular_client_order_id = ClientOrderId::from("OQUERYREGULAR1");
-    cache_limit_order(&cache, regular_client_order_id);
+    let regular_venue_order_id = VenueOrderId::from("regular-venue-id");
+    let regular_order =
+        build_test_regular_order_with_venue_id(regular_client_order_id, regular_venue_order_id);
+    cache
+        .borrow_mut()
+        .add_order(regular_order, None, Some(*OKX_CLIENT_ID), false)
+        .unwrap();
     client
         .query_order(query_order_command(
             regular_client_order_id,
@@ -3015,13 +3065,14 @@ async fn test_query_order_routes_regular_untriggered_and_unknown_orders() {
         .unwrap();
     let regular_report = recv_query_order_report(&mut rx, Some(regular_client_order_id)).await;
     assert_eq!(regular_report.order_type, OrderType::Limit);
-    assert_eq!(
-        regular_report.venue_order_id,
-        VenueOrderId::from("regular-venue-id")
-    );
+    assert_eq!(regular_report.venue_order_id, regular_venue_order_id);
 
     let algo_client_order_id = ClientOrderId::from("OQUERYALGO1");
-    let algo_order = build_test_stop_order(algo_client_order_id);
+    let algo_venue_order_id = VenueOrderId::from("algo-venue-id");
+    let algo_order = build_test_conditional_order_with_single_venue_id(
+        algo_client_order_id,
+        algo_venue_order_id,
+    );
     cache
         .borrow_mut()
         .add_order(algo_order, None, Some(*OKX_CLIENT_ID), false)
@@ -3029,7 +3080,7 @@ async fn test_query_order_routes_regular_untriggered_and_unknown_orders() {
     client
         .query_order(query_order_command(
             algo_client_order_id,
-            Some(VenueOrderId::from("algo-venue-id")),
+            Some(algo_venue_order_id),
         ))
         .unwrap();
     let algo_report = recv_query_order_report(&mut rx, Some(algo_client_order_id)).await;
@@ -3063,10 +3114,10 @@ async fn test_query_order_routes_regular_untriggered_and_unknown_orders() {
 
     assert_eq!(regular_queries.len(), 2);
     assert_eq!(
-        regular_queries[0].get("clOrdId").map(String::as_str),
-        Some("OQUERYREGULAR1")
+        regular_queries[0].get("ordId").map(String::as_str),
+        Some("regular-venue-id")
     );
-    assert!(!regular_queries[0].contains_key("ordId"));
+    assert!(!regular_queries[0].contains_key("clOrdId"));
     assert_eq!(
         regular_queries[1].get("clOrdId").map(String::as_str),
         Some("OQUERYUNKNOWN1")
@@ -3074,13 +3125,10 @@ async fn test_query_order_routes_regular_untriggered_and_unknown_orders() {
     assert!(!regular_queries[1].contains_key("ordId"));
     assert_eq!(algo_queries.len(), 2);
     assert_eq!(
-        algo_queries[0].get("algoId").map(String::as_str),
-        Some("algo-venue-id")
-    );
-    assert_eq!(
         algo_queries[0].get("algoClOrdId").map(String::as_str),
         Some("OQUERYALGO1")
     );
+    assert!(!algo_queries[0].contains_key("algoId"));
     assert_eq!(
         algo_queries[1].get("algoClOrdId").map(String::as_str),
         Some("OQUERYUNKNOWN1")
@@ -3089,7 +3137,7 @@ async fn test_query_order_routes_regular_untriggered_and_unknown_orders() {
     assert_eq!(
         sequence.as_slice(),
         [
-            "regular:OQUERYREGULAR1",
+            "regular:regular-venue-id",
             "algo:OQUERYALGO1",
             "regular:OQUERYUNKNOWN1",
             "algo:OQUERYUNKNOWN1",
@@ -3143,7 +3191,7 @@ async fn test_query_order_market_conditional_with_child_id_queries_child_and_par
     assert!(!algo_queries[0].contains_key("algoId"));
     assert_eq!(
         sequence.as_slice(),
-        ["regular:market-child-venue-id", "algo:OQUERYMARKETCHILD1",]
+        ["algo:OQUERYMARKETCHILD1", "regular:market-child-venue-id",]
     );
 }
 
@@ -3191,27 +3239,131 @@ async fn test_query_order_triggered_conditional_recovers_missed_child_fill() {
     assert!(!algo_queries[0].contains_key("algoId"));
     assert_eq!(
         sequence.as_slice(),
-        ["regular:triggered-child-venue-id", "algo:OQUERYTRIGGERED1",]
+        ["algo:OQUERYTRIGGERED1", "regular:triggered-child-venue-id",]
     );
 }
 
 #[rstest]
 #[tokio::test]
-async fn test_query_order_adopted_external_regular_uses_venue_order_id() {
+async fn test_query_order_recovers_fill_when_child_event_was_completely_missed() {
     let (client, mut rx, cache, state) = create_query_order_test_client().await;
 
-    // Adopted external regular orders synthesize their local client ID from
-    // ordId when OKX reports no clOrdId.
-    let venue_order_id = VenueOrderId::from("external-venue-id");
-    let client_order_id = ClientOrderId::from(venue_order_id.as_str());
-    let order = build_test_adopted_regular_order(client_order_id);
+    let client_order_id = ClientOrderId::from("OQUERYMISSEDCHILD1");
+    let parent_venue_order_id = VenueOrderId::from("parent-missed-algo-id");
+    let child_venue_order_id = VenueOrderId::from("missed-child-venue-id");
+    let order =
+        build_test_conditional_order_with_single_venue_id(client_order_id, parent_venue_order_id);
     cache
         .borrow_mut()
         .add_order(order, None, Some(*OKX_CLIENT_ID), false)
         .unwrap();
 
     client
-        .query_order(query_order_command(client_order_id, Some(venue_order_id)))
+        .query_order(query_order_command(
+            client_order_id,
+            Some(parent_venue_order_id),
+        ))
+        .unwrap();
+    let report = recv_query_order_report(&mut rx, Some(client_order_id)).await;
+
+    assert_eq!(report.order_type, OrderType::Limit);
+    assert_eq!(report.order_status, OrderStatus::Filled);
+    assert_eq!(report.filled_qty, Quantity::from("1"));
+    assert_eq!(report.venue_order_id, child_venue_order_id);
+
+    let regular_queries = state.regular_queries.lock().await;
+    let algo_queries = state.algo_queries.lock().await;
+    let sequence = state.sequence.lock().await;
+    assert_eq!(regular_queries.len(), 1);
+    assert_eq!(
+        regular_queries[0].get("ordId").map(String::as_str),
+        Some("missed-child-venue-id")
+    );
+    assert!(!regular_queries[0].contains_key("clOrdId"));
+    assert_eq!(algo_queries.len(), 1);
+    assert_eq!(
+        algo_queries[0].get("algoClOrdId").map(String::as_str),
+        Some("OQUERYMISSEDCHILD1")
+    );
+    assert!(!algo_queries[0].contains_key("algoId"));
+    assert_eq!(
+        sequence.as_slice(),
+        ["algo:OQUERYMISSEDCHILD1", "regular:missed-child-venue-id",]
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_recovers_fill_when_only_cached_id_is_child() {
+    let (client, mut rx, cache, state) = create_query_order_test_client().await;
+
+    let client_order_id = ClientOrderId::from("OQUERYSINGLECHILD1");
+    let child_venue_order_id = VenueOrderId::from("single-child-venue-id");
+    let order =
+        build_test_conditional_order_with_single_venue_id(client_order_id, child_venue_order_id);
+    cache
+        .borrow_mut()
+        .add_order(order, None, Some(*OKX_CLIENT_ID), false)
+        .unwrap();
+
+    client
+        .query_order(query_order_command(
+            client_order_id,
+            Some(child_venue_order_id),
+        ))
+        .unwrap();
+    let report = recv_query_order_report(&mut rx, Some(client_order_id)).await;
+
+    assert_eq!(report.order_type, OrderType::Limit);
+    assert_eq!(report.order_status, OrderStatus::Filled);
+    assert_eq!(report.filled_qty, Quantity::from("1"));
+    assert_eq!(report.venue_order_id, child_venue_order_id);
+
+    let regular_queries = state.regular_queries.lock().await;
+    let algo_queries = state.algo_queries.lock().await;
+    let sequence = state.sequence.lock().await;
+    assert_eq!(regular_queries.len(), 1);
+    assert_eq!(
+        regular_queries[0].get("ordId").map(String::as_str),
+        Some("single-child-venue-id")
+    );
+    assert!(!regular_queries[0].contains_key("clOrdId"));
+    assert_eq!(algo_queries.len(), 1);
+    assert_eq!(
+        algo_queries[0].get("algoClOrdId").map(String::as_str),
+        Some("OQUERYSINGLECHILD1")
+    );
+    assert!(!algo_queries[0].contains_key("algoId"));
+    assert_eq!(
+        sequence.as_slice(),
+        ["algo:OQUERYSINGLECHILD1", "regular:single-child-venue-id",]
+    );
+}
+
+#[rstest]
+#[case(None)]
+#[case(Some("stale-external-venue-id"))]
+#[tokio::test]
+async fn test_query_order_adopted_external_regular_uses_cached_venue_order_id(
+    #[case] command_venue_order_id: Option<&str>,
+) {
+    let (client, mut rx, cache, state) = create_query_order_test_client().await;
+
+    // Adopted external regular orders synthesize their local client ID from
+    // ordId when OKX reports no clOrdId.
+    let venue_order_id = VenueOrderId::from("external-venue-id");
+    let client_order_id = ClientOrderId::from(venue_order_id.as_str());
+    let order = build_test_regular_order_with_venue_id(client_order_id, venue_order_id);
+    cache
+        .borrow_mut()
+        .add_order(order, None, Some(*OKX_CLIENT_ID), false)
+        .unwrap();
+
+    client
+        .query_order(query_order_command(
+            client_order_id,
+            command_venue_order_id.map(VenueOrderId::from),
+        ))
         .unwrap();
     let report = recv_query_order_report(&mut rx, None).await;
 
@@ -3383,6 +3535,51 @@ fn build_test_stop_order(client_order_id: ClientOrderId) -> OrderAny {
         .build()
 }
 
+fn build_test_conditional_order_with_single_venue_id(
+    client_order_id: ClientOrderId,
+    venue_order_id: VenueOrderId,
+) -> OrderAny {
+    let trader_id = TraderId::from("TESTER-001");
+    let strategy_id = StrategyId::from("STRATEGY-001");
+    let instrument_id = InstrumentId::from("ETH-USDT-SWAP.OKX");
+    let account_id = AccountId::from("OKX-001");
+    let mut order = OrderTestBuilder::new(OrderType::StopLimit)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .side(OrderSide::Sell)
+        .price(Price::from("850.00"))
+        .quantity(Quantity::from("1"))
+        .trigger_price(Price::from("1000.00"))
+        .trigger_type(TriggerType::MarkPrice)
+        .time_in_force(TimeInForce::Gtc)
+        .build();
+    let submitted = OrderSubmittedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .account_id(account_id)
+        .build();
+    let accepted = OrderAcceptedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .venue_order_id(venue_order_id)
+        .account_id(account_id)
+        .build();
+
+    order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+    order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+
+    assert_eq!(order.is_triggered(), Some(false));
+    assert_eq!(order.venue_order_ids(), vec![&venue_order_id]);
+    assert_eq!(order.venue_order_id(), Some(venue_order_id));
+    order
+}
+
 fn build_test_triggered_conditional_order(
     client_order_id: ClientOrderId,
     child_venue_order_id: VenueOrderId,
@@ -3490,12 +3687,14 @@ fn build_test_market_conditional_order_with_child(
     order
 }
 
-fn build_test_adopted_regular_order(client_order_id: ClientOrderId) -> OrderAny {
+fn build_test_regular_order_with_venue_id(
+    client_order_id: ClientOrderId,
+    venue_order_id: VenueOrderId,
+) -> OrderAny {
     let trader_id = TraderId::from("TESTER-001");
     let strategy_id = StrategyId::from("STRATEGY-001");
     let instrument_id = InstrumentId::from("ETH-USDT-SWAP.OKX");
     let account_id = AccountId::from("OKX-001");
-    let venue_order_id = VenueOrderId::from(client_order_id.as_str());
     let mut order = build_test_limit_order(instrument_id, client_order_id);
     let submitted = OrderSubmittedSpec::builder()
         .trader_id(trader_id)

--- a/crates/adapters/okx/tests/exec_client.rs
+++ b/crates/adapters/okx/tests/exec_client.rs
@@ -309,7 +309,7 @@ fn drain_events(
 
 async fn recv_query_order_report(
     rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
-    client_order_id: ClientOrderId,
+    expected_client_order_id: Option<ClientOrderId>,
 ) -> OrderStatusReport {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
 
@@ -321,12 +321,12 @@ async fn recv_query_order_report(
                 };
 
                 if let ExecutionEvent::Report(CommonExecutionReport::Order(report)) = event {
-                    assert_eq!(report.client_order_id, Some(client_order_id));
+                    assert_eq!(report.client_order_id, expected_client_order_id);
                     return *report;
                 }
             }
             () = tokio::time::sleep_until(deadline) => {
-                panic!("timed out waiting for query order report for {client_order_id}");
+                panic!("timed out waiting for query order report for {expected_client_order_id:?}");
             }
         }
     }
@@ -2347,20 +2347,57 @@ fn query_order_instrument() -> InstrumentAny {
         .expect("expected parsed ETH-USDT-SWAP instrument")
 }
 
-fn regular_order_detail_response(client_order_id: &str) -> serde_json::Value {
+fn regular_order_detail_response(params: &HashMap<String, String>) -> serde_json::Value {
     let mut response = load_test_data("http_get_orders_history.json");
     let order = &mut response["data"][0];
-    order["accFillSz"] = json!("0");
-    order["avgPx"] = json!("");
+    let query_id = params
+        .get("clOrdId")
+        .or_else(|| params.get("ordId"))
+        .map(String::as_str)
+        .expect("expected clOrdId or ordId query parameter");
+    let (algo_client_order_id, client_order_id, venue_order_id, order_type, state, price) =
+        match query_id {
+            "OQUERYREGULAR1" => (
+                "",
+                "OQUERYREGULAR1",
+                "regular-venue-id",
+                "limit",
+                "live",
+                "2000.00",
+            ),
+            "market-child-venue-id" => (
+                "OQUERYMARKETCHILD1",
+                "",
+                "market-child-venue-id",
+                "market",
+                "filled",
+                "1000.00",
+            ),
+            "triggered-child-venue-id" => (
+                "OQUERYTRIGGERED1",
+                "",
+                "triggered-child-venue-id",
+                "limit",
+                "filled",
+                "900.00",
+            ),
+            "external-venue-id" => ("", "", "external-venue-id", "limit", "live", "2000.00"),
+            other => panic!("unexpected regular order detail query: {other}"),
+        };
+    let is_filled = state == "filled";
+
+    order["accFillSz"] = json!(if is_filled { "1" } else { "0" });
+    order["algoClOrdId"] = json!(algo_client_order_id);
+    order["avgPx"] = json!(if is_filled { price } else { "" });
     order["clOrdId"] = json!(client_order_id);
-    order["fillPx"] = json!("");
-    order["fillSz"] = json!("");
+    order["fillPx"] = json!(if is_filled { price } else { "" });
+    order["fillSz"] = json!(if is_filled { "1" } else { "" });
     order["instId"] = json!("ETH-USDT-SWAP");
-    order["ordId"] = json!("regular-venue-id");
-    order["ordType"] = json!("limit");
+    order["ordId"] = json!(venue_order_id);
+    order["ordType"] = json!(order_type);
     order["posSide"] = json!("net");
-    order["px"] = json!("2000.00");
-    order["state"] = json!("live");
+    order["px"] = json!(if order_type == "market" { "" } else { price });
+    order["state"] = json!(state);
     order["sz"] = json!("1");
     order["tdMode"] = json!("cross");
     response
@@ -2380,6 +2417,22 @@ fn algo_order_detail_response(params: &HashMap<String, String>) -> serde_json::V
             .map_or("unknown-algo-client-id", String::as_str)
     );
     order["instId"] = json!("ETH-USDT-SWAP");
+
+    match params.get("algoClOrdId").map(String::as_str) {
+        Some("OQUERYMARKETCHILD1") => {
+            order["algoId"] = json!("parent-market-algo-id");
+            order["ordId"] = json!("market-child-venue-id");
+            order["state"] = json!("effective");
+        }
+        Some("OQUERYTRIGGERED1") => {
+            order["algoId"] = json!("parent-algo-id");
+            order["ordId"] = json!("triggered-child-venue-id");
+            order["slOrdPx"] = json!("900.00");
+            order["state"] = json!("effective");
+        }
+        _ => {}
+    }
+
     response
 }
 
@@ -2403,15 +2456,19 @@ async fn start_exec_query_order_test_server(state: Arc<QueryOrderRouteState>) ->
             get(move |Query(params): Query<HashMap<String, String>>| {
                 let state = Arc::clone(&regular_state);
                 async move {
-                    let client_order_id = params.get("clOrdId").cloned().unwrap_or_default();
+                    let query_id = params
+                        .get("clOrdId")
+                        .or_else(|| params.get("ordId"))
+                        .cloned()
+                        .unwrap_or_default();
                     state
                         .sequence
                         .lock()
                         .await
-                        .push(format!("regular:{client_order_id}"));
-                    state.regular_queries.lock().await.push(params);
+                        .push(format!("regular:{query_id}"));
 
-                    if client_order_id == "OQUERYUNKNOWN1" {
+                    if query_id == "OQUERYUNKNOWN1" {
+                        state.regular_queries.lock().await.push(params);
                         return Json(json!({
                             "code": "51603",
                             "msg": "Order does not exist",
@@ -2420,7 +2477,9 @@ async fn start_exec_query_order_test_server(state: Arc<QueryOrderRouteState>) ->
                         .into_response();
                     }
 
-                    Json(regular_order_detail_response(&client_order_id)).into_response()
+                    let response = regular_order_detail_response(&params);
+                    state.regular_queries.lock().await.push(params);
+                    Json(response).into_response()
                 }
             }),
         )
@@ -2429,13 +2488,14 @@ async fn start_exec_query_order_test_server(state: Arc<QueryOrderRouteState>) ->
             get(move |Query(params): Query<HashMap<String, String>>| {
                 let state = Arc::clone(&algo_state);
                 async move {
-                    let client_order_id = params.get("algoClOrdId").cloned().unwrap_or_default();
-                    state
-                        .sequence
-                        .lock()
-                        .await
-                        .push(format!("algo:{client_order_id}"));
+                    let query_id = params
+                        .get("algoClOrdId")
+                        .or_else(|| params.get("algoId"))
+                        .cloned()
+                        .unwrap_or_default();
+                    state.sequence.lock().await.push(format!("algo:{query_id}"));
                     state.algo_queries.lock().await.push(params.clone());
+
                     Json(algo_order_detail_response(&params))
                 }
             }),
@@ -2450,6 +2510,26 @@ async fn start_exec_query_order_test_server(state: Arc<QueryOrderRouteState>) ->
     });
 
     addr
+}
+
+async fn create_query_order_test_client() -> (
+    OKXExecutionClient,
+    tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    Rc<RefCell<Cache>>,
+    Arc<QueryOrderRouteState>,
+) {
+    let state = Arc::new(QueryOrderRouteState::default());
+    let addr = start_exec_query_order_test_server(Arc::clone(&state)).await;
+    let base_url = format!("http://{addr}");
+    let (mut client, mut rx, cache) =
+        create_test_execution_client_configured(&base_url, |config| {
+            config.instrument_types = vec![OKXInstrumentType::Swap];
+        });
+    client.on_instrument(query_order_instrument());
+    client.start().unwrap();
+    let _ = drain_events(&mut rx);
+
+    (client, rx, cache, state)
 }
 
 fn create_exec_test_router() -> Router {
@@ -2922,17 +3002,8 @@ async fn test_margin_only_restart_recovers_spot_fill_reports() {
 
 #[rstest]
 #[tokio::test]
-async fn test_query_order_routes_regular_untriggered_triggered_and_unknown_orders() {
-    let state = Arc::new(QueryOrderRouteState::default());
-    let addr = start_exec_query_order_test_server(Arc::clone(&state)).await;
-    let base_url = format!("http://{addr}");
-    let (mut client, mut rx, cache) =
-        create_test_execution_client_configured(&base_url, |config| {
-            config.instrument_types = vec![OKXInstrumentType::Swap];
-        });
-    client.on_instrument(query_order_instrument());
-    client.start().unwrap();
-    let _ = drain_events(&mut rx);
+async fn test_query_order_routes_regular_untriggered_and_unknown_orders() {
+    let (client, mut rx, cache, state) = create_query_order_test_client().await;
 
     let regular_client_order_id = ClientOrderId::from("OQUERYREGULAR1");
     cache_limit_order(&cache, regular_client_order_id);
@@ -2942,7 +3013,7 @@ async fn test_query_order_routes_regular_untriggered_triggered_and_unknown_order
             Some(VenueOrderId::from("stale-regular-venue-id")),
         ))
         .unwrap();
-    let regular_report = recv_query_order_report(&mut rx, regular_client_order_id).await;
+    let regular_report = recv_query_order_report(&mut rx, Some(regular_client_order_id)).await;
     assert_eq!(regular_report.order_type, OrderType::Limit);
     assert_eq!(
         regular_report.venue_order_id,
@@ -2961,31 +3032,14 @@ async fn test_query_order_routes_regular_untriggered_triggered_and_unknown_order
             Some(VenueOrderId::from("algo-venue-id")),
         ))
         .unwrap();
-    let algo_report = recv_query_order_report(&mut rx, algo_client_order_id).await;
+    let algo_report = recv_query_order_report(&mut rx, Some(algo_client_order_id)).await;
     assert_eq!(algo_report.order_type, OrderType::StopMarket);
-
-    let triggered_client_order_id = ClientOrderId::from("OQUERYTRIGGERED1");
-    let child_venue_order_id = VenueOrderId::from("triggered-child-venue-id");
-    let triggered_order =
-        build_test_triggered_conditional_order(triggered_client_order_id, child_venue_order_id);
-    cache
-        .borrow_mut()
-        .add_order(triggered_order, None, Some(*OKX_CLIENT_ID), false)
-        .unwrap();
-    client
-        .query_order(query_order_command(
-            triggered_client_order_id,
-            Some(child_venue_order_id),
-        ))
-        .unwrap();
-    let triggered_report = recv_query_order_report(&mut rx, triggered_client_order_id).await;
-    assert_eq!(triggered_report.order_type, OrderType::StopMarket);
 
     let unknown_client_order_id = ClientOrderId::from("OQUERYUNKNOWN1");
     client
         .query_order(query_order_command(unknown_client_order_id, None))
         .unwrap();
-    let unknown_report = recv_query_order_report(&mut rx, unknown_client_order_id).await;
+    let unknown_report = recv_query_order_report(&mut rx, Some(unknown_client_order_id)).await;
     assert_eq!(unknown_report.order_type, OrderType::StopMarket);
 
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -3017,7 +3071,8 @@ async fn test_query_order_routes_regular_untriggered_triggered_and_unknown_order
         regular_queries[1].get("clOrdId").map(String::as_str),
         Some("OQUERYUNKNOWN1")
     );
-    assert_eq!(algo_queries.len(), 3);
+    assert!(!regular_queries[1].contains_key("ordId"));
+    assert_eq!(algo_queries.len(), 2);
     assert_eq!(
         algo_queries[0].get("algoId").map(String::as_str),
         Some("algo-venue-id")
@@ -3028,24 +3083,153 @@ async fn test_query_order_routes_regular_untriggered_triggered_and_unknown_order
     );
     assert_eq!(
         algo_queries[1].get("algoClOrdId").map(String::as_str),
-        Some("OQUERYTRIGGERED1")
-    );
-    assert!(!algo_queries[1].contains_key("algoId"));
-    assert_eq!(
-        algo_queries[2].get("algoClOrdId").map(String::as_str),
         Some("OQUERYUNKNOWN1")
     );
-    assert!(!algo_queries[2].contains_key("algoId"));
+    assert!(!algo_queries[1].contains_key("algoId"));
     assert_eq!(
         sequence.as_slice(),
         [
             "regular:OQUERYREGULAR1",
             "algo:OQUERYALGO1",
-            "algo:OQUERYTRIGGERED1",
             "regular:OQUERYUNKNOWN1",
             "algo:OQUERYUNKNOWN1",
         ]
     );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_market_conditional_with_child_id_queries_child_and_parent() {
+    let (client, mut rx, cache, state) = create_query_order_test_client().await;
+
+    // Market-style conditional orders can receive a regular child venue ID
+    // without transitioning their cached triggered flag.
+    let client_order_id = ClientOrderId::from("OQUERYMARKETCHILD1");
+    let child_venue_order_id = VenueOrderId::from("market-child-venue-id");
+    let order =
+        build_test_market_conditional_order_with_child(client_order_id, child_venue_order_id);
+    cache
+        .borrow_mut()
+        .add_order(order, None, Some(*OKX_CLIENT_ID), false)
+        .unwrap();
+
+    client
+        .query_order(query_order_command(
+            client_order_id,
+            Some(child_venue_order_id),
+        ))
+        .unwrap();
+    let report = recv_query_order_report(&mut rx, Some(client_order_id)).await;
+
+    assert_eq!(report.order_type, OrderType::Market);
+    assert_eq!(report.order_status, OrderStatus::Filled);
+    assert_eq!(report.filled_qty, Quantity::from("1"));
+    assert_eq!(report.venue_order_id, child_venue_order_id);
+
+    let regular_queries = state.regular_queries.lock().await;
+    let algo_queries = state.algo_queries.lock().await;
+    let sequence = state.sequence.lock().await;
+    assert_eq!(regular_queries.len(), 1);
+    assert_eq!(
+        regular_queries[0].get("ordId").map(String::as_str),
+        Some("market-child-venue-id")
+    );
+    assert!(!regular_queries[0].contains_key("clOrdId"));
+    assert_eq!(algo_queries.len(), 1);
+    assert_eq!(
+        algo_queries[0].get("algoClOrdId").map(String::as_str),
+        Some("OQUERYMARKETCHILD1")
+    );
+    assert!(!algo_queries[0].contains_key("algoId"));
+    assert_eq!(
+        sequence.as_slice(),
+        ["regular:market-child-venue-id", "algo:OQUERYMARKETCHILD1",]
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_triggered_conditional_recovers_missed_child_fill() {
+    let (client, mut rx, cache, state) = create_query_order_test_client().await;
+
+    let client_order_id = ClientOrderId::from("OQUERYTRIGGERED1");
+    let child_venue_order_id = VenueOrderId::from("triggered-child-venue-id");
+    let order = build_test_triggered_conditional_order(client_order_id, child_venue_order_id);
+    cache
+        .borrow_mut()
+        .add_order(order, None, Some(*OKX_CLIENT_ID), false)
+        .unwrap();
+
+    client
+        .query_order(query_order_command(
+            client_order_id,
+            Some(child_venue_order_id),
+        ))
+        .unwrap();
+    let report = recv_query_order_report(&mut rx, Some(client_order_id)).await;
+
+    // The algo parent is only Triggered, while the regular child is Filled.
+    assert_eq!(report.order_type, OrderType::Limit);
+    assert_eq!(report.order_status, OrderStatus::Filled);
+    assert_eq!(report.filled_qty, Quantity::from("1"));
+    assert_eq!(report.venue_order_id, child_venue_order_id);
+
+    let regular_queries = state.regular_queries.lock().await;
+    let algo_queries = state.algo_queries.lock().await;
+    let sequence = state.sequence.lock().await;
+    assert_eq!(regular_queries.len(), 1);
+    assert_eq!(
+        regular_queries[0].get("ordId").map(String::as_str),
+        Some("triggered-child-venue-id")
+    );
+    assert!(!regular_queries[0].contains_key("clOrdId"));
+    assert_eq!(algo_queries.len(), 1);
+    assert_eq!(
+        algo_queries[0].get("algoClOrdId").map(String::as_str),
+        Some("OQUERYTRIGGERED1")
+    );
+    assert!(!algo_queries[0].contains_key("algoId"));
+    assert_eq!(
+        sequence.as_slice(),
+        ["regular:triggered-child-venue-id", "algo:OQUERYTRIGGERED1",]
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_query_order_adopted_external_regular_uses_venue_order_id() {
+    let (client, mut rx, cache, state) = create_query_order_test_client().await;
+
+    // Adopted external regular orders synthesize their local client ID from
+    // ordId when OKX reports no clOrdId.
+    let venue_order_id = VenueOrderId::from("external-venue-id");
+    let client_order_id = ClientOrderId::from(venue_order_id.as_str());
+    let order = build_test_adopted_regular_order(client_order_id);
+    cache
+        .borrow_mut()
+        .add_order(order, None, Some(*OKX_CLIENT_ID), false)
+        .unwrap();
+
+    client
+        .query_order(query_order_command(client_order_id, Some(venue_order_id)))
+        .unwrap();
+    let report = recv_query_order_report(&mut rx, None).await;
+
+    assert_eq!(report.order_type, OrderType::Limit);
+    assert_eq!(report.order_status, OrderStatus::Accepted);
+    assert_eq!(report.venue_order_id, venue_order_id);
+
+    let regular_queries = state.regular_queries.lock().await;
+    let algo_queries = state.algo_queries.lock().await;
+    let sequence = state.sequence.lock().await;
+    assert_eq!(regular_queries.len(), 1);
+    assert_eq!(
+        regular_queries[0].get("ordId").map(String::as_str),
+        Some("external-venue-id")
+    );
+    assert!(!regular_queries[0].contains_key("clOrdId"));
+    assert!(algo_queries.is_empty());
+    assert_eq!(sequence.as_slice(), ["regular:external-venue-id"]);
 }
 
 #[rstest]
@@ -3259,6 +3443,80 @@ fn build_test_triggered_conditional_order(
 
     assert_eq!(order.is_triggered(), Some(true));
     assert_eq!(order.venue_order_id(), Some(child_venue_order_id));
+    order
+}
+
+fn build_test_market_conditional_order_with_child(
+    client_order_id: ClientOrderId,
+    child_venue_order_id: VenueOrderId,
+) -> OrderAny {
+    let trader_id = TraderId::from("TESTER-001");
+    let strategy_id = StrategyId::from("STRATEGY-001");
+    let instrument_id = InstrumentId::from("ETH-USDT-SWAP.OKX");
+    let account_id = AccountId::from("OKX-001");
+    let mut order = build_test_stop_order(client_order_id);
+    let submitted = OrderSubmittedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .account_id(account_id)
+        .build();
+    let accepted = OrderAcceptedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .venue_order_id(VenueOrderId::from("parent-market-algo-id"))
+        .account_id(account_id)
+        .build();
+    let updated = OrderUpdatedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .venue_order_id(child_venue_order_id)
+        .account_id(account_id)
+        .quantity(Quantity::from("1"))
+        .build();
+
+    order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+    order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+    order.apply(OrderEventAny::Updated(updated)).unwrap();
+
+    assert_eq!(order.is_triggered(), Some(false));
+    assert_eq!(order.venue_order_ids().len(), 2);
+    assert_eq!(order.venue_order_id(), Some(child_venue_order_id));
+    order
+}
+
+fn build_test_adopted_regular_order(client_order_id: ClientOrderId) -> OrderAny {
+    let trader_id = TraderId::from("TESTER-001");
+    let strategy_id = StrategyId::from("STRATEGY-001");
+    let instrument_id = InstrumentId::from("ETH-USDT-SWAP.OKX");
+    let account_id = AccountId::from("OKX-001");
+    let venue_order_id = VenueOrderId::from(client_order_id.as_str());
+    let mut order = build_test_limit_order(instrument_id, client_order_id);
+    let submitted = OrderSubmittedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .account_id(account_id)
+        .build();
+    let accepted = OrderAcceptedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .venue_order_id(venue_order_id)
+        .account_id(account_id)
+        .build();
+
+    order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+    order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+
+    assert_eq!(order.venue_order_id(), Some(venue_order_id));
     order
 }
 

--- a/crates/adapters/okx/tests/exec_client.rs
+++ b/crates/adapters/okx/tests/exec_client.rs
@@ -43,7 +43,7 @@ use nautilus_common::{
         ExecutionEvent,
         execution::{
             BatchCancelOrders, CancelOrder, ExecutionReport as CommonExecutionReport, ModifyOrder,
-            QueryAccount, SubmitOrder, SubmitOrderList,
+            QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList,
             report::{GenerateFillReports, GenerateOrderStatusReports},
         },
     },
@@ -58,7 +58,12 @@ use nautilus_model::{
         AccountType, LiquiditySide, OmsType, OrderSide, OrderStatus, OrderType, TimeInForce,
         TriggerType,
     },
-    events::{OrderEventAny, OrderInitialized},
+    events::{
+        OrderEventAny, OrderInitialized,
+        order::spec::{
+            OrderAcceptedSpec, OrderSubmittedSpec, OrderTriggeredSpec, OrderUpdatedSpec,
+        },
+    },
     identifiers::{
         AccountId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TradeId, TraderId,
         VenueOrderId,
@@ -83,10 +88,15 @@ use nautilus_okx::{
         enums::{
             OKXInstrumentType, OKXMarginMode, OKXOrderStatus, OKXOrderType, OKXSide, OKXTradeMode,
         },
+        models::OKXInstrument,
+        parse::parse_instrument_any,
     },
     config::OKXExecClientConfig,
     execution::OKXExecutionClient,
-    http::models::{OKXCancelAlgoOrderResponse, OKXSpreadOrder},
+    http::{
+        client::OKXResponse,
+        models::{OKXCancelAlgoOrderResponse, OKXSpreadOrder},
+    },
     websocket::{
         dispatch::{
             AlgoCancelContext, WsDispatchState, dispatch_execution_reports, dispatch_ws_message,
@@ -295,6 +305,31 @@ fn drain_events(
         events.push(e);
     }
     events
+}
+
+async fn recv_query_order_report(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    client_order_id: ClientOrderId,
+) -> OrderStatusReport {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+
+    loop {
+        tokio::select! {
+            event = rx.recv() => {
+                let Some(event) = event else {
+                    panic!("event stream closed before query order report");
+                };
+
+                if let ExecutionEvent::Report(CommonExecutionReport::Order(report)) = event {
+                    assert_eq!(report.client_order_id, Some(client_order_id));
+                    return *report;
+                }
+            }
+            () = tokio::time::sleep_until(deadline) => {
+                panic!("timed out waiting for query order report for {client_order_id}");
+            }
+        }
+    }
 }
 
 #[rstest]
@@ -2298,6 +2333,125 @@ fn load_test_data(filename: &str) -> serde_json::Value {
     serde_json::from_str(&content).unwrap()
 }
 
+fn query_order_instrument() -> InstrumentAny {
+    let response: OKXResponse<OKXInstrument> =
+        serde_json::from_value(load_test_data("http_get_instruments_swap.json")).unwrap();
+    let raw = response
+        .data
+        .iter()
+        .find(|instrument| instrument.inst_id == Ustr::from("ETH-USDT-SWAP"))
+        .expect("expected ETH-USDT-SWAP fixture");
+
+    parse_instrument_any(raw, None, None, None, None, UnixNanos::default())
+        .unwrap()
+        .expect("expected parsed ETH-USDT-SWAP instrument")
+}
+
+fn regular_order_detail_response(client_order_id: &str) -> serde_json::Value {
+    let mut response = load_test_data("http_get_orders_history.json");
+    let order = &mut response["data"][0];
+    order["accFillSz"] = json!("0");
+    order["avgPx"] = json!("");
+    order["clOrdId"] = json!(client_order_id);
+    order["fillPx"] = json!("");
+    order["fillSz"] = json!("");
+    order["instId"] = json!("ETH-USDT-SWAP");
+    order["ordId"] = json!("regular-venue-id");
+    order["ordType"] = json!("limit");
+    order["posSide"] = json!("net");
+    order["px"] = json!("2000.00");
+    order["state"] = json!("live");
+    order["sz"] = json!("1");
+    order["tdMode"] = json!("cross");
+    response
+}
+
+fn algo_order_detail_response(params: &HashMap<String, String>) -> serde_json::Value {
+    let mut response = load_test_data("http_get_orders_algo_pending_close_fraction.json");
+    let order = &mut response["data"][0];
+    order["algoId"] = json!(
+        params
+            .get("algoId")
+            .map_or("unknown-algo-id", String::as_str)
+    );
+    order["algoClOrdId"] = json!(
+        params
+            .get("algoClOrdId")
+            .map_or("unknown-algo-client-id", String::as_str)
+    );
+    order["instId"] = json!("ETH-USDT-SWAP");
+    response
+}
+
+#[derive(Default)]
+struct QueryOrderRouteState {
+    regular_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
+    algo_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
+    sequence: tokio::sync::Mutex<Vec<String>>,
+}
+
+async fn start_exec_query_order_test_server(state: Arc<QueryOrderRouteState>) -> SocketAddr {
+    let regular_state = Arc::clone(&state);
+    let algo_state = state;
+    let router = create_exec_test_router()
+        .route(
+            "/api/v5/public/instruments",
+            get(|| async { Json(load_test_data("http_get_instruments_swap.json")) }),
+        )
+        .route(
+            "/api/v5/trade/order",
+            get(move |Query(params): Query<HashMap<String, String>>| {
+                let state = Arc::clone(&regular_state);
+                async move {
+                    let client_order_id = params.get("clOrdId").cloned().unwrap_or_default();
+                    state
+                        .sequence
+                        .lock()
+                        .await
+                        .push(format!("regular:{client_order_id}"));
+                    state.regular_queries.lock().await.push(params);
+
+                    if client_order_id == "OQUERYUNKNOWN1" {
+                        return Json(json!({
+                            "code": "51603",
+                            "msg": "Order does not exist",
+                            "data": [],
+                        }))
+                        .into_response();
+                    }
+
+                    Json(regular_order_detail_response(&client_order_id)).into_response()
+                }
+            }),
+        )
+        .route(
+            "/api/v5/trade/order-algo",
+            get(move |Query(params): Query<HashMap<String, String>>| {
+                let state = Arc::clone(&algo_state);
+                async move {
+                    let client_order_id = params.get("algoClOrdId").cloned().unwrap_or_default();
+                    state
+                        .sequence
+                        .lock()
+                        .await
+                        .push(format!("algo:{client_order_id}"));
+                    state.algo_queries.lock().await.push(params.clone());
+                    Json(algo_order_detail_response(&params))
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    addr
+}
+
 fn create_exec_test_router() -> Router {
     Router::new().route(
         "/api/v5/account/balance",
@@ -2768,6 +2922,134 @@ async fn test_margin_only_restart_recovers_spot_fill_reports() {
 
 #[rstest]
 #[tokio::test]
+async fn test_query_order_routes_regular_untriggered_triggered_and_unknown_orders() {
+    let state = Arc::new(QueryOrderRouteState::default());
+    let addr = start_exec_query_order_test_server(Arc::clone(&state)).await;
+    let base_url = format!("http://{addr}");
+    let (mut client, mut rx, cache) =
+        create_test_execution_client_configured(&base_url, |config| {
+            config.instrument_types = vec![OKXInstrumentType::Swap];
+        });
+    client.on_instrument(query_order_instrument());
+    client.start().unwrap();
+    let _ = drain_events(&mut rx);
+
+    let regular_client_order_id = ClientOrderId::from("OQUERYREGULAR1");
+    cache_limit_order(&cache, regular_client_order_id);
+    client
+        .query_order(query_order_command(
+            regular_client_order_id,
+            Some(VenueOrderId::from("stale-regular-venue-id")),
+        ))
+        .unwrap();
+    let regular_report = recv_query_order_report(&mut rx, regular_client_order_id).await;
+    assert_eq!(regular_report.order_type, OrderType::Limit);
+    assert_eq!(
+        regular_report.venue_order_id,
+        VenueOrderId::from("regular-venue-id")
+    );
+
+    let algo_client_order_id = ClientOrderId::from("OQUERYALGO1");
+    let algo_order = build_test_stop_order(algo_client_order_id);
+    cache
+        .borrow_mut()
+        .add_order(algo_order, None, Some(*OKX_CLIENT_ID), false)
+        .unwrap();
+    client
+        .query_order(query_order_command(
+            algo_client_order_id,
+            Some(VenueOrderId::from("algo-venue-id")),
+        ))
+        .unwrap();
+    let algo_report = recv_query_order_report(&mut rx, algo_client_order_id).await;
+    assert_eq!(algo_report.order_type, OrderType::StopMarket);
+
+    let triggered_client_order_id = ClientOrderId::from("OQUERYTRIGGERED1");
+    let child_venue_order_id = VenueOrderId::from("triggered-child-venue-id");
+    let triggered_order =
+        build_test_triggered_conditional_order(triggered_client_order_id, child_venue_order_id);
+    cache
+        .borrow_mut()
+        .add_order(triggered_order, None, Some(*OKX_CLIENT_ID), false)
+        .unwrap();
+    client
+        .query_order(query_order_command(
+            triggered_client_order_id,
+            Some(child_venue_order_id),
+        ))
+        .unwrap();
+    let triggered_report = recv_query_order_report(&mut rx, triggered_client_order_id).await;
+    assert_eq!(triggered_report.order_type, OrderType::StopMarket);
+
+    let unknown_client_order_id = ClientOrderId::from("OQUERYUNKNOWN1");
+    client
+        .query_order(query_order_command(unknown_client_order_id, None))
+        .unwrap();
+    let unknown_report = recv_query_order_report(&mut rx, unknown_client_order_id).await;
+    assert_eq!(unknown_report.order_type, OrderType::StopMarket);
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let unexpected_reports: Vec<_> = drain_events(&mut rx)
+        .into_iter()
+        .filter(|event| {
+            matches!(
+                event,
+                ExecutionEvent::Report(CommonExecutionReport::Order(_))
+            )
+        })
+        .collect();
+    assert!(
+        unexpected_reports.is_empty(),
+        "query_order emitted duplicate reports: {unexpected_reports:?}"
+    );
+
+    let regular_queries = state.regular_queries.lock().await;
+    let algo_queries = state.algo_queries.lock().await;
+    let sequence = state.sequence.lock().await;
+
+    assert_eq!(regular_queries.len(), 2);
+    assert_eq!(
+        regular_queries[0].get("clOrdId").map(String::as_str),
+        Some("OQUERYREGULAR1")
+    );
+    assert!(!regular_queries[0].contains_key("ordId"));
+    assert_eq!(
+        regular_queries[1].get("clOrdId").map(String::as_str),
+        Some("OQUERYUNKNOWN1")
+    );
+    assert_eq!(algo_queries.len(), 3);
+    assert_eq!(
+        algo_queries[0].get("algoId").map(String::as_str),
+        Some("algo-venue-id")
+    );
+    assert_eq!(
+        algo_queries[0].get("algoClOrdId").map(String::as_str),
+        Some("OQUERYALGO1")
+    );
+    assert_eq!(
+        algo_queries[1].get("algoClOrdId").map(String::as_str),
+        Some("OQUERYTRIGGERED1")
+    );
+    assert!(!algo_queries[1].contains_key("algoId"));
+    assert_eq!(
+        algo_queries[2].get("algoClOrdId").map(String::as_str),
+        Some("OQUERYUNKNOWN1")
+    );
+    assert!(!algo_queries[2].contains_key("algoId"));
+    assert_eq!(
+        sequence.as_slice(),
+        [
+            "regular:OQUERYREGULAR1",
+            "algo:OQUERYALGO1",
+            "algo:OQUERYTRIGGERED1",
+            "regular:OQUERYUNKNOWN1",
+            "algo:OQUERYUNKNOWN1",
+        ]
+    );
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_generate_order_status_reports_includes_spreads_when_enabled() {
     let state = Arc::new(ReportRouteState::default());
     let addr = start_exec_report_test_server(Arc::clone(&state)).await;
@@ -2915,6 +3197,87 @@ fn build_test_stop_order(client_order_id: ClientOrderId) -> OrderAny {
         .trigger_type(TriggerType::MarkPrice)
         .time_in_force(TimeInForce::Gtc)
         .build()
+}
+
+fn build_test_triggered_conditional_order(
+    client_order_id: ClientOrderId,
+    child_venue_order_id: VenueOrderId,
+) -> OrderAny {
+    let trader_id = TraderId::from("TESTER-001");
+    let strategy_id = StrategyId::from("STRATEGY-001");
+    let instrument_id = InstrumentId::from("ETH-USDT-SWAP.OKX");
+    let account_id = AccountId::from("OKX-001");
+    let mut order = OrderTestBuilder::new(OrderType::StopLimit)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .side(OrderSide::Sell)
+        .price(Price::from("900.00"))
+        .quantity(Quantity::from("1"))
+        .trigger_price(Price::from("1000.00"))
+        .trigger_type(TriggerType::MarkPrice)
+        .time_in_force(TimeInForce::Gtc)
+        .build();
+    let submitted = OrderSubmittedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .account_id(account_id)
+        .build();
+    let accepted = OrderAcceptedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .venue_order_id(VenueOrderId::from("parent-algo-id"))
+        .account_id(account_id)
+        .build();
+    let triggered = OrderTriggeredSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .venue_order_id(child_venue_order_id)
+        .account_id(account_id)
+        .build();
+    let updated = OrderUpdatedSpec::builder()
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .venue_order_id(child_venue_order_id)
+        .account_id(account_id)
+        .quantity(Quantity::from("1"))
+        .build();
+
+    order.apply(OrderEventAny::Submitted(submitted)).unwrap();
+    order.apply(OrderEventAny::Accepted(accepted)).unwrap();
+    order.apply(OrderEventAny::Triggered(triggered)).unwrap();
+    order.apply(OrderEventAny::Updated(updated)).unwrap();
+
+    assert_eq!(order.is_triggered(), Some(true));
+    assert_eq!(order.venue_order_id(), Some(child_venue_order_id));
+    order
+}
+
+fn query_order_command(
+    client_order_id: ClientOrderId,
+    venue_order_id: Option<VenueOrderId>,
+) -> QueryOrder {
+    QueryOrder::new(
+        TraderId::from("TESTER-001"),
+        Some(*OKX_CLIENT_ID),
+        StrategyId::from("STRATEGY-001"),
+        InstrumentId::from("ETH-USDT-SWAP.OKX"),
+        client_order_id,
+        venue_order_id,
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+    )
 }
 
 fn collect_order_denied_events(events: Vec<ExecutionEvent>) -> HashMap<ClientOrderId, String> {

--- a/crates/adapters/okx/tests/http.rs
+++ b/crates/adapters/okx/tests/http.rs
@@ -789,6 +789,15 @@ fn create_router(state: Arc<TestServerState>) -> Router {
                                 .into_response();
                         }
 
+                        if params.get("clOrdId").map(String::as_str) == Some("O-missing-regular") {
+                            return Json(json!({
+                                "code": "51603",
+                                "msg": "Order does not exist",
+                                "data": [],
+                            }))
+                            .into_response();
+                        }
+
                         *state.last_order_detail_query.lock().await = Some(params);
                         Json(load_test_data("http_get_orders_history.json")).into_response()
                     }
@@ -1022,6 +1031,15 @@ fn create_router(state: Arc<TestServerState>) -> Router {
                                 })),
                             )
                                 .into_response();
+                        }
+
+                        if params.get("algoClOrdId").map(String::as_str) == Some("O-missing") {
+                            return Json(json!({
+                                "code": "51603",
+                                "msg": "Order does not exist",
+                                "data": [],
+                            }))
+                            .into_response();
                         }
 
                         let fixture = match params.get("algoClOrdId").map(String::as_str) {
@@ -2402,7 +2420,6 @@ async fn test_http_get_order_by_client_and_exchange_ids() {
     .unwrap();
 
     let params = GetOrderParamsBuilder::default()
-        .inst_type(OKXInstrumentType::Swap)
         .inst_id("BTC-USDT-SWAP")
         .ord_id("1234567890123456789")
         .cl_ord_id("client-order-1")
@@ -2413,10 +2430,64 @@ async fn test_http_get_order_by_client_and_exchange_ids() {
     assert_eq!(orders.len(), 1);
 
     let query = state.last_order_detail_query.lock().await.clone().unwrap();
-    assert_eq!(query.get("instType"), Some(&"SWAP".to_string()));
+    assert_eq!(query.len(), 3);
     assert_eq!(query.get("instId"), Some(&"BTC-USDT-SWAP".to_string()));
     assert_eq!(query.get("ordId"), Some(&"1234567890123456789".to_string()));
     assert_eq!(query.get("clOrdId"), Some(&"client-order-1".to_string()));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_request_order_status_report_uses_client_order_id_and_handles_missing_order() {
+    let state = Arc::new(TestServerState::default());
+    let addr = start_test_server(state.clone()).await;
+    let base_url = format!("http://{addr}");
+    let client = OKXHttpClient::with_credentials(
+        Some("key".to_string()),
+        Some("secret".to_string()),
+        Some("pass".to_string()),
+        Some(base_url),
+        60,
+        3,
+        1000,
+        10_000,
+        OKXEnvironment::Live,
+        None,
+    )
+    .unwrap();
+
+    for instrument in load_swap_instruments_any() {
+        client.cache_instrument(instrument);
+    }
+
+    let report = client
+        .request_order_status_report(
+            AccountId::new("OKX-001"),
+            InstrumentId::from("BTC-USDT-SWAP.OKX"),
+            ClientOrderId::from("O-recover"),
+        )
+        .await
+        .unwrap()
+        .expect("expected regular order report");
+
+    assert_eq!(report.venue_order_id.as_str(), "2497956918703120384");
+    let query = state.last_order_detail_query.lock().await.clone().unwrap();
+    assert_eq!(
+        query.get("instId").map(String::as_str),
+        Some("BTC-USDT-SWAP")
+    );
+    assert_eq!(query.get("clOrdId").map(String::as_str), Some("O-recover"));
+    assert!(!query.contains_key("ordId"));
+
+    let missing = client
+        .request_order_status_report(
+            AccountId::new("OKX-001"),
+            InstrumentId::from("BTC-USDT-SWAP.OKX"),
+            ClientOrderId::from("O-missing-regular"),
+        )
+        .await
+        .unwrap();
+    assert!(missing.is_none());
 }
 
 #[tokio::test]
@@ -3830,6 +3901,41 @@ async fn test_http_request_algo_order_status_report_parses_close_fraction_condit
 
 #[rstest]
 #[tokio::test]
+async fn test_http_request_algo_order_status_report_treats_missing_order_as_none() {
+    let addr = start_test_server(Arc::new(TestServerState::default())).await;
+    let base_url = format!("http://{addr}");
+    let client = OKXHttpClient::with_credentials(
+        Some("test_key".to_string()),
+        Some("test_secret".to_string()),
+        Some("test_passphrase".to_string()),
+        Some(base_url),
+        60,
+        3,
+        1000,
+        10_000,
+        OKXEnvironment::Live,
+        None,
+    )
+    .unwrap();
+
+    for instrument in load_swap_instruments_any() {
+        client.cache_instrument(instrument);
+    }
+
+    let report = client
+        .request_algo_order_status_report(
+            AccountId::new("OKX-001"),
+            InstrumentId::from("BTC-USDT-SWAP.OKX"),
+            ClientOrderId::from("O-missing"),
+        )
+        .await
+        .unwrap();
+
+    assert!(report.is_none());
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_http_request_algo_order_status_report_queries_attached_oco_details() {
     let state = Arc::new(TestServerState::default());
     let addr = start_test_server(state.clone()).await;
@@ -4146,7 +4252,7 @@ async fn test_http_request_algo_order_status_reports_uses_details_for_exact_look
             None,
             Some(InstrumentId::from("ETH-USDT-SWAP.OKX")),
             Some("987654321".to_string()),
-            None,
+            Some(ClientOrderId::from("client_algo_2")),
             None,
             Some(1),
         )
@@ -4167,6 +4273,10 @@ async fn test_http_request_algo_order_status_reports_uses_details_for_exact_look
     assert_eq!(
         details_queries[0].get("algoId").map(String::as_str),
         Some("987654321")
+    );
+    assert_eq!(
+        details_queries[0].get("algoClOrdId").map(String::as_str),
+        Some("client_algo_2")
     );
     assert!(pending_queries.is_empty());
     assert!(history_queries.is_empty());

--- a/crates/adapters/okx/tests/http.rs
+++ b/crates/adapters/okx/tests/http.rs
@@ -51,7 +51,8 @@ use nautilus_okx::{
     common::{
         enums::{
             OKXAlgoOrderStatus, OKXEnvironment, OKXInstrumentType, OKXOrderStatus, OKXOrderType,
-            OKXPositionMode, OKXRpiPermission, OKXSide, OKXTradeMode, OKXTriggerType,
+            OKXPositionMode, OKXPositionSide, OKXRpiPermission, OKXSide, OKXTradeMode,
+            OKXTriggerType,
         },
         models::OKXInstrument,
     },
@@ -2420,9 +2421,11 @@ async fn test_http_get_order_by_client_and_exchange_ids() {
     .unwrap();
 
     let params = GetOrderParamsBuilder::default()
+        .inst_type(OKXInstrumentType::Swap)
         .inst_id("BTC-USDT-SWAP")
         .ord_id("1234567890123456789")
         .cl_ord_id("client-order-1")
+        .pos_side(OKXPositionSide::Net)
         .build()
         .unwrap();
 


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, because AI assistance was used,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed
- [x] I ran all relevant tests locally
- [x] I have not modified `RELEASES.md`

## Summary

Route `QueryOrder` through the regular or algo detail endpoint according to the cached order type, with regular-to-algo fallback only for uncached orders after an order-not-found response. The exact lookup helpers now treat OKX `51603` as a scoped no-match, use documented request fields and identifier precedence, and deserialize current algo child identifier lists without adding multi-child lifecycle behavior.

The regression coverage includes triggered conditionals whose cached venue ID has become the child `ordId`, ensuring the parent lookup uses `algoClOrdId`, and regular orders where a stale `ordId` must not override a valid `clOrdId`.

## Related issues/PRs

Resolves #4717

Related to #4716

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

None.

## Documentation

- [x] Documentation changes follow the style guide (not applicable; no documentation changed)
- [x] PyO3 stubs are current (not applicable; no PyO3 bindings or wrapped Rust docs changed)

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

- `make format`
- `make pre-commit`
- `cargo test -p nautilus-okx --lib --test http --test exec_client`
  - 648 library tests passed
  - 58 execution-client tests passed
  - 100 HTTP tests passed

Issue #4717 also records a bounded OKX EEA Demo proof of the regular, cached-algo, and uncached fallback routes. The test-created orders were canceled and reconciled with no fills or residual exposure.
