### PR TITLE
Defer backtest order events during immediate dispatch

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -282,6 +282,7 @@ impl BacktestEngine {
 
         let routing = Some(config.routing);
         let frozen_account = Some(config.frozen_account);
+        let use_message_queue = config.use_message_queue;
 
         let exchange =
             SimulatedExchange::new(config, self.kernel.cache.clone(), self.kernel.clock.clone())?;
@@ -298,6 +299,12 @@ impl BacktestEngine {
             routing,
             frozen_account,
         );
+
+        if !use_message_queue {
+            exchange
+                .borrow_mut()
+                .set_event_handler(exec_client.order_event_handler());
+        }
 
         exchange
             .borrow_mut()
@@ -2156,7 +2163,7 @@ mod tests {
         enums::Environment,
         messages::{
             data::{DataCommand, UnsubscribeCommand},
-            execution::{SubmitOrder, TradingCommand},
+            execution::{ModifyOrder, SubmitOrder, TradingCommand},
         },
         msgbus::{
             self, MessagingSwitchboard, TypedHandler,
@@ -2170,11 +2177,12 @@ mod tests {
             AccountType, BookType, MarketStatus, MarketStatusAction, OmsType, OrderSide,
             OrderStatus, OrderType, TriggerType,
         },
-        identifiers::{AccountId, ActorId, ClientId, PositionId, StrategyId, Venue},
+        events::OrderEventAny,
+        identifiers::{AccountId, ActorId, ClientId, ClientOrderId, PositionId, StrategyId, Venue},
         instruments::{
             CryptoPerpetual, Instrument, InstrumentAny, stubs::crypto_perpetual_ethusdt,
         },
-        orders::{Order, OrderAny, OrderTestBuilder},
+        orders::{Order, OrderAny, OrderTestBuilder, stubs::TestOrderEventStubs},
         types::{Money, Price, Quantity},
     };
     use nautilus_system::{KernelEventStore, RegisteredComponents};
@@ -2270,6 +2278,210 @@ mod tests {
             .unwrap();
         engine.add_venue(venue_config).unwrap();
         engine
+    }
+
+    fn create_immediate_engine(instrument: &CryptoPerpetual) -> BacktestEngine {
+        let mut engine = BacktestEngine::new(BacktestEngineConfig::default()).unwrap();
+        let venue_config = SimulatedVenueConfig::builder()
+            .venue(instrument.id().venue)
+            .oms_type(OmsType::Netting)
+            .account_type(AccountType::Margin)
+            .book_type(BookType::L1_MBP)
+            .starting_balances(vec![Money::from("1_000_000 USDT")])
+            .use_message_queue(false)
+            .build()
+            .unwrap();
+        engine.add_venue(venue_config).unwrap();
+        engine
+            .add_instrument(&InstrumentAny::CryptoPerpetual(instrument.clone()))
+            .unwrap();
+        engine
+            .venues
+            .get(&instrument.id().venue)
+            .unwrap()
+            .borrow_mut()
+            .initialize_account();
+        engine
+    }
+
+    fn send_execution_command(command: TradingCommand) {
+        msgbus::send_trading_command(MessagingSwitchboard::exec_engine_execute(), command);
+    }
+
+    #[rstest]
+    fn test_immediate_submit_defers_order_events(crypto_perpetual_ethusdt: CryptoPerpetual) {
+        let engine = create_immediate_engine(&crypto_perpetual_ethusdt);
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .trader_id(engine.trader_id())
+            .instrument_id(crypto_perpetual_ethusdt.id)
+            .client_order_id(ClientOrderId::from("O-IMMEDIATE-SUBMIT"))
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1.000"))
+            .price(Price::from("1000.00"))
+            .build();
+        engine
+            .kernel
+            .cache
+            .borrow_mut()
+            .add_order(order.clone(), None, Some(ClientId::from("BINANCE")), false)
+            .unwrap();
+
+        send_execution_command(TradingCommand::SubmitOrder(SubmitOrder::new(
+            order.trader_id(),
+            Some(ClientId::from("BINANCE")),
+            order.strategy_id(),
+            order.instrument_id(),
+            order.client_order_id(),
+            order.init_event().clone(),
+            order.exec_algorithm_id(),
+            None,
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+        )));
+
+        {
+            let cache = engine.kernel.cache.borrow();
+            let cached_order = cache.order(&order.client_order_id()).unwrap();
+            assert_eq!(cached_order.status(), OrderStatus::Initialized);
+            assert_eq!(cached_order.event_count(), 1);
+        }
+
+        engine.drain_command_queues();
+
+        let cache = engine.kernel.cache.borrow();
+        let cached_order = cache.order(&order.client_order_id()).unwrap();
+        let events = cached_order.events();
+        assert!(matches!(events[1], OrderEventAny::Submitted(_)));
+        assert!(matches!(events[2], OrderEventAny::Accepted(_)));
+    }
+
+    #[rstest]
+    fn test_immediate_modify_submitted_order_defers_updated_event(
+        crypto_perpetual_ethusdt: CryptoPerpetual,
+    ) {
+        let engine = create_immediate_engine(&crypto_perpetual_ethusdt);
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .trader_id(engine.trader_id())
+            .instrument_id(crypto_perpetual_ethusdt.id)
+            .client_order_id(ClientOrderId::from("O-IMMEDIATE-MODIFY"))
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1.000"))
+            .price(Price::from("1000.00"))
+            .build();
+        let account_id = AccountId::from("BINANCE-001");
+        engine
+            .kernel
+            .cache
+            .borrow_mut()
+            .add_order(order.clone(), None, Some(ClientId::from("BINANCE")), false)
+            .unwrap();
+        engine
+            .kernel
+            .cache
+            .borrow_mut()
+            .update_order(&TestOrderEventStubs::submitted(&order, account_id))
+            .unwrap();
+
+        send_execution_command(TradingCommand::ModifyOrder(ModifyOrder::new(
+            order.trader_id(),
+            Some(ClientId::from("BINANCE")),
+            order.strategy_id(),
+            order.instrument_id(),
+            order.client_order_id(),
+            None,
+            Some(Quantity::from("2.000")),
+            None,
+            None,
+            UUID4::new(),
+            UnixNanos::from(1),
+            None,
+            None,
+        )));
+
+        {
+            let cache = engine.kernel.cache.borrow();
+            let cached_order = cache.order(&order.client_order_id()).unwrap();
+            assert_eq!(cached_order.quantity(), Quantity::from("1.000"));
+            assert!(matches!(
+                cached_order.events().last(),
+                Some(OrderEventAny::Submitted(_))
+            ));
+        }
+
+        engine.drain_command_queues();
+
+        let cache = engine.kernel.cache.borrow();
+        let order = cache.order(&order.client_order_id()).unwrap();
+        assert_eq!(order.quantity(), Quantity::from("2.000"));
+        assert!(matches!(
+            order.events().last(),
+            Some(OrderEventAny::Updated(_))
+        ));
+    }
+
+    #[rstest]
+    fn test_immediate_market_data_dispatches_fill_synchronously(
+        crypto_perpetual_ethusdt: CryptoPerpetual,
+    ) {
+        let engine = create_immediate_engine(&crypto_perpetual_ethusdt);
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .trader_id(engine.trader_id())
+            .instrument_id(crypto_perpetual_ethusdt.id)
+            .client_order_id(ClientOrderId::from("O-IMMEDIATE-QUOTE-FILL"))
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1.000"))
+            .price(Price::from("1000.00"))
+            .build();
+        engine
+            .kernel
+            .cache
+            .borrow_mut()
+            .add_order(order.clone(), None, Some(ClientId::from("BINANCE")), false)
+            .unwrap();
+
+        send_execution_command(TradingCommand::SubmitOrder(SubmitOrder::new(
+            order.trader_id(),
+            Some(ClientId::from("BINANCE")),
+            order.strategy_id(),
+            order.instrument_id(),
+            order.client_order_id(),
+            order.init_event().clone(),
+            order.exec_algorithm_id(),
+            None,
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+        )));
+        engine.drain_command_queues();
+
+        let quote = QuoteTick::new(
+            order.instrument_id(),
+            Price::from("999.00"),
+            Price::from("1000.00"),
+            Quantity::from("1.000"),
+            Quantity::from("1.000"),
+            UnixNanos::from(1),
+            UnixNanos::from(1),
+        );
+        msgbus::send_quote(
+            format!(
+                "SimulatedExchange.process_new_quote.{}",
+                order.instrument_id().venue
+            )
+            .into(),
+            &quote,
+        );
+
+        let cache = engine.kernel.cache.borrow();
+        let cached_order = cache.order(&order.client_order_id()).unwrap();
+        assert_eq!(cached_order.status(), OrderStatus::Filled);
+        assert!(matches!(
+            cached_order.events().last(),
+            Some(OrderEventAny::Filled(_))
+        ));
     }
 
     #[rstest]

--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -16,7 +16,7 @@
 //! Provides a `SimulatedExchange` venue for backtesting on historical data.
 
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque},
     fmt::Debug,
     rc::Rc,
@@ -134,6 +134,12 @@ pub struct SimulatedExchange {
     book_type: BookType,
     default_leverage: Decimal,
     exec_client: Option<Rc<dyn ExecutionClient>>,
+    event_handler: Option<Rc<dyn Fn(OrderEventAny)>>,
+    /// Set only while a trading command is being processed synchronously, which is the
+    /// window in which the execution engine holds a borrow and a re-entrant event would
+    /// panic. Outside it (market data, iteration, expiration, liquidation, open-order
+    /// loading) events dispatch directly, so immediate mode keeps its synchronous timing.
+    deferring_events: Rc<Cell<bool>>,
     fee_model: FeeModelHandle,
     fill_model: FillModelHandle,
     latency_model: Option<Box<dyn LatencyModel>>,
@@ -220,6 +226,8 @@ impl SimulatedExchange {
             book_type: config.book_type,
             default_leverage,
             exec_client: None,
+            event_handler: None,
+            deferring_events: Rc::new(Cell::new(false)),
             fee_model: config.fee_model,
             fill_model: config.fill_model,
             latency_model: config.latency_model,
@@ -422,7 +430,7 @@ impl SimulatedExchange {
             .checked_add(1)
             .ok_or_else(|| anyhow::anyhow!("matching engine raw ID exhausted at u32::MAX"))?;
         self.last_raw_id = raw_id;
-        let matching_engine = OrderMatchingEngine::new(
+        let mut matching_engine = OrderMatchingEngine::new(
             instrument.clone(),
             raw_id,
             self.fill_model.clone(),
@@ -434,11 +442,36 @@ impl SimulatedExchange {
             Rc::clone(&self.cache),
             matching_engine_config,
         );
+
+        if let Some(handler) = &self.event_handler {
+            matching_engine.set_event_handler(Rc::clone(handler));
+        }
         self.instruments.insert(instrument_id, instrument);
         self.matching_engines.insert(instrument_id, matching_engine);
 
         log::info!("Added instrument {instrument_id} and created matching engine");
         Ok(())
+    }
+
+    /// Sets the deferred event handler used while a trading command is processed
+    /// synchronously.
+    ///
+    /// The supplied handler is wrapped so it applies only inside that window; outside it
+    /// events go straight to the execution engine as before.
+    pub(crate) fn set_event_handler(&mut self, handler: Rc<dyn Fn(OrderEventAny)>) {
+        let deferring = Rc::clone(&self.deferring_events);
+        let gated: Rc<dyn Fn(OrderEventAny)> = Rc::new(move |event| {
+            if deferring.get() {
+                handler(event);
+            } else {
+                msgbus::send_order_event(MessagingSwitchboard::exec_engine_process(), event);
+            }
+        });
+
+        for matching_engine in self.matching_engines.values_mut() {
+            matching_engine.set_event_handler(Rc::clone(&gated));
+        }
+        self.event_handler = Some(gated);
     }
 
     /// Returns the best bid price for the given instrument, if available.
@@ -722,6 +755,7 @@ impl SimulatedExchange {
         }
 
         if !self.use_message_queue {
+            let _guard = DeferEventsGuard::new(Rc::clone(&self.deferring_events));
             self.process_trading_command(command);
         } else if self.latency_model.is_none() {
             self.message_queue.push_back(command);
@@ -1787,11 +1821,15 @@ impl SimulatedExchange {
             None,
             order.is_quote_quantity(),
         ));
-        Self::dispatch_order_event(event);
+        self.dispatch_order_event(event);
     }
 
-    fn dispatch_order_event(event: OrderEventAny) {
-        msgbus::send_order_event(MessagingSwitchboard::exec_engine_process(), event);
+    fn dispatch_order_event(&self, event: OrderEventAny) {
+        if let Some(handler) = &self.event_handler {
+            handler(event);
+        } else {
+            msgbus::send_order_event(MessagingSwitchboard::exec_engine_process(), event);
+        }
     }
 
     fn account_at_starting_balances(&self) -> bool {
@@ -1852,6 +1890,26 @@ impl SimulatedExchange {
 
             self.cache.borrow_mut().update_account(&account).unwrap();
         }
+    }
+}
+
+/// Marks the window in which order events are routed to the deferred handler, and clears
+/// it on drop so an unwind cannot leave the exchange deferring every later event.
+#[derive(Debug)]
+struct DeferEventsGuard {
+    deferring: Rc<Cell<bool>>,
+}
+
+impl DeferEventsGuard {
+    fn new(deferring: Rc<Cell<bool>>) -> Self {
+        deferring.set(true);
+        Self { deferring }
+    }
+}
+
+impl Drop for DeferEventsGuard {
+    fn drop(&mut self) {
+        self.deferring.set(false);
     }
 }
 

--- a/crates/backtest/src/execution_client.rs
+++ b/crates/backtest/src/execution_client.rs
@@ -131,6 +131,11 @@ impl BacktestExecutionClient {
             msgbus::send_order_event(endpoint, event);
         }
     }
+
+    pub(crate) fn order_event_handler(&self) -> Rc<dyn Fn(OrderEventAny)> {
+        let queued_events = Rc::clone(&self.queued_events);
+        Rc::new(move |event| queued_events.borrow_mut().push(event))
+    }
 }
 
 #[async_trait(?Send)]


### PR DESCRIPTION
A `SimulatedVenueConfig` with `use_message_queue = false` aborts the backtest with a `BorrowMutError` on the first order it is given.

## The re-entrancy

`ExecutionEngine::register_msgbus_handlers` registers `exec_engine_execute` as `rc.borrow().execute(cmd)` and `exec_engine_process` as `rc.borrow_mut().process(&event)` against the same `Rc<RefCell<ExecutionEngine>>`. A submitted order therefore holds a shared borrow for the whole of `execute`, which reaches `BacktestExecutionClient::submit_order` and `exchange.send(...)`.

With `use_message_queue = false`, `send` dispatches synchronously into `process_trading_command` instead of buffering the command. The matching engine emits `OrderAccepted` or `OrderFilled` through `dispatch_order_event`, which with no handler installed publishes to `exec_engine_process` - taking a mutable borrow while the shared one is still live.

`BacktestExecutionClient` already defends against this for the one event it generates itself: `submit_order` pushes `OrderSubmitted` into a `queued_events` buffer drained later by the engine loop, with a comment naming the re-entrancy. The events the exchange generates had no equivalent.

The exchange now takes an optional order event handler that feeds that same buffer, installed by `BacktestEngine::add_venue` only when `use_message_queue` is false. Both dispatch sites use it: the matching engines, and the exchange's own `dispatch_order_event`, which generates `OrderUpdated` when modifying an order still in `Submitted` and previously published unconditionally. That second site is the one a matching-engine-only fix misses; with it left alone, an immediate `ModifyOrder` still panics while a submit test passes.

## Deferral is scoped to the borrow window

A flag is set across `process_trading_command` and cleared by a guard on drop, and the handler defers only while it is set. Events raised by market data, matching engine iteration, expiration, liquidation and open order loading do not run beneath the execution engine borrow, so they continue straight to `exec_engine_process` and keep their synchronous timing.

Left permanently installed, the handler would buffer those too, and a fill driven by a quote would reach the strategy after the data rather than before it. Since submitting an order in this mode panics today, that ordering is not history being preserved but semantics being chosen, and an immediate dispatch venue whose fills arrive at drain time is not immediate in the sense the option offers.

The two queued modes install no handler and are unchanged: the command is buffered, the matching engine runs after the borrow has ended, and both dispatch sites take their existing message bus path.

## Reachability

`use_message_queue` is a public `SimulatedVenueConfig` field with a builder setter, defaulted `true`, and passed through `BacktestEngine.add_venue` in Python. No backtest, example or test in the tree sets it false; the existing immediate-dispatch tests cover query commands being ignored and an instrument ID overflow, none of which routes an order through the execution engine. So this is a documented option that fails deterministically for anyone who selects it, rather than a defect in a configuration under test.

## Testing

Three tests in `crates/backtest/src/engine.rs`, all driving commands through the registered `exec_engine_execute` endpoint - calling the client directly does not reproduce the defect, because it never establishes the outstanding engine borrow.

`test_immediate_submit_defers_order_events` asserts the order is still `Initialized` with one event before draining, then `Submitted` ahead of `Accepted` after. `test_immediate_modify_submitted_order_defers_updated_event` covers the exchange-local path, asserting the quantity is unchanged and `Submitted` still last before draining, then `2.000` and a final `Updated`. `test_immediate_market_data_dispatches_fill_synchronously` covers the other half of the contract: a resting order filled by a quote is applied to the cache immediately, with no drain.

Each assertion was checked against a mutated implementation. Installing no handler makes both command tests panic with `RefCell already borrowed`. Reverting the exchange's dispatcher to publish unconditionally, with the matching engine handler still in place, fails only the modify test. Making the handler defer unconditionally fails only the market data test.

## A shared deferred event path

The message bus already protects commands against this class: `exec_engine_queue_execute` defers when a command is dispatching. Extending the same treatment to order events would remove the class rather than contain it per adapter, and would let the sandbox adapter and this one drop their separate handlers. It moves ordering and callback timing for every execution client, so it wants its own change with coverage across live, sandbox and backtest.

I am glad to take that on in whatever shape you prefer, or to leave it with you.
