### PR TITLE
Reset the inner moving average in AverageTrueRange

### DIFF
--- a/crates/indicators/src/volatility/atr.rs
+++ b/crates/indicators/src/volatility/atr.rs
@@ -84,6 +84,7 @@ impl Indicator for AverageTrueRange {
     }
 
     fn reset(&mut self) {
+        self.ma.reset();
         self.previous_close = 0.0;
         self.value = 0.0;
         self.count = 0;
@@ -298,5 +299,13 @@ mod tests {
         atr.reset();
         assert!(!atr.initialized);
         assert_eq!(atr.value, 0.0);
+    }
+
+    #[rstest]
+    fn test_reset_resets_inner_ma() {
+        let mut atr = AverageTrueRange::new(10, Some(MovingAverageType::Simple), None, None);
+        atr.update_raw(1.00010, 1.0, 1.00005);
+        atr.reset();
+        assert_eq!(atr.ma.count(), 0);
     }
 }


### PR DESCRIPTION
## Summary

reset() does not touch self.ma.

It clears previous_close, value, count, has_inputs and initialized, and self.ma is where the state actually lives: update_raw feeds it and then reads self.value = self.ma.value(). So the first values after a reset come from the previous run. At period 3 on five bars, the first run starts at 0.1000 and the replay starts at 0.2333, and it stays wrong for period - 1 values until the stale window has rolled out.

22 indicators in this crate hold another indicator inside. On develop this is the only one that does not reset it, and RelativeStrengthIndex already has test_reset_resets_inner_mas for the same thing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added test_reset_resets_inner_ma, the same shape as rsi.rs.

544 tests pass in nautilus-indicators and make pre-commit is green over 61 hooks. Removing the one added line turns the new test red, and restoring it turns it green.
