### PR TITLE
Use tolerance function for remaining indicator tests

### DIFF
--- a/crates/indicators/src/average/rma.rs
+++ b/crates/indicators/src/average/rma.rs
@@ -145,6 +145,7 @@ mod tests {
         average::rma::WilderMovingAverage,
         indicator::{Indicator, MovingAverage},
         stubs::*,
+        testing::assert_approx_equal,
     };
 
     #[rstest]
@@ -189,7 +190,7 @@ mod tests {
         assert!(rma.has_inputs());
         assert!(rma.initialized());
         assert_eq!(rma.count, 10);
-        assert_eq!(rma.value, 4.486_784_401);
+        assert_approx_equal(rma.value, 4.486_784_401);
     }
 
     #[rstest]
@@ -271,8 +272,7 @@ mod tests {
 
         assert!(rma.initialized());
         assert_eq!(rma.count(), 10);
-        let expected = 4.486_784_401_f64;
-        assert!((rma.value() - expected).abs() < 1e-12);
+        assert_approx_equal(rma.value(), 4.486_784_401);
     }
 
     /// Period = 1 should act as a pure 1-tick MA (α = 1) and be initialized immediately.

--- a/crates/indicators/src/volatility/dc.rs
+++ b/crates/indicators/src/volatility/dc.rs
@@ -145,6 +145,7 @@ mod tests {
     use crate::{
         indicator::Indicator,
         stubs::{bar_ethusdt_binance_minute_bid, dc_10},
+        testing::assert_approx_equal,
         volatility::dc::DonchianChannel,
     };
 
@@ -161,7 +162,7 @@ mod tests {
     fn test_value_with_one_input(mut dc_10: DonchianChannel) {
         dc_10.update_raw(1.0, 0.9);
         assert_eq!(dc_10.upper, 1.0);
-        assert_eq!(dc_10.middle, 0.95);
+        assert_approx_equal(dc_10.middle, 0.95);
         assert_eq!(dc_10.lower, 0.9);
     }
 
@@ -171,7 +172,7 @@ mod tests {
         dc_10.update_raw(2.0, 1.8);
         dc_10.update_raw(3.0, 2.7);
         assert_eq!(dc_10.upper, 3.0);
-        assert_eq!(dc_10.middle, 1.95);
+        assert_approx_equal(dc_10.middle, 1.95);
         assert_eq!(dc_10.lower, 0.9);
     }
 
@@ -189,7 +190,7 @@ mod tests {
         }
 
         assert_eq!(dc_10.upper, 15.0);
-        assert_eq!(dc_10.middle, 10.45);
+        assert_approx_equal(dc_10.middle, 10.45);
         assert_eq!(dc_10.lower, 5.9);
     }
 


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and, if I used AI, [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

#4718 converted the calculated comparisons in the indicator tests but missed five. rma.rs compares a ten-step Wilder average against 4.486_784_401, once with assert_eq! and once behind a hand-rolled 1e-12 absolute bound, and dc.rs compares f64::midpoint output against 0.95, 1.95 and 10.45. All five now use assert_approx_equal.

## Related issues/PRs

Follows #4718 and the sweep scoped in #4678.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Testing

- [x] I added/updated tests to cover new or changed logic

543 tests pass in nautilus-indicators. `make pre-commit` passes, 60 hooks including cargo fmt, cargo clippy, cargo doc and cargo machete.

Planting a value 2.2e-8 away relatively makes assert_approx_equal fail and print both errors, so the assertions still bite. One ULP above 4.486784401 is 2.0e-16 relative, which assert_eq! rejects and the 1e-9 bound accepts; the 1e-12 absolute bound at line 274 holds at 4.49 by luck and fails at 1e6, where one ULP is 1.2e-10.
