### PR TITLE
Commit cached position state before persisting it

### DIFF
--- a/crates/backtest/src/exchange.rs
+++ b/crates/backtest/src/exchange.rs
@@ -1374,7 +1374,10 @@ impl SimulatedExchange {
                         adjusted.id
                     );
 
-                    for (original, _, _) in adjusted_positions[..index].iter().rev() {
+                    // Inclusive of `index`: the failed update commits the adjusted position
+                    // to the cache before attempting to persist it, so the position whose
+                    // update returned the error also needs restoring.
+                    for (original, _, _) in adjusted_positions[..=index].iter().rev() {
                         if let Err(rollback_error) = cache.update_position(original) {
                             log::error!(
                                 "Cannot roll back position {} after failed funding settlement: {rollback_error}",

--- a/crates/backtest/tests/exchange.rs
+++ b/crates/backtest/tests/exchange.rs
@@ -81,6 +81,7 @@ use nautilus_model::{
         AccountBalance, Currency, MarginBalance, Money, Price, Quantity, money::MONEY_RAW_MAX,
     },
 };
+use nautilus_testkit::cache::TestCacheDatabaseControl;
 use rstest::rstest;
 use rust_decimal::Decimal;
 use ustr::Ustr;
@@ -1791,6 +1792,96 @@ fn test_process_funding_rate_settles_open_position(crypto_perpetual_ethusdt: Cry
     assert_eq!(adjustment.adjustment_type, PositionAdjustmentType::Funding);
     assert_eq!(adjustment.pnl_change, Some(Money::from("-1 USDT")));
     assert_eq!(account_state.balances[0].total, Money::from("999 USDT"));
+}
+
+#[rstest]
+fn test_process_funding_rate_restores_position_when_database_update_fails(
+    crypto_perpetual_ethusdt: CryptoPerpetual,
+) {
+    let account_id = AccountId::from("BINANCE-001");
+    let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt.clone());
+    let (database, database_control) = TestCacheDatabaseControl::create();
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    pre_populate_margin_account_with_balance(&mut cache, "BINANCE-001", Money::from("1000 USDT"));
+    cache.add_instrument(instrument.clone()).unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(crypto_perpetual_ethusdt.id)
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("1.000"))
+        .build();
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(TradeId::from("T-001")),
+        None,
+        Some(Price::from("1000.00")),
+        Some(Quantity::from("1.000")),
+        None,
+        Some(Money::from("0 USDT")),
+        Some(UnixNanos::from(1)),
+        Some(account_id),
+    );
+    let position = Position::new(&instrument, fill.into());
+    let position_id = position.id;
+    let adjustments_before = position.adjustments.clone();
+    let realized_pnl_before = position.realized_pnl;
+    cache.add_position(&position, OmsType::Netting).unwrap();
+    cache
+        .add_mark_price(MarkPriceUpdate::new(
+            crypto_perpetual_ethusdt.id,
+            Price::from("1000.00"),
+            UnixNanos::from(2),
+            UnixNanos::from(2),
+        ))
+        .unwrap();
+
+    let cache = Rc::new(RefCell::new(cache));
+    let (position_handler, position_saver) =
+        get_typed_message_saving_handler::<PositionEvent>(None);
+    msgbus::subscribe_position_events("events.position.*".into(), position_handler, None);
+    let (settlement_handler, settlement_saver) = get_any_saving_handler::<FundingSettlement>(None);
+    msgbus::subscribe_any(
+        "events.funding_settlements.*".into(),
+        settlement_handler,
+        None,
+    );
+    let exchange = build_exchange_with_options(
+        Venue::new("BINANCE"),
+        AccountType::Margin,
+        false,
+        false,
+        cache.clone(),
+    );
+    exchange.borrow_mut().add_instrument(instrument).unwrap();
+    let settlement_ns = UnixNanos::from(3);
+    exchange
+        .borrow_mut()
+        .process_funding_rate(FundingRateUpdate::new(
+            crypto_perpetual_ethusdt.id,
+            Decimal::from_str("0.001").unwrap(),
+            Some(480),
+            Some(settlement_ns),
+            UnixNanos::from(2),
+            UnixNanos::from(2),
+        ));
+    database_control.set_fail_update_position(true);
+
+    exchange
+        .borrow_mut()
+        .process_funding_settlement(crypto_perpetual_ethusdt.id, settlement_ns);
+
+    let cached_position = cache.borrow().position_owned(&position_id).unwrap();
+    assert_eq!(cached_position.adjustments, adjustments_before);
+    assert_eq!(cached_position.realized_pnl, realized_pnl_before);
+    assert!(position_saver.get_messages().is_empty());
+    assert!(settlement_saver.get_messages().is_empty());
+
+    database_control.set_fail_update_position(false);
+    exchange
+        .borrow_mut()
+        .process_funding_settlement(crypto_perpetual_ethusdt.id, settlement_ns);
+    assert_eq!(settlement_saver.get_messages().len(), 1);
 }
 
 #[rstest]

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -5137,20 +5137,20 @@ impl Cache {
             self.index.positions_open.remove(&position.id);
         }
 
-        if let Some(database) = &mut self.database {
-            database.update_position(position)?;
-            // TODO: Implement order snapshots
-            // if self.snapshot_orders {
-            //     database.snapshot_order_state(order)?;
-            // }
-        }
-
         match self.positions.get(&position.id) {
             Some(position_cell) => *position_cell.borrow_mut() = position.clone(),
             None => {
                 self.positions
                     .insert(position.id, SharedCell::new(position.clone()));
             }
+        }
+
+        if let Some(database) = &mut self.database {
+            database.update_position(position)?;
+            // TODO: Implement order snapshots
+            // if self.snapshot_orders {
+            //     database.snapshot_order_state(order)?;
+            // }
         }
 
         Ok(())

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -7242,6 +7242,7 @@ struct SnapshotBlobTestDatabase {
     order_positions: AHashMap<ClientOrderId, PositionId>,
     fail_add: bool,
     fail_update_order: bool,
+    fail_update_position: bool,
 }
 
 impl SnapshotBlobTestDatabase {
@@ -7278,6 +7279,13 @@ impl SnapshotBlobTestDatabase {
     fn fail_update_order() -> Self {
         Self {
             fail_update_order: true,
+            ..Default::default()
+        }
+    }
+
+    fn fail_update_position() -> Self {
+        Self {
+            fail_update_position: true,
             ..Default::default()
         }
     }
@@ -7550,6 +7558,9 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
     }
 
     fn update_position(&self, _position: &Position) -> anyhow::Result<()> {
+        if self.fail_update_position {
+            anyhow::bail!("update position failed");
+        }
         Ok(())
     }
 
@@ -7590,6 +7601,67 @@ fn test_update_order_commits_canonical_state_when_database_update_fails() {
     let canonical = cache.order(&client_order_id).unwrap();
     assert_eq!(canonical.status(), OrderStatus::Submitted);
     assert_eq!(canonical.last_event(), &submitted);
+}
+
+#[rstest]
+fn test_update_position_commits_canonical_state_when_database_update_fails() {
+    let database = SnapshotBlobTestDatabase::fail_update_position();
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim());
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(TradeId::new("T-DATABASE-OPEN")),
+        Some(PositionId::new("P-DATABASE-FAILURE")),
+        Some(Price::from("1.00000")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let mut closed = Position::new(&instrument, fill.into());
+    let position_id = closed.id;
+    cache.add_position(&closed, OmsType::Netting).unwrap();
+    let closing_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let closing_fill = TestOrderEventStubs::filled(
+        &closing_order,
+        &instrument,
+        Some(TradeId::new("T-DATABASE-CLOSE")),
+        Some(position_id),
+        Some(Price::from("1.00010")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    closed.apply(&closing_fill.into());
+
+    let error = cache.update_position(&closed).unwrap_err();
+
+    assert_eq!(error.to_string(), "update position failed");
+
+    // `Position` equality compares only the ID, so the canonical value is pinned by
+    // structural comparison. Fields such as `quantity`, `realized_pnl` and `adjustments`
+    // can otherwise change without adding an event or reopening the position.
+    let cached = cache.position(&position_id).unwrap();
+    assert_eq!(
+        serde_json::to_value(&*cached).unwrap(),
+        serde_json::to_value(&closed).unwrap(),
+    );
+    assert!(cached.is_closed());
+    assert!(cache.is_position_closed(&position_id));
+    assert!(!cache.is_position_open(&position_id));
 }
 
 #[rstest]

--- a/crates/testkit/src/cache.rs
+++ b/crates/testkit/src/cache.rs
@@ -46,7 +46,7 @@ use ustr::Ustr;
 
 #[expect(
     clippy::struct_excessive_bools,
-    reason = "independent switches cover actor and strategy load and update failures"
+    reason = "independent switches cover lifecycle persistence failure modes"
 )]
 #[derive(Debug, Default)]
 struct TestCacheDatabaseState {
@@ -57,6 +57,7 @@ struct TestCacheDatabaseState {
     fail_load_strategy: bool,
     fail_update_actor: bool,
     fail_update_strategy: bool,
+    fail_update_position: bool,
 }
 
 /// Shared control and observation handle for [`TestCacheDatabase`].
@@ -153,6 +154,11 @@ impl TestCacheDatabaseControl {
     /// Configures strategy updates to fail.
     pub fn set_fail_update_strategy(&self, fail: bool) {
         self.state.lock().unwrap().fail_update_strategy = fail;
+    }
+
+    /// Configures position updates to fail.
+    pub fn set_fail_update_position(&self, fail: bool) {
+        self.state.lock().unwrap().fail_update_position = fail;
     }
 }
 
@@ -457,6 +463,9 @@ impl CacheDatabaseAdapter for TestCacheDatabase {
     }
 
     fn update_position(&self, _position: &Position) -> anyhow::Result<()> {
+        if self.control.state.lock().unwrap().fail_update_position {
+            anyhow::bail!("test position update failure");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
`Cache::update_position` commits one representation of a position and rejects the other when the database write fails.

## The split transition

The method does three things in order: the open/closed index transition, the database write, then the replacement of the canonical position cell. The database call propagates with `?`, so an error returns with the index already moved and the value never written.

A failed close leaves the cache disagreeing with itself, and both halves are publicly readable: `is_position_closed(&id)` returns `true` while `position(&id)` returns a position whose `is_closed()` is `false`, and `positions_closed(...)` hands back that open position. A failed open-to-open update is quieter and worse - the index transition is a no-op, so nothing appears wrong, and the new quantity is discarded while the caller receives an error the execution engine only logs.

Moving the cell write ahead of the database call leaves the canonical value and its indexes describing one completed transition. The error is returned unchanged, so callers see exactly what they saw before.

This follows what the order path already does. `update_order` commits the canonical event transition first and logs a database failure afterwards, with a regression test requiring the applied event to survive persistence failure. A database error is a durability failure; it is not evidence that the fill or the close did not happen. Rolling the cache back instead would make memory and storage agree while both were knowingly wrong about the position, and `update_position` receives an already-applied `Position` from a caller that has not rolled anything back, so a cache-only rollback would move the inconsistency outward rather than remove it.

## The compensation that depended on the old timing

`SimulatedExchange` funding settlement adjusts every open position, and on a failed `update_position` restores the ones it already changed. It restored `adjusted_positions[..index]` - everything before the failure - which was right while a failed update committed nothing.

With the cell written first, the position whose update failed is committed too, and the exclusive bound leaves it adjusted. At index zero the rollback is empty, so a single-position venue keeps the adjustment outright, while settlement returns false, the account adjustment never runs, and no funding settlement or position event is published. The bound is now inclusive.

## Testing

`test_update_position_commits_canonical_state_when_database_update_fails` fails the database write on a close and asserts the cached position matches the supplied one, that it reports closed, and that the indexes agree. The canonical value is compared structurally rather than with `assert_eq!`: `Position` implements `PartialEq` as an ID comparison, so equality between two states of the same position is always true. Comparing events alone would also be insufficient here, since a funding adjustment changes `adjustments`, `realized_pnl` and `replay_events` without appending one.

`test_process_funding_rate_restores_position_when_database_update_fails` drives a settlement against a failing database and asserts the position's adjustments and realized PnL are restored, that neither a funding settlement nor a position event is published, and that the settlement succeeds when retried once persistence recovers.

Each was checked against the unfixed code. Restoring the original ordering fails the first on the cached position's event history, one event against two. Restoring the exclusive bound fails the second on the position's adjustments, which retains a funding entry of -1.00 USDT where none is expected.

## Adjacent, and not addressed

`Cache::add_position_id` has the same split shape - it inserts the order-to-position mapping, persists, then populates the remaining index buckets. Reordering it locally would not make the addition atomic, because its caller `add_position_inner` populates the venue, instrument and account buckets after it returns and persists the position afterwards, so a failure would still leave those unset.

That wants a change covering the whole add transaction rather than one function, and I have left it alone. I am glad to take it on if you would like it done, in whatever shape suits you.
