### PR TITLE
Centralize Polymarket approval plan

### DIFF
--- a/crates/adapters/polymarket/bin/set_allowances.rs
+++ b/crates/adapters/polymarket/bin/set_allowances.rs
@@ -25,18 +25,16 @@ use std::str::FromStr;
 
 use alloy::{
     network::{EthereumWallet, ReceiptResponse},
-    primitives::{Address, U256, address},
     providers::ProviderBuilder,
     signers::local::PrivateKeySigner,
 };
 use nautilus_polymarket::{
-    common::credential::EvmPrivateKey, signing::eip712::COLLATERAL_APPROVAL_TARGETS,
+    common::credential::EvmPrivateKey,
+    signing::eip712::{PolymarketApproval, approval_plan},
 };
 
 const DEFAULT_POLYGON_RPC_URL: &str = "https://polygon.drpc.org";
 const POLYGON_CHAIN_ID: u64 = 137;
-const PUSD_COLLATERAL: Address = address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB");
-const CONDITIONAL_TOKENS: Address = address!("0x4D97DCd97eC945f40cF65F87097ACe5EA0476045");
 
 alloy::sol! {
     #[sol(rpc)]
@@ -48,12 +46,6 @@ alloy::sol! {
     interface Erc1155 {
         function setApprovalForAll(address operator, bool approved) external;
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Approval {
-    Collateral { spender: Address, amount: U256 },
-    Ctf { operator: Address, approved: bool },
 }
 
 #[tokio::main]
@@ -75,12 +67,15 @@ async fn run(private_key: &str, rpc_url: &str) -> Result<(), Box<dyn std::error:
         .with_chain_id(POLYGON_CHAIN_ID)
         .wallet(wallet)
         .connect_http(rpc_url.parse()?);
-    let collateral = Erc20::new(PUSD_COLLATERAL, provider.clone());
-    let ctf = Erc1155::new(CONDITIONAL_TOKENS, provider);
 
-    for approval in approval_transactions() {
+    for approval in approval_plan() {
         match approval {
-            Approval::Collateral { spender, amount } => {
+            PolymarketApproval::Collateral {
+                contract,
+                spender,
+                amount,
+            } => {
+                let collateral = Erc20::new(contract, provider.clone());
                 let call = collateral.approve(spender, amount);
                 let receipt = call.send().await?.get_receipt().await?;
                 receipt.ensure_success()?;
@@ -89,7 +84,12 @@ async fn run(private_key: &str, rpc_url: &str) -> Result<(), Box<dyn std::error:
                     receipt.transaction_hash(),
                 );
             }
-            Approval::Ctf { operator, approved } => {
+            PolymarketApproval::ConditionalTokens {
+                contract,
+                operator,
+                approved,
+            } => {
+                let ctf = Erc1155::new(contract, provider.clone());
                 let call = ctf.setApprovalForAll(operator, approved);
                 let receipt = call.send().await?.get_receipt().await?;
                 receipt.ensure_success()?;
@@ -102,22 +102,4 @@ async fn run(private_key: &str, rpc_url: &str) -> Result<(), Box<dyn std::error:
     }
 
     Ok(())
-}
-
-fn approval_transactions() -> impl Iterator<Item = Approval> {
-    COLLATERAL_APPROVAL_TARGETS
-        .iter()
-        .copied()
-        .flat_map(|target| {
-            [
-                Approval::Collateral {
-                    spender: target,
-                    amount: U256::MAX,
-                },
-                Approval::Ctf {
-                    operator: target,
-                    approved: true,
-                },
-            ]
-        })
 }

--- a/crates/adapters/polymarket/src/signing/eip712.rs
+++ b/crates/adapters/polymarket/src/signing/eip712.rs
@@ -22,6 +22,9 @@
 //!
 //! Both share the same EIP-712 domain name and version; only the
 //! `verifyingContract` differs.
+//!
+//! This module also owns the CLOB V2 contract identities and ordered on-chain
+//! approval plan ([`approval_plan`]) used by the set-allowances binary.
 
 use std::str::FromStr;
 
@@ -58,12 +61,63 @@ pub const NEG_RISK_CTF_EXCHANGE: Address = address!("0xe2222d279d744050d28e00520
 pub const NEG_RISK_CTF_COLLATERAL_ADAPTER: Address =
     address!("0xadA2005600Dec949baf300f4C6120000bDB6eAab");
 
+/// Polymarket pUSD collateral token contract address on Polygon mainnet.
+pub const POLYMARKET_COLLATERAL_TOKEN: Address =
+    address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB");
+
+/// Conditional Tokens Framework contract address on Polygon mainnet.
+pub const CONDITIONAL_TOKENS: Address = address!("0x4D97DCd97eC945f40cF65F87097ACe5EA0476045");
+
 /// Complete spender set requiring collateral approval for Polymarket CLOB V2 orders.
 pub const COLLATERAL_APPROVAL_TARGETS: &[Address] = &[
     CTF_EXCHANGE,
     NEG_RISK_CTF_EXCHANGE,
     NEG_RISK_CTF_COLLATERAL_ADAPTER,
 ];
+
+/// One transaction in the Polymarket approval plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolymarketApproval {
+    /// Approves a contract to spend pUSD collateral.
+    Collateral {
+        /// Collateral token contract receiving the approval call.
+        contract: Address,
+        /// Contract receiving the collateral allowance.
+        spender: Address,
+        /// Collateral allowance amount.
+        amount: U256,
+    },
+    /// Enables a contract as an operator for conditional tokens.
+    ConditionalTokens {
+        /// Conditional Tokens contract receiving the operator call.
+        contract: Address,
+        /// Contract receiving conditional-token operator authority.
+        operator: Address,
+        /// Whether operator authority is enabled.
+        approved: bool,
+    },
+}
+
+/// Returns the ordered approval plan for Polymarket CLOB V2.
+pub fn approval_plan() -> impl Iterator<Item = PolymarketApproval> {
+    COLLATERAL_APPROVAL_TARGETS
+        .iter()
+        .copied()
+        .flat_map(|target| {
+            [
+                PolymarketApproval::Collateral {
+                    contract: POLYMARKET_COLLATERAL_TOKEN,
+                    spender: target,
+                    amount: U256::MAX,
+                },
+                PolymarketApproval::ConditionalTokens {
+                    contract: CONDITIONAL_TOKENS,
+                    operator: target,
+                    approved: true,
+                },
+            ]
+        })
+}
 
 const DOMAIN_NAME: &str = "Polymarket CTF Exchange";
 const DOMAIN_VERSION: &str = "2";
@@ -652,6 +706,14 @@ mod tests {
             "0xada2005600dec949baf300f4c6120000bdb6eaab"
         );
         assert_eq!(
+            format!("{POLYMARKET_COLLATERAL_TOKEN:#x}"),
+            "0xc011a7e12a19f7b1f670d46f03b03f3342e82dfb"
+        );
+        assert_eq!(
+            format!("{CONDITIONAL_TOKENS:#x}"),
+            "0x4d97dcd97ec945f40cf65f87097ace5ea0476045"
+        );
+        assert_eq!(
             COLLATERAL_APPROVAL_TARGETS,
             &[
                 CTF_EXCHANGE,
@@ -659,6 +721,49 @@ mod tests {
                 NEG_RISK_CTF_COLLATERAL_ADAPTER,
             ]
         );
+    }
+
+    #[rstest]
+    fn test_approval_plan() {
+        let collateral_token = address!("0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB");
+        let conditional_tokens = address!("0x4D97DCd97eC945f40cF65F87097ACe5EA0476045");
+        let ctf_exchange = address!("0xE111180000d2663C0091e4f400237545B87B996B");
+        let neg_risk_ctf_exchange = address!("0xe2222d279d744050d28e00520010520000310F59");
+        let neg_risk_collateral_adapter = address!("0xadA2005600Dec949baf300f4C6120000bDB6eAab");
+        let expected = vec![
+            PolymarketApproval::Collateral {
+                contract: collateral_token,
+                spender: ctf_exchange,
+                amount: U256::MAX,
+            },
+            PolymarketApproval::ConditionalTokens {
+                contract: conditional_tokens,
+                operator: ctf_exchange,
+                approved: true,
+            },
+            PolymarketApproval::Collateral {
+                contract: collateral_token,
+                spender: neg_risk_ctf_exchange,
+                amount: U256::MAX,
+            },
+            PolymarketApproval::ConditionalTokens {
+                contract: conditional_tokens,
+                operator: neg_risk_ctf_exchange,
+                approved: true,
+            },
+            PolymarketApproval::Collateral {
+                contract: collateral_token,
+                spender: neg_risk_collateral_adapter,
+                amount: U256::MAX,
+            },
+            PolymarketApproval::ConditionalTokens {
+                contract: conditional_tokens,
+                operator: neg_risk_collateral_adapter,
+                approved: true,
+            },
+        ];
+
+        assert_eq!(approval_plan().collect::<Vec<_>>(), expected);
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/signing/mod.rs
+++ b/crates/adapters/polymarket/src/signing/mod.rs
@@ -13,7 +13,9 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-//! Polymarket EIP-712 (L1) signing.
+//! Polymarket EIP-712 (L1) signing and on-chain approval planning.
+//!
+//! CLOB V2 contract identities and the approval plan live in [`eip712`].
 //!
 //! L2 HMAC-SHA256 signing lives on [`Credential`](crate::common::credential::Credential).
 


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Move the complete six-operation Polymarket approval plan—including the called token contracts,
targets, values, and ordering—from the test-disabled set-allowances binary into library code. The
binary consumes the shared plan without changing transaction sequencing or failure behavior, while
a runnable library test now independently pins the exact on-chain operations.

This closes the coverage gap left by the binary's intentional `test = false` configuration without
adding a manifest exception or a second source of contract identity.

## Related issues/PRs

Follow-up to #4760. Independent of settlement-reconciliation Discussion #4722.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

- `make format`
- `make pre-commit`
- `cargo test -p nautilus-polymarket`
