### PR TITLE
Guard the domain of the f32 ln approximation

### DIFF
--- a/crates/model/src/data/black_scholes.rs
+++ b/crates/model/src/data/black_scholes.rs
@@ -105,30 +105,12 @@ impl BlackScholesReal for f32 {
         // See: J.-M. Muller et al., "Handbook of Floating-Point Arithmetic", 2018, Section 10.2
         //      A. J. Salgado & S. M. Wise, "Classical Numerical Analysis", 2023, Chapter 10
         let bits = self.to_bits();
-        let magnitude = bits & 0x7fff_ffff;
-        if magnitude == 0 {
-            return Self::NEG_INFINITY;
-        }
 
-        let exponent_bits = magnitude & 0x7f80_0000;
-        let fraction_bits = magnitude & 0x007f_ffff;
-        if exponent_bits == 0x7f80_0000 && fraction_bits != 0 {
-            return Self::NAN;
-        }
-
-        if bits & 0x8000_0000 != 0 {
-            return Self::NAN;
-        }
-
-        if exponent_bits == 0x7f80_0000 {
-            return Self::INFINITY;
-        }
-
-        if exponent_bits == 0 {
-            // Scaling by 2^23 is exact and carries every positive subnormal into the
-            // normal range, so this recurses exactly once.
-            return <Self as BlackScholesReal>::ln(self * 8_388_608.0)
-                - 23.0 * std::f32::consts::LN_2;
+        // Positive normal bit patterns occupy one contiguous interval, so the ordinary
+        // path reaches the polynomial through a single range test. Everything else -
+        // zeros, negatives, subnormals, infinity, NaN - is handled out of line.
+        if !(0x0080_0000..0x7f80_0000).contains(&bits) {
+            return ln_f32_outside_normal_range(self);
         }
 
         let exponent = ((bits >> 23) as i32 - 127) as Self;
@@ -411,6 +393,39 @@ pub fn compute_iv_and_greeks<T: BlackScholesReal>(
     g_final.vol = vol;
 
     g_final
+}
+
+/// Returns `ln(value)` for the inputs outside the positive normal range: zeros, negatives,
+/// subnormals, infinity, and NaN.
+///
+/// Kept out of line because `<f32 as BlackScholesReal>::ln` is `#[inline(always)]`, so any
+/// classification left in its body is duplicated at every call site on the pricing path.
+#[cold]
+#[inline(never)]
+fn ln_f32_outside_normal_range(value: f32) -> f32 {
+    let bits = value.to_bits();
+    let magnitude = bits & 0x7fff_ffff;
+    if magnitude == 0 {
+        return f32::NEG_INFINITY;
+    }
+
+    let exponent_bits = magnitude & 0x7f80_0000;
+    let fraction_bits = magnitude & 0x007f_ffff;
+    if exponent_bits == 0x7f80_0000 && fraction_bits != 0 {
+        return f32::NAN;
+    }
+
+    if bits & 0x8000_0000 != 0 {
+        return f32::NAN;
+    }
+
+    if exponent_bits == 0x7f80_0000 {
+        return f32::INFINITY;
+    }
+
+    // Only positive subnormals remain. Scaling by 2^23 is exact and carries every one of
+    // them into the normal range, so this re-enters the ordinary path exactly once.
+    <f32 as BlackScholesReal>::ln(value * 8_388_608.0) - 23.0 * std::f32::consts::LN_2
 }
 
 // 4. UNIT TESTS

--- a/crates/model/src/data/black_scholes.rs
+++ b/crates/model/src/data/black_scholes.rs
@@ -105,6 +105,32 @@ impl BlackScholesReal for f32 {
         // See: J.-M. Muller et al., "Handbook of Floating-Point Arithmetic", 2018, Section 10.2
         //      A. J. Salgado & S. M. Wise, "Classical Numerical Analysis", 2023, Chapter 10
         let bits = self.to_bits();
+        let magnitude = bits & 0x7fff_ffff;
+        if magnitude == 0 {
+            return Self::NEG_INFINITY;
+        }
+
+        let exponent_bits = magnitude & 0x7f80_0000;
+        let fraction_bits = magnitude & 0x007f_ffff;
+        if exponent_bits == 0x7f80_0000 && fraction_bits != 0 {
+            return Self::NAN;
+        }
+
+        if bits & 0x8000_0000 != 0 {
+            return Self::NAN;
+        }
+
+        if exponent_bits == 0x7f80_0000 {
+            return Self::INFINITY;
+        }
+
+        if exponent_bits == 0 {
+            // Scaling by 2^23 is exact and carries every positive subnormal into the
+            // normal range, so this recurses exactly once.
+            return <Self as BlackScholesReal>::ln(self * 8_388_608.0)
+                - 23.0 * std::f32::consts::LN_2;
+        }
+
         let exponent = ((bits >> 23) as i32 - 127) as Self;
         let mantissa = Self::from_bits((bits & 0x007F_FFFF) | 0x3f80_0000);
         let x = (mantissa - 1.0) / (mantissa + 1.0);
@@ -395,6 +421,37 @@ mod tests {
     use super::*;
     use crate::data::greeks::black_scholes_greeks_exact;
 
+    /// The positive-normal `ln` formula exactly as it stood before the domain guard.
+    /// Frozen deliberately: it is the oracle for the byte-identity characterization
+    /// below, so it must not be updated alongside the implementation.
+    fn old_ln_formula(input: f32) -> f32 {
+        let bits = input.to_bits();
+        let exponent = ((bits >> 23) as i32 - 127) as f32;
+        let mantissa = f32::from_bits((bits & 0x007F_FFFF) | 0x3f80_0000);
+        let x = (mantissa - 1.0) / (mantissa + 1.0);
+        let x2 = x * x;
+        let mut res = 0.239_282_85_f32;
+        res = x2.mul_add(res, 0.285_182_11);
+        res = x2.mul_add(res, 0.400_005_83);
+        res = x2.mul_add(res, 0.666_666_7);
+        res = x2.mul_add(res, 2.0);
+        x.mul_add(res, exponent * std::f32::consts::LN_2)
+    }
+
+    fn assert_ln_close(actual: f32, expected: f32, max_ulps: u32) {
+        assert_eq!(actual.is_nan(), expected.is_nan());
+        assert_eq!(actual.is_infinite(), expected.is_infinite());
+        assert_eq!(actual.is_sign_negative(), expected.is_sign_negative());
+        if actual.is_finite() {
+            assert!(
+                actual.to_bits().abs_diff(expected.to_bits()) <= max_ulps,
+                "ln mismatch: actual={actual:e} ({:#010x}), expected={expected:e} ({:#010x})",
+                actual.to_bits(),
+                expected.to_bits(),
+            );
+        }
+    }
+
     fn assert_exp_close(actual: f32, expected: f32, max_ulps: u32) {
         assert_eq!(actual.is_nan(), expected.is_nan());
         assert_eq!(actual.is_infinite(), expected.is_infinite());
@@ -407,6 +464,86 @@ mod tests {
                 expected.to_bits(),
             );
         }
+    }
+
+    #[rstest]
+    fn test_ln_special_values() {
+        for input in [0.0_f32, -0.0] {
+            let actual = <f32 as BlackScholesReal>::ln(input);
+            assert_eq!(actual, f32::NEG_INFINITY, "input={input:?}");
+        }
+
+        for input in [-1.0_f32, -2.0, -f32::MIN_POSITIVE, f32::NEG_INFINITY] {
+            assert!(
+                <f32 as BlackScholesReal>::ln(input).is_nan(),
+                "input={input:?}"
+            );
+        }
+
+        assert_eq!(<f32 as BlackScholesReal>::ln(f32::INFINITY), f32::INFINITY);
+
+        for input in [f32::from_bits(0x7fc0_1234), f32::from_bits(0xffc0_5678)] {
+            assert!(
+                <f32 as BlackScholesReal>::ln(input).is_nan(),
+                "input_bits={:#010x}",
+                input.to_bits()
+            );
+        }
+    }
+
+    #[rstest]
+    fn test_ln_positive_subnormals() {
+        for input in [
+            f32::from_bits(1),
+            f32::from_bits(0x0040_0000),
+            f32::from_bits(0x007f_ffff),
+        ] {
+            assert_ln_close(<f32 as BlackScholesReal>::ln(input), input.ln(), 3);
+        }
+    }
+
+    #[rstest]
+    fn test_ln_positive_normal_path_is_unchanged() {
+        // Every normal exponent field crossed with a spread of mantissa patterns.
+        // Exhausting the exponent matters because the final fused addition combines
+        // the polynomial with `exponent * LN_2`, so rounding can differ per exponent
+        // even when mantissa handling is untouched.
+        let fractions = [
+            0x0000_0000,
+            0x0000_0001,
+            0x001f_ffff,
+            0x003f_ffff,
+            0x0040_0000,
+            0x0055_5555,
+            0x007f_fffe,
+            0x007f_ffff,
+        ];
+
+        for exponent in 1_u32..=254 {
+            for fraction in fractions {
+                let input = f32::from_bits((exponent << 23) | fraction);
+                assert_eq!(
+                    <f32 as BlackScholesReal>::ln(input).to_bits(),
+                    old_ln_formula(input).to_bits(),
+                    "input={input:e} ({:#010x})",
+                    input.to_bits()
+                );
+            }
+        }
+    }
+
+    #[rstest]
+    fn test_compute_greeks_negative_strike_returns_nan_price() {
+        let greeks = compute_greeks::<f32>(100.0, -100.0, 1.0, 0.05, 0.05, 0.2, true);
+
+        assert!(greeks.price.is_nan());
+    }
+
+    #[rstest]
+    fn test_compute_iv_and_greeks_negative_strike_returns_nan_price() {
+        let greeks = compute_iv_and_greeks::<f32>(10.0, 100.0, -100.0, 1.0, 0.05, 0.05, true, 0.2);
+
+        assert!(greeks.price.is_nan());
     }
 
     #[rstest]


### PR DESCRIPTION
`<f32 as BlackScholesReal>::ln` in `crates/model/src/data/black_scholes.rs` reconstructs a logarithm from raw IEEE-754 bits and assumes a positive, finite, normal input without checking any of the three. A follow-up to the exponent-range work in #4709, in the same file.

## Unchecked input domain

The method reads `exponent` from `bits >> 23` and rebuilds a mantissa from the fraction field. The sign bit is not discarded by that shift - it survives as an additional 256 in the exponent, so `ln(-1.0)` returns `256 * LN_2 = 177.44568` rather than NaN. Subnormals are read as normal mantissas with an implicit leading one they do not carry, so the smallest returns `-88.02969` against a correct `-103.27893`. The two signed zeros diverge, `+0.0` giving `-88.02969` and `-0.0` following the sign-bit path to `+89.415985`, where IEEE specifies `-inf` for both. Infinities and NaNs reconstruct finite values, `+inf` giving `128 * LN_2 = 88.72284`.

Every one of these returns a plausible finite number where the correct result is a special value or a different magnitude, so a caller has nothing to test for.

`ln` now classifies the raw bits before evaluating: zero magnitude returns `-inf`, NaN and negative inputs return NaN, `+inf` returns `+inf`, and positive subnormals are normalized by an exact multiplication by `2^23` and corrected by `23 * LN_2` afterwards. The zero test precedes the sign test so `-0.0` reaches `-inf` rather than NaN. Positive normal inputs keep the original statements, constants and `mul_add` sequence unchanged.

## Behaviour

Results for positive normal `ln` arguments are byte-identical. Pricing results may change where the logarithm argument falls outside that range - this is a property of the argument, not of `s` and `k`, since valid positive operands can still form a subnormal or infinite `s / k`. Both `compute_greeks` and `compute_iv_and_greeks` call this method through the generic parameter, so both are affected. The PR validates no Black-Scholes parameter and changes no constructor or API policy.

## Testing

`test_ln_special_values` pins both signed zeros, negative finite values, `-inf`, `+inf`, and NaNs with explicit payload bits. `test_ln_positive_subnormals` compares the smallest, a middle, and the largest subnormal against `f32::ln` within three ULPs; the smallest is what makes it differential, since the largest happens to return `-87.33655` and is close to correct unfixed. `test_compute_greeks_negative_strike_returns_nan_price` and its `compute_iv_and_greeks` counterpart pass a negative strike and assert `price` is NaN, which pins that both generic callers resolve to this method rather than to the inherent `f32::ln`. A negative strike is used rather than a zero one because `ln(s/0)` is `+inf`, and the kernel maps an infinite `d1` back to finite limiting values that the unfixed large finite `d1` also produces.

These four fail against the unfixed implementation. `test_ln_positive_normal_path_is_unchanged` compares against a frozen copy of the previous formula across all 254 normal exponent fields and eight mantissa patterns; it is a characterization test and passes either way.
