### PR TITLE
Fix Binance Futures hedge-mode positionSide for close_position orders

### DIFF
--- a/crates/adapters/binance/src/futures/conversions.rs
+++ b/crates/adapters/binance/src/futures/conversions.rs
@@ -45,19 +45,21 @@ pub(crate) fn normalize_futures_asset<T: AsRef<str>>(
 /// Determines the Binance `positionSide` for hedge mode from the Nautilus order side.
 ///
 /// Returns `None` when not in hedge mode (one-way mode orders omit `positionSide`).
-/// In hedge mode, `reduce_only` flips the mapping so that Buy closes Short and
-/// Sell closes Long.
+/// In hedge mode, `is_closing` flips the mapping so that Buy closes Short and
+/// Sell closes Long. Close intent comes from the Nautilus `reduce_only` flag for
+/// explicit-quantity orders and from the `close_position` order parameter for
+/// whole-leg exits, which cannot carry `reduce_only`.
 #[must_use]
 pub(crate) fn determine_position_side(
     is_hedge_mode: bool,
     order_side: OrderSide,
-    reduce_only: bool,
+    is_closing: bool,
 ) -> Option<BinancePositionSide> {
     if !is_hedge_mode {
         return None;
     }
 
-    Some(if reduce_only {
+    Some(if is_closing {
         match order_side {
             OrderSide::Buy => BinancePositionSide::Short,
             OrderSide::Sell => BinancePositionSide::Long,
@@ -202,11 +204,11 @@ mod tests {
     fn test_determine_position_side(
         #[case] is_hedge_mode: bool,
         #[case] order_side: OrderSide,
-        #[case] reduce_only: bool,
+        #[case] is_closing: bool,
         #[case] expected: Option<BinancePositionSide>,
     ) {
         assert_eq!(
-            determine_position_side(is_hedge_mode, order_side, reduce_only),
+            determine_position_side(is_hedge_mode, order_side, is_closing),
             expected,
         );
     }

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -515,7 +515,21 @@ impl BinanceFuturesExecutionClient {
         let activation_price = order.activation_price();
         let trailing_offset = order.trailing_offset();
         let trigger_type = order.trigger_type();
-        let position_side = determine_position_side(self.is_hedge_mode(), order_side, reduce_only);
+
+        let close_position = cmd
+            .params
+            .as_ref()
+            .and_then(|p| p.get_bool("close_position"))
+            .unwrap_or(false);
+
+        // `close_position` retires an entire hedge leg, so it carries close intent on
+        // its own. It cannot be combined with `reduce_only` (rejected in `submit_order`),
+        // which is otherwise the flag that selects the closing `positionSide`.
+        let position_side = determine_position_side(
+            self.is_hedge_mode(),
+            order_side,
+            reduce_only || close_position,
+        );
 
         // Register identity for tracked/external dispatch routing
         self.dispatch_state.order_identities.insert(
@@ -531,12 +545,6 @@ impl BinanceFuturesExecutionClient {
         );
 
         let use_algo_api = is_algo_order_type(order_type);
-
-        let close_position = cmd
-            .params
-            .as_ref()
-            .and_then(|p| p.get_bool("close_position"))
-            .unwrap_or(false);
 
         let price_match = cmd
             .params

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -1890,6 +1890,152 @@ async fn test_submit_algo_order_in_hedge_mode_omits_reduce_only() {
     assert!(!query.contains_key("reduceOnly"));
 }
 
+/// Binance retires a whole hedge leg with `closePosition=true` submitted on the
+/// side that closes that leg: `SELL`+`positionSide=LONG` for the long leg and
+/// `BUY`+`positionSide=SHORT` for the short leg. `positionSide` must therefore
+/// follow close intent, which `close_position` expresses on its own — the wire
+/// `reduceOnly` field is forbidden alongside `positionSide`, and the internal
+/// `reduce_only` flag cannot be combined with `close_position` at all.
+#[rstest]
+#[case::close_long_leg(OrderSide::Sell, "LONG")]
+#[case::close_short_leg(OrderSide::Buy, "SHORT")]
+#[tokio::test]
+async fn test_submit_close_position_in_hedge_mode_emits_closing_position_side(
+    #[case] order_side: OrderSide,
+    #[case] expected_position_side: &'static str,
+) {
+    let (addr, captured_query) =
+        start_exec_test_server_with_algo_capture_and_hedge_mode(true).await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let client_order_id = ClientOrderId::new("hedge-close-position-test-001");
+    let order_any = add_stop_market_order_to_cache(&cache, client_order_id, order_side, false);
+
+    client
+        .submit_order(submit_order_command_with_params(
+            &order_any,
+            Some(close_position_params()),
+        ))
+        .unwrap();
+
+    wait_until_async(
+        || {
+            let captured_query = captured_query.clone();
+
+            async move { captured_query.lock().unwrap().is_some() }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let query = captured_query.lock().unwrap().clone().unwrap();
+    assert_eq!(query.get("closePosition").map(String::as_str), Some("true"));
+    assert_eq!(
+        query.get("positionSide").map(String::as_str),
+        Some(expected_position_side),
+    );
+    assert!(!query.contains_key("reduceOnly"));
+    assert!(!query.contains_key("quantity"));
+}
+
+/// `close_position` already carries close intent, so pairing it with the internal
+/// `reduce_only` flag is refused locally before anything reaches the venue. This
+/// is the second half of the hedge-mode full-exit trap: the flag that would
+/// otherwise select the closing `positionSide` is exactly the flag that is
+/// rejected here.
+#[rstest]
+#[case::hedge(true)]
+#[case::one_way(false)]
+#[tokio::test]
+async fn test_submit_close_position_with_reduce_only_is_denied_locally(#[case] hedge_mode: bool) {
+    let (addr, _captured_query) =
+        start_exec_test_server_with_algo_capture_and_hedge_mode(hedge_mode).await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let client_order_id = ClientOrderId::new("hedge-close-position-reduce-only-001");
+    let order_any = add_stop_market_order_to_cache(&cache, client_order_id, OrderSide::Sell, true);
+
+    let error = client
+        .submit_order(submit_order_command_with_params(
+            &order_any,
+            Some(close_position_params()),
+        ))
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "`close_position` cannot be combined with `reduce_only` on Binance",
+    );
+}
+
+/// An explicit-quantity hedge-mode exit is close-only purely by virtue of its
+/// `positionSide`, and that side is selected by the internal `reduce_only` flag.
+/// Leaving the flag unset to avoid the forbidden wire field therefore emits the
+/// *opening* leg and adds exposure instead of removing it.
+#[rstest]
+#[case::sell_opens_short_without_reduce_only(OrderSide::Sell, false, "SHORT")]
+#[case::sell_closes_long_with_reduce_only(OrderSide::Sell, true, "LONG")]
+#[case::buy_opens_long_without_reduce_only(OrderSide::Buy, false, "LONG")]
+#[case::buy_closes_short_with_reduce_only(OrderSide::Buy, true, "SHORT")]
+#[tokio::test]
+async fn test_submit_partial_exit_position_side_follows_reduce_only(
+    #[case] order_side: OrderSide,
+    #[case] reduce_only: bool,
+    #[case] expected_position_side: &'static str,
+) {
+    let (addr, captured_query) =
+        start_exec_test_server_with_algo_capture_and_hedge_mode(true).await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let client_order_id = ClientOrderId::new("hedge-partial-exit-test-001");
+    let order_any =
+        add_stop_market_order_to_cache(&cache, client_order_id, order_side, reduce_only);
+
+    client
+        .submit_order(submit_order_command(&order_any))
+        .unwrap();
+
+    wait_until_async(
+        || {
+            let captured_query = captured_query.clone();
+
+            async move { captured_query.lock().unwrap().is_some() }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let query = captured_query.lock().unwrap().clone().unwrap();
+    assert_eq!(
+        query.get("positionSide").map(String::as_str),
+        Some(expected_position_side),
+    );
+    assert_eq!(query.get("quantity").map(String::as_str), Some("0.001"));
+    assert!(!query.contains_key("reduceOnly"));
+    assert!(!query.contains_key("closePosition"));
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_submit_usdm_gtd_algo_uses_http_when_ws_trading_is_active() {
@@ -4275,6 +4421,54 @@ fn add_triggered_stop_market_order_to_cache(
     order_any
 }
 
+fn add_stop_market_order_to_cache(
+    cache: &Rc<RefCell<Cache>>,
+    client_order_id: ClientOrderId,
+    order_side: OrderSide,
+    reduce_only: bool,
+) -> OrderAny {
+    let order = StopMarketOrder::new(
+        test_trader_id(),
+        test_strategy_id(),
+        test_instrument_id(),
+        client_order_id,
+        order_side,
+        Quantity::from("0.001"),
+        Price::from("45000.00"),
+        TriggerType::MarkPrice,
+        TimeInForce::Gtc,
+        None,
+        reduce_only,
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        nautilus_core::UUID4::new(),
+        UnixNanos::default(),
+    );
+
+    let order_any = OrderAny::StopMarket(order);
+    cache
+        .borrow_mut()
+        .add_order(order_any.clone(), None, None, false)
+        .unwrap();
+    order_any
+}
+
+fn close_position_params() -> Params {
+    let mut params = Params::new();
+    params.insert("close_position".to_string(), json!(true));
+    params
+}
+
 fn algo_order_query_params() -> Params {
     let mut params = Params::new();
     params.insert(
@@ -4396,6 +4590,10 @@ fn add_linked_conditional_orders_to_cache(cache: &Rc<RefCell<Cache>>) -> Vec<Ord
 }
 
 fn submit_order_command(order: &OrderAny) -> SubmitOrder {
+    submit_order_command_with_params(order, None)
+}
+
+fn submit_order_command_with_params(order: &OrderAny, params: Option<Params>) -> SubmitOrder {
     SubmitOrder::new(
         test_trader_id(),
         Some(*BINANCE_CLIENT_ID),
@@ -4405,7 +4603,7 @@ fn submit_order_command(order: &OrderAny) -> SubmitOrder {
         order.init_event().clone(),
         None,
         None,
-        None,
+        params,
         nautilus_core::UUID4::new(),
         UnixNanos::default(),
         None,

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -1893,7 +1893,7 @@ async fn test_submit_algo_order_in_hedge_mode_omits_reduce_only() {
 /// Binance retires a whole hedge leg with `closePosition=true` submitted on the
 /// side that closes that leg: `SELL`+`positionSide=LONG` for the long leg and
 /// `BUY`+`positionSide=SHORT` for the short leg. `positionSide` must therefore
-/// follow close intent, which `close_position` expresses on its own — the wire
+/// follow close intent, which `close_position` expresses on its own - the wire
 /// `reduceOnly` field is forbidden alongside `positionSide`, and the internal
 /// `reduce_only` flag cannot be combined with `close_position` at all.
 #[rstest]


### PR DESCRIPTION
## Problem

In hedge mode, a full-position exit (`params={"close_position": true}`) has no
way to express close intent, so it emits the **opening** `positionSide` and
Binance rejects it.

`determine_position_side(is_hedge_mode, order_side, reduce_only)` derives
`positionSide` from the `reduce_only` flag alone, while `submit_order` rejects
`close_position` combined with `reduce_only` (correctly — Binance forbids the
wire `reduceOnly` field together with `closePosition=true`). Before this
change:

| Case | Emitted | Binance requires |
| --- | --- | --- |
| close LONG leg — `SELL` + `closePosition=true` | `positionSide=SHORT` | `positionSide=LONG` |
| close SHORT leg — `BUY` + `closePosition=true` | `positionSide=LONG` | `positionSide=SHORT` |

Binance's New Order parameter documentation pins the legal shapes for
`closePosition`: *"In Hedge Mode, cannot be used with BUY orders in LONG
position side and cannot be used with SELL orders in SHORT position side"* —
i.e. `SELL`+`LONG` and `BUY`+`SHORT` are the only valid full-leg closes.

## Fix

`close_position` carries close intent on its own. Pass
`reduce_only || close_position` as the close-intent argument to
`determine_position_side`; the third parameter is renamed `is_closing` with
its doc updated, since that is what it always meant. No behavior change in
one-way mode, where `positionSide` is omitted entirely.

## Tests

Wire-level, through the existing axum capture harness in
`crates/adapters/binance/tests/futures/exec_client.rs`, hedge mode on both
legs:

- `closePosition=true` emits the closing `positionSide` (both legs);
- local refusal of `close_position` + `reduce_only` (hedge and one-way);
- explicit-quantity exits keep deriving `positionSide` from `reduce_only`
  (regression lock for the existing partial-exit path).

`cargo test -p nautilus-binance` — 925 + 200 + 144 pass, 0 fail.
`cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

Related: #4231 resolved the hedge-mode `reduceOnly` wire-field handling for
explicit-quantity orders; this addresses the remaining full-position
(`close_position`) side derivation.
