### PR TITLE
Fix Bybit open-only reports missing closed orders

### DIFF
--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -4223,6 +4223,10 @@ impl BybitHttpClient {
     ///
     /// Orders for instruments not currently loaded in cache will be skipped.
     ///
+    /// When `open_only` is true the realtime endpoint is queried twice per order filter,
+    /// once for currently open orders and once for recently closed orders, so terminal
+    /// reports are included.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -4291,63 +4295,75 @@ impl BybitHttpClient {
                         vec![None, Some(BybitOrderFilter::StopOrder)]
                     };
 
-                for order_filter in order_filters {
-                    let mut cursor: Option<String> = None;
+                // Query currently open orders, then recently closed ones. Without the
+                // `openOnly` parameter the realtime endpoint returns open orders only, so
+                // an order the venue has already cancelled, rejected or filled would never
+                // produce a report and a stale cache entry could not be resolved.
+                let open_only_modes = [None, Some(BybitOpenOnly::ClosedRecent)];
 
-                    loop {
-                        let remaining = if let Some(limit) = remaining_limit {
-                            (limit as usize).saturating_sub(all_orders.len())
-                        } else {
-                            usize::MAX
-                        };
+                for oo in open_only_modes {
+                    for order_filter in &order_filters {
+                        let mut cursor: Option<String> = None;
 
-                        if remaining == 0 {
-                            break;
-                        }
+                        loop {
+                            let remaining = if let Some(limit) = remaining_limit {
+                                (limit as usize).saturating_sub(all_orders.len())
+                            } else {
+                                usize::MAX
+                            };
 
-                        // Max 50 per Bybit API
-                        let page_limit = std::cmp::min(remaining, 50);
-
-                        let mut p = BybitOpenOrdersParamsBuilder::default();
-                        p.category(product_type);
-
-                        if let Some(symbol) = symbol_param.clone() {
-                            p.symbol(symbol);
-                        }
-
-                        if let Some(coin) = settle_coin.clone() {
-                            p.settle_coin(coin);
-                        }
-
-                        if let Some(of) = order_filter {
-                            p.order_filter(of);
-                        }
-                        p.limit(page_limit as u32);
-
-                        if let Some(c) = cursor {
-                            p.cursor(c);
-                        }
-                        let params = p.build().build_anyhow()?;
-                        let response: BybitOpenOrdersResponse = self
-                            .inner
-                            .send_request(
-                                Method::GET,
-                                BYBIT_ORDER_REALTIME,
-                                Some(&params),
-                                None,
-                                true,
-                            )
-                            .await?;
-
-                        for order in response.result.list {
-                            if seen_ids.insert(order.order_id) {
-                                all_orders.push(order);
+                            if remaining == 0 {
+                                break;
                             }
-                        }
 
-                        cursor = response.result.next_page_cursor;
-                        if cursor.as_ref().is_none_or(|c| c.is_empty()) {
-                            break;
+                            // Max 50 per Bybit API
+                            let page_limit = std::cmp::min(remaining, 50);
+
+                            let mut p = BybitOpenOrdersParamsBuilder::default();
+                            p.category(product_type);
+
+                            if let Some(symbol) = symbol_param.clone() {
+                                p.symbol(symbol);
+                            }
+
+                            if let Some(coin) = settle_coin.clone() {
+                                p.settle_coin(coin);
+                            }
+
+                            if let Some(of) = order_filter {
+                                p.order_filter(*of);
+                            }
+
+                            if let Some(oo) = oo {
+                                p.open_only(oo);
+                            }
+                            p.limit(page_limit as u32);
+
+                            if let Some(c) = cursor {
+                                p.cursor(c);
+                            }
+                            let params = p.build().build_anyhow()?;
+                            let response: BybitOpenOrdersResponse = self
+                                .inner
+                                .send_request(
+                                    Method::GET,
+                                    BYBIT_ORDER_REALTIME,
+                                    Some(&params),
+                                    None,
+                                    true,
+                                )
+                                .await?;
+
+                            for order in response.result.list {
+                                if seen_ids.insert(order.order_id) {
+                                    all_orders.push(order);
+                                }
+                            }
+
+                            cursor = response.result.next_page_cursor;
+                            if cursor.as_ref().is_none_or(|c| c.is_empty()) {
+                                break;
+                            }
                         }
                     }
                 }

--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -4225,7 +4225,8 @@ impl BybitHttpClient {
     ///
     /// When `open_only` is true the realtime endpoint is queried twice per order filter,
     /// once for currently open orders and once for recently closed orders, so terminal
-    /// reports are included.
+    /// reports are included. The closed pass fetches the most recent page only and is not
+    /// constrained by `start` or `end`.
     ///
     /// # Errors
     ///
@@ -4358,6 +4359,12 @@ impl BybitHttpClient {
                                 if seen_ids.insert(order.order_id) {
                                     all_orders.push(order);
                                 }
+                            }
+
+                            // The closed pass only needs the most recent page; the caller
+                            // re-filters reports on `start`, so older pages are discarded.
+                            if oo.is_some() {
+                                break;
                             }
 
                             cursor = response.result.next_page_cursor;

--- a/crates/adapters/bybit/tests/http.rs
+++ b/crates/adapters/bybit/tests/http.rs
@@ -45,7 +45,7 @@ use nautilus_bybit::{
 use nautilus_common::{cache::InstrumentLookupError, testing::wait_until_async};
 use nautilus_model::{
     data::BarType,
-    enums::{OrderSide, OrderType, PositionSideSpecified, TimeInForce, TriggerType},
+    enums::{OrderSide, OrderStatus, OrderType, PositionSideSpecified, TimeInForce, TriggerType},
     identifiers::{AccountId, ClientOrderId, InstrumentId, Symbol},
     instruments::{CurrencyPair, InstrumentAny},
     types::{Currency, Price, Quantity},
@@ -1926,11 +1926,11 @@ async fn test_request_order_status_reports_linear_queries_all_settle_coins() {
         .map(|(_, coin)| coin)
         .collect();
 
-    // 2 settle coins x 2 order filters (regular + StopOrder) = 4 queries
+    // 2 settle coins x 2 order filters (regular + StopOrder) x 2 openOnly passes = 8 queries
     assert_eq!(
         realtime_queries.len(),
-        4,
-        "Should query realtime endpoint for each settle coin and order filter"
+        8,
+        "Should query realtime endpoint for each settle coin, order filter and openOnly pass"
     );
     assert!(
         realtime_queries.contains(&&Some("USDT".to_string())),
@@ -2000,7 +2000,7 @@ async fn test_request_order_status_reports_respects_limit_across_settle_coins() 
         .filter(|(endpoint, _)| endpoint == "realtime")
         .count();
 
-    // At least 2 queries (both settle coins), up to 4 with StopOrder filter passes
+    // At least 2 queries (both settle coins), up to 8 with StopOrder and openOnly passes
     assert!(
         realtime_query_count >= 2,
         "Should query both settle coins, was {realtime_query_count}",
@@ -2123,11 +2123,11 @@ async fn test_request_order_status_reports_combines_orders_from_each_settle_coin
         .map(|(_, coin)| coin)
         .collect();
 
-    // 2 settle coins x 2 order filters (regular + StopOrder) = 4 queries
+    // 2 settle coins x 2 order filters (regular + StopOrder) x 2 openOnly passes = 8 queries
     assert_eq!(
         realtime_queries.len(),
-        4,
-        "Should query both USDT and USDC with both order filters"
+        8,
+        "Should query both USDT and USDC with both order filters and openOnly passes"
     );
     assert!(
         realtime_queries.contains(&&Some("USDT".to_string())),
@@ -2169,6 +2169,164 @@ async fn test_request_order_status_reports_combines_orders_from_each_settle_coin
         order_ids.contains(&"open-order-2-USDC".to_string()),
         "Should contain open-order-2-USDC from USDC settle coin"
     );
+}
+
+// Handler mirroring the venue: `/v5/order/realtime` returns open orders only unless
+// `openOnly=1` is sent, in which case recently closed orders are returned too.
+#[allow(dead_code)]
+async fn handle_get_orders_realtime_open_only(
+    query: Query<HashMap<String, String>>,
+    State(state): State<TestServerState>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    if !headers.contains_key("X-BAPI-API-KEY") {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({
+                "retCode": 10003,
+                "retMsg": "Invalid API key",
+                "result": {},
+                "retExtInfo": {},
+                "time": 1704470400123i64
+            })),
+        )
+            .into_response();
+    }
+
+    {
+        let mut count = state.realtime_requests.lock().await;
+        *count += 1;
+    }
+
+    // The fixture holds no conditional orders
+    if query.get("orderFilter").map(String::as_str) == Some("StopOrder") {
+        return Json(json!({
+            "retCode": 0,
+            "retMsg": "OK",
+            "result": { "list": [], "nextPageCursor": "" },
+            "retExtInfo": {},
+            "time": 1704470400123i64
+        }))
+        .into_response();
+    }
+
+    let mut orders = load_test_data("http_get_orders_realtime.json");
+    let list = orders["result"]["list"]
+        .as_array_mut()
+        .expect("Fixture should contain an order list");
+    list.truncate(1);
+
+    if query.get("openOnly").map(String::as_str) == Some("1") {
+        // The venue echoes the still open order back alongside the closed one
+        let mut cancelled = list[0].clone();
+        let fields = cancelled
+            .as_object_mut()
+            .expect("Fixture order should be an object");
+        fields.insert("orderId".to_string(), json!("cancelled-order-1"));
+        fields.insert("orderLinkId".to_string(), json!("client-cancelled-1"));
+        fields.insert("orderStatus".to_string(), json!("Cancelled"));
+        fields.insert("cancelType".to_string(), json!("CancelByUser"));
+        list.push(cancelled);
+    }
+
+    Json(orders).into_response()
+}
+
+#[allow(dead_code)]
+fn create_open_only_test_router(state: TestServerState) -> Router {
+    Router::new()
+        .route("/v5/market/time", get(handle_get_server_time))
+        .route("/v5/market/instruments-info", get(handle_get_instruments))
+        .route("/v5/account/fee-rate", get(handle_get_fee_rate))
+        .route(
+            "/v5/order/realtime",
+            get(handle_get_orders_realtime_open_only),
+        )
+        .with_state(state)
+}
+
+#[allow(dead_code)]
+async fn start_open_only_test_server()
+-> Result<(SocketAddr, TestServerState), Box<dyn std::error::Error + Send + Sync>> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let state = TestServerState::default();
+    let router = create_open_only_test_router(state.clone());
+
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    wait_for_server(addr, "/v5/market/time").await;
+    Ok((addr, state))
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_order_status_reports_open_only_includes_recently_closed() {
+    let (addr, state) = start_open_only_test_server().await.unwrap();
+    let base_url = format!("http://{addr}");
+
+    let client = BybitHttpClient::with_credentials(
+        "test_api_key".to_string(),
+        "test_api_secret".to_string(),
+        Some(base_url),
+        60,
+        3,
+        1000,
+        10_000,
+        5_000,
+        None,
+    )
+    .unwrap();
+
+    let instruments = client
+        .request_instruments(BybitProductType::Linear, None, None)
+        .await
+        .unwrap();
+
+    for instrument in instruments {
+        client.cache_instrument(instrument);
+    }
+
+    let account_id = AccountId::from("BYBIT-UNIFIED");
+    let instrument_id = InstrumentId::new(Symbol::from("ETHUSDT-LINEAR"), *BYBIT_VENUE);
+
+    let reports = client
+        .request_order_status_reports(
+            account_id,
+            BybitProductType::Linear,
+            Some(instrument_id),
+            true, // open_only
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // 2 order filters (regular + StopOrder) x 2 openOnly passes (open + recently closed)
+    let realtime_requests = *state.realtime_requests.lock().await;
+    assert_eq!(
+        realtime_requests, 4,
+        "Should query realtime for both openOnly passes and both order filters"
+    );
+
+    let cancelled = reports
+        .iter()
+        .find(|r| r.venue_order_id.as_str() == "cancelled-order-1")
+        .expect("Terminal report for the closed order should be returned");
+    assert_eq!(cancelled.order_status, OrderStatus::Canceled);
+
+    let open_count = reports
+        .iter()
+        .filter(|r| r.venue_order_id.as_str() == "open-order-1")
+        .count();
+    assert_eq!(
+        open_count, 1,
+        "Open order returned by both passes should be deduplicated"
+    );
+    assert_eq!(reports.len(), 2, "Should have the open and the closed order");
 }
 
 #[rstest]

--- a/crates/adapters/bybit/tests/http.rs
+++ b/crates/adapters/bybit/tests/http.rs
@@ -2217,7 +2217,8 @@ async fn handle_get_orders_realtime_open_only(
     list.truncate(1);
 
     if query.get("openOnly").map(String::as_str) == Some("1") {
-        // The venue echoes the still open order back alongside the closed one
+        // The venue returns recently closed orders here; keep the still-open order in the
+        // response too so both passes overlap and the dedup logic is exercised.
         let mut cancelled = list[0].clone();
         let fields = cancelled
             .as_object_mut()
@@ -2326,7 +2327,11 @@ async fn test_request_order_status_reports_open_only_includes_recently_closed() 
         open_count, 1,
         "Open order returned by both passes should be deduplicated"
     );
-    assert_eq!(reports.len(), 2, "Should have the open and the closed order");
+    assert_eq!(
+        reports.len(),
+        2,
+        "Should have the open and the closed order"
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [ ] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [ ] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

The `open_only` branch of `request_order_status_reports` built `BybitOpenOrdersParams` without setting `open_only`, and `/v5/order/realtime` with no `openOnly` parameter returns genuinely open orders only. An order the venue had already cancelled, rejected or filled therefore produced no report at all. The live open-order consistency check resolves a stale cache entry from a positive terminal report and on purpose does not act on absence, so an order left in `PENDING_CANCEL` by a lost cancel ack could never heal, even though the venue held the `Cancelled` report the whole time.

The branch now makes a second pass with `openOnly=1` (`BybitOpenOnly::ClosedRecent`) for each order filter. The `seen_ids` set already in the branch drops orders that come back in both passes, and the `remaining_limit` bookkeeping still caps the total. Nothing in the engine changes. The Bybit execution client passes no limit and post-filters reports on `start`, so the widened set stays bounded by `open_check_lookback_mins`.

One judgement call worth flagging. This doubles the realtime calls per open check, from 2 to 4 for a single settle coin and from 4 to 8 for LINEAR without a symbol. The reporter is running a vendored patch that instead routes the consistency check through the `open_only=false` path, which already queries `/v5/order/history` with a bounded `start` and adds no realtime calls. I picked the in-branch `ClosedRecent` pass because it is the smaller change, stays inside the adapter, and leaves the engine alone, but the other shape is defensible and I am happy to switch if you prefer it.

## Related issues/PRs

Closes #4730

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

The only doc change is three lines of rustdoc on `BybitHttpClient::request_order_status_reports`. The PyO3 wrapper `py_request_order_status_reports` and its stub are untouched, so no stub regeneration applies.

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

`test_request_order_status_reports_open_only_includes_recently_closed` adds a mock router whose `/v5/order/realtime` handler serves a `Cancelled` order only when `openOnly=1` is present, matching the venue. It checks the terminal report comes back, that the open order returned by both passes appears exactly once, and that four realtime calls were made. Two existing tests had their hard-coded realtime query counts moved from 4 to 8 for the extra pass. Their report counts are unchanged because the shared handler returns the same orders for both passes and they are deduplicated.

Limitation, stated up front: I could not run anything locally. The machine I prepared this on has no Rust toolchain and no C toolchain, so `make format`, `make pre-commit`, and `cargo nextest run -p nautilus-bybit --test http` were all skipped. I reviewed the change by hand against the sibling `open_only=false` branch, which uses the same borrow pattern over `order_filters`, and against `get_open_orders`, which already calls `open_only` on this builder, but I have not seen it compile or the new test go green. Please treat CI as the first real signal here, and tell me if you would rather I hold this until I can validate it locally.

I used AI assistance while preparing this change.