### PR TITLE
Fix backtest timer callback time

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -845,7 +845,6 @@ impl BacktestEngine {
             let d = self.data_iterator.next_item().unwrap();
 
             if ts_init > self.last_ns {
-                self.last_ns = ts_init;
                 self.advance_time_impl(ts_init, &clocks)?;
             }
 
@@ -1463,6 +1462,7 @@ impl BacktestEngine {
         if let Some(ts_event) = shutdown_at {
             self.last_ns = ts_event;
         } else {
+            self.last_ns = ts_now;
             Self::set_all_clocks_time(clocks, ts_now);
             logging_clock_set_static_time(ts_now.as_u64());
         }
@@ -1548,6 +1548,7 @@ impl BacktestEngine {
         ts_event: UnixNanos,
         advance_to: UnixNanos,
     ) {
+        self.last_ns = ts_event;
         while self.accumulator.peek_next_time() == Some(ts_event) {
             let handler = self
                 .accumulator
@@ -2141,6 +2142,8 @@ fn log_portfolio_performance(analyzer: &PortfolioAnalyzer) {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use indexmap::IndexMap;
     use nautilus_common::{
         actor::DataActor,
@@ -2261,6 +2264,45 @@ mod tests {
             .unwrap();
         engine.add_venue(venue_config).unwrap();
         engine
+    }
+
+    #[rstest]
+    fn test_timer_handler_sets_last_ns_to_fire_time() {
+        let mut engine = create_engine();
+        engine.last_ns = UnixNanos::from(30);
+        let fired = Rc::new(Cell::new(false));
+        let fired_clone = Rc::clone(&fired);
+        let callback = TimeEventCallback::RustLocal(Rc::new(move |_| {
+            fired_clone.set(true);
+        }));
+        engine
+            .kernel
+            .clock
+            .borrow_mut()
+            .set_timer_ns(
+                "ROLL",
+                1,
+                Some(UnixNanos::from(20)),
+                None,
+                Some(callback),
+                Some(true),
+                Some(true),
+            )
+            .unwrap();
+        let clocks = engine.collect_all_clocks();
+
+        for clock in &clocks {
+            BacktestEngine::advance_clock_on_accumulator(
+                &mut engine.accumulator,
+                clock,
+                UnixNanos::from(30),
+                false,
+            );
+        }
+        engine.run_timer_handlers_at(&clocks, UnixNanos::from(20), UnixNanos::from(30));
+
+        assert!(fired.get());
+        assert_eq!(engine.last_ns, UnixNanos::from(20));
     }
 
     #[rstest]


### PR DESCRIPTION
- [x] This is a small, self-contained fix that does not need prior discussion
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed
- [x] I ran all relevant tests locally
- [x] I have not modified `RELEASES.md`

## Summary

The backtest engine now exposes each timer's fire time through its logical cursor while the timer callback runs. A callback that starts historical work at time 20 no longer inherits the next data event's later timestamp, such as time 30, and miss data between those points.

The cursor advances to the target data time after all earlier timer callbacks complete. Graceful shutdown remains anchored to the firing timer's timestamp.

```mermaid
sequenceDiagram
    participant Data as Next data event
    participant Engine as Backtest engine
    participant Timer as Timer callback
    Data->>Engine: Advance toward time 30
    Engine->>Timer: Fire at time 20
    Note over Engine,Timer: logical cursor = 20
    Timer-->>Engine: Start historical work at time 20
    Engine-->>Data: Resume with logical cursor = 30
```

## Related issues/PRs

None.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details

None.

## Documentation

- [x] No documentation changes are required for this internal timing correction
- [x] No PyO3 binding or wrapped Rust documentation changed

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added tests to cover the changed logic
- [ ] No logic changed

- `make cargo-test-crate-nautilus-backtest`: 164 passed.
- `make format`: passed.
- `make pre-commit`: passed.
