### PR TITLE
Reject a GTD market exit time in force in strategy config

### DIFF
--- a/crates/trading/src/strategy/config.rs
+++ b/crates/trading/src/strategy/config.rs
@@ -174,6 +174,15 @@ impl StrategyConfig {
             ),
         );
 
+        let time_in_force = self.market_exit_time_in_force;
+        errors.check(
+            time_in_force != TimeInForce::Gtd,
+            ConfigError::unsupported_value(
+                "market_exit_time_in_force",
+                format!("{time_in_force} is not supported for market orders"),
+            ),
+        );
+
         errors.into_result()
     }
 }
@@ -216,6 +225,7 @@ impl Default for StrategyConfig {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use strum::IntoEnumIterator;
 
     use super::*;
 
@@ -275,15 +285,58 @@ mod tests {
     }
 
     #[rstest]
+    fn test_gtd_market_exit_time_in_force_rejected() {
+        let result = StrategyConfig::builder()
+            .market_exit_time_in_force(TimeInForce::Gtd)
+            .build();
+        let Err(ConfigError::UnsupportedValue { field, reason }) = result else {
+            panic!("expected ConfigError::UnsupportedValue");
+        };
+        assert_eq!(field, "market_exit_time_in_force");
+        assert_eq!(reason, "GTD is not supported for market orders");
+    }
+
+    // Iterates the enum rather than listing cases, so a variant added later is covered
+    // without editing this test: the invariant is that every time in force except GTD
+    // is accepted, mirroring `MarketOrder::new_checked`.
+    #[rstest]
+    fn test_non_gtd_market_exit_time_in_force_accepted() {
+        for time_in_force in TimeInForce::iter().filter(|t| *t != TimeInForce::Gtd) {
+            assert!(
+                StrategyConfig::builder()
+                    .market_exit_time_in_force(time_in_force)
+                    .build()
+                    .is_ok(),
+                "{time_in_force} should be accepted"
+            );
+        }
+    }
+
+    #[rstest]
     fn test_multiple_violations_collected() {
         let result = StrategyConfig::builder()
             .market_exit_interval_ms(0)
             .market_exit_max_attempts(0)
+            .market_exit_time_in_force(TimeInForce::Gtd)
             .build();
         let ConfigError::Multiple { errors } = result.unwrap_err() else {
             panic!("expected ConfigError::Multiple");
         };
-        assert_eq!(errors.len(), 2);
+        // Asserted by index, not membership: the collector preserves insertion order, so
+        // checking position also pins that the new check runs after the two numeric ones.
+        assert_eq!(errors.len(), 3);
+        assert!(matches!(
+            &errors[0],
+            ConfigError::Range { field, .. } if field == "market_exit_interval_ms"
+        ));
+        assert!(matches!(
+            &errors[1],
+            ConfigError::Range { field, .. } if field == "market_exit_max_attempts"
+        ));
+        assert!(matches!(
+            &errors[2],
+            ConfigError::UnsupportedValue { field, .. } if field == "market_exit_time_in_force"
+        ));
     }
 
     #[rstest]


### PR DESCRIPTION
`StrategyConfig` accepts a `market_exit_time_in_force` that no market order can carry, and the failure surfaces as a panic during the exit rather than at construction.

## The configuration outlives its own validation

`StrategyConfig::validate` collects violations for `market_exit_interval_ms` and `market_exit_max_attempts`, and examines no other field. `market_exit_time_in_force` is therefore unchecked, so `StrategyConfigBuilder::build` returns `Ok` for `TimeInForce::Gtd`.

`MarketOrder::new_checked` rejects GTD outright. Nothing between the two layers relates them, so the config is accepted and the incompatibility is discovered later: `Strategy::market_exit` reads the field, `close_all_positions` passes it to `OrderFactory::market`, and that method unwraps `try_market` and panics. A strategy configured this way runs normally until it tries to flatten - which includes the `manage_stop` teardown path, where the strategy is stopping and the positions are meant to be closed.

The check now sits with the other two in `validate`, using `ConfigError::unsupported_value` and naming the field. Both validated construction paths call `validate`, so the Python constructor inherits the rejection without a binding change.

## Rejecting exactly GTD

The check mirrors `MarketOrder::new_checked` and rejects the one value the order model rejects, rather than asserting an allowlist of time in force values that suit a closing order. `Fok`, `Day`, `AtTheOpen` and `AtTheClose` are accepted by the market order API; whether a particular venue honours them is venue capability, and `StrategyConfig` carries no venue or instrument context to decide it. An allowlist here would also let the two layers drift as the enum grows.

The exit path is left alone. Refusing at `market_exit` would defer the discovery to the moment the strategy is trying to flatten, the retry branch constructs a second market order independently and would need its own guard, and `OrderFactory::try_market` is `pub(crate)` in `nautilus-common`, so the trading crate cannot reach the fallible form without widening that API.

## What this does not close

`StrategyConfig` has public fields and derives `Deserialize`, and `StrategyCore::new` does not call `validate`, so a struct literal or a deserialized config can still carry GTD. This change closes the builder and the Python constructor rather than making the invalid state unrepresentable; doing that would mean a fallible `StrategyCore::new` or validation at registration, which reaches many callers.

Two neighbouring fields have the same shape and are left for separate changes: `market_exit_interval_ms` is checked for positivity but then multiplied by 1_000_000 without a `checked_mul` on the exit path, and `order_id_tag` is interpolated into a `StrategyId` through a panicking constructor with no format validation.

I can take either as a follow-up.

## Testing

Three tests in the config module. `test_gtd_market_exit_time_in_force_rejected` asserts the variant, the field, and the rendered reason, so an empty or mismatched message fails it. `test_non_gtd_market_exit_time_in_force_accepted` iterates `TimeInForce::iter()` and requires every variant except GTD to build, so a variant added later is covered without editing the test and a narrowing allowlist cannot pass. `test_multiple_violations_collected` now builds a config invalid in all three fields and asserts the collected errors by index, which pins both the count and the position of the new check.

Each assertion was checked against a mutated implementation: removing the check fails the rejection test while the acceptance loop stays green, weakening the reason string fails the reason assertion, and moving the check ahead of the two numeric ones fails at the first index with the count unchanged.
