### PR TITLE
Fix panic on contract expiration for restored positions

### DIFF
--- a/crates/execution/src/matching_engine/mod.rs
+++ b/crates/execution/src/matching_engine/mod.rs
@@ -2417,7 +2417,14 @@ impl OrderMatchingEngine {
         self.cancel_open_orders_for_expiration();
 
         let instrument_id = self.instrument.id();
-        let positions: Vec<(TraderId, StrategyId, PositionId, OrderSide, Quantity)> = {
+        let positions: Vec<(
+            TraderId,
+            StrategyId,
+            AccountId,
+            PositionId,
+            OrderSide,
+            Quantity,
+        )> = {
             let cache = self.cache.borrow();
             cache
                 .positions_open(None, Some(&instrument_id), None, None, None)
@@ -2431,6 +2438,7 @@ impl OrderMatchingEngine {
                     (
                         pos.trader_id,
                         pos.strategy_id,
+                        pos.account_id,
                         pos.id,
                         closing_side,
                         pos.quantity,
@@ -2442,7 +2450,7 @@ impl OrderMatchingEngine {
         let ts_now = self.clock.borrow().timestamp_ns();
         let close_price_fallback = close.as_ref().map(|c| c.close_price);
 
-        for (trader_id, strategy_id, position_id, closing_side, quantity) in positions {
+        for (trader_id, strategy_id, account_id, position_id, closing_side, quantity) in positions {
             let client_order_id =
                 ClientOrderId::from(format!("EXPIRATION-{}-{}", self.venue, UUID4::new()).as_str());
             let mut order = OrderAny::Market(MarketOrder::new(
@@ -2482,6 +2490,10 @@ impl OrderMatchingEngine {
             }
 
             let venue_order_id = self.ids_generator.get_venue_order_id(&order).unwrap();
+            // The position may have been restored from a cache database without any
+            // order for this trader passing through the engine, so index the account
+            // ID from the position before emitting events.
+            self.account_ids.insert(trader_id, account_id);
             self.generate_order_accepted(&order, venue_order_id);
 
             let fill_price = self.settlement_price.or(close_price_fallback);

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -14693,6 +14693,125 @@ fn test_check_instrument_expiration_uses_close_price_fallback(account_id: Accoun
 }
 
 #[rstest]
+fn test_check_instrument_expiration_with_restored_position_uses_position_account_id() {
+    // A position loaded from a cache database after a restart has never been seen by
+    // this engine, so `account_ids` holds no entry for its trader. The expiration close
+    // order must still be accepted, carrying the account ID from the position.
+    let cache = Rc::new(RefCell::new(Cache::default()));
+    let order_event_handler = order_event_handler_with_cache(cache.clone());
+
+    let activation = UnixNanos::from(
+        u64::try_from(utc_timestamp(2021, 9, 10, 0, 0, 0).as_nanosecond()).unwrap(),
+    );
+    let expiration_ns = UnixNanos::from(
+        u64::try_from(utc_timestamp(2099, 12, 17, 0, 0, 0).as_nanosecond()).unwrap(),
+    );
+    let instrument =
+        InstrumentAny::FuturesContract(futures_contract_es(Some(activation), Some(expiration_ns)));
+
+    let clock = Rc::new(RefCell::new(TestClock::new()));
+    clock
+        .borrow_mut()
+        .set_time(UnixNanos::from(activation.as_u64() + 1));
+
+    let fee_model =
+        FeeModelAny::Fixed(FixedFeeModel::new(Money::new(0.0, Currency::USD()), None).unwrap());
+    let mut engine = OrderMatchingEngine::new(
+        instrument.clone(),
+        1,
+        FillModelHandle::default(),
+        fee_model.into(),
+        BookType::L2_MBP,
+        OmsType::Netting,
+        AccountType::Margin,
+        clock,
+        cache.clone(),
+        OrderMatchingEngineConfig {
+            use_position_ids: true,
+            ..Default::default()
+        },
+    );
+
+    let opening_bid = OrderBookDeltaTestBuilder::new(instrument.id())
+        .book_action(BookAction::Add)
+        .book_order(BookOrder::new(
+            OrderSide::Buy,
+            Price::from("4499.00"),
+            Quantity::from(10),
+            1,
+        ))
+        .build();
+    engine.process_order_book_delta(&opening_bid).unwrap();
+
+    // Restore an open position straight into the cache, with no order ever submitted
+    // through `process_order`.
+    let restored_account_id = AccountId::from("SIM-002");
+    let position_id = PositionId::from("P-RESTORED-1");
+    let opening_fill = build_order_filled(
+        TraderId::from("TRADER-001"),
+        StrategyId::from("S-001"),
+        instrument.id(),
+        ClientOrderId::from("RESTORED-1"),
+        VenueOrderId::from("V-RESTORED-1"),
+        restored_account_id,
+        TradeId::new("T-RESTORED-1"),
+        OrderSide::Buy,
+        OrderType::Market,
+        Quantity::from(1),
+        Price::from("4500.00"),
+        instrument.quote_currency(),
+        LiquiditySide::Taker,
+        Some(position_id),
+        Some(Money::new(0.0, instrument.quote_currency())),
+    );
+    let position = Position::new(&instrument, opening_fill);
+    cache
+        .borrow_mut()
+        .add_position(&position, OmsType::Netting)
+        .unwrap();
+
+    clear_order_event_handler_messages(&order_event_handler);
+
+    let settlement = Price::from("4600.00");
+    engine.set_settlement_price(settlement);
+
+    // Drive the clock past expiration to trigger `check_instrument_expiration`.
+    let trigger_delta = OrderBookDeltaTestBuilder::new(instrument.id())
+        .book_action(BookAction::Update)
+        .book_order(BookOrder::new(
+            OrderSide::Buy,
+            Price::from("4499.00"),
+            Quantity::from(10),
+            1,
+        ))
+        .ts_init(expiration_ns)
+        .build();
+    engine.process_order_book_delta(&trigger_delta).unwrap();
+
+    let is_expiration = |id: ClientOrderId| id.as_str().starts_with("EXPIRATION-");
+    let messages = get_order_event_handler_messages(&order_event_handler);
+
+    let accepted = messages
+        .iter()
+        .find_map(|e| match e {
+            OrderEventAny::Accepted(a) if is_expiration(a.client_order_id) => Some(a.clone()),
+            _ => None,
+        })
+        .expect("Expected OrderAccepted for the EXPIRATION close order");
+    assert_eq!(accepted.account_id, restored_account_id);
+
+    let fill = messages
+        .iter()
+        .find_map(|e| match e {
+            OrderEventAny::Filled(f) if is_expiration(f.client_order_id) => Some(f.clone()),
+            _ => None,
+        })
+        .expect("Expected OrderFilled for the EXPIRATION close order");
+    assert_eq!(fill.account_id, restored_account_id);
+    assert_eq!(fill.last_px, settlement);
+}
+
+#[rstest]
 fn test_binary_option_pending_resolution_then_instrument_close_settles_position(
     account_id: AccountId,
 ) {


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [ ] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

The issue points at v1 line numbers, but the same problem is in the v2 Rust matching engine. In `check_instrument_expiration` the synthetic EXPIRATION close order is built with `MarketOrder::new`, so it has no account ID of its own (mod.rs:2420-2485). `create_order_accepted` then falls back to `self.account_ids.get(&order.trader_id()).unwrap()` (mod.rs:6022), and `generate_order_filled` does the same. That index is only written by `process_order` and `liquidate_open_positions`, so a position loaded from a cache database after a restart has no entry for its trader and the unwrap panics.

`liquidate_open_positions` already gets this right. It collects `pos.account_id` (mod.rs:2561) and inserts it into `account_ids` before emitting any event (mod.rs:2630). This change applies the same pattern to the expiration path. Open positions are collected with their account ID, and that ID is put into `account_ids` before the accepted event is generated, which covers the later fill event too. Behaviour is unchanged for positions the engine has already seen, since the value written is the one `process_order` would have written.

The option expiry branch was already safe, so it is untouched. As a note for later, the three `.unwrap()` calls on `account_ids` at mod.rs:5982, 6022 and 6200 are all the same shape, and mod.rs:4963 shows the safe form. Hardening those is a separate change and is not in this PR.

## Related issues/PRs

Closes #4721

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Added `test_check_instrument_expiration_with_restored_position_uses_position_account_id` in `crates/execution/tests/matching_engine.rs`. It builds the engine for an expiring futures contract, puts an open position straight into the cache without ever calling `process_order`, sets a settlement price, then drives the clock past expiry. It checks that the EXPIRATION accepted and filled events both carry the account ID from the position. The test panics on `develop` and passes with this change.

The existing `test_check_instrument_expiration_*` tests all submit an order through `process_order` first, which populates `account_ids` and hides the problem.

Run it with:

```
cargo nextest run -p nautilus-execution --test matching_engine --features high-precision,python -E 'test(check_instrument_expiration)'
```
