### PR TITLE
Fix macOS Python allocator compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ DEX), traditional markets (FX, equities, futures, options), and betting exchange
 
 ## Features
 
-- **Fast**: Rust core with the [mimalloc](https://github.com/microsoft/mimalloc)\* allocator and asynchronous networking using [tokio](https://crates.io/crates/tokio).
+- **Fast**: Rust core with the [mimalloc](https://github.com/microsoft/mimalloc) allocator and asynchronous networking using [tokio](https://crates.io/crates/tokio).
 - **Reliable**: Type- and thread-safety backed by Rust, with optional Redis-backed state persistence.
 - **Portable**: Runs on Linux, macOS, and Windows. Deploy using Docker.
 - **Flexible**: Modular adapters integrate any REST API or WebSocket feed.
@@ -61,8 +61,6 @@ DEX), traditional markets (FX, equities, futures, options), and betting exchange
 - **Live**: Identical strategy implementations between research and live deployment.
 - **Multi-venue**: Run market-making and cross-venue strategies across multiple venues simultaneously.
 - **AI Training**: Engine fast enough to train AI trading agents (RL/ES).
-
-*\* Python wheels use mimalloc on Linux and Windows. macOS wheels use the system allocator for PyArrow compatibility.*
 
 ![nautilus](https://github.com/nautechsystems/nautilus_trader/raw/develop/assets/nautilus-art.png "nautilus")
 

--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -157,12 +157,21 @@ nautilus-polymarket = { workspace = true, features = ["python"] }
 nautilus-sandbox = { workspace = true, features = ["python"] }
 nautilus-tardis = { workspace = true, features = ["python", "replay"] }
 
-# local_dynamic_tls avoids exhausting static TLS space when the extension is dlopen'd
+pyo3 = { workspace = true }
+pyo3-stub-gen = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+# v2 avoids conflicting with PyArrow's independent mimalloc instance on macOS;
+# remove it once libmimalloc-sys bundles native mimalloc v3.4.4 or later
+mimalloc = { workspace = true, features = [
+  "local_dynamic_tls",
+  "v2",
+], optional = true }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 mimalloc = { workspace = true, features = [
   "local_dynamic_tls",
 ], optional = true }
-pyo3 = { workspace = true }
-pyo3-stub-gen = { workspace = true }
 
 # Run with `cargo run --bin python-stub-gen`
 [[bin]]

--- a/crates/pyo3/src/lib.rs
+++ b/crates/pyo3/src/lib.rs
@@ -39,7 +39,7 @@
 //! - `hypersync`: Enables hypersync support (fast parallel hash maps) where available.
 //! - `tracing-bridge`: Enables the `tracing` subscriber bridge for log integration.
 //! - `defi`: Enables DeFi (Decentralized Finance) support including blockchain adapters.
-//! - `mimalloc`: Sets [mimalloc](https://github.com/microsoft/mimalloc) as Rust's global allocator on platforms other than macOS.
+//! - `mimalloc`: Sets [mimalloc](https://github.com/microsoft/mimalloc) as Rust's global allocator.
 
 #![warn(rustc::all)]
 #![deny(unsafe_code)]
@@ -52,13 +52,13 @@
 
 use std::{path::Path, time::Duration};
 
-#[cfg(all(feature = "mimalloc", not(target_os = "macos")))]
+#[cfg(feature = "mimalloc")]
 use mimalloc::MiMalloc;
 use nautilus_common::live::runtime::shutdown_runtime;
 use nautilus_system::python::controller::PyController;
 use pyo3::{prelude::*, pyfunction};
 
-#[cfg(all(feature = "mimalloc", not(target_os = "macos")))]
+#[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -798,11 +798,9 @@ order event handling, and order book maintenance all exercise the heap on every 
 system allocators handle this pattern poorly; profiling shows allocator overhead approaching half
 of hot‑loop time on both the Windows CRT heap and glibc malloc under order‑flow workloads.
 
-The `nautilus` CLI and Python wheels on Linux and Windows use
-[mimalloc](https://github.com/microsoft/mimalloc) for Rust allocations. macOS Python wheels use the
-system allocator to remain compatible with Python packages that embed their own allocator.
-Backtest engine benchmarks run roughly 3% to 44% faster depending on workload, with order‑flow
-heavy paths gaining the most. The trade‑off is a modest increase in resident memory from
+The `nautilus` CLI and Python wheels use [mimalloc](https://github.com/microsoft/mimalloc) for Rust
+allocations. Backtest engine benchmarks run roughly 3% to 44% faster depending on workload, with
+order‑flow heavy paths gaining the most. The trade‑off is a modest increase in resident memory from
 mimalloc's segment caching.
 
 A Rust binary links exactly one global allocator, and libraries do not impose one, so the

--- a/docs/concepts/rust.md
+++ b/docs/concepts/rust.md
@@ -140,10 +140,8 @@ places (e.g. `0.00000001`).
 
 ### Memory allocator
 
-The `nautilus` CLI and Python wheels on Linux and Windows use
-[mimalloc](https://crates.io/crates/mimalloc) for Rust allocations. macOS Python wheels use the
-system allocator to remain compatible with Python packages that embed their own allocator. A Rust
-binary chooses its own allocator, so add mimalloc to yours to match:
+The `nautilus` CLI and Python wheels use [mimalloc](https://crates.io/crates/mimalloc) for Rust
+allocations. A Rust binary chooses its own allocator, so add mimalloc to yours to match:
 
 ```toml
 [dependencies]


### PR DESCRIPTION
### Summary

Enable mimalloc as the Rust global allocator for macOS Python wheels. macOS selects the Rust
wrapper's `v2` feature, while Linux, Windows, and the `nautilus` CLI retain their existing mimalloc
feature selection.

This restores allocator consistency across Python wheels without exposing macOS processes to the
native mimalloc v3 TLS collision that can occur when PyArrow loads an independent allocator
instance.

### Allocator selection

```mermaid
flowchart LR
    Feature["Python wheel enables mimalloc"] --> Target{"Build target"}
    Target -->|"macOS"| V2["Native mimalloc v2.3.2<br/>local_dynamic_tls + v2"]
    Target -->|"Linux or Windows"| Default["Default native mimalloc<br/>local_dynamic_tls"]
    V2 --> Global["PyO3 global allocator"]
    Default --> Global
```

macOS alone selects native mimalloc v2; the other build targets retain the wrapper default.

### Rationale

The `mimalloc` Rust crate version and the bundled native allocator version use separate version
schemes. `mimalloc 0.1.52` resolves to `libmimalloc-sys 0.1.49`, which bundles native mimalloc
v3.3.2 by default and v2.3.2 when the `v2` feature is enabled.

Native mimalloc v3 releases before v3.4.4 can conflict when multiple allocator instances use the
same fixed macOS thread‑local storage slots. The
[upstream Microsoft investigation](https://github.com/microsoft/mimalloc/issues/1327) documents
the collision and the move to pthread TLS in v3.4.4. The macOS `v2` selection remains a temporary
workaround until `libmimalloc-sys` bundles native mimalloc v3.4.4 or later.

### Changes

- Enable `MiMalloc` as the PyO3 global allocator on macOS.
- Select `local_dynamic_tls` and `v2` only for the macOS PyO3 dependency.
- Preserve `local_dynamic_tls` without `v2` for Linux and Windows Python wheels.
- Remove documentation that identifies the macOS system allocator as the active wheel allocator.

### Testing

- `CARGO_BUILD_JOBS=16 make build-debug DYNAMIC=true`: passed on macOS arm64 with Python 3.14.
- Runtime allocator diagnostics report native mimalloc v2.3.2.
- `uv run --no-sync pytest tests/unit/test_macos_extension.py -q`: 3 passed, covering PyArrow and
  pandas imports, the Rust extension, and DuckLake catalog initialization.
- Cargo feature graphs select `local_dynamic_tls,v2` for macOS PyO3,
  `local_dynamic_tls` for Linux and Windows PyO3, and no added features for the CLI.
- Staged pre‑commit gate: passed.
