### PR TITLE
Insert encoded query parameters before any URL fragment

### DIFF
--- a/crates/network/src/http/client.rs
+++ b/crates/network/src/http/client.rs
@@ -669,6 +669,7 @@ impl Default for InnerHttpClient {
 /// Returns `Cow::Borrowed` when no parameters need appending (zero-alloc fast path).
 /// Parameters can have multiple values per key (for doseq=True behavior).
 /// Preserves existing query strings in the URL by appending with '&' instead of '?'.
+/// The query is inserted before any fragment, which is preserved unchanged.
 fn encode_url_params<'a>(
     url: &'a str,
     params: Option<&HashMap<String, Vec<String>>>,
@@ -693,8 +694,73 @@ fn encode_url_params<'a>(
     let query_string = serde_urlencoded::to_string(pairs)
         .map_err(|e| HttpClientError::Error(format!("Failed to encode params: {e}")))?;
 
-    let separator = if url.contains('?') { '&' } else { '?' };
-    Ok(Cow::Owned(format!("{url}{separator}{query_string}")))
+    // The first literal '#' starts the fragment per RFC 3986 section 3.5.
+    // A data '#' in an earlier component must be percent-encoded as "%23".
+    let (base, fragment) = match url.split_once('#') {
+        Some((base, fragment)) => (base, Some(fragment)),
+        None => (url, None),
+    };
+    let separator = if base.contains('?') { '&' } else { '?' };
+
+    Ok(Cow::Owned(match fragment {
+        Some(fragment) => format!("{base}{separator}{query_string}#{fragment}"),
+        None => format!("{base}{separator}{query_string}"),
+    }))
+}
+
+#[cfg(test)]
+mod encode_url_params_tests {
+    use std::{borrow::Cow, collections::HashMap};
+
+    use rstest::rstest;
+
+    use super::encode_url_params;
+
+    fn params(pairs: &[(&str, &str)]) -> HashMap<String, Vec<String>> {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+
+        for (key, value) in pairs {
+            map.entry((*key).to_string())
+                .or_default()
+                .push((*value).to_string());
+        }
+
+        map
+    }
+
+    #[rstest]
+    #[case("https://x/y", "https://x/y?a=b")]
+    #[case("https://x/y?old=1", "https://x/y?old=1&a=b")]
+    #[case("https://x/y#frag", "https://x/y?a=b#frag")]
+    #[case("https://x/y?old=1#frag", "https://x/y?old=1&a=b#frag")]
+    #[case(
+        "https://x/y#section?display=full",
+        "https://x/y?a=b#section?display=full"
+    )]
+    #[case("https://x/y#", "https://x/y?a=b#")]
+    fn test_query_is_inserted_before_the_fragment(#[case] url: &str, #[case] expected: &str) {
+        let params = params(&[("a", "b")]);
+
+        assert_eq!(encode_url_params(url, Some(&params)).unwrap(), expected);
+    }
+
+    #[rstest]
+    fn test_url_is_borrowed_when_no_params_are_supplied() {
+        assert!(matches!(
+            encode_url_params("https://x/y#frag", None).unwrap(),
+            Cow::Borrowed("https://x/y#frag")
+        ));
+    }
+
+    #[rstest]
+    fn test_url_is_borrowed_when_params_are_empty() {
+        let params = HashMap::new();
+
+        assert!(matches!(
+            encode_url_params("https://x/y#frag", Some(&params)).unwrap(),
+            Cow::Borrowed("https://x/y#frag")
+        ));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`HttpClient` builds its final request URL in `encode_url_params` (`crates/network/src/http/client.rs`) by concatenating the encoded query onto the end of the URL string, with no awareness of a fragment.

## The query lands inside the fragment

RFC 3986 orders the components `scheme://authority/path?query#fragment`, so everything after the first `#` belongs to the fragment. Appending to the end of the string therefore puts the encoded parameters inside it: `https://x/y#frag` with `a=b` becomes `https://x/y#frag?a=b`. A fragment is never sent to the server, so the parameters the caller supplied are dropped from the request and nothing reports an error. The fragment is also mutated in place - `frag` becomes `frag?a=b` - which is visible to anything that logs or returns the constructed URL, and an explicitly empty fragment `https://x/y#` acquires the fragment `?a=b`.

The separator test reads the wrong component for the same reason. `url.contains('?')` is true for a `?` that occurs only inside the fragment, which RFC 3986 section 3.5 permits, so `https://x/y#section?display=full` selects `&` despite having no query component at all.

The fix splits the URL once on the first literal `#`, inserts the query into the part preceding it, and reattaches the fragment unchanged. A data `#` in an earlier component must be percent-encoded as `%23`, so it cannot split. URLs without a fragment take the former construction exactly, and both `Cow::Borrowed` fast paths are unchanged.

No in-tree default or hard-coded adapter endpoint contains a fragment. Polymarket Gamma is the only adapter caller supplying this parameter shape, and its standard base URL is fragment-free. This therefore fixes an unenforced correctness property on the public `HttpClient` URL path rather than request corruption observed under an in-tree configuration; caller-supplied URLs and configurable adapter base URLs are outside the repository's control.

## Testing

`test_query_is_inserted_before_the_fragment` is parameterized over six URLs: no fragment, an existing query, a fragment, a fragment with an existing query, a fragment containing `?`, and an empty fragment. The four fragment-bearing cases fail against the unfixed function - `https://x/y#frag` yields `https://x/y#frag?a=b`, and `https://x/y?old=1#frag` yields `https://x/y?old=1#frag&a=b` - while the two without a fragment pass unchanged, pinning that this alters nothing for the ordinary shape. `test_url_is_borrowed_when_no_params_are_supplied` and `test_url_is_borrowed_when_params_are_empty` match on `Cow::Borrowed` so the zero-allocation paths cannot regress into allocating on every request.

These are pure string tests and live in their own module rather than the file's existing `#[cfg(target_os = "linux")]` module, which is gated for server-backed tests, so they run on every target. `socket/client.rs` and `websocket/client.rs` carry the same split.
