### PR TITLE
Accrue position fees across a fee growth counter wrap

### DIFF
--- a/crates/model/src/defi/pool_analysis/position.rs
+++ b/crates/model/src/defi/pool_analysis/position.rs
@@ -103,8 +103,8 @@ impl PoolPosition {
     pub fn update_fees(&mut self, fee_growth_inside_0: U256, fee_growth_inside_1: U256) {
         if self.liquidity > 0 {
             // Calculate fee deltas
-            let fee_delta_0 = fee_growth_inside_0.saturating_sub(self.fee_growth_inside_0_last);
-            let fee_delta_1 = fee_growth_inside_1.saturating_sub(self.fee_growth_inside_1_last);
+            let fee_delta_0 = fee_growth_inside_0.wrapping_sub(self.fee_growth_inside_0_last);
+            let fee_delta_1 = fee_growth_inside_1.wrapping_sub(self.fee_growth_inside_1_last);
 
             let tokens_owed_0_full =
                 FullMath::mul_div(fee_delta_0, U256::from(self.liquidity), Q128)

--- a/crates/model/src/defi/pool_analysis/tests.rs
+++ b/crates/model/src/defi/pool_analysis/tests.rs
@@ -42,6 +42,7 @@ use crate::defi::{
     },
     stubs::{arbitrum, uniswap_v3},
     tick_map::{
+        full_math::{FullMath, Q128},
         liquidity_math::tick_spacing_to_max_liquidity_per_tick,
         sqrt_price_math::{
             decode_sqrt_price_x96_to_price_tokens_adjusted, encode_sqrt_ratio_x96,
@@ -2391,6 +2392,83 @@ fn test_fee_growth_well_after_cap_binds(mut empty_low_fee_pool_profiler: PoolPro
 }
 
 // ---------- WORKS ACROSS OVERFLOW BOUNDARIES ----------
+
+#[rstest]
+fn test_fee_growth_wrap_accrues_from_high_position_snapshot(
+    mut empty_low_fee_pool_profiler: PoolProfiler,
+) {
+    const LOW_FEE_TICK_SPACING: i32 = 10;
+    let min_tick = PoolTick::get_min_tick(LOW_FEE_TICK_SPACING);
+    let max_tick = PoolTick::get_max_tick(LOW_FEE_TICK_SPACING);
+    let liquidity = 1;
+
+    let mint_event = create_mint_event(lp_address(), min_tick, max_tick, liquidity);
+    empty_low_fee_pool_profiler
+        .process(&DexPoolData::LiquidityUpdate(mint_event))
+        .unwrap();
+
+    let fee_growth_before_wrap = U256::MAX - Q128 * U256::from(2);
+    empty_low_fee_pool_profiler.set_fee_growth_global(fee_growth_before_wrap, U256::ZERO);
+
+    let burn_event = create_burn_event(lp_address(), min_tick, max_tick, 0);
+    empty_low_fee_pool_profiler
+        .process(&DexPoolData::LiquidityUpdate(burn_event))
+        .unwrap();
+
+    empty_low_fee_pool_profiler
+        .process(&DexPoolData::FeeCollect(create_collect_event(
+            min_tick,
+            max_tick,
+            u128::MAX,
+            u128::MAX,
+        )))
+        .unwrap();
+    assert_eq!(
+        empty_low_fee_pool_profiler
+            .get_position(&lp_address(), min_tick, max_tick)
+            .expect("Position should exist")
+            .tokens_owed_0,
+        0
+    );
+
+    let fee_growth_global_before = empty_low_fee_pool_profiler.state.fee_growth_global_0;
+    empty_low_fee_pool_profiler
+        .process(&DexPoolData::Flash(create_flash_event(
+            U256::from(3),
+            U256::ZERO,
+        )))
+        .unwrap();
+    let fee_growth_global_after = empty_low_fee_pool_profiler.state.fee_growth_global_0;
+    assert!(fee_growth_global_after < fee_growth_global_before);
+
+    let fee_growth_delta = fee_growth_global_after.wrapping_sub(fee_growth_global_before);
+    assert_ne!(fee_growth_delta, U256::ZERO);
+    let expected_tokens_owed =
+        FullMath::mul_div(fee_growth_delta, U256::from(liquidity), Q128).unwrap();
+    assert_eq!(expected_tokens_owed, U256::from(3));
+
+    empty_low_fee_pool_profiler
+        .process(&DexPoolData::LiquidityUpdate(create_burn_event(
+            lp_address(),
+            min_tick,
+            max_tick,
+            0,
+        )))
+        .unwrap();
+
+    let position = empty_low_fee_pool_profiler
+        .get_position(&lp_address(), min_tick, max_tick)
+        .expect("Position should exist");
+
+    assert_eq!(
+        position.tokens_owed_0, 3,
+        "wrapped fee growth should accrue token0 fees"
+    );
+    assert_eq!(
+        position.fee_growth_inside_0_last, fee_growth_global_after,
+        "position should snapshot wrapped fee growth"
+    );
+}
 
 #[rstest]
 fn test_overflow_boundary_token0(mut empty_low_fee_pool_profiler: PoolProfiler) {


### PR DESCRIPTION
`PoolPosition::update_fees` drops a position's entire accrual when the pool's fee growth counter wraps.

## The clamp

Uniswap V3's `feeGrowthGlobal` and `feeGrowthInside` are modular `uint256` counters. The reference subtracts them inside `unchecked` blocks because a wrap is expected and the difference remains correct mod 2^256.

`update_fees` takes the per-position delta with `saturating_sub`. Once the global counter has wrapped, the current inside value is numerically below the position's stored `fee_growth_inside_last`, the subtraction clamps to zero, and the fees earned over that period are never credited - no error, no log, and the position's snapshot is then advanced to the new value, so the accrual is unrecoverable on the next poke.

The two statements below book the result with `wrapping_add`, so the function already treats these counters as modular in one direction and not the other.

Taking the delta with `wrapping_sub` matches the reference. The call is explicit rather than a bare `-` because this is the site whose previous code selected the opposite policy, and it reads alongside the `wrapping_add` immediately below it.

## Scope

The `TickMap` subtractions are unchanged. The pinned `U256` subtraction operator is already modular - `test_get_fee_growth_inside_with_overflow` covers exactly that, computing `15 - (MAX - 3) - 3` and expecting `16` - so those sites already carry the reference semantics and need no change. Replacing them with checked arithmetic would be wrong in the other direction: it would reject a legal post-wrap state, since the invariant they maintain is a modular partition identity rather than an ordering between operands.

This is a position accounting fix only. It does not claim, and does not need, any change to tick state handling.

## Testing

`test_fee_growth_wrap_accrues_from_high_position_snapshot` drives the public `PoolProfiler` API: mint a full-range position, advance global fee growth near `U256::MAX`, poke to snapshot that high value, collect so the position owes nothing, then process a flash paying three units of token0.

The test asserts the global counter wrapped, derives the delta from the observed values rather than assuming one, and requires the position to be credited exactly three tokens with its snapshot equal to the wrapped global. A full-range position crosses no ticks, so this needs no unusual tick state - only a counter that has wrapped.

Against the previous `saturating_sub` the test fails on that accrual, crediting zero where three are owed, while every setup assertion still passes.

The existing `test_overflow_boundary_token0` does not cover this: it mints after setting the global counter to `U256::MAX`, so the position's initial snapshot is zero and no high `fee_growth_inside_last` is ever established before a wrap.
