### PR TITLE
Standardize risk engine order denied reasons

### DIFF
--- a/crates/model/src/events/mod.rs
+++ b/crates/model/src/events/mod.rs
@@ -37,7 +37,7 @@ pub use crate::events::{
         canceled::OrderCanceled,
         canceled_batch::OrderCanceledBatch,
         denied::OrderDenied,
-        denied_reason::{OrderDeniedCode, OrderDeniedReason},
+        denied_reason::{OrderDeniedCode, OrderDeniedReason, OrderPriceType},
         emulated::OrderEmulated,
         expired::OrderExpired,
         fill_voided::OrderFillVoided,

--- a/crates/model/src/events/order/denied_reason.rs
+++ b/crates/model/src/events/order/denied_reason.rs
@@ -29,8 +29,18 @@ use thiserror::Error;
 use crate::{
     enums::{OrderSide, OrderType, TimeInForce, TrailingOffsetType},
     identifiers::{ClientId, InstrumentId, OrderListId, PositionId, Venue},
-    types::{Money, Quantity},
+    types::{Money, Price, Quantity},
 };
+
+/// The order price field being validated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrderPriceType {
+    /// The order's execution price.
+    Order,
+    /// The order's trigger price.
+    Trigger,
+}
 
 /// A standardized reason an order was denied locally by the Nautilus system.
 ///
@@ -43,6 +53,40 @@ use crate::{
     strum(serialize_all = "SCREAMING_SNAKE_CASE")
 )]
 pub enum OrderDeniedReason {
+    /// The price precision exceeds the instrument maximum.
+    #[error(
+        "PRICE_PRECISION_EXCEEDS_MAXIMUM: price_type={price_type}, price={price}, price_precision={price_precision}, max_precision={max_precision}"
+    )]
+    PricePrecisionExceedsMaximum {
+        /// The price field being validated.
+        price_type: OrderPriceType,
+        /// The submitted price.
+        price: Price,
+        /// The submitted price precision.
+        price_precision: u8,
+        /// The instrument's maximum price precision.
+        max_precision: u8,
+    },
+    /// The price is not positive for an instrument that disallows negative prices.
+    #[error("PRICE_NOT_POSITIVE: price_type={price_type}, price={price}")]
+    PriceNotPositive {
+        /// The price field being validated.
+        price_type: OrderPriceType,
+        /// The submitted price.
+        price: Price,
+    },
+    /// The quantity precision exceeds the instrument maximum.
+    #[error(
+        "QUANTITY_PRECISION_EXCEEDS_MAXIMUM: quantity={quantity}, quantity_precision={quantity_precision}, max_precision={max_precision}"
+    )]
+    QuantityPrecisionExceedsMaximum {
+        /// The submitted quantity.
+        quantity: Quantity,
+        /// The submitted quantity precision.
+        quantity_precision: u8,
+        /// The instrument's maximum quantity precision.
+        max_precision: u8,
+    },
     /// The effective order quantity exceeds the instrument maximum.
     #[error(
         "QUANTITY_EXCEEDS_MAXIMUM: effective_quantity={effective_quantity}, max_quantity={max_quantity}"
@@ -169,6 +213,38 @@ pub enum OrderDeniedReason {
         /// The underlying conversion error.
         detail: String,
     },
+    /// The order notional value could not be calculated.
+    #[error("NOTIONAL_CALCULATION_FAILED: detail={detail}")]
+    NotionalCalculationFailed {
+        /// The underlying calculation error.
+        detail: String,
+    },
+    /// The order initial margin could not be calculated.
+    #[error("INITIAL_MARGIN_CALCULATION_FAILED: detail={detail}")]
+    InitialMarginCalculationFailed {
+        /// The underlying calculation error.
+        detail: String,
+    },
+    /// The cumulative initial margin could not be calculated.
+    #[error("CUMULATIVE_MARGIN_CALCULATION_FAILED: detail={detail}")]
+    CumulativeMarginCalculationFailed {
+        /// The underlying calculation error.
+        detail: String,
+    },
+    /// The betting balance locked amount could not be calculated.
+    #[error("BETTING_BALANCE_CALCULATION_FAILED: detail={detail}")]
+    BettingBalanceCalculationFailed {
+        /// The underlying calculation error.
+        detail: String,
+    },
+    /// No market price is available for the order risk check.
+    #[error("MARKET_PRICE_UNAVAILABLE: order_type={order_type}, instrument_id={instrument_id}")]
+    MarketPriceUnavailable {
+        /// The order type requiring a market price.
+        order_type: OrderType,
+        /// The instrument with no available market price.
+        instrument_id: InstrumentId,
+    },
     /// The instrument was not found in the cache.
     #[error("INSTRUMENT_NOT_FOUND: instrument_id={instrument_id}")]
     InstrumentNotFound {
@@ -292,6 +368,13 @@ impl OrderDeniedCode {
     #[must_use]
     pub fn description(&self) -> &'static str {
         match self {
+            Self::PricePrecisionExceedsMaximum => {
+                "The price precision exceeds the instrument maximum."
+            }
+            Self::PriceNotPositive => "The price is not positive.",
+            Self::QuantityPrecisionExceedsMaximum => {
+                "The quantity precision exceeds the instrument maximum."
+            }
             Self::QuantityExceedsMaximum => {
                 "The effective order quantity exceeds the instrument maximum."
             }
@@ -334,6 +417,19 @@ impl OrderDeniedCode {
             }
             Self::QuantityConversionFailed => {
                 "The order quantity could not be converted for risk checks."
+            }
+            Self::NotionalCalculationFailed => "The order notional value could not be calculated.",
+            Self::InitialMarginCalculationFailed => {
+                "The order initial margin could not be calculated."
+            }
+            Self::CumulativeMarginCalculationFailed => {
+                "The cumulative initial margin could not be calculated."
+            }
+            Self::BettingBalanceCalculationFailed => {
+                "The betting balance locked amount could not be calculated."
+            }
+            Self::MarketPriceUnavailable => {
+                "No market price is available for the order risk check."
             }
             Self::InstrumentNotFound => "The instrument was not found in the cache.",
             Self::PositionNotFound => "The position for a reduce‑only order was not found.",
@@ -534,6 +630,21 @@ mod tests {
     fn message_prefix_matches_code() {
         let usd = || Money::from("100.00 USD");
         let samples = [
+            OrderDeniedReason::PricePrecisionExceedsMaximum {
+                price_type: OrderPriceType::Order,
+                price: Price::from("1.00"),
+                price_precision: 2,
+                max_precision: 1,
+            },
+            OrderDeniedReason::PriceNotPositive {
+                price_type: OrderPriceType::Trigger,
+                price: Price::from("0.00"),
+            },
+            OrderDeniedReason::QuantityPrecisionExceedsMaximum {
+                quantity: Quantity::from("1.00"),
+                quantity_precision: 2,
+                max_precision: 1,
+            },
             OrderDeniedReason::QuantityExceedsMaximum {
                 effective_quantity: Quantity::from("15"),
                 max_quantity: Quantity::from("10"),
@@ -592,6 +703,22 @@ mod tests {
             },
             OrderDeniedReason::QuantityConversionFailed {
                 detail: "boom".to_string(),
+            },
+            OrderDeniedReason::NotionalCalculationFailed {
+                detail: "boom".to_string(),
+            },
+            OrderDeniedReason::InitialMarginCalculationFailed {
+                detail: "boom".to_string(),
+            },
+            OrderDeniedReason::CumulativeMarginCalculationFailed {
+                detail: "boom".to_string(),
+            },
+            OrderDeniedReason::BettingBalanceCalculationFailed {
+                detail: "boom".to_string(),
+            },
+            OrderDeniedReason::MarketPriceUnavailable {
+                order_type: OrderType::Market,
+                instrument_id: InstrumentId::from("AUD/USD.SIM"),
             },
             OrderDeniedReason::InstrumentNotFound {
                 instrument_id: InstrumentId::from("AUD/USD.SIM"),

--- a/crates/risk/src/engine/mod.rs
+++ b/crates/risk/src/engine/mod.rs
@@ -45,7 +45,10 @@ use nautilus_model::{
         AggregationSource, OrderSide, OrderStatus, PositionSide, PriceType, TimeInForce,
         TradingState, TrailingOffsetType, TriggerType,
     },
-    events::{OrderDenied, OrderDeniedReason, OrderEventAny, OrderModifyRejected, PositionEvent},
+    events::{
+        OrderDenied, OrderDeniedReason, OrderEventAny, OrderModifyRejected, OrderPriceType,
+        PositionEvent,
+    },
     identifiers::{AccountId, InstrumentId},
     instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
@@ -872,23 +875,23 @@ impl RiskEngine {
         };
 
         // Check Price
-        let mut risk_msg = Self::check_price(&instrument, command.price);
-        if let Some(risk_msg) = risk_msg {
-            self.reject_modify_order(&order, &risk_msg);
+        let mut reason = Self::check_price(&instrument, command.price, OrderPriceType::Order);
+        if let Some(reason) = reason {
+            self.reject_modify_order(&order, &reason.to_string());
             return false;
         }
 
         // Check Trigger
-        risk_msg = Self::check_price(&instrument, command.trigger_price);
-        if let Some(risk_msg) = risk_msg {
-            self.reject_modify_order(&order, &risk_msg);
+        reason = Self::check_price(&instrument, command.trigger_price, OrderPriceType::Trigger);
+        if let Some(reason) = reason {
+            self.reject_modify_order(&order, &reason.to_string());
             return false;
         }
 
         // Check Quantity
-        risk_msg = Self::check_quantity(&instrument, command.quantity, order.is_quote_quantity());
-        if let Some(risk_msg) = risk_msg {
-            self.reject_modify_order(&order, &risk_msg);
+        reason = Self::check_quantity(&instrument, command.quantity, order.is_quote_quantity());
+        if let Some(reason) = reason {
+            self.reject_modify_order(&order, &reason.to_string());
             return false;
         }
 
@@ -950,17 +953,19 @@ impl RiskEngine {
 
     fn check_order_price(&self, instrument: &InstrumentAny, order: &OrderAny) -> bool {
         if order.price().is_some() {
-            let risk_msg = Self::check_price(instrument, order.price());
-            if let Some(risk_msg) = risk_msg {
-                self.deny_order(order, &risk_msg);
+            let reason = Self::check_price(instrument, order.price(), OrderPriceType::Order);
+            if let Some(reason) = reason {
+                self.deny_order(order, &reason.to_string());
                 return false; // Denied
             }
         }
 
         if order.trigger_price().is_some() {
-            let risk_msg = Self::check_price(instrument, order.trigger_price());
-            if let Some(risk_msg) = risk_msg {
-                self.deny_order(order, &format!("trigger {risk_msg}"));
+            let reason =
+                Self::check_price(instrument, order.trigger_price(), OrderPriceType::Trigger);
+
+            if let Some(reason) = reason {
+                self.deny_order(order, &reason.to_string());
                 return false; // Denied
             }
         }
@@ -969,14 +974,14 @@ impl RiskEngine {
     }
 
     fn check_order_quantity(&self, instrument: &InstrumentAny, order: &OrderAny) -> bool {
-        let risk_msg = Self::check_quantity(
+        let reason = Self::check_quantity(
             instrument,
             Some(order.quantity()),
             order.is_quote_quantity(),
         );
 
-        if let Some(risk_msg) = risk_msg {
-            self.deny_order(order, &risk_msg);
+        if let Some(reason) = reason {
+            self.deny_order(order, &reason.to_string());
             return false; // Denied
         }
 
@@ -1427,7 +1432,13 @@ impl RiskEngine {
             ) {
                 Ok(notional) => notional,
                 Err(e) => {
-                    self.deny_order(order, &format!("Cannot calculate notional value: {e}"));
+                    self.deny_order(
+                        order,
+                        &OrderDeniedReason::NotionalCalculationFailed {
+                            detail: e.to_string(),
+                        }
+                        .to_string(),
+                    );
                     return false;
                 }
             };
@@ -1497,7 +1508,10 @@ impl RiskEngine {
                         Err(e) => {
                             self.deny_order(
                                 order,
-                                &format!("Cannot calculate initial margin: {e}"),
+                                &OrderDeniedReason::InitialMarginCalculationFailed {
+                                    detail: e.to_string(),
+                                }
+                                .to_string(),
                             );
                             return false;
                         }
@@ -1565,7 +1579,10 @@ impl RiskEngine {
                         let Some(total) = cum.checked_add(margin_req) else {
                             self.deny_order(
                                 order,
-                                "Cannot calculate cumulative margin: total exceeds Money bounds",
+                                &OrderDeniedReason::CumulativeMarginCalculationFailed {
+                                    detail: "total exceeds Money bounds".to_string(),
+                                }
+                                .to_string(),
                             );
                             return false;
                         };
@@ -1600,7 +1617,13 @@ impl RiskEngine {
                 ) {
                     Ok(notional) => notional,
                     Err(e) => {
-                        self.deny_order(order, &format!("Cannot calculate notional value: {e}"));
+                        self.deny_order(
+                            order,
+                            &OrderDeniedReason::NotionalCalculationFailed {
+                                detail: e.to_string(),
+                            }
+                            .to_string(),
+                        );
                         return false;
                     }
                 };
@@ -1620,7 +1643,10 @@ impl RiskEngine {
                                 Err(e) => {
                                     self.deny_order(
                                         order,
-                                        &format!("Cannot calculate betting balance locked: {e}"),
+                                        &OrderDeniedReason::BettingBalanceCalculationFailed {
+                                            detail: e.to_string(),
+                                        }
+                                        .to_string(),
                                     );
                                     return false;
                                 }
@@ -1928,27 +1954,35 @@ impl RiskEngine {
     fn deny_no_market_price(&self, instrument_id: InstrumentId, order: &OrderAny) {
         self.deny_order(
             order,
-            &format!(
-                "Cannot check {} order risk: no prices for {instrument_id}",
-                order.order_type()
-            ),
+            &OrderDeniedReason::MarketPriceUnavailable {
+                order_type: order.order_type(),
+                instrument_id,
+            }
+            .to_string(),
         );
     }
 
-    fn check_price(instrument: &InstrumentAny, price: Option<Price>) -> Option<String> {
+    fn check_price(
+        instrument: &InstrumentAny,
+        price: Option<Price>,
+        price_type: OrderPriceType,
+    ) -> Option<OrderDeniedReason> {
         let price_val = price?;
 
         if price_val.precision > instrument.price_precision() {
-            return Some(format!(
-                "price {} invalid (precision {} > {})",
-                price_val,
-                price_val.precision,
-                instrument.price_precision()
-            ));
+            return Some(OrderDeniedReason::PricePrecisionExceedsMaximum {
+                price_type,
+                price: price_val,
+                price_precision: price_val.precision,
+                max_precision: instrument.price_precision(),
+            });
         }
 
         if !instrument.allows_negative_price() && price_val.raw <= 0 {
-            return Some(format!("price {price_val} invalid (<= 0)"));
+            return Some(OrderDeniedReason::PriceNotPositive {
+                price_type,
+                price: price_val,
+            });
         }
 
         None
@@ -1958,20 +1992,21 @@ impl RiskEngine {
         instrument: &InstrumentAny,
         quantity: Option<Quantity>,
         is_quote_quantity: bool,
-    ) -> Option<String> {
+    ) -> Option<OrderDeniedReason> {
         let quantity_val = quantity?;
 
         // Check precision
         if quantity_val.precision > instrument.size_precision() {
-            return Some(format!(
-                "quantity {} invalid (precision {} > {})",
-                quantity_val,
-                quantity_val.precision,
-                instrument.size_precision()
-            ));
+            return Some(OrderDeniedReason::QuantityPrecisionExceedsMaximum {
+                quantity: quantity_val,
+                quantity_precision: quantity_val.precision,
+                max_precision: instrument.size_precision(),
+            });
         }
 
-        // Skip min/max checks for quote quantities (they will be checked in check_orders_risk using effective_quantity)
+        // Base-quantity bounds are deliberately not applied to quote-denominated orders here,
+        // and they are not applied later either: `check_orders_risk_for_account` skips the same
+        // comparisons for them. Applicable notional limits are checked during account risk.
         if is_quote_quantity {
             return None;
         }
@@ -1980,18 +2015,20 @@ impl RiskEngine {
         if let Some(max_quantity) = instrument.max_quantity()
             && quantity_val > max_quantity
         {
-            return Some(format!(
-                "quantity {quantity_val} invalid (> maximum trade size of {max_quantity})"
-            ));
+            return Some(OrderDeniedReason::QuantityExceedsMaximum {
+                effective_quantity: quantity_val,
+                max_quantity,
+            });
         }
 
         // Check minimum quantity
         if let Some(min_quantity) = instrument.min_quantity()
             && quantity_val < min_quantity
         {
-            return Some(format!(
-                "quantity {quantity_val} invalid (< minimum trade size of {min_quantity})"
-            ));
+            return Some(OrderDeniedReason::QuantityBelowMinimum {
+                effective_quantity: quantity_val,
+                min_quantity,
+            });
         }
 
         None

--- a/crates/risk/tests/risk_engine.rs
+++ b/crates/risk/tests/risk_engine.rs
@@ -80,7 +80,7 @@ use nautilus_model::{
     },
     orders::{Order, OrderAny, OrderList, OrderTestBuilder},
     position::Position,
-    types::{AccountBalance, Currency, Money, Price, Quantity, fixed::FIXED_PRECISION},
+    types::{AccountBalance, Currency, MONEY_MAX, Money, Price, Quantity, fixed::FIXED_PRECISION},
 };
 use nautilus_portfolio::Portfolio;
 use rstest::{fixture, rstest};
@@ -1774,7 +1774,7 @@ fn test_submit_order_when_invalid_price_precision_then_denies(
             .unwrap()
             .message()
             .unwrap()
-            .contains(&format!("invalid (precision {FIXED_PRECISION} > 5)"))
+            .starts_with("PRICE_PRECISION_EXCEEDS_MAXIMUM:")
     );
 }
 
@@ -1842,7 +1842,7 @@ fn test_submit_order_when_invalid_negative_price_and_not_option_then_denies(
     );
     assert_eq!(
         saved_process_messages.first().unwrap().message().unwrap(),
-        Ustr::from("price -0.1 invalid (<= 0)")
+        Ustr::from("PRICE_NOT_POSITIVE: price_type=ORDER, price=-0.1")
     );
 }
 
@@ -2149,12 +2149,14 @@ fn test_submit_order_when_invalid_trigger_price_then_denies(
         saved_process_messages.first().unwrap().event_type(),
         OrderEventType::Denied
     );
-    // assert!(saved_process_messages
-    //     .first()
-    //     .unwrap()
-    //     .message()
-    //     .unwrap()
-    //     .contains(&format!("invalid (precision {PRECISION})")));
+    assert!(
+        saved_process_messages
+            .first()
+            .unwrap()
+            .message()
+            .unwrap()
+            .starts_with("PRICE_PRECISION_EXCEEDS_MAXIMUM: price_type=TRIGGER")
+    );
 }
 
 #[rstest]
@@ -2220,7 +2222,9 @@ fn test_submit_order_when_invalid_quantity_precision_then_denies(
     );
     assert_eq!(
         saved_process_messages.first().unwrap().message().unwrap(),
-        Ustr::from("quantity 0.1 invalid (precision 1 > 0)")
+        Ustr::from(
+            "QUANTITY_PRECISION_EXCEEDS_MAXIMUM: quantity=0.1, quantity_precision=1, max_precision=0",
+        )
     );
 }
 
@@ -2287,7 +2291,7 @@ fn test_submit_order_when_invalid_quantity_exceeds_maximum_then_denies(
     );
     assert_eq!(
         saved_process_messages.first().unwrap().message().unwrap(),
-        Ustr::from("quantity 100000000 invalid (> maximum trade size of 1000000)")
+        Ustr::from("QUANTITY_EXCEEDS_MAXIMUM: effective_quantity=100000000, max_quantity=1000000",)
     );
 }
 
@@ -2354,18 +2358,18 @@ fn test_submit_order_when_invalid_quantity_less_than_minimum_then_denies(
     );
     assert_eq!(
         saved_process_messages.first().unwrap().message().unwrap(),
-        Ustr::from("quantity 1 invalid (< minimum trade size of 100)")
+        Ustr::from("QUANTITY_BELOW_MINIMUM: effective_quantity=1, min_quantity=100")
     );
 }
 
 #[rstest]
 #[case::market(
     OrderType::Market,
-    "Cannot check MARKET order risk: no prices for AUD/USD.SIM"
+    "MARKET_PRICE_UNAVAILABLE: order_type=MARKET, instrument_id=AUD/USD.SIM"
 )]
 #[case::market_to_limit(
     OrderType::MarketToLimit,
-    "Cannot check MARKET_TO_LIMIT order risk: no prices for AUD/USD.SIM"
+    "MARKET_PRICE_UNAVAILABLE: order_type=MARKET_TO_LIMIT, instrument_id=AUD/USD.SIM"
 )]
 fn test_submit_market_order_without_price_then_denies(
     #[case] order_type: OrderType,
@@ -2780,7 +2784,7 @@ fn test_submit_market_order_wallet_sell_within_balance_without_price_denies_no_m
     assert_eq!(
         process_messages[0].message().unwrap(),
         Ustr::from(&format!(
-            "Cannot check MARKET order risk: no prices for {}",
+            "MARKET_PRICE_UNAVAILABLE: order_type=MARKET, instrument_id={}",
             instrument_eth_usdt.id()
         ))
     );
@@ -3649,7 +3653,7 @@ fn test_submit_order_when_notional_is_unrepresentable_then_denies(
             .message()
             .unwrap()
             .as_str()
-            .starts_with("Cannot calculate notional value:")
+            .starts_with("NOTIONAL_CALCULATION_FAILED:")
     );
 }
 
@@ -5790,6 +5794,84 @@ fn test_submit_order_when_betting_back_order_liability_exceeds_free_balance_then
 }
 
 #[rstest]
+fn test_submit_order_when_betting_balance_calculation_fails_then_denies(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    mut simple_cache: Cache,
+) {
+    let gbp = Currency::GBP();
+    let instrument = InstrumentAny::Betting(betting());
+    let account_state = AccountState::new(
+        AccountId::new("BETFAIR-003"),
+        AccountType::Betting,
+        vec![AccountBalance::new(
+            Money::new(1_000.0, gbp),
+            Money::zero(gbp),
+            Money::new(1_000.0, gbp),
+        )],
+        vec![],
+        true,
+        UUID4::new(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+        Some(gbp),
+    );
+
+    simple_cache.add_instrument(instrument.clone()).unwrap();
+    simple_cache
+        .add_account(AccountAny::Betting(BettingAccount::new(
+            account_state,
+            true,
+        )))
+        .unwrap();
+
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .side(OrderSide::NoOrderSide)
+        .price(Price::from("2.00"))
+        .quantity(Quantity::from("100"))
+        .build();
+
+    risk_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(client_id_binance), false)
+        .unwrap();
+
+    let submit_order = SubmitOrder::new(
+        trader_id,
+        Some(client_id_binance),
+        strategy_id_ema_cross,
+        instrument.id(),
+        order.client_order_id(),
+        order.init_event().clone(),
+        None,
+        None,
+        None,
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let saved = get_process_order_event_handler_messages(&process_order_event_handler);
+    assert_eq!(saved.len(), 1);
+    assert_eq!(saved[0].event_type(), OrderEventType::Denied);
+    assert!(
+        saved[0]
+            .message()
+            .unwrap()
+            .as_str()
+            .starts_with("BETTING_BALANCE_CALCULATION_FAILED:")
+    );
+}
+
+#[rstest]
 fn test_submit_order_when_betting_sell_reduces_long_position_then_accepts(
     strategy_id_ema_cross: StrategyId,
     client_id_binance: ClientId,
@@ -7252,6 +7334,85 @@ fn test_submit_order_margin_account_buy_exceeds_free_balance(
 }
 
 #[rstest]
+fn test_submit_order_when_initial_margin_is_unrepresentable_then_denies(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    mut instrument_eth_usdt: InstrumentAny,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    mut simple_cache: Cache,
+) {
+    let InstrumentAny::CryptoPerpetual(instrument) = &mut instrument_eth_usdt else {
+        unreachable!();
+    };
+    instrument.margin_init = Decimal::MAX;
+
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache
+        .add_account(AccountAny::Margin(margin_account_with_usdt_balance(
+            "100000 USDT",
+            "0 USDT",
+            "100000 USDT",
+        )))
+        .unwrap();
+    simple_cache
+        .add_quote(QuoteTick::new(
+            instrument_eth_usdt.id(),
+            Price::from("3000.00"),
+            Price::from("3000.01"),
+            Quantity::from("100"),
+            Quantity::from("100"),
+            UnixNanos::default(),
+            UnixNanos::default(),
+        ))
+        .unwrap();
+
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("1.000"))
+        .build();
+
+    risk_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(client_id_binance), false)
+        .unwrap();
+
+    let submit_order = SubmitOrder::new(
+        trader_id,
+        Some(client_id_binance),
+        strategy_id_ema_cross,
+        instrument_eth_usdt.id(),
+        order.client_order_id(),
+        order.init_event().clone(),
+        None,
+        None,
+        None,
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let saved = get_process_order_event_handler_messages(&process_order_event_handler);
+    assert_eq!(saved.len(), 1);
+    assert_eq!(saved[0].event_type(), OrderEventType::Denied);
+    assert!(
+        saved[0]
+            .message()
+            .unwrap()
+            .as_str()
+            .starts_with("INITIAL_MARGIN_CALCULATION_FAILED:")
+    );
+}
+
+#[rstest]
 fn test_submit_order_margin_account_sell_short_exceeds_free_balance(
     strategy_id_ema_cross: StrategyId,
     client_id_binance: ClientId,
@@ -7620,6 +7781,109 @@ fn test_submit_order_list_margin_account_cum_margin_exceeds_free_balance(
     for event in &saved_process_messages {
         assert_eq!(event.event_type(), OrderEventType::Denied);
     }
+}
+
+#[rstest]
+fn test_submit_order_list_when_cumulative_margin_is_unrepresentable_then_denies(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    mut instrument_eth_usdt: InstrumentAny,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    mut simple_cache: Cache,
+) {
+    let InstrumentAny::CryptoPerpetual(instrument) = &mut instrument_eth_usdt else {
+        unreachable!();
+    };
+    instrument.margin_init = Decimal::ONE;
+    instrument.max_quantity = None;
+    instrument.max_notional = None;
+
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    let max_balance = format!("{MONEY_MAX:.0} USDT");
+    simple_cache
+        .add_account(AccountAny::Margin(margin_account_with_usdt_balance(
+            &max_balance,
+            "0 USDT",
+            &max_balance,
+        )))
+        .unwrap();
+    simple_cache
+        .add_quote(QuoteTick::new(
+            instrument_eth_usdt.id(),
+            Price::from("1.00"),
+            Price::from("1.00"),
+            Quantity::from("100"),
+            Quantity::from("100"),
+            UnixNanos::default(),
+            UnixNanos::default(),
+        ))
+        .unwrap();
+
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    let quantity = Quantity::new(MONEY_MAX * 0.75, 3);
+    let orders = [
+        OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(instrument_eth_usdt.id())
+            .client_order_id(ClientOrderId::from("O-001"))
+            .side(OrderSide::Buy)
+            .quantity(quantity)
+            .build(),
+        OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(instrument_eth_usdt.id())
+            .client_order_id(ClientOrderId::from("O-002"))
+            .side(OrderSide::Buy)
+            .quantity(quantity)
+            .build(),
+    ];
+
+    for order in &orders {
+        risk_engine
+            .cache()
+            .borrow_mut()
+            .add_order(order.clone(), None, Some(client_id_binance), true)
+            .unwrap();
+    }
+
+    let order_list = OrderList::new(
+        OrderListId::new("OL-001"),
+        instrument_eth_usdt.id(),
+        strategy_id_ema_cross,
+        orders.iter().map(Order::client_order_id).collect(),
+        risk_engine.clock().borrow().timestamp_ns(),
+    );
+    let submit = SubmitOrderList::new(
+        trader_id,
+        Some(client_id_binance),
+        strategy_id_ema_cross,
+        order_list,
+        orders
+            .iter()
+            .map(|order| order.init_event().clone())
+            .collect(),
+        None,
+        None,
+        None,
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrderList(submit));
+
+    let saved = get_process_order_event_handler_messages(&process_order_event_handler);
+    assert_eq!(saved.len(), 3);
+    assert_eq!(saved[0].event_type(), OrderEventType::Denied);
+    assert!(
+        saved[0]
+            .message()
+            .unwrap()
+            .as_str()
+            .starts_with("CUMULATIVE_MARGIN_CALCULATION_FAILED:")
+    );
 }
 
 #[rstest]
@@ -8373,7 +8637,7 @@ fn test_submit_order_with_zero_price_on_non_spread_instrument_then_denies(
         saved_process_messages[0]
             .message()
             .unwrap()
-            .contains("<= 0")
+            .starts_with("PRICE_NOT_POSITIVE:")
     );
 }
 
@@ -8542,7 +8806,7 @@ fn test_modify_order_with_invalid_price_precision_then_rejects(
         saved_process_messages[0]
             .message()
             .unwrap()
-            .contains("precision")
+            .starts_with("PRICE_PRECISION_EXCEEDS_MAXIMUM:")
     );
 }
 
@@ -8623,7 +8887,7 @@ fn test_modify_order_with_invalid_quantity_precision_then_rejects(
         saved_process_messages[0]
             .message()
             .unwrap()
-            .contains("precision")
+            .starts_with("QUANTITY_PRECISION_EXCEEDS_MAXIMUM:")
     );
 }
 

--- a/docs/concepts/execution.md
+++ b/docs/concepts/execution.md
@@ -138,46 +138,54 @@ cross or immediately match. Other venue rejections leave it `false`.
 <!-- Generated from the `OrderDeniedReason` enum (crates/model). Regenerate with: cargo test -p nautilus-model regenerate_order_denied_reasons_doc -- --ignored -->
 <!-- BEGIN GENERATED: order-denied-reasons -->
 
-| Code                                  | Description                                                                     |
-| ------------------------------------- | ------------------------------------------------------------------------------- |
-| `CLIENT_VENUE_MISMATCH`               | The execution client does not handle the order venue.                           |
-| `CUM_MARGIN_EXCEEDS_FREE_BALANCE`     | The cumulative initial margin exceeds the account free balance.                 |
-| `CUM_NOTIONAL_EXCEEDS_FREE_BALANCE`   | The cumulative order notional exceeds the account free balance.                 |
-| `EXPIRE_TIME_IN_PAST`                 | The order's expire time is in the past.                                         |
-| `INSTRUMENT_NOT_FOUND`                | The instrument was not found in the cache.                                      |
-| `INVALID_CLIENT_ORDER_ID`             | The client order ID is invalid for the venue.                                   |
-| `INVALID_MAX_NOTIONAL_PER_ORDER`      | The configured maximum notional per order is invalid.                           |
-| `INVALID_ORDER_SIDE`                  | The order side is invalid for this operation.                                   |
-| `INVALID_POSITION_ID`                 | The supplied position ID is invalid for the order submission.                   |
-| `MARGIN_EXCEEDS_FREE_BALANCE`         | The order initial margin exceeds the account free balance.                      |
-| `MISSING_EXPIRE_TIME`                 | A GTD order is missing its expire time.                                         |
-| `MISSING_TRAILING_OFFSET`             | The order is missing a required trailing offset.                                |
-| `MISSING_TRAILING_OFFSET_TYPE`        | The order is missing a required trailing offset type.                           |
-| `MISSING_TRIGGER_TYPE`                | The order is missing a required trigger type.                                   |
-| `NOTIONAL_BELOW_MINIMUM`              | The order notional is below the instrument minimum.                             |
-| `NOTIONAL_EXCEEDS_FREE_BALANCE`       | The order notional exceeds the account free balance.                            |
-| `NOTIONAL_EXCEEDS_MAXIMUM`            | The order notional exceeds the instrument maximum.                              |
-| `NOTIONAL_EXCEEDS_MAX_PER_ORDER`      | The order notional exceeds the configured maximum per order.                    |
-| `NO_EXECUTION_CLIENT`                 | No execution client was found for the routed command.                           |
-| `ORDER_LIST_DENIED`                   | The order was denied because its order list failed risk checks.                 |
-| `ORDER_LIST_INCOMPLETE`               | The order list is missing orders in the cache.                                  |
-| `POSITION_NOT_FOUND`                  | The position for a reduce‑only order was not found.                             |
-| `QUANTITY_BELOW_MINIMUM`              | The effective order quantity is below the instrument minimum.                   |
-| `QUANTITY_CONVERSION_FAILED`          | The order quantity could not be converted for risk checks.                      |
-| `QUANTITY_EXCEEDS_MAXIMUM`            | The effective order quantity exceeds the instrument maximum.                    |
-| `RATE_LIMIT_EXCEEDED`                 | The order submission rate limit was exceeded.                                   |
-| `REDUCE_ONLY_WOULD_INCREASE_POSITION` | A reduce‑only order would increase the position.                                |
-| `STREAM_RECONCILING`                  | A post‑reconnect stream reconciliation is in progress; retry once it completes. |
-| `SUBMIT_FAILED`                       | Submitting the order to the execution client failed.                            |
-| `TRADING_HALTED`                      | Trading is halted; new orders are denied.                                       |
-| `TRADING_STATE_REDUCING`              | Trading is reducing; the order would increase exposure.                         |
-| `TRAILING_STOP_CALC_FAILED`           | The trailing stop trigger price could not be calculated.                        |
-| `UNSUPPORTED_ORDER_LIST`              | The venue does not support the requested order list.                            |
-| `UNSUPPORTED_ORDER_TYPE`              | The order type is not supported.                                                |
-| `UNSUPPORTED_TIME_IN_FORCE`           | The order's time in force is not supported.                                     |
-| `UNSUPPORTED_TP_SL`                   | The venue does not support the requested take‑profit/stop‑loss parameters.      |
-| `UNSUPPORTED_TRAILING_OFFSET_TYPE`    | The order's trailing offset type is not supported.                              |
-| `VALIDATION_FAILED`                   | The order failed validation before submission.                                  |
+| Code                                   | Description                                                                     |
+| -------------------------------------- | ------------------------------------------------------------------------------- |
+| `BETTING_BALANCE_CALCULATION_FAILED`   | The betting balance locked amount could not be calculated.                      |
+| `CLIENT_VENUE_MISMATCH`                | The execution client does not handle the order venue.                           |
+| `CUMULATIVE_MARGIN_CALCULATION_FAILED` | The cumulative initial margin could not be calculated.                          |
+| `CUM_MARGIN_EXCEEDS_FREE_BALANCE`      | The cumulative initial margin exceeds the account free balance.                 |
+| `CUM_NOTIONAL_EXCEEDS_FREE_BALANCE`    | The cumulative order notional exceeds the account free balance.                 |
+| `EXPIRE_TIME_IN_PAST`                  | The order's expire time is in the past.                                         |
+| `INITIAL_MARGIN_CALCULATION_FAILED`    | The order initial margin could not be calculated.                               |
+| `INSTRUMENT_NOT_FOUND`                 | The instrument was not found in the cache.                                      |
+| `INVALID_CLIENT_ORDER_ID`              | The client order ID is invalid for the venue.                                   |
+| `INVALID_MAX_NOTIONAL_PER_ORDER`       | The configured maximum notional per order is invalid.                           |
+| `INVALID_ORDER_SIDE`                   | The order side is invalid for this operation.                                   |
+| `INVALID_POSITION_ID`                  | The supplied position ID is invalid for the order submission.                   |
+| `MARGIN_EXCEEDS_FREE_BALANCE`          | The order initial margin exceeds the account free balance.                      |
+| `MARKET_PRICE_UNAVAILABLE`             | No market price is available for the order risk check.                          |
+| `MISSING_EXPIRE_TIME`                  | A GTD order is missing its expire time.                                         |
+| `MISSING_TRAILING_OFFSET`              | The order is missing a required trailing offset.                                |
+| `MISSING_TRAILING_OFFSET_TYPE`         | The order is missing a required trailing offset type.                           |
+| `MISSING_TRIGGER_TYPE`                 | The order is missing a required trigger type.                                   |
+| `NOTIONAL_BELOW_MINIMUM`               | The order notional is below the instrument minimum.                             |
+| `NOTIONAL_CALCULATION_FAILED`          | The order notional value could not be calculated.                               |
+| `NOTIONAL_EXCEEDS_FREE_BALANCE`        | The order notional exceeds the account free balance.                            |
+| `NOTIONAL_EXCEEDS_MAXIMUM`             | The order notional exceeds the instrument maximum.                              |
+| `NOTIONAL_EXCEEDS_MAX_PER_ORDER`       | The order notional exceeds the configured maximum per order.                    |
+| `NO_EXECUTION_CLIENT`                  | No execution client was found for the routed command.                           |
+| `ORDER_LIST_DENIED`                    | The order was denied because its order list failed risk checks.                 |
+| `ORDER_LIST_INCOMPLETE`                | The order list is missing orders in the cache.                                  |
+| `POSITION_NOT_FOUND`                   | The position for a reduce‑only order was not found.                             |
+| `PRICE_NOT_POSITIVE`                   | The price is not positive.                                                      |
+| `PRICE_PRECISION_EXCEEDS_MAXIMUM`      | The price precision exceeds the instrument maximum.                             |
+| `QUANTITY_BELOW_MINIMUM`               | The effective order quantity is below the instrument minimum.                   |
+| `QUANTITY_CONVERSION_FAILED`           | The order quantity could not be converted for risk checks.                      |
+| `QUANTITY_EXCEEDS_MAXIMUM`             | The effective order quantity exceeds the instrument maximum.                    |
+| `QUANTITY_PRECISION_EXCEEDS_MAXIMUM`   | The quantity precision exceeds the instrument maximum.                          |
+| `RATE_LIMIT_EXCEEDED`                  | The order submission rate limit was exceeded.                                   |
+| `REDUCE_ONLY_WOULD_INCREASE_POSITION`  | A reduce‑only order would increase the position.                                |
+| `STREAM_RECONCILING`                   | A post‑reconnect stream reconciliation is in progress; retry once it completes. |
+| `SUBMIT_FAILED`                        | Submitting the order to the execution client failed.                            |
+| `TRADING_HALTED`                       | Trading is halted; new orders are denied.                                       |
+| `TRADING_STATE_REDUCING`               | Trading is reducing; the order would increase exposure.                         |
+| `TRAILING_STOP_CALC_FAILED`            | The trailing stop trigger price could not be calculated.                        |
+| `UNSUPPORTED_ORDER_LIST`               | The venue does not support the requested order list.                            |
+| `UNSUPPORTED_ORDER_TYPE`               | The order type is not supported.                                                |
+| `UNSUPPORTED_TIME_IN_FORCE`            | The order's time in force is not supported.                                     |
+| `UNSUPPORTED_TP_SL`                    | The venue does not support the requested take‑profit/stop‑loss parameters.      |
+| `UNSUPPORTED_TRAILING_OFFSET_TYPE`     | The order's trailing offset type is not supported.                              |
+| `VALIDATION_FAILED`                    | The order failed validation before submission.                                  |
 
 <!-- END GENERATED: order-denied-reasons -->
 


### PR DESCRIPTION
A follow-up to the reason-code standardization in [`0301425975`](https://github.com/nautechsystems/nautilus_trader/commit/030142597520211cb199e2c897686efc90422772), which converted most of the risk engine's denials and left several branches emitting free-form text.

## The denials still rendered as prose

`RiskEngine::deny_order` takes `reason: &str`, so a caller may pass a rendered `OrderDeniedReason` or an arbitrary string. Eleven sites pass strings: both `check_price` conditions and their trigger-price variants, all three `check_quantity` conditions, two notional calculation failures, an initial-margin failure, a cumulative-margin overflow, a betting balance-lock failure, and the missing-market-price denial. Each reaches an `OrderDenied` whose reason carries no code, while `docs/concepts/execution.md` documents the codes as the source of truth for locally denied orders.

The clearest case is a condition already in the vocabulary. `check_orders_risk_for_account` denies a max-quantity breach as `QUANTITY_EXCEEDS_MAXIMUM: effective_quantity=15, max_quantity=10`; `check_quantity` denies the same condition as `quantity 15 invalid (> maximum trade size of 10)`.

`check_price` and `check_quantity` now return `Option<OrderDeniedReason>` and their callers render at the existing `deny_order` boundary. The min/max arms reuse `QuantityExceedsMaximum` and `QuantityBelowMinimum`; the calculation failures take one variant each, following `TrailingStopCalcFailed` and `QuantityConversionFailed`.

NB: the comment above `check_quantity`'s quote-quantity early return said the skipped bounds "will be checked in `check_orders_risk` using `effective_quantity`". They are not - `check_orders_risk_for_account` guards the same comparisons with `if !order.is_quote_quantity()` and skips them too. Corrected in passing.

## The price leg becomes a field

The trigger-price denial was `format!("trigger {risk_msg}")`, a prefix ahead of the message, which a typed reason cannot carry without putting prose before the code. The leg moves into the reason as `OrderPriceType::{Order, Trigger}`, so both render code-led: `PRICE_NOT_POSITIVE: price_type=TRIGGER, price=-0.1`. Four parallel variants would have forced consumers to match two codes for one rule.

## Whether `deny_order` should still take a string

With these branches converted, every caller of `deny_order`, `deny_order_list` and `deny_command` in this engine passes a rendered `OrderDeniedReason`. Narrowing those three to `&OrderDeniedReason` and rendering inside them would make a free-form risk-engine denial unrepresentable rather than merely absent. I left it out because it changes signatures beyond the branches at issue - say the word and I will add it here or file it separately.

`reject_modify_order` is not a candidate: closed orders, pending cancellations, missing instruments, halted trading and rate limits legitimately emit prose there.

## What this does not cover

Local denials outside the risk engine still emit free-form text - execution clients across ten adapters, and `crates/trading`'s market-exit path. Two of those, `MARKET_EXIT_IN_PROGRESS` and Interactive Brokers' `UNSUPPORTED_QUOTE_QUANTITY`, are formatted like codes without being in `OrderDeniedCode`. Those need per-adapter decisions and are untouched here.

Shared price and quantity failures also reach `OrderModifyRejected`, which now carries the same code-led text. Modify rejections are not standardized generally, so the documentation for that event is unchanged.

## Testing

No validation behaviour changes, so there is no behavioural differential to show: the tests pin the reason format, not which orders are denied. Existing risk-engine assertions moved to the new codes and still pin event type and count. `test_submit_order_when_invalid_trigger_price_then_denies` had its message assertion commented out; it is live again and pins `price_type=TRIGGER`. Three error branches that had no coverage now have it - initial-margin overflow, cumulative-margin overflow past `Money` bounds, and a betting balance-lock failure - each induced through fixture values with no production-code change. Check ordering is unchanged at every site, which is load-bearing: it is first-failure-wins, so a reordering would change which reason an order failing two rules receives.
