### PR TITLE
Exempt `close_position` orders from pre-trade quantity and notional limits (#4746)

### DIFF
--- a/crates/risk/src/engine/mod.rs
+++ b/crates/risk/src/engine/mod.rs
@@ -639,11 +639,17 @@ impl RiskEngine {
             return; // Denied
         };
 
-        if !self.check_order(&instrument, &order) {
+        let close_position = command
+            .params
+            .as_ref()
+            .and_then(|p| p.get_bool("close_position"))
+            .unwrap_or(false);
+
+        if !self.check_order(&instrument, &order, close_position) {
             return; // Denied
         }
 
-        if !self.check_orders_risk(&instrument, &[order]) {
+        if !self.check_orders_risk(&instrument, &[order], close_position) {
             return; // Denied
         }
 
@@ -694,6 +700,12 @@ impl RiskEngine {
             instruments.insert(instrument_id, instrument);
         }
 
+        let close_position = command
+            .params
+            .as_ref()
+            .and_then(|p| p.get_bool("close_position"))
+            .unwrap_or(false);
+
         for order in &orders {
             let Some(instrument) = instruments.get(&order.instrument_id()) else {
                 self.deny_order(
@@ -706,7 +718,7 @@ impl RiskEngine {
                 return; // Denied
             };
 
-            if !self.check_order(instrument, order) {
+            if !self.check_order(instrument, order, close_position) {
                 return; // Denied
             }
         }
@@ -724,7 +736,7 @@ impl RiskEngine {
             return; // Denied
         };
 
-        if !self.check_orders_risk(&representative, &orders) {
+        if !self.check_orders_risk(&representative, &orders, close_position) {
             self.deny_order_list(
                 &orders,
                 &OrderDeniedReason::OrderListDenied {
@@ -894,7 +906,12 @@ impl RiskEngine {
         }
 
         // Check Quantity
-        reason = Self::check_quantity(&instrument, command.quantity, order.is_quote_quantity());
+        reason = Self::check_quantity(
+            &instrument,
+            command.quantity,
+            order.is_quote_quantity(),
+            false,
+        );
         if let Some(reason) = reason {
             self.reject_modify_order(&order, &reason.to_string());
             return false;
@@ -928,9 +945,14 @@ impl RiskEngine {
         true
     }
 
-    fn check_order(&self, instrument: &InstrumentAny, order: &OrderAny) -> bool {
+    fn check_order(
+        &self,
+        instrument: &InstrumentAny,
+        order: &OrderAny,
+        close_position: bool,
+    ) -> bool {
         if !self.check_order_price(instrument, order)
-            || !self.check_order_quantity(instrument, order)
+            || !self.check_order_quantity(instrument, order, close_position)
         {
             return false; // Denied
         }
@@ -981,11 +1003,17 @@ impl RiskEngine {
         true
     }
 
-    fn check_order_quantity(&self, instrument: &InstrumentAny, order: &OrderAny) -> bool {
+    fn check_order_quantity(
+        &self,
+        instrument: &InstrumentAny,
+        order: &OrderAny,
+        close_position: bool,
+    ) -> bool {
         let reason = Self::check_quantity(
             instrument,
             Some(order.quantity()),
             order.is_quote_quantity(),
+            close_position,
         );
 
         if let Some(reason) = reason {
@@ -996,7 +1024,12 @@ impl RiskEngine {
         true
     }
 
-    fn check_orders_risk(&self, instrument: &InstrumentAny, orders: &[OrderAny]) -> bool {
+    fn check_orders_risk(
+        &self,
+        instrument: &InstrumentAny,
+        orders: &[OrderAny],
+        close_position: bool,
+    ) -> bool {
         let mut orders_by_account: AHashMap<Option<AccountId>, Vec<&OrderAny>> = AHashMap::new();
         for order in orders {
             orders_by_account
@@ -1006,7 +1039,12 @@ impl RiskEngine {
         }
 
         for (account_id, account_orders) in &orders_by_account {
-            if !self.check_orders_risk_for_account(instrument, account_orders, *account_id) {
+            if !self.check_orders_risk_for_account(
+                instrument,
+                account_orders,
+                *account_id,
+                close_position,
+            ) {
                 return false;
             }
         }
@@ -1023,6 +1061,7 @@ impl RiskEngine {
         instrument: &InstrumentAny,
         orders: &[&OrderAny],
         account_id: Option<AccountId>,
+        close_position: bool,
     ) -> bool {
         let mut max_notional: Option<Money> = None;
 
@@ -1209,6 +1248,7 @@ impl RiskEngine {
                     let Some(price) = market_price else {
                         let is_reducing = !is_wallet
                             && (order.is_reduce_only()
+                                || close_position
                                 || (order.is_sell()
                                     && (cum_sell_qty_raw + order.quantity().raw)
                                         <= available_long_qty_raw));
@@ -1403,7 +1443,7 @@ impl RiskEngine {
             // price and may differ from the venue fill, and some venues enforce
             // distinct per-order-type minimums. The venue is authoritative for
             // quote-denominated sizing; rely on `min_notional`/`max_notional` below.
-            if !order.is_quote_quantity() {
+            if !order.is_quote_quantity() && !close_position {
                 if let Some(max_quantity) = instrument.max_quantity()
                     && effective_quantity > max_quantity
                 {
@@ -1456,7 +1496,8 @@ impl RiskEngine {
             }
 
             // Check MAX notional per order limit
-            if let Some(max_notional_value) = max_notional
+            if !close_position
+                && let Some(max_notional_value) = max_notional
                 && notional > max_notional_value
             {
                 self.deny_order(
@@ -1470,8 +1511,9 @@ impl RiskEngine {
                 return false; // Denied
             }
 
-            // Reduce-only orders may close residual positions below venue minimum
+            // Reduce-only or close-position orders may close residual positions below venue minimum
             if !order.is_reduce_only()
+                && !close_position
                 && let Some(min_notional) = instrument.min_notional()
                 && notional.currency == min_notional.currency
                 && notional < min_notional
@@ -1488,7 +1530,8 @@ impl RiskEngine {
             }
 
             // Check MAX notional instrument limit
-            if let Some(max_notional) = instrument.max_notional()
+            if !close_position
+                && let Some(max_notional) = instrument.max_notional()
                 && notional.currency == max_notional.currency
                 && notional > max_notional
             {
@@ -1533,6 +1576,7 @@ impl RiskEngine {
 
                 // Determine if order is position-reducing
                 let is_reducing = order.is_reduce_only()
+                    || close_position
                     || (order.is_sell()
                         && (cum_sell_qty_raw + effective_quantity.raw) <= available_long_qty_raw)
                     || (order.is_buy()
@@ -1685,12 +1729,13 @@ impl RiskEngine {
 
                 // Check if order reduces an existing position
                 let is_position_reducing = if order.is_buy() {
-                    let reducing =
-                        (cum_buy_qty_raw + effective_quantity.raw) <= available_short_qty_raw;
+                    let reducing = close_position
+                        || (cum_buy_qty_raw + effective_quantity.raw) <= available_short_qty_raw;
                     cum_buy_qty_raw += effective_quantity.raw;
                     reducing
                 } else if order.is_sell() {
                     let reducing = order.is_reduce_only()
+                        || close_position
                         || (cum_sell_qty_raw + effective_quantity.raw) <= available_long_qty_raw;
                     cum_sell_qty_raw += effective_quantity.raw;
                     reducing
@@ -2000,6 +2045,7 @@ impl RiskEngine {
         instrument: &InstrumentAny,
         quantity: Option<Quantity>,
         is_quote_quantity: bool,
+        close_position: bool,
     ) -> Option<OrderDeniedReason> {
         let quantity_val = quantity?;
 
@@ -2012,10 +2058,10 @@ impl RiskEngine {
             });
         }
 
-        // Base-quantity bounds are deliberately not applied to quote-denominated orders here,
+        // Base-quantity bounds are deliberately not applied to quote-denominated or close-position orders here,
         // and they are not applied later either: `check_orders_risk_for_account` skips the same
         // comparisons for them. Applicable notional limits are checked during account risk.
-        if is_quote_quantity {
+        if is_quote_quantity || close_position {
             return None;
         }
 

--- a/crates/risk/tests/risk_engine.rs
+++ b/crates/risk/tests/risk_engine.rs
@@ -41,7 +41,7 @@ use nautilus_common::{
     },
     throttler::RateLimit,
 };
-use nautilus_core::{UUID4, UnixNanos};
+use nautilus_core::{Params, UUID4, UnixNanos};
 use nautilus_execution::engine::{ExecutionEngine, config::ExecutionEngineConfig};
 use nautilus_model::{
     accounts::{
@@ -9010,4 +9010,201 @@ fn test_submit_sell_cash_account_with_long_position_reduces_then_passes(
     let saved_execute_messages =
         get_execute_order_event_handler_messages(&execute_order_event_handler);
     assert_eq!(saved_execute_messages.len(), 1);
+}
+
+#[rstest]
+fn test_submit_order_close_position_exempt_from_notional_and_quantity_bounds(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    execute_order_event_handler: TypedIntoMessageSavingHandler<TradingCommand>,
+    mut simple_cache: Cache,
+) {
+    let btc_usdt = InstrumentAny::CurrencyPair(CurrencyPair::new(
+        InstrumentId::from("BTCUSDT-PERP.BINANCE"),
+        Symbol::from("BTCUSDT"),
+        Currency::BTC(),
+        Currency::USDT(),
+        1,
+        6,
+        Price::from("0.1"),
+        Quantity::from("0.000001"),
+        Some(Quantity::from("1")),
+        Some(Quantity::from("0.000001")),
+        Some(Quantity::from("10")),      // max_quantity
+        Some(Quantity::from("0.01")),    // min_quantity
+        Some(Money::from("10000 USDT")), // max_notional
+        Some(Money::from("50 USDT")),    // min_notional
+        None,
+        None,
+        Some(dec!(0.1)),
+        Some(dec!(0.1)),
+        Some(dec!(-0.00005)),
+        Some(dec!(0.00015)),
+        None,
+        None,
+        UnixNanos::default(),
+        UnixNanos::default(),
+    ));
+
+    simple_cache.add_instrument(btc_usdt.clone()).unwrap();
+
+    let margin_account = margin_account_with_usdt_balance("10000 USDT", "0 USDT", "10000 USDT");
+    simple_cache
+        .add_account(AccountAny::Margin(margin_account))
+        .unwrap();
+
+    let cache = Rc::new(RefCell::new(simple_cache));
+    let mut risk_engine = get_risk_engine(Some(cache), None, None, false);
+
+    // StopMarket order with placeholder quantity 0.001 BTC (< min_qty 0.01) and trigger price 40000 USDT -> notional 40 USDT (< min_notional 50 USDT)
+    let order = OrderTestBuilder::new(OrderType::StopMarket)
+        .instrument_id(btc_usdt.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("0.001"))
+        .trigger_price(Price::from("40000.0"))
+        .build();
+
+    risk_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(client_id_binance), false)
+        .unwrap();
+
+    let mut params = Params::new();
+    params.insert("close_position".to_string(), true.into());
+
+    let submit_order = SubmitOrder::new(
+        trader_id,
+        Some(client_id_binance),
+        strategy_id_ema_cross,
+        btc_usdt.id(),
+        order.client_order_id(),
+        order.init_event().clone(),
+        None,
+        None,
+        Some(params),
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let process_messages = get_process_order_event_handler_messages(&process_order_event_handler);
+    assert_eq!(
+        process_messages.len(),
+        0,
+        "Order should not be denied when close_position is true"
+    );
+
+    let saved_execute_messages =
+        get_execute_order_event_handler_messages(&execute_order_event_handler);
+    assert_eq!(
+        saved_execute_messages.len(),
+        1,
+        "close_position order must be forwarded to execution"
+    );
+}
+
+#[rstest]
+fn test_submit_order_close_position_still_enforces_quantity_precision(
+    strategy_id_ema_cross: StrategyId,
+    client_id_binance: ClientId,
+    trader_id: TraderId,
+    process_order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    mut simple_cache: Cache,
+) {
+    let btc_usdt = InstrumentAny::CurrencyPair(CurrencyPair::new(
+        InstrumentId::from("BTCUSDT-PERP.BINANCE"),
+        Symbol::from("BTCUSDT"),
+        Currency::BTC(),
+        Currency::USDT(),
+        1,
+        6, // size_precision = 6
+        Price::from("0.1"),
+        Quantity::from("0.000001"),
+        Some(Quantity::from("1")),
+        Some(Quantity::from("0.000001")),
+        Some(Quantity::from("10")),
+        Some(Quantity::from("0.01")),
+        Some(Money::from("10000 USDT")),
+        Some(Money::from("50 USDT")),
+        None,
+        None,
+        Some(dec!(0.1)),
+        Some(dec!(0.1)),
+        Some(dec!(-0.00005)),
+        Some(dec!(0.00015)),
+        None,
+        None,
+        UnixNanos::default(),
+        UnixNanos::default(),
+    ));
+
+    simple_cache.add_instrument(btc_usdt.clone()).unwrap();
+
+    let margin_account = margin_account_with_usdt_balance("10000 USDT", "0 USDT", "10000 USDT");
+    simple_cache
+        .add_account(AccountAny::Margin(margin_account))
+        .unwrap();
+
+    let cache = Rc::new(RefCell::new(simple_cache));
+    let mut risk_engine = get_risk_engine(Some(cache), None, None, false);
+
+    // Quantity precision 8 exceeds instrument size_precision 6
+    let order = OrderTestBuilder::new(OrderType::StopMarket)
+        .instrument_id(btc_usdt.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from("0.00100000"))
+        .trigger_price(Price::from("40000.0"))
+        .build();
+
+    risk_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(client_id_binance), false)
+        .unwrap();
+
+    let mut params = Params::new();
+    params.insert("close_position".to_string(), true.into());
+
+    let submit_order = SubmitOrder::new(
+        trader_id,
+        Some(client_id_binance),
+        strategy_id_ema_cross,
+        btc_usdt.id(),
+        order.client_order_id(),
+        order.init_event().clone(),
+        None,
+        None,
+        Some(params),
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let process_messages = get_process_order_event_handler_messages(&process_order_event_handler);
+    assert_eq!(
+        process_messages.len(),
+        1,
+        "Order must be denied when placeholder quantity precision exceeds instrument precision"
+    );
+
+    if let OrderEventAny::Denied(denied) = &process_messages[0] {
+        assert_eq!(
+            denied.reason,
+            OrderDeniedReason::QuantityPrecisionExceedsMaximum {
+                quantity: Quantity::from("0.00100000"),
+                quantity_precision: 8,
+                max_precision: 6,
+            }
+            .to_string()
+        );
+    } else {
+        panic!("Expected OrderDenied event");
+    }
 }


### PR DESCRIPTION
### Problem

Closes #4746

On derivatives venues such as Binance USD-M Futures, whole-position protective exits (e.g. conditional stop-loss / take-profit orders with `closePosition=true`) carry no quantity on the wire (`quantity: 0.0`) and cannot be combined with `reduce_only=true` per venue wire contract.

Previously, `RiskEngine` only exempted `is_reduce_only()` orders from `min_notional` and never read `close_position` from command parameters. Consequently:
- Sizing a short leg at venue minimum with a take-profit trigger below the mark evaluated notional below `min_notional` (`NOTIONAL_BELOW_MINIMUM`).
- The risk engine blocked the protective order locally, even though the order only reduces risk and is accepted by the venue.
- Phantom placeholder quantities were also subject to base min/max quantity and max notional limits.

### Root Cause

`RiskEngine::check_orders_risk_for_account` and `check_order_quantity` evaluated placeholder quantities and trigger valuations against instrument bounds (`min_notional`, `max_notional`, `min_quantity`, `max_quantity`) without recognizing `close_position: true` command parameters. Furthermore, margin and balance checks did not mark `close_position` orders as position-reducing.

### Solution

1. In `RiskEngine::handle_submit_order` and `handle_submit_order_list`, read `close_position` from command `params`.
2. Symmetrically extend the `is_reduce_only()` exemption to `close_position` for:
   - `min_notional` checks
   - `max_notional` checks
   - Base quantity min/max bounds (matching the `is_quote_quantity()` bypass)
3. Treat `close_position` orders as position-reducing for margin and balance evaluations.

### Test Plan

- Added unit test `test_submit_order_close_position_exempt_from_notional_and_quantity_bounds` in `crates/risk/tests/risk_engine.rs` verifying that an order with sub-minimum notional and placeholder quantity is accepted and forwarded to execution when `close_position: true` is passed.
