### PR TITLE
Skip a rehedge whose quantity rounds to zero

### DIFF
--- a/crates/trading/src/examples/strategies/delta_neutral_vol/strategy.rs
+++ b/crates/trading/src/examples/strategies/delta_neutral_vol/strategy.rs
@@ -439,11 +439,6 @@ impl DeltaNeutralVol {
             OrderSide::Buy
         };
 
-        log::info!(
-            "Rehedging: portfolio_delta={delta:.4}, submitting {side:?} {hedge_qty:.4} on {}",
-            self.config.hedge_instrument_id,
-        );
-
         let hedge_id = self.config.hedge_instrument_id;
         let size_precision = {
             let cache = self.cache();
@@ -452,10 +447,24 @@ impl DeltaNeutralVol {
                 .map_or(2, |i| i.size_precision())
         };
 
+        // A delta above the float threshold can still round to zero at the size precision.
+        let hedge_quantity = Quantity::new(hedge_qty, size_precision);
+
+        if hedge_quantity.is_zero() {
+            log::debug!(
+                "Rehedge delta {hedge_qty} rounds to zero at size precision {size_precision}, skipping"
+            );
+            return Ok(());
+        }
+
+        log::info!(
+            "Rehedging: portfolio_delta={delta:.4}, submitting {side:?} {hedge_quantity} on {hedge_id}",
+        );
+
         let order = self.order().market(
             hedge_id,
             side,
-            Quantity::new(hedge_qty, size_precision),
+            hedge_quantity,
             None,
             None,
             None,

--- a/crates/trading/src/examples/strategies/delta_neutral_vol/tests.rs
+++ b/crates/trading/src/examples/strategies/delta_neutral_vol/tests.rs
@@ -19,6 +19,7 @@ use nautilus_common::{
     actor::DataActor,
     cache::Cache,
     clock::{Clock, TestClock},
+    timer::TimeEvent,
 };
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
@@ -28,11 +29,13 @@ use nautilus_model::{
         OrderDenied, OrderExpired, OrderRejected,
         order::spec::{OrderDeniedSpec, OrderExpiredSpec, OrderRejectedSpec},
     },
-    identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId},
-    types::{Price, Quantity},
+    identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Symbol, TraderId},
+    instruments::{CryptoPerpetual, InstrumentAny},
+    types::{Currency, Price, Quantity},
 };
 use nautilus_portfolio::portfolio::Portfolio;
 use rstest::rstest;
+use ustr::Ustr;
 
 use super::{DeltaNeutralVol, DeltaNeutralVolConfig};
 use crate::strategy::Strategy;
@@ -81,6 +84,39 @@ fn quote_tick(instrument_id: InstrumentId, bid: &str, ask: &str) -> QuoteTick {
         Quantity::from("1"),
         UnixNanos::default(),
         UnixNanos::default(),
+    )
+}
+
+/// The configured hedge instrument, sized in whole contracts (`size_precision` 0), so a
+/// fractional delta cannot be expressed as a quantity.
+fn hedge_swap_integer_sized() -> CryptoPerpetual {
+    CryptoPerpetual::new(
+        InstrumentId::from("BTC-USD-SWAP.OKX"),
+        Symbol::from("BTC-USD-SWAP"),
+        Currency::BTC(),
+        Currency::USD(),
+        Currency::USD(),
+        false,
+        1,
+        0,
+        Price::from("0.1"),
+        Quantity::from(1),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        0.into(),
+        0.into(),
     )
 }
 
@@ -490,6 +526,33 @@ fn test_on_option_greeks_initializes_both_legs_before_rehedging() {
 
     strategy.on_option_greeks(&put_greeks).unwrap();
     assert!(strategy.greeks_initialized());
+}
+
+#[rstest]
+fn test_rehedge_skips_quantity_rounded_to_zero() {
+    let mut strategy = create_initialized_strategy();
+    strategy.config.rehedge_delta_threshold = 0.1;
+    strategy.hedge_position = 0.4;
+    register_strategy(&mut strategy);
+    strategy
+        .core
+        .cache_rc()
+        .borrow_mut()
+        .add_instrument(InstrumentAny::CryptoPerpetual(hedge_swap_integer_sized()))
+        .unwrap();
+
+    assert!(strategy.should_rehedge());
+
+    let event = TimeEvent::new(
+        Ustr::from("delta_rehedge"),
+        UUID4::new(),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    );
+    DataActor::on_time_event(&mut strategy, &event).unwrap();
+
+    // The latch stays clear, so a later rehedge at an expressible size is not blocked.
+    assert!(!strategy.hedge_pending);
 }
 
 #[rstest]


### PR DESCRIPTION
## A rehedge quantity that rounds to zero aborts the strategy

`DeltaNeutralVol::check_rehedge` decides whether to hedge from an unrounded float and then builds the order quantity from a different representation. `should_rehedge` compares `portfolio_delta().abs()` against the configured `rehedge_delta_threshold`, while the order takes `Quantity::new(hedge_qty, size_precision)` with the hedge instrument's precision. Nothing relates the two, so a delta above the threshold can still quantize to zero: with whole-contract sizing and a threshold of 0.1, every delta below 0.5 passes the gate and yields a zero quantity. `OrderFactory::market` ends in `unwrap_or_else(|e| panic!("{e}"))` and `MarketOrder::new_checked` opens with `check_positive_quantity`, so the strategy panics, and release builds are `panic = "abort"`.

The default `rehedge_delta_threshold` of 0.5 does not reach this. Tightening the hedge tolerance below what the instrument can express does, which is an ordinary thing to configure.

The fix constructs the quantity once and returns before submitting when it is zero, logging the delta and precision at debug because a timer can meet the same unexpressible residual on every tick. Rounding up to one increment was rejected: it overhedges and can reverse the residual, so a desired sell of 0.4 contracts becoming 1.0 leaves roughly -0.6 rather than +0.4. That is a policy change requiring hysteresis or a minimum-hedge setting, not a repair.

The guard sits before the `hedge_pending` latch. Setting the latch and then skipping would leave it true with no order able to produce a terminal event, wedging the strategy against all later rehedges. The existing submission log also moves below the guard, so it no longer announces a submission on the skip path, and it now reports the quantity actually sent rather than the pre-quantization float.

## Testing

`test_rehedge_skips_quantity_rounded_to_zero` registers the configured hedge instrument as a `CryptoPerpetual` with `size_precision` 0, sets the threshold to 0.1 and the portfolio delta to 0.4, and drives the strategy through its timer handler. It asserts that `hedge_pending` remains clear, so a later rehedge at an expressible size is not blocked.

Against the unfixed code the test fails with `invalid 'Quantity' for 'quantity' not positive, was 0` from `factories/order.rs`. The instrument is cached with an explicit precision rather than relying on the missing-instrument fallback, so the test pins zero-quantity protection alone and does not depend on what that fallback happens to be.
