### PR TITLE
Allow verified emergency position exits under a trading halt

### DIFF
--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -1335,6 +1335,23 @@ fn resolve_order_position_identity(
     Ok((position_side, venue_position_id))
 }
 
+fn binance_enforces_reduce_only(
+    is_hedge_mode: bool,
+    command: &SubmitOrder,
+    order: &OrderAny,
+) -> bool {
+    let close_position = command
+        .params
+        .as_ref()
+        .and_then(|params| params.get_bool(PARAMS_CLOSE_POSITION))
+        .unwrap_or(false);
+
+    order.is_reduce_only()
+        && !is_hedge_mode
+        && !close_position
+        && order_type_to_binance_futures(order.order_type()).is_ok()
+}
+
 fn validate_submit_position_id(
     submitted_position_id: Option<PositionId>,
     venue_position_id: Option<PositionId>,
@@ -1672,6 +1689,10 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
 
     fn get_account(&self) -> Option<AccountAny> {
         self.core.cache().account_owned(&self.core.account_id)
+    }
+
+    fn enforces_reduce_only(&self, command: &SubmitOrder, order: &OrderAny) -> bool {
+        binance_enforces_reduce_only(self.is_hedge_mode(), command, order)
     }
 
     async fn connect(&mut self) -> anyhow::Result<()> {
@@ -3801,10 +3822,12 @@ fn is_instrument_for_product(instrument: &InstrumentAny, product_type: BinancePr
 #[cfg(test)]
 mod tests {
     use nautilus_model::{
+        enums::OrderSide,
         instruments::stubs::{
             crypto_future_btcusdt, crypto_perpetual_ethusdt, currency_pair_btcusdt,
             perpetual_contract_eurusd, xbtusd_bitmex,
         },
+        orders::{Order, builder::OrderTestBuilder},
         types::Price,
     };
     use rstest::rstest;
@@ -3817,6 +3840,56 @@ mod tests {
             code,
             message: format!("test error {code}"),
         })
+    }
+
+    fn reduce_only_capability_command(order: &OrderAny, close_position: bool) -> SubmitOrder {
+        let params = close_position.then(|| {
+            let mut params = Params::new();
+            params.insert(PARAMS_CLOSE_POSITION.to_string(), true.into());
+            params
+        });
+
+        SubmitOrder::new(
+            order.trader_id(),
+            None,
+            order.strategy_id(),
+            order.instrument_id(),
+            order.client_order_id(),
+            order.init_event().clone(),
+            None,
+            None,
+            params,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+        )
+    }
+
+    #[rstest]
+    #[case::one_way(false, OrderType::Market, true, false, true)]
+    #[case::hedge(true, OrderType::Market, true, false, false)]
+    #[case::not_reduce_only(false, OrderType::Market, false, false, false)]
+    #[case::close_position(false, OrderType::Market, true, true, false)]
+    #[case::unsupported_order_type(false, OrderType::MarketToLimit, true, false, false)]
+    fn test_binance_enforces_reduce_only_predicate(
+        #[case] is_hedge_mode: bool,
+        #[case] order_type: OrderType,
+        #[case] reduce_only: bool,
+        #[case] close_position: bool,
+        #[case] expected: bool,
+    ) {
+        let order = OrderTestBuilder::new(order_type)
+            .instrument_id(InstrumentId::from("BTCUSDT-PERP.BINANCE"))
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from(1))
+            .reduce_only(reduce_only)
+            .build();
+        let command = reduce_only_capability_command(&order, close_position);
+
+        assert_eq!(
+            binance_enforces_reduce_only(is_hedge_mode, &command, &order),
+            expected
+        );
     }
 
     #[rstest]

--- a/crates/adapters/sandbox/src/execution.rs
+++ b/crates/adapters/sandbox/src/execution.rs
@@ -929,6 +929,12 @@ impl ExecutionClient for SandboxExecutionClient {
         self.cache.borrow().account_owned(&account_id)
     }
 
+    fn enforces_reduce_only(&self, _command: &SubmitOrder, order: &OrderAny) -> bool {
+        // Every matching engine is built from this config, and the engine clamps
+        // reduce-only fills against the position it holds at execution time.
+        order.is_reduce_only() && self.config.use_reduce_only
+    }
+
     fn generate_account_state(
         &self,
         balances: Vec<AccountBalance>,

--- a/crates/adapters/sandbox/tests/execution.rs
+++ b/crates/adapters/sandbox/tests/execution.rs
@@ -3693,3 +3693,37 @@ fn test_submit_order_through_exec_engine_no_reentrant_panic(
         "Expected order events through the exec event channel"
     );
 }
+
+#[rstest]
+#[case::enabled(true, true, true)]
+#[case::disabled(false, true, false)]
+#[case::not_reduce_only(true, false, false)]
+fn test_enforces_reduce_only_follows_config(
+    trader_id: TraderId,
+    account_id: AccountId,
+    venue: Venue,
+    instrument: InstrumentAny,
+    #[case] use_reduce_only: bool,
+    #[case] reduce_only: bool,
+    #[case] expected: bool,
+) {
+    let ctx = create_test_context_with(trader_id, account_id, venue, |config| {
+        config.use_reduce_only = use_reduce_only;
+    });
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from("0.001"))
+        .reduce_only(reduce_only)
+        .build();
+    let command = SubmitOrder::from_order(
+        &order,
+        trader_id,
+        None,
+        None,
+        UUID4::new(),
+        UnixNanos::default(),
+    );
+
+    assert_eq!(ctx.client.enforces_reduce_only(&command, &order), expected);
+}

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -203,6 +203,10 @@ impl Debug for SimulatedExchange {
 }
 
 impl SimulatedExchange {
+    pub(crate) const fn use_reduce_only(&self) -> bool {
+        self.use_reduce_only
+    }
+
     /// Creates a new [`SimulatedExchange`] instance from a venue configuration.
     ///
     /// # Errors

--- a/crates/backtest/src/execution_client.rs
+++ b/crates/backtest/src/execution_client.rs
@@ -36,7 +36,7 @@ use nautilus_model::{
     enums::OmsType,
     events::OrderEventAny,
     identifiers::{AccountId, ClientId, ClientOrderId, TraderId, Venue},
-    orders::OrderAny,
+    orders::{Order, OrderAny},
     types::{AccountBalance, MarginBalance},
 };
 
@@ -161,6 +161,20 @@ impl ExecutionClient for BacktestExecutionClient {
 
     fn get_account(&self) -> Option<AccountAny> {
         self.cache.borrow().account_owned(&self.core.account_id)
+    }
+
+    fn enforces_reduce_only(&self, _command: &SubmitOrder, order: &OrderAny) -> bool {
+        order.is_reduce_only()
+            && self
+                .exchange
+                .upgrade()
+                .and_then(|exchange| {
+                    exchange
+                        .try_borrow()
+                        .ok()
+                        .map(|exchange| exchange.use_reduce_only())
+                })
+                .unwrap_or(false)
     }
 
     fn generate_account_state(
@@ -303,10 +317,11 @@ mod tests {
     use nautilus_core::UUID4;
     use nautilus_execution::models::latency::{LatencyModelHandle, StaticLatencyModel};
     use nautilus_model::{
-        enums::{AccountType, BookType, OmsType},
+        enums::{AccountType, BookType, OmsType, OrderSide, OrderType},
         identifiers::{InstrumentId, StrategyId},
+        orders::{Order, builder::OrderTestBuilder},
         stubs::TestDefault,
-        types::{Currency, Money},
+        types::{Currency, Money, Quantity},
     };
     use rstest::rstest;
 
@@ -314,6 +329,12 @@ mod tests {
     use crate::config::SimulatedVenueConfig;
 
     fn setup_client_with_latency() -> (BacktestExecutionClient, Rc<RefCell<SimulatedExchange>>) {
+        setup_client_with_reduce_only(true)
+    }
+
+    fn setup_client_with_reduce_only(
+        use_reduce_only: bool,
+    ) -> (BacktestExecutionClient, Rc<RefCell<SimulatedExchange>>) {
         let cache = Rc::new(RefCell::new(Cache::default()));
         let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
         let latency_model = StaticLatencyModel::new(
@@ -329,6 +350,7 @@ mod tests {
             .book_type(BookType::L2_MBP)
             .starting_balances(vec![Money::new(1_000.0, Currency::USD())])
             .latency_model(LatencyModelHandle::new(latency_model))
+            .use_reduce_only(use_reduce_only)
             .build()
             .unwrap();
         let exchange = Rc::new(RefCell::new(
@@ -389,6 +411,71 @@ mod tests {
             .into();
 
         assert!(Rc::ptr_eq(&upgraded, &exchange));
+    }
+
+    #[rstest]
+    #[case::enabled(true, true, true)]
+    #[case::disabled(false, true, false)]
+    #[case::not_reduce_only(true, false, false)]
+    fn test_enforces_reduce_only_follows_exchange_config(
+        #[case] use_reduce_only: bool,
+        #[case] reduce_only: bool,
+        #[case] expected: bool,
+    ) {
+        let (client, _exchange) = setup_client_with_reduce_only(use_reduce_only);
+        let order = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from(1))
+            .reduce_only(reduce_only)
+            .build();
+        let command = SubmitOrder::new(
+            TraderId::test_default(),
+            None,
+            StrategyId::test_default(),
+            order.instrument_id(),
+            order.client_order_id(),
+            order.init_event().clone(),
+            None,
+            None,
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+        );
+
+        assert_eq!(client.enforces_reduce_only(&command, &order), expected);
+    }
+
+    #[rstest]
+    fn test_enforces_reduce_only_fails_closed_when_exchange_unavailable() {
+        let (client, exchange) = setup_client_with_reduce_only(true);
+        let order = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(InstrumentId::from("AUD/USD.SIM"))
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from(1))
+            .reduce_only(true)
+            .build();
+        let command = SubmitOrder::new(
+            TraderId::test_default(),
+            None,
+            StrategyId::test_default(),
+            order.instrument_id(),
+            order.client_order_id(),
+            order.init_event().clone(),
+            None,
+            None,
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+        );
+
+        let borrow = exchange.borrow_mut();
+        assert!(!client.enforces_reduce_only(&command, &order));
+        drop(borrow);
+        drop(exchange);
+        assert!(!client.enforces_reduce_only(&command, &order));
     }
 
     #[rstest]

--- a/crates/common/src/clients/execution.rs
+++ b/crates/common/src/clients/execution.rs
@@ -27,6 +27,7 @@ use nautilus_model::{
         AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Venue, VenueOrderId,
     },
     instruments::InstrumentAny,
+    orders::OrderAny,
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
     types::{AccountBalance, MarginBalance, Money, Price, Quantity},
 };
@@ -72,6 +73,18 @@ pub trait ExecutionClient {
     /// the instrument's exchange venue.
     fn handles_order_venue(&self, venue: Venue) -> bool {
         self.venue() == venue
+    }
+
+    /// Returns whether this client, for this exact command and cached order, will use a
+    /// downstream execution path that prevents any execution which would increase or reverse the
+    /// position once it reaches flat.
+    ///
+    /// The guarantee may be native venue enforcement or matching-engine enforcement against
+    /// execution-time position state. Serializing a flag the venue ignores, selecting a nominal
+    /// closing side, relying on balance rejection, or checking a cached position before submission
+    /// is not sufficient because an in-flight fill can make that check stale.
+    fn enforces_reduce_only(&self, _command: &SubmitOrder, _order: &OrderAny) -> bool {
+        false
     }
 
     /// Returns whether a bulk position status report request provides complete coverage for the

--- a/crates/common/src/messages/execution/mod.rs
+++ b/crates/common/src/messages/execution/mod.rs
@@ -44,6 +44,9 @@ pub use self::{
 /// Parameter indicating that a conditional order should close the whole position at trigger time.
 pub const PARAMS_CLOSE_POSITION: &str = "close_position";
 
+/// Parameter indicating that a reduce-only order is an emergency position exit.
+pub const PARAMS_EMERGENCY_EXIT: &str = "emergency_exit";
+
 /// Execution report variants for reconciliation.
 #[derive(Clone, Debug, Display)]
 pub enum ExecutionReport {

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -48,7 +48,8 @@ use nautilus_common::{
         ExecutionReport,
         execution::{
             BatchCancelOrders, BatchModifyOrders, CancelAllOrders, CancelOrder, ModifyOrder,
-            QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList, TradingCommand,
+            PARAMS_EMERGENCY_EXIT, QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList,
+            TradingCommand,
         },
     },
     msgbus::{
@@ -1955,6 +1956,10 @@ impl ExecutionEngine {
         if let Some(cid) = command.client_id()
             && self.external_clients.contains(&cid)
         {
+            if self.deny_external_emergency_exit(&command, cid) {
+                return;
+            }
+
             let topic = format!("commands.trading.{cid}");
             msgbus::publish_any(topic.into(), &command);
 
@@ -2019,6 +2024,46 @@ impl ExecutionEngine {
             TradingCommand::QueryOrder(cmd) => self.handle_query_order(client, cmd),
             TradingCommand::QueryAccount(cmd) => self.handle_query_account(client, cmd),
         }
+    }
+
+    fn deny_external_emergency_exit(&self, command: &TradingCommand, client_id: ClientId) -> bool {
+        let TradingCommand::SubmitOrder(cmd) = command else {
+            return false;
+        };
+        let is_verified_emergency_exit = cmd
+            .params
+            .as_ref()
+            .and_then(|params| params.get_bool(PARAMS_EMERGENCY_EXIT))
+            .unwrap_or(false);
+
+        if !is_verified_emergency_exit {
+            return false;
+        }
+
+        let cached_order = {
+            self.cache
+                .borrow()
+                .order(&cmd.client_order_id)
+                .map(|o| o.clone())
+        };
+        let order = cached_order
+            .or_else(|| self.add_order_from_init(&cmd.order_init, cmd.position_id, cmd));
+        let Some(order) = order else {
+            log::error!(
+                "Cannot deny external emergency exit: client_order_id={}, external_client_id={client_id}, suppressed_command={cmd}",
+                cmd.client_order_id,
+            );
+            return true;
+        };
+
+        let reason = OrderDeniedReason::ReduceOnlyEnforcementNotEstablished {
+            client_id,
+            instrument_id: order.instrument_id(),
+        }
+        .to_string();
+        self.deny_order(&order, &reason);
+
+        true
     }
 
     fn routing_context_for_command(command: &TradingCommand) -> String {
@@ -2138,6 +2183,23 @@ impl ExecutionEngine {
                 client_id,
                 order_venue,
                 client_venue,
+            }
+            .to_string();
+            self.deny_order(&order, &reason);
+            return;
+        }
+
+        let is_verified_emergency_exit = cmd
+            .params
+            .as_ref()
+            .and_then(|params| params.get_bool(PARAMS_EMERGENCY_EXIT))
+            .unwrap_or(false);
+        // This marker records risk-engine provenance in the supported pipeline; it is not an
+        // authentication boundary for components that publish directly to execution.
+        if is_verified_emergency_exit && !client.enforces_reduce_only(&cmd, &order) {
+            let reason = OrderDeniedReason::ReduceOnlyNotEnforced {
+                client_id: client.client_id(),
+                instrument_id: order.instrument_id(),
             }
             .to_string();
             self.deny_order(&order, &reason);

--- a/crates/execution/src/engine/stubs.rs
+++ b/crates/execution/src/engine/stubs.rs
@@ -36,6 +36,7 @@ use nautilus_model::{
         AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Venue, VenueOrderId,
     },
     instruments::InstrumentAny,
+    orders::{Order, OrderAny},
     types::{AccountBalance, MarginBalance},
 };
 
@@ -64,6 +65,7 @@ pub struct StubExecutionClient {
     queried_account_ids: Rc<RefCell<Vec<AccountId>>>,
     registered_external_order_ids: Rc<RefCell<Vec<ClientOrderId>>>,
     handles_all_order_venues: bool,
+    enforces_reduce_only: bool,
     submit_order_error: Option<String>,
     submit_order_list_error: Option<String>,
 }
@@ -97,6 +99,7 @@ impl StubExecutionClient {
             queried_account_ids: Rc::new(RefCell::new(Vec::new())),
             registered_external_order_ids: Rc::new(RefCell::new(Vec::new())),
             handles_all_order_venues: false,
+            enforces_reduce_only: false,
             submit_order_error: None,
             submit_order_list_error: None,
         }
@@ -106,6 +109,13 @@ impl StubExecutionClient {
     #[must_use]
     pub fn with_handles_all_order_venues(mut self) -> Self {
         self.handles_all_order_venues = true;
+        self
+    }
+
+    /// Configures this stub to enforce reduce-only orders.
+    #[must_use]
+    pub fn with_enforces_reduce_only(mut self) -> Self {
+        self.enforces_reduce_only = true;
         self
     }
 
@@ -205,6 +215,10 @@ impl ExecutionClient for StubExecutionClient {
 
     fn handles_order_venue(&self, venue: Venue) -> bool {
         self.handles_all_order_venues || self.venue == venue
+    }
+
+    fn enforces_reduce_only(&self, _command: &SubmitOrder, order: &OrderAny) -> bool {
+        self.enforces_reduce_only && order.is_reduce_only()
     }
 
     fn oms_type(&self) -> OmsType {

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -38,8 +38,8 @@ use nautilus_common::{
     messages::{
         ExecutionReport,
         execution::{
-            BatchModifyOrders, CancelAllOrders, CancelOrder, ModifyOrder, QueryAccount,
-            SubmitOrder, SubmitOrderList, TradingCommand,
+            BatchModifyOrders, CancelAllOrders, CancelOrder, ModifyOrder, PARAMS_EMERGENCY_EXIT,
+            QueryAccount, SubmitOrder, SubmitOrderList, TradingCommand,
         },
     },
     msgbus::{
@@ -724,6 +724,148 @@ fn test_external_client_command_publishes_to_client_topic_and_skips_local_routin
         captured[0],
         TradingCommand::CancelAllOrders(command),
         "external client command should publish to the client command topic",
+    );
+}
+
+#[rstest]
+#[case::emergency_exit(true)]
+#[case::ordinary(false)]
+fn test_external_client_submit_order_denied_only_when_emergency_exit(#[case] emergency_exit: bool) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+    let external_client_id = ClientId::from("EXTERNAL");
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let config = ExecutionEngineConfig {
+        external_clients: Some(vec![external_client_id]),
+        ..Default::default()
+    };
+    let execution_engine = ExecutionEngine::new(clock, cache, Some(config));
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(1))
+        .reduce_only(true)
+        .build();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(external_client_id), true)
+        .unwrap();
+
+    let params = emergency_exit.then(|| {
+        let mut params = Params::new();
+        params.insert(PARAMS_EMERGENCY_EXIT.to_string(), true.into());
+        params
+    });
+    let command = SubmitOrder {
+        trader_id,
+        strategy_id,
+        position_id: None,
+        params,
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        client_id: Some(external_client_id),
+        instrument_id: instrument.id,
+        exec_algorithm_id: None,
+        correlation_id: None,
+        causation_id: None,
+    };
+    let topic = format!("commands.trading.{external_client_id}");
+    let pattern: msgbus::MStr<msgbus::Pattern> = topic.as_str().into();
+    let (handler, saver) = get_any_saving_handler::<TradingCommand>(None);
+    msgbus::subscribe_any(pattern, handler.clone(), None);
+
+    execution_engine.execute(TradingCommand::SubmitOrder(command.clone()));
+
+    msgbus::unsubscribe_any(pattern, &handler);
+    let captured = saver.get_messages();
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
+
+    if emergency_exit {
+        assert!(captured.is_empty());
+        assert_eq!(cached_order.status(), OrderStatus::Denied);
+        let OrderEventAny::Denied(denied) = cached_order.last_event() else {
+            panic!("Expected OrderDenied event");
+        };
+        assert_eq!(
+            denied.reason.as_str(),
+            "REDUCE_ONLY_ENFORCEMENT_NOT_ESTABLISHED: client_id=EXTERNAL, instrument_id=AUD/USD.SIM",
+        );
+    } else {
+        assert_eq!(captured.as_slice(), &[TradingCommand::SubmitOrder(command)]);
+        assert_eq!(cached_order.status(), OrderStatus::Initialized);
+    }
+}
+
+#[rstest]
+fn test_external_client_emergency_exit_cache_miss_is_denied() {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+    let external_client_id = ClientId::from("EXTERNAL");
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let config = ExecutionEngineConfig {
+        external_clients: Some(vec![external_client_id]),
+        ..Default::default()
+    };
+    let execution_engine = ExecutionEngine::new(clock, cache, Some(config));
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(1))
+        .reduce_only(true)
+        .build();
+    let mut params = Params::new();
+    params.insert(PARAMS_EMERGENCY_EXIT.to_string(), true.into());
+    let command = SubmitOrder {
+        trader_id,
+        strategy_id,
+        position_id: None,
+        params: Some(params),
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        client_id: Some(external_client_id),
+        instrument_id: instrument.id,
+        exec_algorithm_id: None,
+        correlation_id: None,
+        causation_id: None,
+    };
+    let topic = format!("commands.trading.{external_client_id}");
+    let pattern: msgbus::MStr<msgbus::Pattern> = topic.as_str().into();
+    let (handler, saver) = get_any_saving_handler::<TradingCommand>(None);
+    msgbus::subscribe_any(pattern, handler.clone(), None);
+
+    execution_engine.execute(TradingCommand::SubmitOrder(command));
+
+    msgbus::unsubscribe_any(pattern, &handler);
+    let captured = saver.get_messages();
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
+
+    assert!(captured.is_empty());
+    assert_eq!(cached_order.status(), OrderStatus::Denied);
+    let OrderEventAny::Denied(denied) = cached_order.last_event() else {
+        panic!("Expected OrderDenied event");
+    };
+    assert_eq!(
+        denied.reason.as_str(),
+        "REDUCE_ONLY_ENFORCEMENT_NOT_ESTABLISHED: client_id=EXTERNAL, instrument_id=AUD/USD.SIM",
     );
 }
 
@@ -4260,6 +4402,89 @@ fn test_submit_order_denies_when_client_does_not_handle_instrument_venue(
         panic!("Expected OrderDenied event");
     }
     assert!(submitted_order_ids.borrow().is_empty());
+}
+
+#[rstest]
+#[case::non_capable(false)]
+#[case::capable(true)]
+fn test_submit_emergency_exit_requires_capable_route(
+    #[case] capable: bool,
+    mut execution_engine: ExecutionEngine,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+    let client_id = ClientId::from("STUB");
+    let mut client = StubExecutionClient::new(
+        client_id,
+        AccountId::from("TEST-ACCOUNT"),
+        instrument.id.venue,
+        OmsType::Netting,
+        None,
+    );
+
+    if capable {
+        client = client.with_enforces_reduce_only();
+    }
+    let submitted_order_ids = client.submitted_order_ids();
+    execution_engine.register_client(Box::new(client)).unwrap();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(1))
+        .reduce_only(true)
+        .build();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(client_id), true)
+        .unwrap();
+    let mut params = Params::new();
+    params.insert(PARAMS_EMERGENCY_EXIT.to_string(), true.into());
+    let submit_order = SubmitOrder {
+        trader_id,
+        strategy_id,
+        position_id: None,
+        params: Some(params),
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        client_id: Some(client_id),
+        instrument_id: instrument.id,
+        exec_algorithm_id: None,
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
+    if capable {
+        assert_eq!(cached_order.status(), OrderStatus::Initialized);
+        assert_eq!(
+            submitted_order_ids.borrow().as_slice(),
+            &[order.client_order_id()]
+        );
+    } else {
+        assert_eq!(cached_order.status(), OrderStatus::Denied);
+        let OrderEventAny::Denied(denied) = cached_order.last_event() else {
+            panic!("Expected OrderDenied event");
+        };
+        assert_eq!(
+            denied.reason.as_str(),
+            "REDUCE_ONLY_NOT_ENFORCED: client_id=STUB, instrument_id=AUD/USD.SIM",
+        );
+        assert!(submitted_order_ids.borrow().is_empty());
+    }
 }
 
 #[rstest]

--- a/crates/live/src/execution/client.rs
+++ b/crates/live/src/execution/client.rs
@@ -41,6 +41,7 @@ use nautilus_model::{
         AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, Venue, VenueOrderId,
     },
     instruments::{Instrument, InstrumentAny},
+    orders::OrderAny,
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
     types::{AccountBalance, MarginBalance, Money, Price, Quantity},
 };
@@ -205,6 +206,10 @@ impl ExecutionClient for LiveExecutionClient {
 
     fn handles_order_venue(&self, venue: Venue) -> bool {
         self.client.borrow().handles_order_venue(venue)
+    }
+
+    fn enforces_reduce_only(&self, command: &SubmitOrder, order: &OrderAny) -> bool {
+        self.client.borrow().enforces_reduce_only(command, order)
     }
 
     fn provides_bulk_position_coverage(&self, instrument_id: InstrumentId) -> bool {
@@ -380,5 +385,71 @@ impl ExecutionClient for LiveExecutionClient {
         self.client
             .borrow()
             .calculate_commission(instrument, last_qty, last_px, liquidity_side)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_core::UUID4;
+    use nautilus_execution::engine::stubs::StubExecutionClient;
+    use nautilus_model::{
+        enums::{OrderSide, OrderType},
+        identifiers::TraderId,
+        instruments::stubs::audusd_sim,
+        orders::{Order, OrderTestBuilder},
+    };
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::incapable(false)]
+    #[case::capable(true)]
+    fn test_enforces_reduce_only_forwards_to_wrapped_client(#[case] capable: bool) {
+        let instrument = audusd_sim();
+        let trader_id = TraderId::from("TRADER-001");
+        let strategy_id = StrategyId::from("S-001");
+        let client_id = ClientId::from("STUB");
+        let mut wrapped = StubExecutionClient::new(
+            client_id,
+            AccountId::from("TEST-ACCOUNT"),
+            instrument.id().venue,
+            OmsType::Netting,
+            None,
+        );
+
+        if capable {
+            wrapped = wrapped.with_enforces_reduce_only();
+        }
+
+        let facade = LiveExecutionClient::new(Box::new(wrapped));
+        let order = OrderTestBuilder::new(OrderType::Market)
+            .trader_id(trader_id)
+            .strategy_id(strategy_id)
+            .instrument_id(instrument.id())
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from(1))
+            .reduce_only(true)
+            .build();
+        let command = SubmitOrder {
+            trader_id,
+            strategy_id,
+            position_id: None,
+            params: None,
+            client_order_id: order.client_order_id(),
+            order_init: order.init_event().clone(),
+            command_id: UUID4::new(),
+            ts_init: UnixNanos::default(),
+            client_id: Some(client_id),
+            instrument_id: instrument.id(),
+            exec_algorithm_id: None,
+            correlation_id: None,
+            causation_id: None,
+        };
+
+        assert_eq!(
+            ExecutionClient::enforces_reduce_only(&facade, &command, &order),
+            capable
+        );
     }
 }

--- a/crates/model/src/enums.rs
+++ b/crates/model/src/enums.rs
@@ -2019,7 +2019,8 @@ pub enum TimeInForce {
 pub enum TradingState {
     /// Normal trading operations.
     Active = 1,
-    /// Trading is completely halted, no new order commands will be emitted.
+    /// Trading is halted except for verified emergency position exits routed through an
+    /// execution client which enforces reduce-only for the order.
     Halted = 2,
     /// Only order commands which would cancel order, or reduce position sizes are permitted.
     Reducing = 3,

--- a/crates/model/src/events/order/denied_reason.rs
+++ b/crates/model/src/events/order/denied_reason.rs
@@ -338,6 +338,24 @@ pub enum OrderDeniedReason {
         /// The execution client's venue.
         client_venue: Venue,
     },
+    /// The routed execution client does not enforce reduce-only for this order.
+    #[error("REDUCE_ONLY_NOT_ENFORCED: client_id={client_id}, instrument_id={instrument_id}")]
+    ReduceOnlyNotEnforced {
+        /// The selected execution client.
+        client_id: ClientId,
+        /// The submitted instrument.
+        instrument_id: InstrumentId,
+    },
+    /// Reduce-only enforcement is not established for the external execution route.
+    #[error(
+        "REDUCE_ONLY_ENFORCEMENT_NOT_ESTABLISHED: client_id={client_id}, instrument_id={instrument_id}"
+    )]
+    ReduceOnlyEnforcementNotEstablished {
+        /// The external execution client.
+        client_id: ClientId,
+        /// The submitted instrument.
+        instrument_id: InstrumentId,
+    },
     /// Submitting the order to the execution client failed.
     #[error("SUBMIT_FAILED: {detail}")]
     SubmitFailed {
@@ -473,6 +491,12 @@ impl OrderDeniedCode {
             }
             Self::NoExecutionClient => "No execution client was found for the routed command.",
             Self::ClientVenueMismatch => "The execution client does not handle the order venue.",
+            Self::ReduceOnlyNotEnforced => {
+                "The routed execution client does not enforce reduce-only for this order."
+            }
+            Self::ReduceOnlyEnforcementNotEstablished => {
+                "Reduce-only enforcement is not established for the external execution route."
+            }
             Self::SubmitFailed => "Submitting the order to the execution client failed.",
             Self::InvalidClientOrderId => "The client order ID is invalid for the venue.",
             Self::InvalidPositionId => {
@@ -724,6 +748,10 @@ mod tests {
             order_venue: Venue::from("XCME"),
             client_venue: Venue::from("IB"),
         };
+        let external_capability = OrderDeniedReason::ReduceOnlyEnforcementNotEstablished {
+            client_id: ClientId::from("EXTERNAL"),
+            instrument_id: InstrumentId::from("AUD/USD.SIM"),
+        };
         let submit_failed = OrderDeniedReason::SubmitFailed {
             detail: "transport closed".to_string(),
         };
@@ -735,6 +763,10 @@ mod tests {
         assert_eq!(
             missing_client.to_string(),
             "NO_EXECUTION_CLIENT: client_id=SIM, venue=SIM"
+        );
+        assert_eq!(
+            external_capability.to_string(),
+            "REDUCE_ONLY_ENFORCEMENT_NOT_ESTABLISHED: client_id=EXTERNAL, instrument_id=AUD/USD.SIM"
         );
         assert_eq!(
             mismatch.to_string(),
@@ -922,6 +954,14 @@ mod tests {
                 client_id: ClientId::from("IB"),
                 order_venue: Venue::from("XCME"),
                 client_venue: Venue::from("IB"),
+            },
+            OrderDeniedReason::ReduceOnlyNotEnforced {
+                client_id: ClientId::from("IB"),
+                instrument_id: InstrumentId::from("ES.XCME"),
+            },
+            OrderDeniedReason::ReduceOnlyEnforcementNotEstablished {
+                client_id: ClientId::from("IB"),
+                instrument_id: InstrumentId::from("ES.XCME"),
             },
             OrderDeniedReason::SubmitFailed {
                 detail: "boom".to_string(),

--- a/crates/risk/src/engine/mod.rs
+++ b/crates/risk/src/engine/mod.rs
@@ -28,8 +28,8 @@ use nautilus_common::{
     logging::{CMD, EVT, RECV},
     messages::{
         execution::{
-            BatchModifyOrders, ModifyOrder, PARAMS_CLOSE_POSITION, SubmitOrder, SubmitOrderList,
-            TradingCommand,
+            BatchModifyOrders, ModifyOrder, PARAMS_CLOSE_POSITION, PARAMS_EMERGENCY_EXIT,
+            SubmitOrder, SubmitOrderList, TradingCommand,
         },
         system::trading::TradingStateChanged,
     },
@@ -38,7 +38,7 @@ use nautilus_common::{
     runner::{TradingCommandMessage, try_get_trading_cmd_sender},
     throttler::{RateLimit, Throttler},
 };
-use nautilus_core::{UUID4, WeakCell};
+use nautilus_core::{Params, UUID4, WeakCell};
 use nautilus_execution::trailing::{
     trailing_stop_calculate_with_bid_ask, trailing_stop_calculate_with_last,
 };
@@ -432,6 +432,8 @@ impl RiskEngine {
     }
 
     /// Sets the trading state for risk control enforcement.
+    ///
+    /// [`TradingState::Halted`] denies new order commands except verified emergency position exits.
     pub fn set_trading_state(&mut self, state: TradingState) {
         if state == self.trading_state {
             log::warn!("No change to trading state: already set to {state:?}");
@@ -592,7 +594,8 @@ impl RiskEngine {
         }
     }
 
-    fn handle_submit_order(&mut self, command: SubmitOrder) {
+    fn handle_submit_order(&mut self, mut command: SubmitOrder) {
+        let emergency_exit = Self::consume_emergency_exit_param(&mut command.params);
         if self.config.bypass {
             Self::send_to_execution(TradingCommand::SubmitOrder(command));
             return;
@@ -655,6 +658,12 @@ impl RiskEngine {
         };
 
         let full_position_exit = self.is_full_position_exit(&command, &instrument, &order);
+        let halted_disposition =
+            if self.is_emergency_position_exit(emergency_exit, &command, &order) {
+                HaltedSubmitDisposition::VerifiedEmergencyExit
+            } else {
+                HaltedSubmitDisposition::Deny
+            };
 
         if !self.check_order(&instrument, &order, full_position_exit) {
             return; // Denied
@@ -665,7 +674,19 @@ impl RiskEngine {
         }
 
         // Route through execution gateway for TradingState checks & throttling
-        self.execution_gateway(&instrument, TradingCommand::SubmitOrder(command));
+        if halted_disposition == HaltedSubmitDisposition::VerifiedEmergencyExit
+            && self.trading_state == TradingState::Halted
+        {
+            command
+                .params
+                .get_or_insert_with(Params::new)
+                .insert(PARAMS_EMERGENCY_EXIT.to_string(), true.into());
+        }
+        self.execution_gateway(
+            &instrument,
+            TradingCommand::SubmitOrder(command),
+            halted_disposition,
+        );
     }
 
     fn is_full_position_exit(
@@ -696,7 +717,7 @@ impl RiskEngine {
             return false;
         }
 
-        self.full_position_exit_reduces(command, order)
+        self.reduces_identified_open_position(command, order)
     }
 
     fn has_full_position_exit_intent(command: &SubmitOrder) -> bool {
@@ -724,14 +745,38 @@ impl RiskEngine {
             && order.quantity().is_positive()
     }
 
-    fn full_position_exit_reduces(&self, command: &SubmitOrder, order: &OrderAny) -> bool {
-        let Some(position_id) = command.position_id else {
-            return false;
-        };
+    fn is_emergency_position_exit(
+        &self,
+        has_intent: bool,
+        command: &SubmitOrder,
+        order: &OrderAny,
+    ) -> bool {
+        has_intent
+            && order.is_reduce_only()
+            && order.quantity().is_positive()
+            && command.instrument_id == order.instrument_id()
+            && self
+                .identified_open_position(command, order)
+                .is_some_and(|(side, quantity)| {
+                    order.would_reduce_only(side, quantity) && order.quantity() <= quantity
+                })
+    }
+
+    fn reduces_identified_open_position(&self, command: &SubmitOrder, order: &OrderAny) -> bool {
+        self.identified_open_position(command, order)
+            .is_some_and(|(side, quantity)| order.would_reduce_only(side, quantity))
+    }
+
+    fn identified_open_position(
+        &self,
+        command: &SubmitOrder,
+        order: &OrderAny,
+    ) -> Option<(PositionSide, Quantity)> {
+        let position_id = command.position_id?;
         let position = {
             let cache = self.cache.borrow();
             if cache.position_id(&order.client_order_id()).copied() != Some(position_id) {
-                return false;
+                return None;
             }
             cache.position(&position_id).map(|position| {
                 (
@@ -742,21 +787,32 @@ impl RiskEngine {
                 )
             })
         };
-        let Some((is_open, position_instrument_id, position_side, position_quantity)) = position
-        else {
-            return false;
-        };
+        let (is_open, position_instrument_id, position_side, position_quantity) = position?;
 
-        is_open
+        (is_open
             && position_instrument_id == order.instrument_id()
             && matches!(
                 (order.order_side(), position_side),
                 (OrderSide::Buy, PositionSide::Short) | (OrderSide::Sell, PositionSide::Long)
-            )
-            && order.would_reduce_only(position_side, position_quantity)
+            ))
+        .then_some((position_side, position_quantity))
     }
 
-    fn handle_submit_order_list(&mut self, command: SubmitOrderList) {
+    fn consume_emergency_exit_param(params: &mut Option<Params>) -> bool {
+        let emergency_exit = params
+            .as_mut()
+            .and_then(|params| params.shift_remove(PARAMS_EMERGENCY_EXIT))
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+
+        if params.as_ref().is_some_and(|params| params.is_empty()) {
+            *params = None;
+        }
+        emergency_exit
+    }
+
+    fn handle_submit_order_list(&mut self, mut command: SubmitOrderList) {
+        Self::consume_emergency_exit_param(&mut command.params);
         if self.config.bypass {
             Self::send_to_execution(TradingCommand::SubmitOrderList(command));
             return;
@@ -840,7 +896,11 @@ impl RiskEngine {
             return; // Denied
         }
 
-        self.execution_gateway(&representative, TradingCommand::SubmitOrderList(command));
+        self.execution_gateway(
+            &representative,
+            TradingCommand::SubmitOrderList(command),
+            HaltedSubmitDisposition::Deny,
+        );
     }
 
     fn handle_modify_order(&mut self, command: ModifyOrder) {
@@ -2260,10 +2320,22 @@ impl RiskEngine {
         msgbus::send_order_event(endpoint, denied);
     }
 
-    fn execution_gateway(&mut self, instrument: &InstrumentAny, command: TradingCommand) {
+    fn execution_gateway(
+        &mut self,
+        instrument: &InstrumentAny,
+        command: TradingCommand,
+        halted_disposition: HaltedSubmitDisposition,
+    ) {
         match self.trading_state {
-            TradingState::Halted => match command {
-                TradingCommand::SubmitOrder(submit_order) => {
+            TradingState::Halted => match (command, halted_disposition) {
+                (
+                    TradingCommand::SubmitOrder(submit_order),
+                    HaltedSubmitDisposition::VerifiedEmergencyExit,
+                ) => {
+                    self.throttled_submit
+                        .send(TradingCommand::SubmitOrder(submit_order));
+                }
+                (TradingCommand::SubmitOrder(submit_order), HaltedSubmitDisposition::Deny) => {
                     let order = {
                         let cache = self.cache.borrow();
                         cache
@@ -2275,7 +2347,7 @@ impl RiskEngine {
                         self.deny_order(order, &OrderDeniedReason::TradingHalted.to_string());
                     }
                 }
-                TradingCommand::SubmitOrderList(submit_order_list) => {
+                (TradingCommand::SubmitOrderList(submit_order_list), _) => {
                     let orders: Vec<OrderAny> = self.cache.borrow().orders_for_ids(
                         &submit_order_list.order_list.client_order_ids,
                         &submit_order_list,
@@ -2366,4 +2438,10 @@ impl RiskEngine {
             log::debug!("{RECV}{EVT} {event:?}");
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HaltedSubmitDisposition {
+    Deny,
+    VerifiedEmergencyExit,
 }

--- a/crates/risk/tests/risk_engine.rs
+++ b/crates/risk/tests/risk_engine.rs
@@ -26,8 +26,8 @@ use nautilus_common::{
     clock::{Clock, TestClock},
     messages::{
         execution::{
-            BatchModifyOrders, CancelOrder, ModifyOrder, PARAMS_CLOSE_POSITION, SubmitOrder,
-            SubmitOrderList, TradingCommand,
+            BatchModifyOrders, CancelOrder, ModifyOrder, PARAMS_CLOSE_POSITION,
+            PARAMS_EMERGENCY_EXIT, SubmitOrder, SubmitOrderList, TradingCommand,
         },
         system::trading::TradingStateChanged,
     },
@@ -3966,6 +3966,732 @@ fn close_position_params(close_position: bool) -> Params {
     let mut params = Params::new();
     params.insert(PARAMS_CLOSE_POSITION.to_string(), close_position.into());
     params
+}
+
+fn emergency_exit_params(emergency_exit: bool) -> Params {
+    let mut params = Params::new();
+    params.insert(PARAMS_EMERGENCY_EXIT.to_string(), emergency_exit.into());
+    params
+}
+
+fn emergency_exit_quote(instrument_id: InstrumentId) -> QuoteTick {
+    QuoteTick::new(
+        instrument_id,
+        Price::from("10.00"),
+        Price::from("10.01"),
+        Quantity::from("100.000"),
+        Quantity::from("100.000"),
+        UnixNanos::default(),
+        UnixNanos::default(),
+    )
+}
+
+fn emergency_exit_order(
+    instrument_id: InstrumentId,
+    client_order_id: ClientOrderId,
+    side: OrderSide,
+    quantity: Quantity,
+    reduce_only: bool,
+) -> OrderAny {
+    OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .side(side)
+        .quantity(quantity)
+        .reduce_only(reduce_only)
+        .build()
+}
+
+fn emergency_exit_command(
+    trader_id: TraderId,
+    client_id: ClientId,
+    strategy_id: StrategyId,
+    order: &OrderAny,
+    position_id: Option<PositionId>,
+    emergency_exit: bool,
+    ts_init: UnixNanos,
+) -> SubmitOrder {
+    SubmitOrder::new(
+        trader_id,
+        Some(client_id),
+        strategy_id,
+        order.instrument_id(),
+        order.client_order_id(),
+        order.init_event().clone(),
+        None,
+        position_id,
+        Some(emergency_exit_params(emergency_exit)),
+        UUID4::new(),
+        ts_init,
+        None,
+    )
+}
+
+#[rstest]
+fn test_submit_emergency_exit_when_trading_halted_forwards_to_execution(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    instrument_eth_usdt: InstrumentAny,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache.add_quote(quote_ethusdt_binance()).unwrap();
+    add_margin_account_for_close_position(&mut simple_cache);
+    let position_id = PositionId::from("P-EMERGENCY-EXIT");
+    add_position_for_close_position(
+        &mut simple_cache,
+        &instrument_eth_usdt,
+        Quantity::from("2.000"),
+        position_id,
+        PositionSide::Long,
+    );
+    let order = emergency_exit_order(
+        instrument_eth_usdt.id(),
+        ClientOrderId::from("O-EMERGENCY-EXIT"),
+        OrderSide::Sell,
+        Quantity::from("1.000"),
+        true,
+    );
+    simple_cache
+        .add_order(
+            order.clone(),
+            Some(position_id),
+            Some(client_id_binance),
+            false,
+        )
+        .unwrap();
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    let command = emergency_exit_command(
+        trader_id,
+        client_id_binance,
+        strategy_id_ema_cross,
+        &order,
+        Some(position_id),
+        true,
+        risk_engine.clock().borrow().timestamp_ns(),
+    );
+
+    risk_engine.set_trading_state(TradingState::Halted);
+    risk_engine.execute(TradingCommand::SubmitOrder(command));
+
+    let process_messages = get_process_order_event_handler_messages(&process_order_event_handler);
+    let execute_messages = get_execute_order_event_handler_messages(&execute_order_event_handler);
+    assert!(process_messages.is_empty());
+    assert_eq!(execute_messages.len(), 1);
+    let TradingCommand::SubmitOrder(forwarded) = &execute_messages[0] else {
+        panic!("Expected SubmitOrder command");
+    };
+    assert_eq!(forwarded.client_order_id, order.client_order_id());
+    assert_eq!(forwarded.position_id, Some(position_id));
+    assert!(forwarded.order_init.reduce_only);
+    assert_eq!(
+        forwarded
+            .params
+            .as_ref()
+            .and_then(|params| params.get_bool(PARAMS_EMERGENCY_EXIT)),
+        Some(true)
+    );
+}
+
+#[rstest]
+#[case::active(false)]
+#[case::bypass(true)]
+fn test_submit_order_strips_caller_emergency_exit_param(
+    #[case] bypass: bool,
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    instrument_eth_usdt: InstrumentAny,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache.add_quote(quote_ethusdt_binance()).unwrap();
+    add_margin_account_for_close_position(&mut simple_cache);
+    let position_id = PositionId::from("P-EMERGENCY-EXIT-PROVENANCE");
+    add_position_for_close_position(
+        &mut simple_cache,
+        &instrument_eth_usdt,
+        Quantity::from("2.000"),
+        position_id,
+        PositionSide::Long,
+    );
+    let order = emergency_exit_order(
+        instrument_eth_usdt.id(),
+        ClientOrderId::from("O-EMERGENCY-EXIT-PROVENANCE"),
+        OrderSide::Sell,
+        Quantity::from("1.000"),
+        true,
+    );
+    simple_cache
+        .add_order(
+            order.clone(),
+            Some(position_id),
+            Some(client_id_binance),
+            false,
+        )
+        .unwrap();
+    let mut risk_engine = get_risk_engine(
+        Some(Rc::new(RefCell::new(simple_cache))),
+        Some(RiskEngineConfig {
+            bypass,
+            ..RiskEngineConfig::default()
+        }),
+        None,
+        false,
+    );
+    let command = emergency_exit_command(
+        trader_id,
+        client_id_binance,
+        strategy_id_ema_cross,
+        &order,
+        Some(position_id),
+        true,
+        risk_engine.clock().borrow().timestamp_ns(),
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrder(command));
+
+    let execute_messages = get_execute_order_event_handler_messages(&execute_order_event_handler);
+    assert_eq!(execute_messages.len(), 1);
+    let TradingCommand::SubmitOrder(forwarded) = &execute_messages[0] else {
+        panic!("Expected SubmitOrder command");
+    };
+    assert!(
+        forwarded
+            .params
+            .as_ref()
+            .and_then(|params| params.get_bool(PARAMS_EMERGENCY_EXIT))
+            .is_none()
+    );
+}
+
+#[rstest]
+#[case::submitted_quantity_exceeds_position("10.000", "6.000", "4.000", false)]
+#[case::submitted_quantity_equals_position("4.000", "0.000", "4.000", true)]
+fn test_submit_emergency_exit_uses_submitted_quantity_bound(
+    #[case] submitted_quantity: &str,
+    #[case] filled_quantity: &str,
+    #[case] position_quantity: &str,
+    #[case] should_forward: bool,
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    instrument_eth_usdt: InstrumentAny,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache.add_quote(quote_ethusdt_binance()).unwrap();
+    add_margin_account_for_close_position(&mut simple_cache);
+    let position_id = PositionId::from("P-EMERGENCY-EXIT-QUANTITY");
+    let position_quantity = Quantity::from(position_quantity);
+    add_position_for_close_position(
+        &mut simple_cache,
+        &instrument_eth_usdt,
+        position_quantity,
+        position_id,
+        PositionSide::Long,
+    );
+    let mut order = emergency_exit_order(
+        instrument_eth_usdt.id(),
+        ClientOrderId::from("O-EMERGENCY-EXIT-QUANTITY"),
+        OrderSide::Sell,
+        Quantity::from(submitted_quantity),
+        true,
+    );
+    let filled_quantity = Quantity::from(filled_quantity);
+    if filled_quantity.is_positive() {
+        order
+            .apply(OrderEventAny::Accepted(order_accepted(
+                &order,
+                Some(VenueOrderId::from("V-EMERGENCY-EXIT-QUANTITY")),
+                Some(AccountId::from("BINANCE-001")),
+            )))
+            .unwrap();
+        let fill = order_filled(
+            &order,
+            &instrument_eth_usdt,
+            None,
+            Some(AccountId::from("BINANCE-001")),
+            Some(VenueOrderId::from("V-EMERGENCY-EXIT-QUANTITY")),
+            None,
+            Some(filled_quantity),
+            Some(Price::from("10")),
+            None,
+            None,
+            None,
+        );
+        order.apply(OrderEventAny::Filled(fill)).unwrap();
+    }
+    assert_eq!(order.quantity(), Quantity::from(submitted_quantity));
+    assert_eq!(order.filled_qty(), filled_quantity);
+    assert_eq!(order.leaves_qty(), position_quantity);
+    assert!(order.would_reduce_only(PositionSide::Long, position_quantity));
+    simple_cache
+        .add_order(
+            order.clone(),
+            Some(position_id),
+            Some(client_id_binance),
+            false,
+        )
+        .unwrap();
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    let command = emergency_exit_command(
+        trader_id,
+        client_id_binance,
+        strategy_id_ema_cross,
+        &order,
+        Some(position_id),
+        true,
+        risk_engine.clock().borrow().timestamp_ns(),
+    );
+
+    risk_engine.set_trading_state(TradingState::Halted);
+    risk_engine.execute(TradingCommand::SubmitOrder(command));
+
+    let process_messages = get_process_order_event_handler_messages(&process_order_event_handler);
+    let execute_messages = get_execute_order_event_handler_messages(&execute_order_event_handler);
+
+    if should_forward {
+        assert!(process_messages.is_empty());
+        assert_eq!(execute_messages.len(), 1);
+    } else {
+        // `deny_order` returns early for an order past `Initialized`, so a partially filled
+        // order is blocked without an `OrderDenied` event; not reaching execution is the assertion.
+        assert_eq!(order.status(), OrderStatus::PartiallyFilled);
+        assert!(process_messages.is_empty());
+        assert!(execute_messages.is_empty());
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InvalidEmergencyExit {
+    WrongSide,
+    QuantityExceedsPosition,
+    MissingPositionId,
+    MismatchedCachedPosition,
+    MissingIntent,
+    NotReduceOnly,
+}
+
+#[rstest]
+#[case::wrong_side(InvalidEmergencyExit::WrongSide)]
+#[case::quantity_exceeds_position(InvalidEmergencyExit::QuantityExceedsPosition)]
+#[case::missing_position_id(InvalidEmergencyExit::MissingPositionId)]
+#[case::mismatched_cached_position(InvalidEmergencyExit::MismatchedCachedPosition)]
+#[case::missing_intent(InvalidEmergencyExit::MissingIntent)]
+#[case::not_reduce_only(InvalidEmergencyExit::NotReduceOnly)]
+fn test_submit_invalid_emergency_exit_when_trading_halted_denies(
+    #[case] invalid: InvalidEmergencyExit,
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    instrument_eth_usdt: InstrumentAny,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache.add_quote(quote_ethusdt_binance()).unwrap();
+    add_margin_account_for_close_position(&mut simple_cache);
+    let position_id = PositionId::from("P-INVALID-EMERGENCY-EXIT");
+    add_position_for_close_position(
+        &mut simple_cache,
+        &instrument_eth_usdt,
+        Quantity::from("2.000"),
+        position_id,
+        PositionSide::Long,
+    );
+    let order = emergency_exit_order(
+        instrument_eth_usdt.id(),
+        ClientOrderId::from("O-INVALID-EMERGENCY-EXIT"),
+        if matches!(invalid, InvalidEmergencyExit::WrongSide) {
+            OrderSide::Buy
+        } else {
+            OrderSide::Sell
+        },
+        if matches!(invalid, InvalidEmergencyExit::QuantityExceedsPosition) {
+            Quantity::from("3.000")
+        } else {
+            Quantity::from("1.000")
+        },
+        !matches!(invalid, InvalidEmergencyExit::NotReduceOnly),
+    );
+    simple_cache
+        .add_order(
+            order.clone(),
+            Some(
+                if matches!(invalid, InvalidEmergencyExit::MismatchedCachedPosition) {
+                    PositionId::from("P-OTHER-EMERGENCY-EXIT")
+                } else {
+                    position_id
+                },
+            ),
+            Some(client_id_binance),
+            false,
+        )
+        .unwrap();
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    let command = emergency_exit_command(
+        trader_id,
+        client_id_binance,
+        strategy_id_ema_cross,
+        &order,
+        (!matches!(invalid, InvalidEmergencyExit::MissingPositionId)).then_some(position_id),
+        !matches!(invalid, InvalidEmergencyExit::MissingIntent),
+        risk_engine.clock().borrow().timestamp_ns(),
+    );
+
+    risk_engine.set_trading_state(TradingState::Halted);
+    risk_engine.execute(TradingCommand::SubmitOrder(command));
+
+    let process_messages = get_process_order_event_handler_messages(&process_order_event_handler);
+    let execute_messages = get_execute_order_event_handler_messages(&execute_order_event_handler);
+    assert_eq!(process_messages.len(), 1);
+    assert_eq!(process_messages[0].event_type(), OrderEventType::Denied);
+    // Wrong side and excess quantity are caught by the reduce-only pre-check
+    // before classification; the remaining cases reach the gateway and keep
+    // the ordinary halted denial.
+    let expected_reason = match invalid {
+        InvalidEmergencyExit::WrongSide | InvalidEmergencyExit::QuantityExceedsPosition => {
+            "REDUCE_ONLY_WOULD_INCREASE_POSITION"
+        }
+        InvalidEmergencyExit::MissingPositionId
+        | InvalidEmergencyExit::MismatchedCachedPosition
+        | InvalidEmergencyExit::MissingIntent
+        | InvalidEmergencyExit::NotReduceOnly => "TRADING_HALTED",
+    };
+    assert!(
+        process_messages[0]
+            .message()
+            .unwrap()
+            .starts_with(expected_reason)
+    );
+    assert!(execute_messages.is_empty());
+}
+
+#[rstest]
+fn test_submit_order_list_strips_caller_emergency_exit_param(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    instrument_eth_usdt: InstrumentAny,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache.add_quote(quote_ethusdt_binance()).unwrap();
+    add_margin_account_for_close_position(&mut simple_cache);
+    let position_id = PositionId::from("P-EMERGENCY-EXIT-LIST-PROVENANCE");
+    add_position_for_close_position(
+        &mut simple_cache,
+        &instrument_eth_usdt,
+        Quantity::from("2.000"),
+        position_id,
+        PositionSide::Long,
+    );
+    let order = emergency_exit_order(
+        instrument_eth_usdt.id(),
+        ClientOrderId::from("O-EMERGENCY-EXIT-LIST-PROVENANCE"),
+        OrderSide::Sell,
+        Quantity::from("1.000"),
+        true,
+    );
+    simple_cache
+        .add_order(
+            order.clone(),
+            Some(position_id),
+            Some(client_id_binance),
+            true,
+        )
+        .unwrap();
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    let order_list = OrderList::new(
+        OrderListId::new("EMERGENCY-EXIT-LIST-PROVENANCE"),
+        instrument_eth_usdt.id(),
+        strategy_id_ema_cross,
+        vec![order.client_order_id()],
+        risk_engine.clock().borrow().timestamp_ns(),
+    );
+    let command = SubmitOrderList::new(
+        trader_id,
+        Some(client_id_binance),
+        strategy_id_ema_cross,
+        order_list,
+        vec![order.init_event().clone()],
+        None,
+        Some(position_id),
+        Some(emergency_exit_params(true)),
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrderList(command));
+
+    let execute_messages = get_execute_order_event_handler_messages(&execute_order_event_handler);
+    assert_eq!(execute_messages.len(), 1);
+    let TradingCommand::SubmitOrderList(forwarded) = &execute_messages[0] else {
+        panic!("Expected SubmitOrderList command");
+    };
+    assert!(
+        forwarded
+            .params
+            .as_ref()
+            .and_then(|params| params.get_bool(PARAMS_EMERGENCY_EXIT))
+            .is_none()
+    );
+}
+
+#[rstest]
+fn test_submit_emergency_exit_order_list_when_trading_halted_denies(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    instrument_eth_usdt: InstrumentAny,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache.add_quote(quote_ethusdt_binance()).unwrap();
+    add_margin_account_for_close_position(&mut simple_cache);
+    let position_id = PositionId::from("P-EMERGENCY-EXIT-LIST");
+    add_position_for_close_position(
+        &mut simple_cache,
+        &instrument_eth_usdt,
+        Quantity::from("2.000"),
+        position_id,
+        PositionSide::Long,
+    );
+    let order = emergency_exit_order(
+        instrument_eth_usdt.id(),
+        ClientOrderId::from("O-EMERGENCY-EXIT-LIST"),
+        OrderSide::Sell,
+        Quantity::from("1.000"),
+        true,
+    );
+    simple_cache
+        .add_order(
+            order.clone(),
+            Some(position_id),
+            Some(client_id_binance),
+            true,
+        )
+        .unwrap();
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    let order_list = OrderList::new(
+        OrderListId::new("EMERGENCY-EXIT-LIST"),
+        instrument_eth_usdt.id(),
+        strategy_id_ema_cross,
+        vec![order.client_order_id()],
+        risk_engine.clock().borrow().timestamp_ns(),
+    );
+    let command = SubmitOrderList::new(
+        trader_id,
+        Some(client_id_binance),
+        strategy_id_ema_cross,
+        order_list,
+        vec![order.init_event().clone()],
+        None,
+        Some(position_id),
+        Some(emergency_exit_params(true)),
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.set_trading_state(TradingState::Halted);
+    risk_engine.execute(TradingCommand::SubmitOrderList(command));
+
+    let process_messages = get_process_order_event_handler_messages(&process_order_event_handler);
+    let execute_messages = get_execute_order_event_handler_messages(&execute_order_event_handler);
+    assert_eq!(process_messages.len(), 1);
+    assert_eq!(
+        process_messages[0].message(),
+        Some(Ustr::from("TRADING_HALTED"))
+    );
+    assert!(execute_messages.is_empty());
+}
+
+#[rstest]
+fn test_submit_emergency_exit_when_over_max_notional_denies(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    mut instrument_eth_usdt: InstrumentAny,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    let InstrumentAny::CryptoPerpetual(instrument) = &mut instrument_eth_usdt else {
+        unreachable!();
+    };
+    instrument.max_notional = None;
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache
+        .add_quote(emergency_exit_quote(instrument_eth_usdt.id()))
+        .unwrap();
+    add_margin_account_for_close_position(&mut simple_cache);
+    let position_id = PositionId::from("P-EMERGENCY-EXIT-NOTIONAL");
+    add_position_for_close_position(
+        &mut simple_cache,
+        &instrument_eth_usdt,
+        Quantity::from("2.000"),
+        position_id,
+        PositionSide::Long,
+    );
+    let order = emergency_exit_order(
+        instrument_eth_usdt.id(),
+        ClientOrderId::from("O-EMERGENCY-EXIT-NOTIONAL"),
+        OrderSide::Sell,
+        Quantity::from("1.000"),
+        true,
+    );
+    simple_cache
+        .add_order(
+            order.clone(),
+            Some(position_id),
+            Some(client_id_binance),
+            false,
+        )
+        .unwrap();
+    let mut risk_engine =
+        get_risk_engine(Some(Rc::new(RefCell::new(simple_cache))), None, None, false);
+    risk_engine.set_max_notional_per_order(instrument_eth_usdt.id(), dec!(1));
+    let command = emergency_exit_command(
+        trader_id,
+        client_id_binance,
+        strategy_id_ema_cross,
+        &order,
+        Some(position_id),
+        true,
+        risk_engine.clock().borrow().timestamp_ns(),
+    );
+
+    risk_engine.set_trading_state(TradingState::Halted);
+    risk_engine.execute(TradingCommand::SubmitOrder(command));
+
+    let process_messages = get_process_order_event_handler_messages(&process_order_event_handler);
+    let execute_messages = get_execute_order_event_handler_messages(&execute_order_event_handler);
+    assert_eq!(process_messages.len(), 1);
+    assert!(
+        process_messages[0]
+            .message()
+            .unwrap()
+            .starts_with("NOTIONAL_EXCEEDS_MAX_PER_ORDER")
+    );
+    assert!(execute_messages.is_empty());
+}
+
+#[rstest]
+fn test_submit_emergency_exit_when_over_rate_limit_denies(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    instrument_eth_usdt: InstrumentAny,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    simple_cache
+        .add_instrument(instrument_eth_usdt.clone())
+        .unwrap();
+    simple_cache
+        .add_quote(emergency_exit_quote(instrument_eth_usdt.id()))
+        .unwrap();
+    add_margin_account_for_close_position(&mut simple_cache);
+    let position_id = PositionId::from("P-EMERGENCY-EXIT-RATE");
+    add_position_for_close_position(
+        &mut simple_cache,
+        &instrument_eth_usdt,
+        Quantity::from("2.000"),
+        position_id,
+        PositionSide::Long,
+    );
+    let orders = (0..11)
+        .map(|index| {
+            emergency_exit_order(
+                instrument_eth_usdt.id(),
+                ClientOrderId::new(format!("O-EMERGENCY-EXIT-RATE-{index}")),
+                OrderSide::Sell,
+                Quantity::from("1.000"),
+                true,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for order in &orders {
+        simple_cache
+            .add_order(
+                order.clone(),
+                Some(position_id),
+                Some(client_id_binance),
+                false,
+            )
+            .unwrap();
+    }
+    let config = RiskEngineConfig {
+        debug: true,
+        bypass: false,
+        max_order_submit: RateLimit::new(10, 1000),
+        max_order_modify: RateLimit::new(5, 1000),
+        max_notional_per_order: AHashMap::new(),
+        full_position_exit_venues: AHashSet::new(),
+    };
+    let mut risk_engine = get_risk_engine(
+        Some(Rc::new(RefCell::new(simple_cache))),
+        Some(config),
+        None,
+        false,
+    );
+    risk_engine.set_trading_state(TradingState::Halted);
+
+    for order in &orders {
+        let command = emergency_exit_command(
+            trader_id,
+            client_id_binance,
+            strategy_id_ema_cross,
+            order,
+            Some(position_id),
+            true,
+            risk_engine.clock().borrow().timestamp_ns(),
+        );
+        risk_engine.execute(TradingCommand::SubmitOrder(command));
+    }
+
+    let process_messages = get_process_order_event_handler_messages(&process_order_event_handler);
+    let execute_messages = get_execute_order_event_handler_messages(&execute_order_event_handler);
+    assert_eq!(execute_messages.len(), 10);
+    assert_eq!(process_messages.len(), 1);
+    assert_eq!(
+        process_messages[0].message(),
+        Some(Ustr::from("RATE_LIMIT_EXCEEDED"))
+    );
 }
 
 #[rstest]

--- a/docs/concepts/execution.md
+++ b/docs/concepts/execution.md
@@ -228,7 +228,15 @@ a backtest exit with an explicit quantity and `reduce_only` instead.
 The `TradingState` enum has three variants:
 
 - `ACTIVE`: Submit and modify commands operate normally.
-- `HALTED`: New submit and modify commands are denied. Cancels still pass through.
+- `HALTED`: New submit and modify commands are denied, except that each individual reduce-only
+  `SubmitOrder` marked `emergency_exit=true` is evaluated on its own; there is no limit of one
+  emergency exit per halt, and order lists are always denied. The risk engine requires an
+  identified open position on the same instrument, an opposing order side, and a submitted
+  quantity no greater than the position quantity. The execution engine then denies the order unless
+  the routed client enforces reduce-only for that exact order path. The paths that qualify today
+  are Binance Futures in one-way (non-hedge) position mode for a mapped order type without
+  `close_position`, and backtest or sandbox venues with `use_reduce_only` enabled. Every other
+  execution client, including external clients, is denied. Cancels still pass through.
 - `REDUCING`: Cancels are allowed, and only submit or modify commands that do not increase
   exposure are accepted.
 
@@ -501,54 +509,56 @@ cross or immediately match. Other venue rejections leave it `false`.
 <!-- Generated from the `OrderDeniedReason` enum (crates/model). Regenerate with: cargo test -p nautilus-model regenerate_order_denied_reasons_doc -- --ignored -->
 <!-- BEGIN GENERATED: order-denied-reasons -->
 
-| Code                                             | Description                                                                |
-| ------------------------------------------------ | -------------------------------------------------------------------------- |
-| `PRICE_PRECISION_EXCEEDS_MAXIMUM`                | The price precision exceeds the instrument maximum.                        |
-| `PRICE_NOT_POSITIVE`                             | The price is not positive.                                                 |
-| `QUANTITY_PRECISION_EXCEEDS_MAXIMUM`             | The quantity precision exceeds the instrument maximum.                     |
-| `QUANTITY_CONVERSION_FAILED`                     | The order quantity could not be converted for risk checks.                 |
-| `QUANTITY_EXCEEDS_MAXIMUM`                       | The effective order quantity exceeds the instrument maximum.               |
-| `QUANTITY_BELOW_MINIMUM`                         | The effective order quantity is below the instrument minimum.              |
-| `INVALID_MAX_NOTIONAL_PER_ORDER`                 | The configured maximum notional per order is invalid.                      |
-| `INVALID_ORDER_SIDE`                             | The order side is invalid for this operation.                              |
-| `MISSING_EXPIRE_TIME`                            | A GTD order is missing its expire time.                                    |
-| `EXPIRE_TIME_IN_PAST`                            | The order's expire time is in the past.                                    |
-| `MISSING_TRAILING_OFFSET_TYPE`                   | The order is missing a required trailing offset type.                      |
-| `UNSUPPORTED_TRAILING_OFFSET_TYPE`               | The order's trailing offset type is not supported.                         |
-| `MISSING_TRIGGER_TYPE`                           | The order is missing a required trigger type.                              |
-| `MISSING_TRAILING_OFFSET`                        | The order is missing a required trailing offset.                           |
-| `INSTRUMENT_NOT_FOUND`                           | The instrument was not found in the cache.                                 |
-| `POSITION_NOT_FOUND`                             | The position for a reduce-only order was not found.                        |
-| `MARKET_PRICE_UNAVAILABLE`                       | No market price is available for the order risk check.                     |
-| `TRAILING_STOP_CALCULATION_FAILED`               | The trailing stop trigger price could not be calculated.                   |
-| `NOTIONAL_CALCULATION_FAILED`                    | The order notional value could not be calculated.                          |
-| `NOTIONAL_BELOW_MINIMUM`                         | The order notional is below the instrument minimum.                        |
-| `NOTIONAL_EXCEEDS_MAXIMUM`                       | The order notional exceeds the instrument maximum.                         |
-| `NOTIONAL_EXCEEDS_MAX_PER_ORDER`                 | The order notional exceeds the configured maximum per order.               |
-| `NOTIONAL_EXCEEDS_FREE_BALANCE`                  | The order notional exceeds the account free balance.                       |
-| `INITIAL_MARGIN_CALCULATION_FAILED`              | The order initial margin could not be calculated.                          |
-| `INITIAL_MARGIN_EXCEEDS_FREE_BALANCE`            | The order initial margin exceeds the account free balance.                 |
-| `BETTING_BALANCE_LOCKED_CALCULATION_FAILED`      | The balance to lock for the betting order could not be calculated.         |
-| `CUMULATIVE_NOTIONAL_EXCEEDS_FREE_BALANCE`       | The cumulative order notional exceeds the account free balance.            |
-| `CUMULATIVE_INITIAL_MARGIN_CALCULATION_FAILED`   | The cumulative initial margin could not be calculated.                     |
-| `CUMULATIVE_INITIAL_MARGIN_EXCEEDS_FREE_BALANCE` | The cumulative initial margin exceeds the account free balance.            |
-| `REDUCE_ONLY_WOULD_INCREASE_POSITION`            | A reduce-only order would increase the position.                           |
-| `ORDER_LIST_INCOMPLETE`                          | The order list is missing orders in the cache.                             |
-| `ORDER_LIST_DENIED`                              | The order was denied because its order list failed risk checks.            |
-| `TRADING_HALTED`                                 | Trading is halted; new orders are denied.                                  |
-| `TRADING_STATE_REDUCING`                         | Trading is reducing; the order would increase exposure.                    |
-| `RATE_LIMIT_EXCEEDED`                            | The order submission rate limit was exceeded.                              |
-| `STREAM_RECONCILING`                             | The execution stream is unavailable or recovering; retry after recovery.   |
-| `NO_EXECUTION_CLIENT`                            | No execution client was found for the routed command.                      |
-| `CLIENT_VENUE_MISMATCH`                          | The execution client does not handle the order venue.                      |
-| `SUBMIT_FAILED`                                  | Submitting the order to the execution client failed.                       |
-| `INVALID_CLIENT_ORDER_ID`                        | The client order ID is invalid for the venue.                              |
-| `INVALID_POSITION_ID`                            | The supplied position ID is invalid for the order submission.              |
-| `UNSUPPORTED_ORDER_LIST`                         | The venue does not support the requested order list.                       |
-| `UNSUPPORTED_ORDER_TYPE`                         | The order type is not supported.                                           |
-| `UNSUPPORTED_TIME_IN_FORCE`                      | The order's time in force is not supported.                                |
-| `UNSUPPORTED_TP_SL`                              | The venue does not support the requested take-profit/stop-loss parameters. |
-| `VALIDATION_FAILED`                              | The order failed validation before submission.                             |
+| Code                                             | Description                                                                  |
+| ------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `PRICE_PRECISION_EXCEEDS_MAXIMUM`                | The price precision exceeds the instrument maximum.                          |
+| `PRICE_NOT_POSITIVE`                             | The price is not positive.                                                   |
+| `QUANTITY_PRECISION_EXCEEDS_MAXIMUM`             | The quantity precision exceeds the instrument maximum.                       |
+| `QUANTITY_CONVERSION_FAILED`                     | The order quantity could not be converted for risk checks.                   |
+| `QUANTITY_EXCEEDS_MAXIMUM`                       | The effective order quantity exceeds the instrument maximum.                 |
+| `QUANTITY_BELOW_MINIMUM`                         | The effective order quantity is below the instrument minimum.                |
+| `INVALID_MAX_NOTIONAL_PER_ORDER`                 | The configured maximum notional per order is invalid.                        |
+| `INVALID_ORDER_SIDE`                             | The order side is invalid for this operation.                                |
+| `MISSING_EXPIRE_TIME`                            | A GTD order is missing its expire time.                                      |
+| `EXPIRE_TIME_IN_PAST`                            | The order's expire time is in the past.                                      |
+| `MISSING_TRAILING_OFFSET_TYPE`                   | The order is missing a required trailing offset type.                        |
+| `UNSUPPORTED_TRAILING_OFFSET_TYPE`               | The order's trailing offset type is not supported.                           |
+| `MISSING_TRIGGER_TYPE`                           | The order is missing a required trigger type.                                |
+| `MISSING_TRAILING_OFFSET`                        | The order is missing a required trailing offset.                             |
+| `INSTRUMENT_NOT_FOUND`                           | The instrument was not found in the cache.                                   |
+| `POSITION_NOT_FOUND`                             | The position for a reduce-only order was not found.                          |
+| `MARKET_PRICE_UNAVAILABLE`                       | No market price is available for the order risk check.                       |
+| `TRAILING_STOP_CALCULATION_FAILED`               | The trailing stop trigger price could not be calculated.                     |
+| `NOTIONAL_CALCULATION_FAILED`                    | The order notional value could not be calculated.                            |
+| `NOTIONAL_BELOW_MINIMUM`                         | The order notional is below the instrument minimum.                          |
+| `NOTIONAL_EXCEEDS_MAXIMUM`                       | The order notional exceeds the instrument maximum.                           |
+| `NOTIONAL_EXCEEDS_MAX_PER_ORDER`                 | The order notional exceeds the configured maximum per order.                 |
+| `NOTIONAL_EXCEEDS_FREE_BALANCE`                  | The order notional exceeds the account free balance.                         |
+| `INITIAL_MARGIN_CALCULATION_FAILED`              | The order initial margin could not be calculated.                            |
+| `INITIAL_MARGIN_EXCEEDS_FREE_BALANCE`            | The order initial margin exceeds the account free balance.                   |
+| `BETTING_BALANCE_LOCKED_CALCULATION_FAILED`      | The balance to lock for the betting order could not be calculated.           |
+| `CUMULATIVE_NOTIONAL_EXCEEDS_FREE_BALANCE`       | The cumulative order notional exceeds the account free balance.              |
+| `CUMULATIVE_INITIAL_MARGIN_CALCULATION_FAILED`   | The cumulative initial margin could not be calculated.                       |
+| `CUMULATIVE_INITIAL_MARGIN_EXCEEDS_FREE_BALANCE` | The cumulative initial margin exceeds the account free balance.              |
+| `REDUCE_ONLY_WOULD_INCREASE_POSITION`            | A reduce-only order would increase the position.                             |
+| `ORDER_LIST_INCOMPLETE`                          | The order list is missing orders in the cache.                               |
+| `ORDER_LIST_DENIED`                              | The order was denied because its order list failed risk checks.              |
+| `TRADING_HALTED`                                 | Trading is halted; new orders are denied.                                    |
+| `TRADING_STATE_REDUCING`                         | Trading is reducing; the order would increase exposure.                      |
+| `RATE_LIMIT_EXCEEDED`                            | The order submission rate limit was exceeded.                                |
+| `STREAM_RECONCILING`                             | The execution stream is unavailable or recovering; retry after recovery.     |
+| `NO_EXECUTION_CLIENT`                            | No execution client was found for the routed command.                        |
+| `CLIENT_VENUE_MISMATCH`                          | The execution client does not handle the order venue.                        |
+| `REDUCE_ONLY_NOT_ENFORCED`                       | The routed execution client does not enforce reduce-only for this order.     |
+| `REDUCE_ONLY_ENFORCEMENT_NOT_ESTABLISHED`        | Reduce-only enforcement is not established for the external execution route. |
+| `SUBMIT_FAILED`                                  | Submitting the order to the execution client failed.                         |
+| `INVALID_CLIENT_ORDER_ID`                        | The client order ID is invalid for the venue.                                |
+| `INVALID_POSITION_ID`                            | The supplied position ID is invalid for the order submission.                |
+| `UNSUPPORTED_ORDER_LIST`                         | The venue does not support the requested order list.                         |
+| `UNSUPPORTED_ORDER_TYPE`                         | The order type is not supported.                                             |
+| `UNSUPPORTED_TIME_IN_FORCE`                      | The order's time in force is not supported.                                  |
+| `UNSUPPORTED_TP_SL`                              | The venue does not support the requested take-profit/stop-loss parameters.   |
+| `VALIDATION_FAILED`                              | The order failed validation before submission.                               |
 
 <!-- END GENERATED: order-denied-reasons -->
 


### PR DESCRIPTION
Replaces the `validate_order_risk` entry point with the narrow gateway exception agreed on the thread.

## The HALTED gateway exception

`execution_gateway` denies every submit under `TradingState::Halted`, so an operator's closing order is denied exactly when a halt makes it necessary, and the only alternative was bypassing the risk engine. `handle_submit_order` now classifies a submit before the risk checks: `is_emergency_position_exit` requires the `emergency_exit=true` params intent, a reduce-only order with positive quantity, command/order instrument agreement, and an identified open position - `position_id` on the command, the cached order mapped to it, the position open on the same instrument, and an opposing side. The classification reaches the gateway as a private two-variant enum; under `Halted` a verified exit forwards to the submit throttler and the normal event path, while ordinary submits, generic reduce-only submits, and all order lists keep the `TRADING_HALTED` denial. `Active` and `Reducing` ignore the classification.

A new `PARAMS_EMERGENCY_EXIT` key carries the intent. The Binance futures adapter reads `PARAMS_CLOSE_POSITION` to set venue-side `closePosition` on conditional orders, and `is_full_position_exit_order` requires a non-reduce-only conditional type - a different venue feature, so that key cannot double for this one.

## The route must enforce reduce-only

`order.is_reduce_only()` is not evidence that the venue will refuse to cross flat: the Interactive Brokers client builds an ordinary venue order and never encodes the instruction, so a fill in flight can make the engine's cached-position read stale and the exit can open exposure under a halt. The risk engine cannot answer this itself, because it cannot see which client will be selected - an explicit but unregistered `command.client_id` falls through to account, venue, then default routing in `find_client_for_command`.

`ExecutionClient` gains a default-false `enforces_reduce_only(&SubmitOrder, &OrderAny)`, contracted on the downstream path preventing any execution which would increase or reverse the position once it reaches flat, whether by native venue enforcement or by matching-engine enforcement against execution-time position state. `ExecutionEngine::handle_submit_order` checks it beside the existing `ClientVenueMismatch` denial and denies `REDUCE_ONLY_NOT_ENFORCED` before reaching the client. `BacktestExecutionClient` and `SandboxExecutionClient` qualify when `use_reduce_only` is enabled, which gates every clamp in `OrderMatchingEngine`; `BinanceFuturesExecutionClient` qualifies in one-way mode, where the WS, HTTP and algo paths all send native `reduceOnly` - in hedge mode `reduce_only_param` returns `None`, since Binance rejects `reduceOnly` alongside `positionSide`. Every other client keeps the default, which records that this PR has not established eligibility rather than that the venue cannot support it.

Because `emergency_exit` is caller-supplied, the risk engine removes the key before the bypass return, classifies from the captured value, and re-inserts it only on the branch it admitted under `Halted`, so an emergency-marked order still submits unchanged under `Active`. Caller authentication remains deferred per the thread.

## The bound is the submitted quantity

`would_reduce_only` compares `leaves_qty`, while the execution client reconstructs the venue request from `order.quantity()`. A partially filled order with quantity 10, filled 6 and leaves 4 against an open position of 4 therefore qualified and then submitted 10, crossing flat by 6. Eligibility now also requires `order.quantity() <= position.quantity`, inside the emergency classifier only; the shared position lookup is extracted so `would_reduce_only`, the upstream reduce-only pre-check and the full-position exit path are unchanged.

A partially filled order rejected by this bound produces no `OrderDenied`, because `deny_order` returns early for an order past `Initialized`. It cannot reach the client, and a denial event would be invalid for that order state.

## Testing

`test_submit_emergency_exit_when_trading_halted_forwards_to_execution` pins the forwarded command's client order id, position id, reduce-only flag and restamped params; `test_submit_emergency_exit_when_over_rate_limit_denies` pins the throttler path (`RATE_LIMIT_EXCEEDED` on the 11th submit). `test_submit_emergency_exit_uses_submitted_quantity_bound` pins quantity 10, filled 6, leaves 4 against a position of 4, asserting `would_reduce_only` still holds so the case exercises the new bound, plus the boundary where submitted quantity equals the position. `test_submit_emergency_exit_requires_capable_route` asserts the denial reason and that nothing reaches an incapable client, and submission on a capable one. Two provenance tests pin the intent key absent when forwarded under `Active`, on bypass, and for order lists. A six-case matrix pins each near-miss denial reason, an order list carrying a qualifying leg stays denied, a verified exit over max-notional is denied by the normal check, and the three capability predicates have their own matrices including Binance hedge mode, a disabled backtest exchange, and a sandbox with `use_reduce_only` off. The three existing `HALTED` tests and the `test_submit_close_position_*` family are unchanged.

Reverting the quantity bound makes the partial-fill case forward, and disabling the route check makes the incapable case submit.
