### PR TITLE
Fix OKX margin reconciliation routing

### DIFF
--- a/crates/adapters/okx/src/execution.rs
+++ b/crates/adapters/okx/src/execution.rs
@@ -1165,9 +1165,9 @@ impl ExecutionClient for OKXExecutionClient {
             self.ws_business_stream_handle = Some(handle);
         }
 
-        let order_subscription_types = order_subscription_instrument_types(&instrument_types);
+        let order_routing_types = order_routing_instrument_types(&instrument_types);
 
-        for inst_type in &order_subscription_types {
+        for inst_type in &order_routing_types {
             log::debug!("Subscribing to orders channel for {inst_type:?}");
             self.ws_private.subscribe_orders(*inst_type).await?;
 
@@ -1187,7 +1187,7 @@ impl ExecutionClient for OKXExecutionClient {
         }
 
         // Subscribe to algo orders on business WebSocket (OKX requires this endpoint)
-        for inst_type in &order_subscription_types {
+        for inst_type in &order_routing_types {
             if supports_algo_orders(*inst_type) {
                 self.ws_business.subscribe_orders_algo(*inst_type).await?;
                 self.ws_business.subscribe_algo_advance(*inst_type).await?;
@@ -1571,7 +1571,9 @@ impl ExecutionClient for OKXExecutionClient {
                 }
             }
         } else {
-            for inst_type in self.instrument_types() {
+            let instrument_types = self.instrument_types();
+
+            for inst_type in order_routing_instrument_types(&instrument_types) {
                 let mut fetched = self
                     .http_client
                     .request_order_status_reports(
@@ -1665,7 +1667,9 @@ impl ExecutionClient for OKXExecutionClient {
                 .await?;
             reports.append(&mut fetched);
         } else {
-            for inst_type in self.instrument_types() {
+            let instrument_types = self.instrument_types();
+
+            for inst_type in order_routing_instrument_types(&instrument_types) {
                 let mut fetched = self
                     .http_client
                     .request_fill_reports(
@@ -2463,20 +2467,20 @@ fn supports_algo_orders(instrument_type: OKXInstrumentType) -> bool {
     )
 }
 
-fn order_subscription_instrument_types(
+fn order_routing_instrument_types(
     instrument_types: &[OKXInstrumentType],
 ) -> Vec<OKXInstrumentType> {
-    let mut subscription_types = instrument_types.to_vec();
+    let mut routing_types = instrument_types.to_vec();
 
-    // OKX reports cross-margin spot orders as SPOT in Multi-currency margin mode.
-    if subscription_types.contains(&OKXInstrumentType::Margin)
-        && !subscription_types.contains(&OKXInstrumentType::Spot)
-        && !subscription_types.contains(&OKXInstrumentType::Any)
+    // OKX reports cross-margin spot orders as SPOT on order channels and report endpoints
+    if routing_types.contains(&OKXInstrumentType::Margin)
+        && !routing_types.contains(&OKXInstrumentType::Spot)
+        && !routing_types.contains(&OKXInstrumentType::Any)
     {
-        subscription_types.push(OKXInstrumentType::Spot);
+        routing_types.push(OKXInstrumentType::Spot);
     }
 
-    subscription_types
+    routing_types
 }
 
 fn is_spread_instrument(instrument_id: InstrumentId) -> bool {
@@ -2593,14 +2597,11 @@ mod tests {
         vec![OKXInstrumentType::Swap],
         vec![OKXInstrumentType::Swap]
     )]
-    fn test_order_subscription_instrument_types(
+    fn test_order_routing_instrument_types(
         #[case] instrument_types: Vec<OKXInstrumentType>,
         #[case] expected: Vec<OKXInstrumentType>,
     ) {
-        assert_eq!(
-            order_subscription_instrument_types(&instrument_types),
-            expected
-        );
+        assert_eq!(order_routing_instrument_types(&instrument_types), expected);
     }
 
     #[rstest]

--- a/crates/adapters/okx/tests/exec_client.rs
+++ b/crates/adapters/okx/tests/exec_client.rs
@@ -80,7 +80,9 @@ use nautilus_okx::{
         consts::{
             OKX_CLIENT_ID, OKX_POST_ONLY_CANCEL_REASON, OKX_POST_ONLY_CANCEL_SOURCE, OKX_VENUE,
         },
-        enums::{OKXInstrumentType, OKXOrderStatus, OKXOrderType, OKXSide, OKXTradeMode},
+        enums::{
+            OKXInstrumentType, OKXMarginMode, OKXOrderStatus, OKXOrderType, OKXSide, OKXTradeMode,
+        },
     },
     config::OKXExecClientConfig,
     execution::OKXExecutionClient,
@@ -98,6 +100,11 @@ use nautilus_okx::{
 use rstest::rstest;
 use serde_json::json;
 use ustr::Ustr;
+
+const MARGIN_SPOT_PARENT_CLIENT_ORDER_ID: &str = "OEEADEMOSTOPLIMIT001";
+const MARGIN_SPOT_PARENT_VENUE_ORDER_ID: &str = "2497956918703120500";
+const MARGIN_SPOT_CHILD_VENUE_ORDER_ID: &str = "2497956918703120501";
+const MARGIN_SPOT_TRADE_ID: &str = "1518905600";
 
 fn test_emitter() -> (
     ExecutionEventEmitter,
@@ -2304,6 +2311,8 @@ fn create_exec_test_router() -> Router {
 struct ReportRouteState {
     regular_order_pending_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
     regular_order_history_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
+    algo_order_pending_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
+    algo_order_history_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
     spread_order_pending_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
     spread_order_history_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
     regular_fill_queries: tokio::sync::Mutex<Vec<HashMap<String, String>>>,
@@ -2405,6 +2414,8 @@ async fn start_exec_report_test_server(state: Arc<ReportRouteState>) -> SocketAd
 fn create_exec_report_test_router(state: Arc<ReportRouteState>) -> Router {
     let regular_pending_state = Arc::clone(&state);
     let regular_history_state = Arc::clone(&state);
+    let algo_pending_state = Arc::clone(&state);
+    let algo_history_state = Arc::clone(&state);
     let spread_pending_state = Arc::clone(&state);
     let spread_history_state = Arc::clone(&state);
     let regular_fill_state = Arc::clone(&state);
@@ -2431,12 +2442,72 @@ fn create_exec_report_test_router(state: Arc<ReportRouteState>) -> Router {
             get(move |Query(params): Query<HashMap<String, String>>| {
                 let state = Arc::clone(&regular_history_state);
                 async move {
+                    let is_spot = params.get("instType").is_some_and(|value| value == "SPOT");
                     state
                         .regular_order_history_queries
                         .lock()
                         .await
                         .push(params);
+
+                    if !is_spot {
+                        return Json(json!({"code": "0", "msg": "", "data": []})).into_response();
+                    }
+
+                    let mut response =
+                        load_test_data("ws_orders_algo_child_filled_empty_cl_ord_id.json");
+                    response["code"] = json!("0");
+                    response["msg"] = json!("");
+                    Json(response).into_response()
+                }
+            }),
+        )
+        .route(
+            "/api/v5/trade/orders-algo-pending",
+            get(move |Query(params): Query<HashMap<String, String>>| {
+                let state = Arc::clone(&algo_pending_state);
+                async move {
+                    state.algo_order_pending_queries.lock().await.push(params);
                     Json(json!({"code": "0", "msg": "", "data": []})).into_response()
+                }
+            }),
+        )
+        .route(
+            "/api/v5/trade/orders-algo-history",
+            get(move |Query(params): Query<HashMap<String, String>>| {
+                let state = Arc::clone(&algo_history_state);
+                async move {
+                    let returns_parent =
+                        params.get("instType").is_some_and(|value| value == "SPOT")
+                            && params
+                                .get("ordType")
+                                .is_some_and(|value| value == "trigger")
+                            && params
+                                .get("state")
+                                .is_some_and(|value| value == "effective");
+                    state.algo_order_history_queries.lock().await.push(params);
+
+                    if !returns_parent {
+                        return Json(json!({"code": "0", "msg": "", "data": []})).into_response();
+                    }
+
+                    let mut response = load_test_data("http_get_orders_algo_history.json");
+                    let order = &mut response["data"][0];
+                    order["actualPx"] = json!("1886.00");
+                    order["actualSide"] = json!("buy");
+                    order["actualSz"] = json!("0.003");
+                    order["algoClOrdId"] = json!(MARGIN_SPOT_PARENT_CLIENT_ORDER_ID);
+                    order["algoId"] = json!(MARGIN_SPOT_PARENT_VENUE_ORDER_ID);
+                    order["clOrdId"] = json!("");
+                    order["instId"] = json!("ETH-USDT");
+                    order["instType"] = json!("SPOT");
+                    order["ordId"] = json!(MARGIN_SPOT_CHILD_VENUE_ORDER_ID);
+                    order["ordPx"] = json!("1886.00");
+                    order["posSide"] = json!("net");
+                    order["side"] = json!("buy");
+                    order["sz"] = json!("0.003");
+                    order["tdMode"] = json!("cross");
+                    order["triggerPx"] = json!("1887.00");
+                    Json(response).into_response()
                 }
             }),
         )
@@ -2465,8 +2536,20 @@ fn create_exec_report_test_router(state: Arc<ReportRouteState>) -> Router {
             get(move |Query(params): Query<HashMap<String, String>>| {
                 let state = Arc::clone(&regular_fill_state);
                 async move {
+                    let is_spot = params.get("instType").is_some_and(|value| value == "SPOT");
                     state.regular_fill_queries.lock().await.push(params);
-                    Json(json!({"code": "0", "msg": "", "data": []})).into_response()
+
+                    if !is_spot {
+                        return Json(json!({"code": "0", "msg": "", "data": []})).into_response();
+                    }
+
+                    let mut response =
+                        load_test_data("ws_orders_algo_child_filled_empty_cl_ord_id.json");
+                    response["code"] = json!("0");
+                    response["msg"] = json!("");
+                    response["data"][0]["billId"] = json!("bill-margin-spot-1");
+                    response["data"][0]["ts"] = json!("1786550400100");
+                    Json(response).into_response()
                 }
             }),
         )
@@ -2538,6 +2621,28 @@ fn create_test_execution_client_configured(
     (client, rx, cache)
 }
 
+fn make_margin_spot_report_instrument() -> InstrumentAny {
+    let mut instrument = currency_pair_ethusdt();
+    instrument.id = InstrumentId::from("ETH-USDT.OKX");
+    instrument.raw_symbol = Symbol::from("ETH-USDT");
+    InstrumentAny::CurrencyPair(instrument)
+}
+
+fn assert_margin_spot_queries(queries: &[HashMap<String, String>]) {
+    let margin_count = queries
+        .iter()
+        .filter(|query| query.get("instType").is_some_and(|value| value == "MARGIN"))
+        .count();
+    let spot_count = queries
+        .iter()
+        .filter(|query| query.get("instType").is_some_and(|value| value == "SPOT"))
+        .count();
+
+    assert!(margin_count > 0);
+    assert_eq!(margin_count, spot_count);
+    assert_eq!(queries.len(), margin_count + spot_count);
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_query_account_does_not_block_within_runtime() {
@@ -2571,6 +2676,94 @@ async fn test_query_account_does_not_block_within_runtime() {
         Duration::from_secs(5),
     )
     .await;
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_margin_only_restart_recovers_spot_order_status_reports() {
+    let state = Arc::new(ReportRouteState::default());
+    let addr = start_exec_report_test_server(Arc::clone(&state)).await;
+    let base_url = format!("http://{addr}");
+    let (mut client, _rx, _cache) = create_test_execution_client_configured(&base_url, |config| {
+        config.instrument_types = vec![OKXInstrumentType::Margin];
+        config.margin_mode = Some(OKXMarginMode::Cross);
+        config.use_spot_margin = true;
+    });
+    client.on_instrument(make_margin_spot_report_instrument());
+
+    let cmd = GenerateOrderStatusReports::new(
+        UUID4::new(),
+        UnixNanos::default(),
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    let reports = client.generate_order_status_reports(&cmd).await.unwrap();
+    let regular_pending_queries = state.regular_order_pending_queries.lock().await;
+    let regular_history_queries = state.regular_order_history_queries.lock().await;
+    let algo_pending_queries = state.algo_order_pending_queries.lock().await;
+    let algo_history_queries = state.algo_order_history_queries.lock().await;
+
+    assert_eq!(reports.len(), 1);
+    assert_eq!(reports[0].instrument_id, InstrumentId::from("ETH-USDT.OKX"));
+    assert_eq!(
+        reports[0].client_order_id,
+        Some(ClientOrderId::from(MARGIN_SPOT_PARENT_CLIENT_ORDER_ID))
+    );
+    assert_eq!(
+        reports[0].venue_order_id,
+        VenueOrderId::from(MARGIN_SPOT_CHILD_VENUE_ORDER_ID)
+    );
+    assert_eq!(reports[0].order_status, OrderStatus::Filled);
+    assert_eq!(reports[0].filled_qty, Quantity::from("0.003"));
+    assert_margin_spot_queries(&regular_pending_queries);
+    assert_margin_spot_queries(&regular_history_queries);
+    assert_margin_spot_queries(&algo_pending_queries);
+    assert_margin_spot_queries(&algo_history_queries);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_margin_only_restart_recovers_spot_fill_reports() {
+    let state = Arc::new(ReportRouteState::default());
+    let addr = start_exec_report_test_server(Arc::clone(&state)).await;
+    let base_url = format!("http://{addr}");
+    let (mut client, _rx, _cache) = create_test_execution_client_configured(&base_url, |config| {
+        config.instrument_types = vec![OKXInstrumentType::Margin];
+        config.margin_mode = Some(OKXMarginMode::Cross);
+        config.use_spot_margin = true;
+    });
+    client.on_instrument(make_margin_spot_report_instrument());
+
+    let cmd = GenerateFillReports::new(
+        UUID4::new(),
+        UnixNanos::default(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    let reports = client.generate_fill_reports(cmd).await.unwrap();
+    let regular_fill_queries = state.regular_fill_queries.lock().await;
+
+    assert_eq!(reports.len(), 1);
+    assert_eq!(reports[0].instrument_id, InstrumentId::from("ETH-USDT.OKX"));
+    assert_eq!(reports[0].client_order_id, None);
+    assert_eq!(
+        reports[0].venue_order_id,
+        VenueOrderId::from(MARGIN_SPOT_CHILD_VENUE_ORDER_ID)
+    );
+    assert_eq!(reports[0].trade_id, TradeId::new(MARGIN_SPOT_TRADE_ID));
+    assert_eq!(reports[0].last_qty, Quantity::from("0.003"));
+    assert_eq!(reports[0].last_px, Price::from("1886.00"));
+    assert_margin_spot_queries(&regular_fill_queries);
 }
 
 #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Expand OKX order routing from configured `MARGIN` to `MARGIN + SPOT` for unfiltered order-status
and fill reconciliation, matching the existing live subscription behavior. This recovers
cross-margin spot algo parents, generated child orders, and fills after restart because OKX returns
these records under `instType=SPOT`.

## Related issues/PRs

Related to #4716.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

None.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation or PyO3 binding changes are required.

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

- `cargo test -p nautilus-okx --lib --tests` (856 passed)
- `make format`
- `PYO3_PYTHON=/opt/homebrew/bin/python3.14 make pre-commit`

The new MARGIN-only restart regressions verify that regular and algo order queries, plus fill
queries, include both `MARGIN` and `SPOT`. They also verify recovery of the tracked parent client
order ID, generated child venue order ID, terminal order status, and fill trade ID.
