### PR TITLE
Validate the strike price on option constructors

### DIFF
--- a/crates/model/src/instruments/crypto_option.rs
+++ b/crates/model/src/instruments/crypto_option.rs
@@ -166,6 +166,7 @@ impl CryptoOption {
             stringify!(size_increment.precision),
         )?;
         check_positive_price(price_increment, stringify!(price_increment))?;
+        check_positive_price(strike_price, stringify!(strike_price))?;
         check_positive_quantity(size_increment, stringify!(size_increment))?;
         check_tick_scheme(tick_scheme)?;
 
@@ -634,6 +635,53 @@ mod tests {
             0.into(),
         );
         assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case(Price::from("0"))]
+    #[case(Price::from("-1"))]
+    fn test_new_checked_rejects_non_positive_strike_price(#[case] strike_price: Price) {
+        let result = CryptoOption::new_checked(
+            InstrumentId::from("TEST.DERIBIT"),
+            Symbol::from("TEST"),
+            Currency::BTC(),
+            Currency::USD(),
+            Currency::BTC(),
+            false,
+            OptionKind::Call,
+            strike_price,
+            0.into(),
+            0.into(),
+            1,
+            1,
+            Price::from("0.1"),
+            Quantity::from("0.1"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            0.into(),
+            0.into(),
+        );
+
+        // Assert on the parameter name, not merely `is_err`: this constructor validates a
+        // dozen other fields, and a bare error check would pass if an unrelated one fired.
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("'strike_price' not positive")
+        );
     }
 
     #[rstest]

--- a/crates/model/src/instruments/option_contract.rs
+++ b/crates/model/src/instruments/option_contract.rs
@@ -157,6 +157,7 @@ impl OptionContract {
             stringify!(price_increment.precision),
         )?;
         check_positive_price(price_increment, stringify!(price_increment))?;
+        check_positive_price(strike_price, stringify!(strike_price))?;
         check_tick_scheme(tick_scheme)?;
         check_positive_quantity(multiplier, stringify!(multiplier))?;
         check_positive_quantity(lot_size, stringify!(lot_size))?;
@@ -589,6 +590,49 @@ mod tests {
             0.into(),
         );
         assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case(Price::from("0"))]
+    #[case(Price::from("-1"))]
+    fn test_new_checked_rejects_non_positive_strike_price(#[case] strike_price: Price) {
+        let result = OptionContract::new_checked(
+            InstrumentId::from("TEST.OPRA"),
+            Symbol::from("TEST"),
+            AssetClass::Equity,
+            Some(Ustr::from("GMNI")),
+            Ustr::from("AAPL"),
+            OptionKind::Call,
+            strike_price,
+            Currency::USD(),
+            0.into(),
+            0.into(),
+            2,
+            Price::from("0.01"),
+            Quantity::from(1),
+            Quantity::from(1),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            0.into(),
+            0.into(),
+        );
+
+        // Assert on the parameter name, not merely `is_err`: this constructor validates a
+        // dozen other fields, and a bare error check would pass if an unrelated one fired.
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("'strike_price' not positive")
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
`OptionContract` and `CryptoOption` are the two instrument types reporting `InstrumentClass::Option`, and neither validates the strike it is constructed with.

## An unvalidated strike reaches the greeks calculator

`OptionContract::new_checked` validates `price_increment` with `check_positive_price` and `multiplier` and `lot_size` with `check_positive_quantity`; `CryptoOption::new_checked` validates `price_increment`, `size_increment`, and conditionally `multiplier` and `lot_size`. `strike_price` appears in neither list, so zero and negative strikes construct without complaint. Both types then return `Some(self.strike_price)` unconditionally from their `strike_price()` accessor, so the value flows into `GreeksCalculator::instrument_greeks`.

This adds `check_positive_price(strike_price, stringify!(strike_price))?` to both, beside the existing `price_increment` check. That helper also rejects `PRICE_UNDEF`.

Every instrument-definition path converges on `new_checked`, directly or through `new`: the adapters, the builders, the PyO3 constructors, and the SQL and Arrow reconstruction. No venue path in the tree depends on a zero strike as a sentinel - Bybit derives it from the option symbol's strike component, OKX parses `stk`, Deribit and Derive require it, BitMEX's `option_strike_price` is settlement-only and reaches neither constructor, and Databento dispatches to `OptionContract` only for the `C` and `P` instrument classes. That covers the paths in this repository; it is not a claim about every payload those venues have ever sent.

## What this does not establish

Both types derive `Deserialize`, which constructs their public fields directly and bypasses `new_checked`; the Interactive Brokers instrument cache uses that path when restoring `InstrumentAny`. This change therefore validates constructor-based creation without establishing a complete type invariant for directly deserialized or publicly mutated values.

Validated deserialization is left as a separate decision because the bypass is not specific to the strike: serde already admits an invalid `price_increment`, `size_increment`, `multiplier` or `lot_size` by the same route. A strike-only field deserializer would leave constructors checking the full set of invariants and serde checking exactly one.

What are your thoughts on validated deserialization for these types? Routing serde through `new_checked`, a custom deserializer per instrument type, and leaving the derived form as it stands all seem defensible from here, and the choice affects more than the strike. I can take whichever you prefer as a follow-up.

## Testing

`test_new_checked_rejects_non_positive_strike_price` is added to both types, cased over a zero and a negative strike, and fails against the unfixed constructors. Each asserts the rendered error names `strike_price` rather than only that construction failed - these constructors validate a dozen other fields, so a bare error check would pass if an unrelated one fired. Every other argument in those cases is valid, so the strike is the only reason they fail.

A sweep for existing constructions passing a zero or negative strike - across the adapters, tests, fixtures, stubs, examples, SQL and Arrow reconstruction, the Python constructors and the Cython package - found none, so no fixture needed updating.
