### PR TITLE
Add data request completion callbacks

### DIFF
--- a/crates/common/src/actor/data_actor.rs
+++ b/crates/common/src/actor/data_actor.rs
@@ -155,7 +155,8 @@ pub struct ImportableActorConfig {
     pub config: HashMap<String, serde_json::Value>,
 }
 
-type RequestCallback = Arc<dyn Fn(UUID4) + Send + Sync>;
+/// Callback invoked after a historical request response is processed.
+pub type RequestCallback = Arc<dyn Fn(UUID4) + Send + Sync>;
 
 /// Explicit native-only access for data actor runtime state.
 ///
@@ -2411,6 +2412,7 @@ pub trait DataActor: Component {
     /// # Errors
     ///
     /// Returns an error if input parameters are invalid.
+    #[expect(clippy::too_many_arguments)]
     fn request_data(
         &mut self,
         data_type: DataType,
@@ -2419,6 +2421,7 @@ pub trait DataActor: Component {
         end: Option<Timestamp>,
         limit: Option<NonZeroUsize>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2426,7 +2429,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &CustomDataResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_data_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_data_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_data(
@@ -2438,6 +2443,7 @@ pub trait DataActor: Component {
             limit,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2453,6 +2459,7 @@ pub trait DataActor: Component {
         end: Option<Timestamp>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2460,7 +2467,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &InstrumentResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_instrument_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_instrument_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_instrument(
@@ -2471,6 +2480,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2486,6 +2496,7 @@ pub trait DataActor: Component {
         end: Option<Timestamp>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2493,7 +2504,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &InstrumentsResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_instruments_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_instruments_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_instruments(
@@ -2504,6 +2517,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2518,6 +2532,7 @@ pub trait DataActor: Component {
         depth: Option<NonZeroUsize>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2525,7 +2540,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &BookResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_book_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_book_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_book_snapshot(
@@ -2535,6 +2552,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2543,6 +2561,7 @@ pub trait DataActor: Component {
     /// # Errors
     ///
     /// Returns an error if input parameters are invalid.
+    #[expect(clippy::too_many_arguments)]
     fn request_book_deltas(
         &mut self,
         instrument_id: InstrumentId,
@@ -2551,6 +2570,7 @@ pub trait DataActor: Component {
         limit: Option<NonZeroUsize>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2558,7 +2578,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &BookDeltasResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_book_deltas_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_book_deltas_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_book_deltas(
@@ -2570,6 +2592,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2588,6 +2611,7 @@ pub trait DataActor: Component {
         depth: Option<NonZeroUsize>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2595,7 +2619,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &BookDepthResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_book_depth_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_book_depth_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_book_depth(
@@ -2608,6 +2634,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2616,6 +2643,7 @@ pub trait DataActor: Component {
     /// # Errors
     ///
     /// Returns an error if input parameters are invalid.
+    #[expect(clippy::too_many_arguments)]
     fn request_quotes(
         &mut self,
         instrument_id: InstrumentId,
@@ -2624,6 +2652,7 @@ pub trait DataActor: Component {
         limit: Option<NonZeroUsize>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2631,7 +2660,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &QuotesResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_quotes_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_quotes_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_quotes(
@@ -2643,6 +2674,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2651,6 +2683,7 @@ pub trait DataActor: Component {
     /// # Errors
     ///
     /// Returns an error if input parameters are invalid.
+    #[expect(clippy::too_many_arguments)]
     fn request_trades(
         &mut self,
         instrument_id: InstrumentId,
@@ -2659,6 +2692,7 @@ pub trait DataActor: Component {
         limit: Option<NonZeroUsize>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2666,7 +2700,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &TradesResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_trades_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_trades_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_trades(
@@ -2678,6 +2714,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2686,6 +2723,7 @@ pub trait DataActor: Component {
     /// # Errors
     ///
     /// Returns an error if input parameters are invalid.
+    #[expect(clippy::too_many_arguments)]
     fn request_bars(
         &mut self,
         bar_type: BarType,
@@ -2694,6 +2732,7 @@ pub trait DataActor: Component {
         limit: Option<NonZeroUsize>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2701,7 +2740,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &BarsResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_bars_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_bars_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_bars(
@@ -2713,6 +2754,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2721,6 +2763,7 @@ pub trait DataActor: Component {
     /// # Errors
     ///
     /// Returns an error if input parameters are invalid.
+    #[expect(clippy::too_many_arguments)]
     fn request_funding_rates(
         &mut self,
         instrument_id: InstrumentId,
@@ -2729,6 +2772,7 @@ pub trait DataActor: Component {
         limit: Option<NonZeroUsize>,
         client_id: Option<ClientId>,
         params: Option<Params>,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4>
     where
         Self: DataActorNative,
@@ -2736,7 +2780,9 @@ pub trait DataActor: Component {
     {
         let actor_id = self.core().actor_id().inner();
         let handler = ShareableMessageHandler::from_typed(move |resp: &FundingRatesResponse| {
-            get_actor_unchecked::<Self>(&actor_id).handle_funding_rates_response(resp);
+            let mut actor = get_actor_unchecked::<Self>(&actor_id);
+            actor.handle_funding_rates_response(resp);
+            actor.core_mut().finish_response(resp.correlation_id);
         });
 
         DataActorCore::request_funding_rates(
@@ -2748,6 +2794,7 @@ pub trait DataActor: Component {
             client_id,
             params,
             handler,
+            callback,
         )
     }
 
@@ -2857,6 +2904,7 @@ where
     }
 
     fn on_reset(&mut self) -> anyhow::Result<()> {
+        self.core_mut().pending_requests.clear();
         DataActor::on_reset(self)
     }
 
@@ -2867,10 +2915,7 @@ where
 
 /// Core functionality for all actors.
 #[derive(Clone)]
-#[allow(
-    dead_code,
-    reason = "TODO: Under development (pending_requests, signal_classes)"
-)]
+#[allow(dead_code, reason = "TODO: Under development (signal_classes)")]
 pub struct DataActorCore {
     /// The actor identifier.
     pub actor_id: ActorId,
@@ -4761,7 +4806,7 @@ impl DataActorCore {
     /// Returns an error if input parameters are invalid.
     #[expect(clippy::too_many_arguments)]
     pub fn request_data(
-        &self,
+        &mut self,
         data_type: DataType,
         client_id: ClientId,
         start: Option<Timestamp>,
@@ -4769,6 +4814,7 @@ impl DataActorCore {
         limit: Option<NonZeroUsize>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -4791,6 +4837,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -4801,14 +4848,16 @@ impl DataActorCore {
     /// # Errors
     ///
     /// Returns an error if input parameters are invalid.
+    #[expect(clippy::too_many_arguments)]
     pub fn request_instrument(
-        &self,
+        &mut self,
         instrument_id: InstrumentId,
         start: Option<Timestamp>,
         end: Option<Timestamp>,
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -4830,6 +4879,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -4840,14 +4890,16 @@ impl DataActorCore {
     /// # Errors
     ///
     /// Returns an error if input parameters are invalid.
+    #[expect(clippy::too_many_arguments)]
     pub fn request_instruments(
-        &self,
+        &mut self,
         venue: Option<Venue>,
         start: Option<Timestamp>,
         end: Option<Timestamp>,
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -4869,6 +4921,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -4880,12 +4933,13 @@ impl DataActorCore {
     ///
     /// Returns an error if input parameters are invalid.
     pub fn request_book_snapshot(
-        &self,
+        &mut self,
         instrument_id: InstrumentId,
         depth: Option<NonZeroUsize>,
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -4903,6 +4957,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -4915,7 +4970,7 @@ impl DataActorCore {
     /// Returns an error if input parameters are invalid.
     #[expect(clippy::too_many_arguments)]
     pub fn request_book_deltas(
-        &self,
+        &mut self,
         instrument_id: InstrumentId,
         start: Option<Timestamp>,
         end: Option<Timestamp>,
@@ -4923,6 +4978,7 @@ impl DataActorCore {
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -4945,6 +5001,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -4957,7 +5014,7 @@ impl DataActorCore {
     /// Returns an error if input parameters are invalid.
     #[expect(clippy::too_many_arguments)]
     pub fn request_book_depth(
-        &self,
+        &mut self,
         instrument_id: InstrumentId,
         start: Option<Timestamp>,
         end: Option<Timestamp>,
@@ -4966,6 +5023,7 @@ impl DataActorCore {
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -4989,6 +5047,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -5001,7 +5060,7 @@ impl DataActorCore {
     /// Returns an error if input parameters are invalid.
     #[expect(clippy::too_many_arguments)]
     pub fn request_quotes(
-        &self,
+        &mut self,
         instrument_id: InstrumentId,
         start: Option<Timestamp>,
         end: Option<Timestamp>,
@@ -5009,6 +5068,7 @@ impl DataActorCore {
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -5031,6 +5091,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -5043,7 +5104,7 @@ impl DataActorCore {
     /// Returns an error if input parameters are invalid.
     #[expect(clippy::too_many_arguments)]
     pub fn request_trades(
-        &self,
+        &mut self,
         instrument_id: InstrumentId,
         start: Option<Timestamp>,
         end: Option<Timestamp>,
@@ -5051,6 +5112,7 @@ impl DataActorCore {
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -5073,6 +5135,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -5085,7 +5148,7 @@ impl DataActorCore {
     /// Returns an error if input parameters are invalid.
     #[expect(clippy::too_many_arguments)]
     pub fn request_bars(
-        &self,
+        &mut self,
         bar_type: BarType,
         start: Option<Timestamp>,
         end: Option<Timestamp>,
@@ -5093,6 +5156,7 @@ impl DataActorCore {
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -5121,6 +5185,7 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
@@ -5133,7 +5198,7 @@ impl DataActorCore {
     /// Returns an error if input parameters are invalid.
     #[expect(clippy::too_many_arguments)]
     pub fn request_funding_rates(
-        &self,
+        &mut self,
         instrument_id: InstrumentId,
         start: Option<Timestamp>,
         end: Option<Timestamp>,
@@ -5141,6 +5206,7 @@ impl DataActorCore {
         client_id: Option<ClientId>,
         params: Option<Params>,
         handler: ShareableMessageHandler,
+        callback: Option<RequestCallback>,
     ) -> anyhow::Result<UUID4> {
         self.check_registered();
 
@@ -5163,9 +5229,17 @@ impl DataActorCore {
             .borrow_mut()
             .register_response_handler(command.request_id(), handler)?;
 
+        self.pending_requests.insert(request_id, callback);
         self.send_data_cmd(DataCommand::Request(command));
 
         Ok(request_id)
+    }
+
+    /// Finishes a request and invokes its completion callback, if registered.
+    pub fn finish_response(&mut self, request_id: UUID4) {
+        if let Some(Some(callback)) = self.pending_requests.remove(&request_id) {
+            callback(request_id);
+        }
     }
 
     /// Sends a fire-and-observe reconnect command.

--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -19,7 +19,7 @@ use std::{
     num::NonZeroUsize,
     rc::Rc,
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -68,7 +68,10 @@ use {
     },
 };
 
-use super::{Actor, DataActor, DataActorCore, DataActorNative, data_actor::DataActorConfig};
+use super::{
+    Actor, DataActor, DataActorCore, DataActorNative,
+    data_actor::{DataActorConfig, RequestCallback},
+};
 #[cfg(feature = "defi")]
 use crate::defi::switchboard::{
     get_defi_blocks_topic, get_defi_pool_swaps_topic, get_defi_pool_topic,
@@ -2279,7 +2282,7 @@ fn test_request_instrument(
     actor.start().unwrap();
 
     let request_id = actor
-        .request_instrument(audusd_sim.id, None, None, None, None)
+        .request_instrument(audusd_sim.id, None, None, None, None, None)
         .unwrap();
 
     let client_id = ClientId::new("TestClient");
@@ -2318,7 +2321,7 @@ fn test_request_instruments(
 
     let venue = Venue::test_default();
     let request_id = actor
-        .request_instruments(Some(venue), None, None, None, None)
+        .request_instruments(Some(venue), None, None, None, None, None)
         .unwrap();
 
     let client_id = ClientId::new("TestClient");
@@ -2356,8 +2359,18 @@ fn test_request_quotes(
     let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
     actor.start().unwrap();
 
+    let completed = Arc::new(Mutex::new(Vec::new()));
+    let callback_completed = completed.clone();
+    let callback_actor_id = actor_id;
+    let callback: RequestCallback = Arc::new(move |request_id| {
+        let actor = get_actor_unchecked::<TestDataActor>(&callback_actor_id);
+        callback_completed
+            .lock()
+            .unwrap()
+            .push((request_id, actor.received_quotes.len()));
+    });
     let request_id = actor
-        .request_quotes(audusd_sim.id, None, None, None, None, None)
+        .request_quotes(audusd_sim.id, None, None, None, None, None, Some(callback))
         .unwrap();
 
     let client_id = ClientId::new("TestClient");
@@ -2380,6 +2393,10 @@ fn test_request_quotes(
 
     assert_eq!(actor.received_quotes.len(), 1);
     assert_eq!(actor.received_quotes[0], quote);
+    assert_eq!(*completed.lock().unwrap(), vec![(request_id, 1)]);
+
+    actor.core_mut().finish_response(request_id);
+    assert_eq!(*completed.lock().unwrap(), vec![(request_id, 1)]);
 }
 
 #[rstest]
@@ -2411,6 +2428,7 @@ fn test_request_quotes_accepts_equal_start_and_end(
             Some(point),
             limit,
             client_id,
+            None,
             None,
         )
         .unwrap();
@@ -2459,7 +2477,7 @@ fn test_request_quotes_rejects_invalid_time_range(
     );
 
     let error = actor
-        .request_quotes(audusd_sim.id, start, end, None, None, None)
+        .request_quotes(audusd_sim.id, start, end, None, None, None, None)
         .unwrap_err();
 
     assert_eq!(error.to_string(), expected_error);
@@ -2478,7 +2496,7 @@ fn test_request_trades(
     actor.start().unwrap();
 
     let request_id = actor
-        .request_trades(audusd_sim.id, None, None, None, None, None)
+        .request_trades(audusd_sim.id, None, None, None, None, None, None)
         .unwrap();
 
     let client_id = ClientId::new("TestClient");
@@ -2515,7 +2533,7 @@ fn test_request_book_deltas(
     actor.start().unwrap();
 
     let request_id = actor
-        .request_book_deltas(audusd_sim.id, None, None, None, None, None)
+        .request_book_deltas(audusd_sim.id, None, None, None, None, None, None)
         .unwrap();
 
     let client_id = ClientId::new("TestClient");
@@ -2549,7 +2567,7 @@ fn test_request_book_depth(
     actor.start().unwrap();
 
     let request_id = actor
-        .request_book_depth(audusd_sim.id, None, None, None, None, None, None)
+        .request_book_depth(audusd_sim.id, None, None, None, None, None, None, None)
         .unwrap();
 
     let client_id = ClientId::new("TestClient");
@@ -2584,7 +2602,7 @@ fn test_request_funding_rates(
     actor.start().unwrap();
 
     let request_id = actor
-        .request_funding_rates(audusd_sim.id, None, None, None, None, None)
+        .request_funding_rates(audusd_sim.id, None, None, None, None, None, None)
         .unwrap();
 
     let client_id = ClientId::new("TestClient");
@@ -2629,7 +2647,7 @@ fn test_request_bars(
 
     let bar_type = BarType::from_str(&format!("{}-1-MINUTE-LAST-INTERNAL", audusd_sim.id)).unwrap();
     let request_id = actor
-        .request_bars(bar_type, None, None, None, None, None)
+        .request_bars(bar_type, None, None, None, None, None, None)
         .unwrap();
 
     let client_id = ClientId::new("TestClient");
@@ -3272,7 +3290,7 @@ fn test_request_book_snapshot(
 
     // Request a book snapshot
     let request_id = actor
-        .request_book_snapshot(audusd_sim.id, None, None, None)
+        .request_book_snapshot(audusd_sim.id, None, None, None, None)
         .unwrap();
 
     // Build a dummy book and response
@@ -3314,8 +3332,26 @@ fn test_request_data(
     // Request custom data
     let data_type = DataType::new("TestData", None, None);
     let client_id = ClientId::new("TestClient");
+    let completed = Arc::new(Mutex::new(Vec::new()));
+    let callback_completed = completed.clone();
+    let callback_actor_id = actor_id;
+    let callback: RequestCallback = Arc::new(move |request_id| {
+        let actor = get_actor_unchecked::<TestDataActor>(&callback_actor_id);
+        callback_completed
+            .lock()
+            .unwrap()
+            .push((request_id, actor.received_data.len()));
+    });
     let request_id = actor
-        .request_data(data_type.clone(), client_id, None, None, None, None)
+        .request_data(
+            data_type.clone(),
+            client_id,
+            None,
+            None,
+            None,
+            None,
+            Some(callback),
+        )
         .unwrap();
 
     // Build a response payload containing a String
@@ -3342,6 +3378,131 @@ fn test_request_data(
     // Actor should receive the custom data
     assert_eq!(actor.received_data.len(), 1);
     assert_eq!(actor.received_data[0], "Any { .. }");
+    assert_eq!(*completed.lock().unwrap(), vec![(request_id, 1)]);
+
+    actor.core_mut().finish_response(request_id);
+    assert_eq!(*completed.lock().unwrap(), vec![(request_id, 1)]);
+}
+
+#[rstest]
+fn test_request_data_callbacks_match_out_of_order_responses(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+) {
+    let actor_id = register_data_actor(clock, cache, trader_id);
+    let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
+    actor.start().unwrap();
+
+    let data_type = DataType::new("TestData", None, None);
+    let client_id = ClientId::new("TestClient");
+    let completed = Arc::new(Mutex::new(Vec::new()));
+    let first_completed = completed.clone();
+    let first_callback: RequestCallback = Arc::new(move |request_id| {
+        first_completed.lock().unwrap().push(("first", request_id));
+    });
+    let second_completed = completed.clone();
+    let second_callback: RequestCallback = Arc::new(move |request_id| {
+        second_completed
+            .lock()
+            .unwrap()
+            .push(("second", request_id));
+    });
+
+    let first_request_id = actor
+        .request_data(
+            data_type.clone(),
+            client_id,
+            None,
+            None,
+            None,
+            None,
+            Some(first_callback),
+        )
+        .unwrap();
+    let second_request_id = actor
+        .request_data(
+            data_type.clone(),
+            client_id,
+            None,
+            None,
+            None,
+            None,
+            Some(second_callback),
+        )
+        .unwrap();
+
+    for (request_id, payload) in [
+        (second_request_id, "Data-002"),
+        (first_request_id, "Data-001"),
+    ] {
+        let response = CustomDataResponse::new(
+            request_id,
+            client_id,
+            None,
+            data_type.clone(),
+            Arc::new(Bytes::from(payload)),
+            None,
+            None,
+            UnixNanos::default(),
+            None,
+        );
+        msgbus::send_response(&request_id, &DataResponse::Data(response));
+    }
+
+    assert_eq!(actor.received_data.len(), 2);
+    assert_eq!(
+        *completed.lock().unwrap(),
+        vec![("second", second_request_id), ("first", first_request_id),],
+    );
+}
+
+#[rstest]
+fn test_reset_discards_pending_request_callback(
+    clock: Rc<RefCell<TestClock>>,
+    cache: Rc<RefCell<Cache>>,
+    trader_id: TraderId,
+) {
+    let actor_id = register_data_actor(clock, cache, trader_id);
+    let mut actor = get_actor_unchecked::<TestDataActor>(&actor_id);
+    actor.start().unwrap();
+
+    let data_type = DataType::new("TestData", None, None);
+    let client_id = ClientId::new("TestClient");
+    let completed = Arc::new(Mutex::new(Vec::new()));
+    let callback_completed = completed.clone();
+    let callback: RequestCallback = Arc::new(move |request_id| {
+        callback_completed.lock().unwrap().push(request_id);
+    });
+    let request_id = actor
+        .request_data(
+            data_type.clone(),
+            client_id,
+            None,
+            None,
+            None,
+            None,
+            Some(callback),
+        )
+        .unwrap();
+
+    actor.stop().unwrap();
+    actor.reset().unwrap();
+
+    let response = CustomDataResponse::new(
+        request_id,
+        client_id,
+        None,
+        data_type,
+        Arc::new(Bytes::from("Data-001")),
+        None,
+        None,
+        UnixNanos::default(),
+        None,
+    );
+    msgbus::send_response(&request_id, &DataResponse::Data(response));
+
+    assert!(completed.lock().unwrap().is_empty());
 }
 
 #[rstest]

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -21,6 +21,7 @@ use std::{
     num::NonZeroUsize,
     ops::{Deref, DerefMut},
     rc::Rc,
+    sync::Arc,
 };
 
 use indexmap::IndexMap;
@@ -28,7 +29,7 @@ use jiff::Timestamp;
 use nautilus_core::{
     from_pydict,
     nanos::UnixNanos,
-    python::{to_pyruntime_err, to_pyvalue_err},
+    python::{to_pyruntime_err, to_pytype_err, to_pyvalue_err},
 };
 #[cfg(feature = "defi")]
 use nautilus_model::defi::{
@@ -63,7 +64,7 @@ use ustr::Ustr;
 use crate::{
     actor::{
         Actor, DataActor, DataActorNative,
-        data_actor::{DataActorConfig, DataActorCore, ImportableActorConfig},
+        data_actor::{DataActorConfig, DataActorCore, ImportableActorConfig, RequestCallback},
         registry::{try_get_actor_unchecked, with_actor_registry},
     },
     cache::Cache,
@@ -739,6 +740,28 @@ fn dict_to_params(
         Some(dict) => from_pydict(py, &dict),
         None => Ok(None),
     }
+}
+
+/// Converts an optional Python callable into a request completion callback.
+pub fn request_callback_from_py(
+    py: Python<'_>,
+    callback: Option<Py<PyAny>>,
+) -> PyResult<Option<RequestCallback>> {
+    let Some(callback) = callback else {
+        return Ok(None);
+    };
+
+    if !callback.bind(py).is_callable() {
+        return Err(to_pytype_err("callback must be callable"));
+    }
+
+    Ok(Some(Arc::new(move |request_id| {
+        Python::attach(|py| {
+            if let Err(e) = callback.call1(py, (request_id.to_string(),)) {
+                log::error!("Python request callback failed: {e}");
+            }
+        });
+    })))
 }
 
 fn state_to_pydict(py: Python<'_>, state: &IndexMap<String, Vec<u8>>) -> PyResult<Py<PyDict>> {
@@ -2188,7 +2211,7 @@ impl PyDataActor {
     }
 
     #[pyo3(name = "request_data")]
-    #[pyo3(signature = (data_type, client_id, start=None, end=None, limit=None, params=None))]
+    #[pyo3(signature = (data_type, client_id, start=None, end=None, limit=None, params=None, callback=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_request_data(
         &mut self,
@@ -2199,9 +2222,11 @@ impl PyDataActor {
         end: Option<Timestamp>,
         limit: Option<usize>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_data(
             self.inner_mut(),
@@ -2211,13 +2236,15 @@ impl PyDataActor {
             end,
             limit,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_instrument")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, client_id=None, params=None, callback=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_request_instrument(
         &mut self,
         py: Python<'_>,
@@ -2226,9 +2253,11 @@ impl PyDataActor {
         end: Option<Timestamp>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let request_id = DataActor::request_instrument(
             self.inner_mut(),
             instrument_id,
@@ -2236,13 +2265,15 @@ impl PyDataActor {
             end,
             client_id,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_instruments")]
-    #[pyo3(signature = (venue=None, start=None, end=None, client_id=None, params=None))]
+    #[pyo3(signature = (venue=None, start=None, end=None, client_id=None, params=None, callback=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_request_instruments(
         &mut self,
         py: Python<'_>,
@@ -2251,17 +2282,26 @@ impl PyDataActor {
         end: Option<Timestamp>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
-        let request_id =
-            DataActor::request_instruments(self.inner_mut(), venue, start, end, client_id, params)
-                .map_err(to_pyvalue_err)?;
+        let callback = request_callback_from_py(py, callback)?;
+        let request_id = DataActor::request_instruments(
+            self.inner_mut(),
+            venue,
+            start,
+            end,
+            client_id,
+            params,
+            callback,
+        )
+        .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_book_snapshot")]
-    #[pyo3(signature = (instrument_id, depth=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, depth=None, client_id=None, params=None, callback=None))]
     fn py_request_book_snapshot(
         &mut self,
         py: Python<'_>,
@@ -2269,9 +2309,11 @@ impl PyDataActor {
         depth: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let depth = depth.and_then(NonZeroUsize::new);
 
         let request_id = DataActor::request_book_snapshot(
@@ -2280,13 +2322,14 @@ impl PyDataActor {
             depth,
             client_id,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_book_deltas")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_request_book_deltas(
         &mut self,
@@ -2297,9 +2340,11 @@ impl PyDataActor {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_book_deltas(
             self.inner_mut(),
@@ -2309,13 +2354,14 @@ impl PyDataActor {
             limit,
             client_id,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_book_depth")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, depth=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, depth=None, client_id=None, params=None, callback=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_request_book_depth(
         &mut self,
@@ -2327,9 +2373,11 @@ impl PyDataActor {
         depth: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let limit = limit.and_then(NonZeroUsize::new);
         let depth = depth.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_book_depth(
@@ -2341,13 +2389,14 @@ impl PyDataActor {
             depth,
             client_id,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_quotes")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_request_quotes(
         &mut self,
@@ -2358,9 +2407,11 @@ impl PyDataActor {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_quotes(
             self.inner_mut(),
@@ -2370,13 +2421,14 @@ impl PyDataActor {
             limit,
             client_id,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_trades")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_request_trades(
         &mut self,
@@ -2387,9 +2439,11 @@ impl PyDataActor {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_trades(
             self.inner_mut(),
@@ -2399,13 +2453,14 @@ impl PyDataActor {
             limit,
             client_id,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_funding_rates")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_request_funding_rates(
         &mut self,
@@ -2416,9 +2471,11 @@ impl PyDataActor {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_funding_rates(
             self.inner_mut(),
@@ -2428,13 +2485,14 @@ impl PyDataActor {
             limit,
             client_id,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_bars")]
-    #[pyo3(signature = (bar_type, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (bar_type, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_request_bars(
         &mut self,
@@ -2445,9 +2503,11 @@ impl PyDataActor {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params = dict_to_params(py, params)?;
+        let callback = request_callback_from_py(py, callback)?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_bars(
             self.inner_mut(),
@@ -2457,6 +2517,7 @@ impl PyDataActor {
             limit,
             client_id,
             params,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -2857,7 +2857,7 @@ mod tests {
         enums::{
             AggressorSide, BookType, GreeksConvention, InstrumentCloseType, MarketStatusAction,
         },
-        identifiers::{ClientId, OptionSeriesId, TradeId, TraderId, Venue},
+        identifiers::{ActorId, ClientId, OptionSeriesId, TradeId, TraderId, Venue},
         instruments::{CurrencyPair, InstrumentAny, stubs::audusd_sim},
         orderbook::OrderBook,
         types::{Price, Quantity},
@@ -2870,7 +2870,7 @@ mod tests {
     use rstest::{fixture, rstest};
     use ustr::Ustr;
 
-    use super::PyDataActor;
+    use super::{DataActorConfig, PyDataActor, request_callback_from_py};
     use crate::{
         actor::DataActor,
         cache::Cache,
@@ -2880,7 +2880,9 @@ mod tests {
         live::runner::replace_system_command_sender,
         messages::{
             SystemCommand,
-            data::{BarsResponse, CustomDataResponse, QuotesResponse, TradesResponse},
+            data::{
+                BarsResponse, CustomDataResponse, DataResponse, QuotesResponse, TradesResponse,
+            },
             system::{
                 QueueCondition, QueueState, QueueStateChanged, SocketState, SocketStateChanged,
             },
@@ -5238,6 +5240,134 @@ class IndicatorEventActor:
                 3
             );
             assert_eq!(actual, data);
+        });
+    }
+
+    #[rstest]
+    fn test_python_request_callback_runs_after_response_handler(
+        clock: Rc<RefCell<TestClock>>,
+        cache: Rc<RefCell<Cache>>,
+        trader_id: TraderId,
+        client_id: ClientId,
+        data_type: DataType,
+    ) {
+        pyo3::Python::initialize();
+
+        Python::attach(|py| {
+            let py_actor = create_tracking_python_actor(py).unwrap();
+            let locals = PyDict::new(py);
+            locals.set_item("actor", &py_actor).unwrap();
+            let callback = py
+                .eval(
+                    c_str!(
+                        "lambda request_id, actor=actor: actor._record('request_callback', request_id)"
+                    ),
+                    None,
+                    Some(&locals),
+                )
+                .unwrap()
+                .unbind();
+
+            *get_message_bus().borrow_mut() = MessageBus::default();
+            let config = DataActorConfig {
+                actor_id: Some(ActorId::from("PY-REQUEST-CALLBACK-ACTOR")),
+                ..Default::default()
+            };
+            let mut rust_actor = PyDataActor::new(Some(config));
+            rust_actor.set_python_instance(py_actor.clone_ref(py));
+            rust_actor.register(trader_id, clock, cache).unwrap();
+            rust_actor.register_in_global_registries();
+
+            let request_id = rust_actor
+                .py_request_data(
+                    py,
+                    data_type.clone(),
+                    client_id,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(callback),
+                )
+                .unwrap();
+            let request_uuid = UUID4::from_str(&request_id).unwrap();
+            let response = DataResponse::Data(CustomDataResponse::new(
+                request_uuid,
+                client_id,
+                None,
+                data_type,
+                Vec::<CustomData>::new(),
+                None,
+                None,
+                UnixNanos::default(),
+                None,
+            ));
+
+            msgbus::send_response(&request_uuid, &response);
+
+            let call_names = py
+                .eval(
+                    c_str!("[name for name, _ in actor.calls]"),
+                    None,
+                    Some(&locals),
+                )
+                .unwrap()
+                .extract::<Vec<String>>()
+                .unwrap();
+            let callback_id = py_actor
+                .call_method1(py, "last_call_args", ("request_callback",))
+                .unwrap()
+                .bind(py)
+                .get_item(0)
+                .unwrap()
+                .extract::<String>()
+                .unwrap();
+
+            assert_eq!(call_names, vec!["on_historical_data", "request_callback"]);
+            assert_eq!(callback_id, request_id);
+
+            msgbus::send_response(&request_uuid, &response);
+            assert_eq!(
+                python_method_call_count(&py_actor, py, "request_callback"),
+                1
+            );
+        });
+    }
+
+    #[rstest]
+    fn test_python_request_callback_error_does_not_escape() {
+        pyo3::Python::initialize();
+
+        Python::attach(|py| {
+            let locals = PyDict::new(py);
+            py.run(
+                c_str!(
+                    r#"
+events = []
+
+def callback(request_id, events=events):
+    events.append(request_id)
+    raise RuntimeError("callback failure")
+"#
+                ),
+                None,
+                Some(&locals),
+            )
+            .unwrap();
+            let callback = locals.get_item("callback").unwrap().unbind();
+            let callback = request_callback_from_py(py, Some(callback))
+                .unwrap()
+                .unwrap();
+            let request_id = UUID4::new();
+
+            callback(request_id);
+
+            let events = locals
+                .get_item("events")
+                .unwrap()
+                .extract::<Vec<String>>()
+                .unwrap();
+            assert_eq!(events, vec![request_id.to_string()]);
         });
     }
 

--- a/crates/testkit/src/testers/data/actor.rs
+++ b/crates/testkit/src/testers/data/actor.rs
@@ -80,6 +80,7 @@ impl DataActor for DataTester {
                     None,
                     client_id,
                     request_params.clone(),
+                    None,
                 );
             }
         }
@@ -183,6 +184,7 @@ impl DataActor for DataTester {
                     None,
                     client_id,
                     request_params.clone(),
+                    None,
                 ) {
                     log::error!("Failed to request quotes for {instrument_id}: {e}");
                 }
@@ -202,6 +204,7 @@ impl DataActor for DataTester {
                         .transpose()?,
                     client_id,
                     request_params.clone(),
+                    None,
                 );
             }
 
@@ -218,6 +221,7 @@ impl DataActor for DataTester {
                     None,
                     client_id,
                     request_params.clone(),
+                    None,
                 ) {
                     log::error!("Failed to request trades for {instrument_id}: {e}");
                 }
@@ -234,6 +238,7 @@ impl DataActor for DataTester {
                     None,
                     client_id,
                     request_params.clone(),
+                    None,
                 ) {
                     log::error!("Failed to request funding rates for {instrument_id}: {e}");
                 }
@@ -258,6 +263,7 @@ impl DataActor for DataTester {
                         None,
                         client_id,
                         request_params.clone(),
+                        None,
                     ) {
                         log::error!("Failed to request bars for {bar_type}: {e}");
                     }

--- a/crates/trading/src/python/strategy.rs
+++ b/crates/trading/src/python/strategy.rs
@@ -39,6 +39,7 @@ use nautilus_common::{
     enums::ComponentState,
     messages::system::{QueueStateChanged, SocketStateChanged},
     python::{
+        actor::request_callback_from_py,
         cache::PyCache,
         clock::PyClock,
         config_error_to_pyvalue_err,
@@ -3028,7 +3029,8 @@ impl PyStrategy {
     }
 
     #[pyo3(name = "request_data")]
-    #[pyo3(signature = (data_type, client_id, start=None, end=None, limit=None, params=None))]
+    #[pyo3(signature = (data_type, client_id, start=None, end=None, limit=None, params=None, callback=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_request_data(
         &mut self,
         data_type: DataType,
@@ -3037,6 +3039,7 @@ impl PyStrategy {
         end: Option<Timestamp>,
         limit: Option<usize>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3045,6 +3048,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_data(
             self.inner_mut(),
@@ -3054,13 +3058,14 @@ impl PyStrategy {
             end,
             limit,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_instrument")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, client_id=None, params=None, callback=None))]
     fn py_request_instrument(
         &mut self,
         instrument_id: InstrumentId,
@@ -3068,6 +3073,7 @@ impl PyStrategy {
         end: Option<Timestamp>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3076,6 +3082,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let request_id = DataActor::request_instrument(
             self.inner_mut(),
             instrument_id,
@@ -3083,13 +3090,14 @@ impl PyStrategy {
             end,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_instruments")]
-    #[pyo3(signature = (venue=None, start=None, end=None, client_id=None, params=None))]
+    #[pyo3(signature = (venue=None, start=None, end=None, client_id=None, params=None, callback=None))]
     fn py_request_instruments(
         &mut self,
         venue: Option<Venue>,
@@ -3097,6 +3105,7 @@ impl PyStrategy {
         end: Option<Timestamp>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3105,6 +3114,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let request_id = DataActor::request_instruments(
             self.inner_mut(),
             venue,
@@ -3112,19 +3122,21 @@ impl PyStrategy {
             end,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_book_snapshot")]
-    #[pyo3(signature = (instrument_id, depth=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, depth=None, client_id=None, params=None, callback=None))]
     fn py_request_book_snapshot(
         &mut self,
         instrument_id: InstrumentId,
         depth: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3133,6 +3145,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let depth = depth.and_then(NonZeroUsize::new);
 
         let request_id = DataActor::request_book_snapshot(
@@ -3141,13 +3154,15 @@ impl PyStrategy {
             depth,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_book_deltas")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_request_book_deltas(
         &mut self,
         instrument_id: InstrumentId,
@@ -3156,6 +3171,7 @@ impl PyStrategy {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3164,6 +3180,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_book_deltas(
             self.inner_mut(),
@@ -3173,13 +3190,14 @@ impl PyStrategy {
             limit,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_book_depth")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, depth=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, depth=None, client_id=None, params=None, callback=None))]
     #[expect(clippy::too_many_arguments)]
     fn py_request_book_depth(
         &mut self,
@@ -3190,6 +3208,7 @@ impl PyStrategy {
         depth: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3198,6 +3217,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let limit = limit.and_then(NonZeroUsize::new);
         let depth = depth.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_book_depth(
@@ -3209,13 +3229,15 @@ impl PyStrategy {
             depth,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_quotes")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_request_quotes(
         &mut self,
         instrument_id: InstrumentId,
@@ -3224,6 +3246,7 @@ impl PyStrategy {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3232,6 +3255,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_quotes(
             self.inner_mut(),
@@ -3241,13 +3265,15 @@ impl PyStrategy {
             limit,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_trades")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_request_trades(
         &mut self,
         instrument_id: InstrumentId,
@@ -3256,6 +3282,7 @@ impl PyStrategy {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3264,6 +3291,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_trades(
             self.inner_mut(),
@@ -3273,13 +3301,15 @@ impl PyStrategy {
             limit,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_funding_rates")]
-    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (instrument_id, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_request_funding_rates(
         &mut self,
         instrument_id: InstrumentId,
@@ -3288,6 +3318,7 @@ impl PyStrategy {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3296,6 +3327,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_funding_rates(
             self.inner_mut(),
@@ -3305,13 +3337,15 @@ impl PyStrategy {
             limit,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())
     }
 
     #[pyo3(name = "request_bars")]
-    #[pyo3(signature = (bar_type, start=None, end=None, limit=None, client_id=None, params=None))]
+    #[pyo3(signature = (bar_type, start=None, end=None, limit=None, client_id=None, params=None, callback=None))]
+    #[expect(clippy::too_many_arguments)]
     fn py_request_bars(
         &mut self,
         bar_type: BarType,
@@ -3320,6 +3354,7 @@ impl PyStrategy {
         limit: Option<usize>,
         client_id: Option<ClientId>,
         params: Option<Py<PyDict>>,
+        callback: Option<Py<PyAny>>,
     ) -> PyResult<String> {
         self.ensure_registered_for_data()?;
         let params_map = Python::attach(|py| -> PyResult<Option<Params>> {
@@ -3328,6 +3363,7 @@ impl PyStrategy {
                 None => Ok(None),
             }
         })?;
+        let callback = Python::attach(|py| request_callback_from_py(py, callback))?;
         let limit = limit.and_then(NonZeroUsize::new);
         let request_id = DataActor::request_bars(
             self.inner_mut(),
@@ -3337,6 +3373,7 @@ impl PyStrategy {
             limit,
             client_id,
             params_map,
+            callback,
         )
         .map_err(to_pyvalue_err)?;
         Ok(request_id.to_string())

--- a/python/nautilus_trader/common/__init__.pyi
+++ b/python/nautilus_trader/common/__init__.pyi
@@ -953,6 +953,7 @@ class DataActor:
         end: datetime.datetime | None = None,
         limit: int | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_instrument(
         self,
@@ -961,6 +962,7 @@ class DataActor:
         end: datetime.datetime | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_instruments(
         self,
@@ -969,6 +971,7 @@ class DataActor:
         end: datetime.datetime | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_book_snapshot(
         self,
@@ -976,6 +979,7 @@ class DataActor:
         depth: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_book_deltas(
         self,
@@ -985,6 +989,7 @@ class DataActor:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_book_depth(
         self,
@@ -995,6 +1000,7 @@ class DataActor:
         depth: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_quotes(
         self,
@@ -1004,6 +1010,7 @@ class DataActor:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_trades(
         self,
@@ -1013,6 +1020,7 @@ class DataActor:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_funding_rates(
         self,
@@ -1022,6 +1030,7 @@ class DataActor:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_bars(
         self,
@@ -1031,6 +1040,7 @@ class DataActor:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def reconnect_socket(self, client_id: model.ClientId, endpoint: str) -> None: ...
     def on_historical_data(self, data: typing.Any) -> None: ...

--- a/python/nautilus_trader/trading/__init__.pyi
+++ b/python/nautilus_trader/trading/__init__.pyi
@@ -871,6 +871,7 @@ class Strategy:
         end: datetime.datetime | None = None,
         limit: int | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_instrument(
         self,
@@ -879,6 +880,7 @@ class Strategy:
         end: datetime.datetime | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_instruments(
         self,
@@ -887,6 +889,7 @@ class Strategy:
         end: datetime.datetime | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_book_snapshot(
         self,
@@ -894,6 +897,7 @@ class Strategy:
         depth: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_book_deltas(
         self,
@@ -903,6 +907,7 @@ class Strategy:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_book_depth(
         self,
@@ -913,6 +918,7 @@ class Strategy:
         depth: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_quotes(
         self,
@@ -922,6 +928,7 @@ class Strategy:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_trades(
         self,
@@ -931,6 +938,7 @@ class Strategy:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_funding_rates(
         self,
@@ -940,6 +948,7 @@ class Strategy:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def request_bars(
         self,
@@ -949,6 +958,7 @@ class Strategy:
         limit: int | None = None,
         client_id: model.ClientId | None = None,
         params: dict | None = None,
+        callback: typing.Any | None = None,
     ) -> str: ...
     def reconnect_socket(self, client_id: model.ClientId, endpoint: str) -> None: ...
 

--- a/python/tests/unit/common/test_actor.py
+++ b/python/tests/unit/common/test_actor.py
@@ -568,28 +568,6 @@ class HistoricalRequestProbeActor(TestActor):
         }
 
 
-class RequestCallbackProbeActor(TestActor):
-    events = []
-    callback_ids = []
-    request_id = None
-
-    def on_start(self):
-        type(self).events = []
-        type(self).callback_ids = []
-        type(self).request_id = self.request_data(
-            DataType("TestData"),
-            ClientId("BACKTEST"),
-            callback=self.on_request_complete,
-        )
-
-    def on_historical_data(self, data):
-        type(self).events.append("historical_data")
-
-    def on_request_complete(self, request_id):
-        type(self).events.append("callback")
-        type(self).callback_ids.append(request_id)
-
-
 class InvalidRequestCallbackProbeActor(TestActor):
     error = None
     historical_calls = 0
@@ -608,25 +586,6 @@ class InvalidRequestCallbackProbeActor(TestActor):
 
     def on_historical_data(self, data):
         type(self).historical_calls += 1
-
-
-class RaisingRequestCallbackProbeActor(TestActor):
-    events = []
-
-    def on_start(self):
-        type(self).events = []
-        self.request_data(
-            DataType("TestData"),
-            ClientId("BACKTEST"),
-            callback=self.on_request_complete,
-        )
-
-    def on_historical_data(self, data):
-        type(self).events.append("historical_data")
-
-    def on_request_complete(self, request_id):
-        type(self).events.append("callback")
-        raise RuntimeError("callback failure")
 
 
 def test_data_actor_pre_registration_surface(actor):
@@ -1025,26 +984,6 @@ def test_data_actor_historical_requests_accept_datetimes_when_registered(request
         engine.dispose()
 
 
-def test_data_actor_request_callback_runs_after_response_handler():
-    engine = BacktestEngine(BacktestEngineConfig(bypass_logging=True, run_analysis=False))
-    engine.add_actor_from_config(
-        ImportableActorConfig(
-            actor_path="tests.unit.common.test_actor:RequestCallbackProbeActor",
-            config_path="tests.unit.common.actor:TestActorConfig",
-            config={"actor_id": "REQUEST-CALLBACK-ACTOR"},
-        ),
-    )
-
-    try:
-        engine.run()
-
-        assert RequestCallbackProbeActor.events == ["historical_data", "callback"]
-        assert RequestCallbackProbeActor.callback_ids == [RequestCallbackProbeActor.request_id]
-        assert UUID4.from_str(RequestCallbackProbeActor.request_id)
-    finally:
-        engine.dispose()
-
-
 def test_data_actor_request_rejects_non_callable_callback_without_sending():
     engine = BacktestEngine(BacktestEngineConfig(bypass_logging=True, run_analysis=False))
     engine.add_actor_from_config(
@@ -1060,24 +999,6 @@ def test_data_actor_request_rejects_non_callable_callback_without_sending():
 
         assert InvalidRequestCallbackProbeActor.error == "callback must be callable"
         assert InvalidRequestCallbackProbeActor.historical_calls == 0
-    finally:
-        engine.dispose()
-
-
-def test_data_actor_request_callback_error_does_not_escape_dispatch():
-    engine = BacktestEngine(BacktestEngineConfig(bypass_logging=True, run_analysis=False))
-    engine.add_actor_from_config(
-        ImportableActorConfig(
-            actor_path="tests.unit.common.test_actor:RaisingRequestCallbackProbeActor",
-            config_path="tests.unit.common.actor:TestActorConfig",
-            config={"actor_id": "RAISING-REQUEST-CALLBACK-ACTOR"},
-        ),
-    )
-
-    try:
-        engine.run()
-
-        assert RaisingRequestCallbackProbeActor.events == ["historical_data", "callback"]
     finally:
         engine.dispose()
 

--- a/python/tests/unit/common/test_actor.py
+++ b/python/tests/unit/common/test_actor.py
@@ -207,11 +207,11 @@ CALLBACK_SIGNATURES = (
 )
 
 DATA_SUBSCRIPTION_PARAMETERS = ("data_type", "client_id", "params")
-DATA_REQUEST_PARAMETERS = ("data_type", "client_id", "start", "end", "limit", "params")
+DATA_REQUEST_PARAMETERS = ("data_type", "client_id", "start", "end", "limit", "params", "callback")
 SIGNAL_SUBSCRIPTION_PARAMETERS = ("name", "priority")
 SIGNAL_UNSUBSCRIBE_PARAMETERS = ("name",)
 VENUE_SUBSCRIPTION_PARAMETERS = ("venue", "client_id", "params")
-VENUE_REQUEST_PARAMETERS = ("venue", "start", "end", "client_id", "params")
+VENUE_REQUEST_PARAMETERS = ("venue", "start", "end", "client_id", "params", "callback")
 INSTRUMENT_SUBSCRIPTION_PARAMETERS = ("instrument_id", "client_id", "params")
 BOOK_DELTAS_SUBSCRIPTION_PARAMETERS = (
     "instrument_id",
@@ -246,9 +246,24 @@ OPTION_CHAIN_SUBSCRIPTION_PARAMETERS = (
     "client_id",
     "params",
 )
-INSTRUMENT_REQUEST_PARAMETERS = ("instrument_id", "start", "end", "client_id", "params")
-BOOK_SNAPSHOT_REQUEST_PARAMETERS = ("instrument_id", "depth", "client_id", "params")
-BOOK_DELTAS_REQUEST_PARAMETERS = ("instrument_id", "start", "end", "limit", "client_id", "params")
+INSTRUMENT_REQUEST_PARAMETERS = (
+    "instrument_id",
+    "start",
+    "end",
+    "client_id",
+    "params",
+    "callback",
+)
+BOOK_SNAPSHOT_REQUEST_PARAMETERS = ("instrument_id", "depth", "client_id", "params", "callback")
+BOOK_DELTAS_REQUEST_PARAMETERS = (
+    "instrument_id",
+    "start",
+    "end",
+    "limit",
+    "client_id",
+    "params",
+    "callback",
+)
 BOOK_DEPTH_REQUEST_PARAMETERS = (
     "instrument_id",
     "start",
@@ -257,6 +272,7 @@ BOOK_DEPTH_REQUEST_PARAMETERS = (
     "depth",
     "client_id",
     "params",
+    "callback",
 )
 INSTRUMENT_HISTORY_REQUEST_PARAMETERS = (
     "instrument_id",
@@ -265,8 +281,9 @@ INSTRUMENT_HISTORY_REQUEST_PARAMETERS = (
     "limit",
     "client_id",
     "params",
+    "callback",
 )
-BAR_REQUEST_PARAMETERS = ("bar_type", "start", "end", "limit", "client_id", "params")
+BAR_REQUEST_PARAMETERS = ("bar_type", "start", "end", "limit", "client_id", "params", "callback")
 OPTION_CHAIN_UNSUBSCRIBE_PARAMETERS = ("series_id", "client_id")
 PUBLISH_DATA_PARAMETERS = ("data_type", "data")
 PUBLISH_SIGNAL_PARAMETERS = ("name", "value", "ts_event")
@@ -549,6 +566,67 @@ class HistoricalRequestProbeActor(TestActor):
                 params={"kind": "bars"},
             ),
         }
+
+
+class RequestCallbackProbeActor(TestActor):
+    events = []
+    callback_ids = []
+    request_id = None
+
+    def on_start(self):
+        type(self).events = []
+        type(self).callback_ids = []
+        type(self).request_id = self.request_data(
+            DataType("TestData"),
+            ClientId("BACKTEST"),
+            callback=self.on_request_complete,
+        )
+
+    def on_historical_data(self, data):
+        type(self).events.append("historical_data")
+
+    def on_request_complete(self, request_id):
+        type(self).events.append("callback")
+        type(self).callback_ids.append(request_id)
+
+
+class InvalidRequestCallbackProbeActor(TestActor):
+    error = None
+    historical_calls = 0
+
+    def on_start(self):
+        type(self).error = None
+        type(self).historical_calls = 0
+        try:
+            self.request_data(
+                DataType("TestData"),
+                ClientId("BACKTEST"),
+                callback=1,
+            )
+        except TypeError as e:
+            type(self).error = str(e)
+
+    def on_historical_data(self, data):
+        type(self).historical_calls += 1
+
+
+class RaisingRequestCallbackProbeActor(TestActor):
+    events = []
+
+    def on_start(self):
+        type(self).events = []
+        self.request_data(
+            DataType("TestData"),
+            ClientId("BACKTEST"),
+            callback=self.on_request_complete,
+        )
+
+    def on_historical_data(self, data):
+        type(self).events.append("historical_data")
+
+    def on_request_complete(self, request_id):
+        type(self).events.append("callback")
+        raise RuntimeError("callback failure")
 
 
 def test_data_actor_pre_registration_surface(actor):
@@ -943,6 +1021,63 @@ def test_data_actor_historical_requests_accept_datetimes_when_registered(request
 
         for request_id in HistoricalRequestProbeActor.observed_request_ids.values():
             assert UUID4.from_str(request_id)
+    finally:
+        engine.dispose()
+
+
+def test_data_actor_request_callback_runs_after_response_handler():
+    engine = BacktestEngine(BacktestEngineConfig(bypass_logging=True, run_analysis=False))
+    engine.add_actor_from_config(
+        ImportableActorConfig(
+            actor_path="tests.unit.common.test_actor:RequestCallbackProbeActor",
+            config_path="tests.unit.common.actor:TestActorConfig",
+            config={"actor_id": "REQUEST-CALLBACK-ACTOR"},
+        ),
+    )
+
+    try:
+        engine.run()
+
+        assert RequestCallbackProbeActor.events == ["historical_data", "callback"]
+        assert RequestCallbackProbeActor.callback_ids == [RequestCallbackProbeActor.request_id]
+        assert UUID4.from_str(RequestCallbackProbeActor.request_id)
+    finally:
+        engine.dispose()
+
+
+def test_data_actor_request_rejects_non_callable_callback_without_sending():
+    engine = BacktestEngine(BacktestEngineConfig(bypass_logging=True, run_analysis=False))
+    engine.add_actor_from_config(
+        ImportableActorConfig(
+            actor_path="tests.unit.common.test_actor:InvalidRequestCallbackProbeActor",
+            config_path="tests.unit.common.actor:TestActorConfig",
+            config={"actor_id": "INVALID-REQUEST-CALLBACK-ACTOR"},
+        ),
+    )
+
+    try:
+        engine.run()
+
+        assert InvalidRequestCallbackProbeActor.error == "callback must be callable"
+        assert InvalidRequestCallbackProbeActor.historical_calls == 0
+    finally:
+        engine.dispose()
+
+
+def test_data_actor_request_callback_error_does_not_escape_dispatch():
+    engine = BacktestEngine(BacktestEngineConfig(bypass_logging=True, run_analysis=False))
+    engine.add_actor_from_config(
+        ImportableActorConfig(
+            actor_path="tests.unit.common.test_actor:RaisingRequestCallbackProbeActor",
+            config_path="tests.unit.common.actor:TestActorConfig",
+            config={"actor_id": "RAISING-REQUEST-CALLBACK-ACTOR"},
+        ),
+    )
+
+    try:
+        engine.run()
+
+        assert RaisingRequestCallbackProbeActor.events == ["historical_data", "callback"]
     finally:
         engine.dispose()
 

--- a/python/tests/unit/trading/test_trading.py
+++ b/python/tests/unit/trading/test_trading.py
@@ -204,6 +204,28 @@ class HistoricalRequestProbeStrategy(Strategy):
         }
 
 
+class RequestCallbackProbeStrategy(Strategy):
+    events = []
+    callback_ids = []
+    request_id = None
+
+    def on_start(self):
+        type(self).events = []
+        type(self).callback_ids = []
+        type(self).request_id = self.request_data(
+            DataType("TestData"),
+            ClientId("BACKTEST"),
+            callback=self.on_request_complete,
+        )
+
+    def on_historical_data(self, data):
+        type(self).events.append("historical_data")
+
+    def on_request_complete(self, request_id):
+        type(self).events.append("callback")
+        type(self).callback_ids.append(request_id)
+
+
 def test_strategy_default_construction():
     strategy = Strategy()
 
@@ -1063,9 +1085,9 @@ def test_strategy_portfolio_aggregates_multiple_venues_atomically():
 
 LIFECYCLE_METHODS = ["start", "stop", "resume", "reset", "dispose", "degrade", "fault"]
 DATA_SUBSCRIPTION_PARAMETERS = ("data_type", "client_id", "params")
-DATA_REQUEST_PARAMETERS = ("data_type", "client_id", "start", "end", "limit", "params")
+DATA_REQUEST_PARAMETERS = ("data_type", "client_id", "start", "end", "limit", "params", "callback")
 VENUE_SUBSCRIPTION_PARAMETERS = ("venue", "client_id", "params")
-VENUE_REQUEST_PARAMETERS = ("venue", "start", "end", "client_id", "params")
+VENUE_REQUEST_PARAMETERS = ("venue", "start", "end", "client_id", "params", "callback")
 INSTRUMENT_SUBSCRIPTION_PARAMETERS = ("instrument_id", "client_id", "params")
 BOOK_DELTAS_SUBSCRIPTION_PARAMETERS = (
     "instrument_id",
@@ -1100,9 +1122,24 @@ OPTION_CHAIN_SUBSCRIPTION_PARAMETERS = (
     "params",
 )
 OPTION_CHAIN_UNSUBSCRIBE_PARAMETERS = ("series_id", "client_id")
-INSTRUMENT_REQUEST_PARAMETERS = ("instrument_id", "start", "end", "client_id", "params")
-BOOK_SNAPSHOT_REQUEST_PARAMETERS = ("instrument_id", "depth", "client_id", "params")
-BOOK_DELTAS_REQUEST_PARAMETERS = ("instrument_id", "start", "end", "limit", "client_id", "params")
+INSTRUMENT_REQUEST_PARAMETERS = (
+    "instrument_id",
+    "start",
+    "end",
+    "client_id",
+    "params",
+    "callback",
+)
+BOOK_SNAPSHOT_REQUEST_PARAMETERS = ("instrument_id", "depth", "client_id", "params", "callback")
+BOOK_DELTAS_REQUEST_PARAMETERS = (
+    "instrument_id",
+    "start",
+    "end",
+    "limit",
+    "client_id",
+    "params",
+    "callback",
+)
 BOOK_DEPTH_REQUEST_PARAMETERS = (
     "instrument_id",
     "start",
@@ -1111,6 +1148,7 @@ BOOK_DEPTH_REQUEST_PARAMETERS = (
     "depth",
     "client_id",
     "params",
+    "callback",
 )
 INSTRUMENT_HISTORY_REQUEST_PARAMETERS = (
     "instrument_id",
@@ -1119,8 +1157,9 @@ INSTRUMENT_HISTORY_REQUEST_PARAMETERS = (
     "limit",
     "client_id",
     "params",
+    "callback",
 )
-BAR_REQUEST_PARAMETERS = ("bar_type", "start", "end", "limit", "client_id", "params")
+BAR_REQUEST_PARAMETERS = ("bar_type", "start", "end", "limit", "client_id", "params", "callback")
 SUBMIT_ORDER_PARAMETERS = ("order", "position_id", "client_id", "params")
 SUBMIT_ORDER_LIST_PARAMETERS = ("order_list", "position_id", "client_id", "params")
 MODIFY_ORDER_PARAMETERS = (
@@ -1588,6 +1627,28 @@ def test_strategy_historical_requests_accept_datetimes_when_registered(request_t
 
         for request_id in HistoricalRequestProbeStrategy.observed_request_ids.values():
             assert UUID4.from_str(request_id)
+    finally:
+        engine.dispose()
+
+
+def test_strategy_request_callback_runs_after_response_handler():
+    engine = BacktestEngine(BacktestEngineConfig(bypass_logging=True, run_analysis=False))
+    engine.add_strategy_from_config(
+        ImportableStrategyConfig(
+            strategy_path="tests.unit.trading.test_trading:RequestCallbackProbeStrategy",
+            config_path="nautilus_trader.trading:StrategyConfig",
+            config={},
+        ),
+    )
+
+    try:
+        engine.run()
+
+        assert RequestCallbackProbeStrategy.events == ["historical_data", "callback"]
+        assert RequestCallbackProbeStrategy.callback_ids == [
+            RequestCallbackProbeStrategy.request_id,
+        ]
+        assert UUID4.from_str(RequestCallbackProbeStrategy.request_id)
     finally:
         engine.dispose()
 

--- a/python/tests/unit/trading/test_trading.py
+++ b/python/tests/unit/trading/test_trading.py
@@ -204,28 +204,6 @@ class HistoricalRequestProbeStrategy(Strategy):
         }
 
 
-class RequestCallbackProbeStrategy(Strategy):
-    events = []
-    callback_ids = []
-    request_id = None
-
-    def on_start(self):
-        type(self).events = []
-        type(self).callback_ids = []
-        type(self).request_id = self.request_data(
-            DataType("TestData"),
-            ClientId("BACKTEST"),
-            callback=self.on_request_complete,
-        )
-
-    def on_historical_data(self, data):
-        type(self).events.append("historical_data")
-
-    def on_request_complete(self, request_id):
-        type(self).events.append("callback")
-        type(self).callback_ids.append(request_id)
-
-
 def test_strategy_default_construction():
     strategy = Strategy()
 
@@ -1627,28 +1605,6 @@ def test_strategy_historical_requests_accept_datetimes_when_registered(request_t
 
         for request_id in HistoricalRequestProbeStrategy.observed_request_ids.values():
             assert UUID4.from_str(request_id)
-    finally:
-        engine.dispose()
-
-
-def test_strategy_request_callback_runs_after_response_handler():
-    engine = BacktestEngine(BacktestEngineConfig(bypass_logging=True, run_analysis=False))
-    engine.add_strategy_from_config(
-        ImportableStrategyConfig(
-            strategy_path="tests.unit.trading.test_trading:RequestCallbackProbeStrategy",
-            config_path="nautilus_trader.trading:StrategyConfig",
-            config={},
-        ),
-    )
-
-    try:
-        engine.run()
-
-        assert RequestCallbackProbeStrategy.events == ["historical_data", "callback"]
-        assert RequestCallbackProbeStrategy.callback_ids == [
-            RequestCallbackProbeStrategy.request_id,
-        ]
-        assert UUID4.from_str(RequestCallbackProbeStrategy.request_id)
     finally:
         engine.dispose()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->

### Summary

Actors and strategies can now pass an optional callback to every historical data request method.
The callback runs once after the matching response handler completes and receives the same string
request ID returned to Python. Requests without callbacks keep their existing behavior.

The implementation uses the actor's existing pending‑request map and one‑shot message bus routing.
It does not add callback fields to request messages or change the data engine.

### What changed

- [`DataActor`](../nautilus_trader/crates/common/src/actor/data_actor.rs) stores each optional
  callback by request ID after response handler registration and before request dispatch. Response
  routing removes the entry and invokes the callback after the typed historical handler. Reset
  clears any outstanding entries without invoking them.
- [`PyDataActor`](../nautilus_trader/crates/common/src/python/actor.rs) and
  [`PyStrategy`](../nautilus_trader/crates/trading/src/python/strategy.rs) expose `callback=None` as
  the final keyword on all 10 historical request methods available on `develop`. Non‑callable
  values raise `TypeError` before dispatch.
  Callback exceptions are logged and do not escape message bus dispatch.
- Generated [`common`](../nautilus_trader/python/nautilus_trader/common/__init__.pyi) and
  [`trading`](../nautilus_trader/python/nautilus_trader/trading/__init__.pyi) stubs include the new
  keyword.
- Rust tests cover custom data, typed quotes, concurrent out‑of‑order responses, exact once‑only
  delivery, and reset cleanup. Python tests cover actor and strategy ordering, exact returned IDs,
  invalid callbacks, and callback exceptions.

```mermaid
sequenceDiagram
    participant Caller
    participant DataActor
    participant Core as DataActorCore
    participant Bus as Message bus
    Caller->>DataActor: request_*(callback)
    DataActor->>Core: request_*(handler, callback)
    Core->>Bus: register response handler
    Core->>Core: store callback by request ID
    Core->>Bus: send request
    Bus-->>DataActor: dispatch correlated response
    DataActor->>DataActor: run historical response handler
    DataActor->>Core: finish_response(request ID)
    Core-->>Caller: callback(request ID)
```

### Related issues or PRs

https://github.com/nautechsystems/nautilus_trader/issues/4668

### Verification

Tests were not rerun after cherry‑picking the change onto `develop`; CI will run the branch's test
matrix.
