### PR TITLE
Support canonical OPRA option IDs in the IB adapter

### DIFF
--- a/crates/adapters/interactive_brokers/src/common/parse.rs
+++ b/crates/adapters/interactive_brokers/src/common/parse.rs
@@ -383,6 +383,10 @@ pub fn derive_crypto_venue(contract: &Contract) -> Venue {
 
 #[must_use]
 pub fn possible_exchanges_for_venue(venue: &str) -> Vec<String> {
+    if venue == "OPRA" {
+        return vec!["SMART".to_string()];
+    }
+
     if let Some(exchanges) = VENUE_MEMBERS.get(venue) {
         return exchanges
             .iter()
@@ -452,6 +456,27 @@ fn venue_matches(venue_str: &str, venues: &[&str]) -> bool {
         || VENUE_MEMBERS
             .get(venue_str)
             .is_some_and(|exchanges| exchanges.iter().any(|exchange| venues.contains(exchange)))
+}
+
+fn is_option_venue(venue: &str) -> bool {
+    venue == "OPRA" || venue_matches(venue, VENUES_OPT)
+}
+
+fn is_canonical_occ_option_symbol(symbol: &str) -> bool {
+    let bytes = symbol.as_bytes();
+    if bytes.len() != 21 || !symbol.is_ascii() {
+        return false;
+    }
+
+    let root = &bytes[..6];
+    let root_len = root.iter().position(|byte| *byte == b' ').unwrap_or(6);
+
+    root_len > 0
+        && root[..root_len].iter().all(u8::is_ascii_graphic)
+        && root[root_len..].iter().all(|byte| *byte == b' ')
+        && bytes[6..12].iter().all(u8::is_ascii_digit)
+        && matches!(bytes[12], b'C' | b'P')
+        && bytes[13..].iter().all(u8::is_ascii_digit)
 }
 
 /// Futures month codes mapping (F=Jan, G=Feb, H=Mar, J=Apr, K=May, M=Jun, N=Jul, Q=Aug, U=Sep, V=Oct, X=Nov, Z=Dec)
@@ -568,21 +593,25 @@ pub fn instrument_id_to_ib_contract(
     exchange: Option<&str>,
 ) -> anyhow::Result<Contract> {
     let venue_str = instrument_id.venue.to_string();
-    let derived_exchange = VENUE_MEMBERS
-        .get(venue_str.as_str())
-        .and_then(|exchanges| exchanges.first().copied())
-        .or_else(|| {
-            if venue_matches(venue_str.as_str(), VENUES_CASH)
-                || venue_matches(venue_str.as_str(), VENUES_CRYPTO)
-                || venue_matches(venue_str.as_str(), VENUES_OPT)
-                || venue_matches(venue_str.as_str(), VENUES_FUT)
-            {
-                Some(venue_str.as_str())
-            } else {
-                None
-            }
-        })
-        .unwrap_or("SMART");
+    let derived_exchange = if venue_str == "OPRA" {
+        "SMART"
+    } else {
+        VENUE_MEMBERS
+            .get(venue_str.as_str())
+            .and_then(|exchanges| exchanges.first().copied())
+            .or_else(|| {
+                if venue_matches(venue_str.as_str(), VENUES_CASH)
+                    || venue_matches(venue_str.as_str(), VENUES_CRYPTO)
+                    || venue_matches(venue_str.as_str(), VENUES_OPT)
+                    || venue_matches(venue_str.as_str(), VENUES_FUT)
+                {
+                    Some(venue_str.as_str())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or("SMART")
+    };
     let exchange_str = exchange.unwrap_or(derived_exchange);
     let symbol_str = instrument_id.symbol.as_str();
 
@@ -627,7 +656,22 @@ pub fn instrument_id_to_ib_contract(
     }
 
     // Handle Options (OPT)
-    if venue_matches(venue_str.as_str(), VENUES_OPT) {
+    if is_option_venue(venue_str.as_str()) {
+        if venue_str == "OPRA" {
+            if !is_canonical_occ_option_symbol(symbol_str) {
+                anyhow::bail!("Invalid OPRA option symbol: {symbol_str}");
+            }
+
+            return Ok(Contract {
+                contract_id: 0,
+                security_type: SecurityType::Option,
+                exchange: Exchange::from(exchange_str),
+                currency: Currency::from("USD"),
+                local_symbol: symbol_str.to_string(),
+                ..Default::default()
+            });
+        }
+
         if let Some(opt) = parse_option_symbol(symbol_str) {
             return Ok(Contract {
                 contract_id: 0,
@@ -786,10 +830,16 @@ fn instrument_id_to_ib_contract_raw(
     let (local_symbol, sec_type_code) = instrument_id.symbol.as_str().rsplit_once('=')?;
 
     let venue_exchange = instrument_id.venue.as_str().replace('/', ".");
-    let exchange_str = exchange.unwrap_or(venue_exchange.as_str());
     let security_type = IbSecurityType::from_str(sec_type_code)
         .ok()
         .map(IbSecurityType::ibapi_security_type)?;
+    let default_exchange =
+        if security_type == SecurityType::Option && instrument_id.venue.as_str() == "OPRA" {
+            "SMART"
+        } else {
+            venue_exchange.as_str()
+        };
+    let exchange_str = exchange.unwrap_or(default_exchange);
 
     let contract = match security_type {
         SecurityType::Stock => Contract {
@@ -1215,7 +1265,10 @@ mod tests {
     use nautilus_model::identifiers::InstrumentId;
     use rstest::rstest;
 
-    use super::{ib_contract_to_instrument_id_simplified, instrument_id_to_ib_contract};
+    use super::{
+        exchange_to_mic_venue, ib_contract_to_instrument_id_simplified,
+        instrument_id_to_ib_contract, possible_exchanges_for_venue,
+    };
 
     #[rstest]
     fn test_ib_contract_to_instrument_id_simplified_normalizes_occ_option_root() {
@@ -1312,6 +1365,91 @@ mod tests {
         );
         assert_eq!(contract.right.map(|right| right.as_str()), Some("P"));
         assert_eq!(contract.strike, 155.0);
+    }
+
+    #[rstest]
+    fn test_possible_exchanges_for_opra_routes_to_smart() {
+        assert_eq!(
+            possible_exchanges_for_venue("OPRA"),
+            vec!["SMART".to_string()]
+        );
+    }
+
+    #[rstest]
+    fn test_opra_occ_option_default_contract_routes_to_smart() {
+        let instrument_id = InstrumentId::from("SPY   240319P00511000.OPRA");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Option);
+        assert_eq!(contract.exchange.as_str(), "SMART");
+        assert!(contract.symbol.as_str().is_empty());
+        assert_eq!(contract.currency.as_str(), "USD");
+        assert_eq!(contract.local_symbol.as_str(), "SPY   240319P00511000");
+        assert!(contract.last_trade_date_or_contract_month.is_empty());
+        assert!(contract.right.is_none());
+        assert_eq!(contract.strike, 0.0);
+    }
+
+    #[rstest]
+    fn test_opra_occ_option_qualification_contract_uses_opt_smart() {
+        let instrument_id = InstrumentId::from("SPY   240319P00511000.OPRA");
+        let exchanges = possible_exchanges_for_venue(instrument_id.venue.as_str());
+
+        assert_eq!(exchanges, vec!["SMART".to_string()]);
+
+        let contract =
+            instrument_id_to_ib_contract(instrument_id, exchanges.first().map(String::as_str))
+                .unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Option);
+        assert_eq!(contract.exchange.as_str(), "SMART");
+        assert!(contract.symbol.as_str().is_empty());
+        assert_eq!(contract.currency.as_str(), "USD");
+        assert_eq!(contract.local_symbol.as_str(), "SPY   240319P00511000");
+        assert!(contract.last_trade_date_or_contract_month.is_empty());
+        assert!(contract.right.is_none());
+        assert_eq!(contract.strike, 0.0);
+    }
+
+    #[rstest]
+    fn test_opra_raw_option_default_contract_routes_to_smart() {
+        let instrument_id = InstrumentId::from("SPY   240319P00511000=OPT.OPRA");
+
+        let contract = instrument_id_to_ib_contract(instrument_id, None).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Option);
+        assert_eq!(contract.exchange.as_str(), "SMART");
+        assert_eq!(contract.local_symbol.as_str(), "SPY   240319P00511000");
+    }
+
+    #[rstest]
+    #[case("SPY   240319P00511000.OPRA")]
+    #[case("SPY   240319P00511000=OPT.OPRA")]
+    fn test_opra_option_respects_exchange_override(#[case] value: &str) {
+        let instrument_id = InstrumentId::from(value);
+
+        let contract = instrument_id_to_ib_contract(instrument_id, Some("CBOE")).unwrap();
+
+        assert_eq!(contract.security_type, SecurityType::Option);
+        assert_eq!(contract.exchange.as_str(), "CBOE");
+    }
+
+    #[rstest]
+    #[case("AAPL.OPRA")]
+    #[case("SPY   abcdefP00511000.OPRA")]
+    #[case("P SPY 20240319 511.OPRA")]
+    fn test_invalid_opra_occ_option_returns_error(#[case] value: &str) {
+        let instrument_id = InstrumentId::from(value);
+
+        let result = instrument_id_to_ib_contract(instrument_id, None);
+
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn test_opra_route_does_not_create_reverse_smart_mapping() {
+        assert_eq!(exchange_to_mic_venue("SMART"), None);
     }
 
     #[rstest]

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -1585,6 +1585,22 @@ fn test_parse_historical_fill_report_uses_provider_resolved_stock_venue() {
 }
 
 #[rstest]
+fn test_report_contract_resolution_preserves_canonical_opra_id() {
+    let (client, _, _) = create_test_execution_client();
+    let instrument_id = InstrumentId::from("SPY   250101C00400000.OPRA");
+    client
+        .instrument_provider
+        .insert_test_contract_id_mapping(12_345, instrument_id);
+    let exec_data = create_test_execution_data(123, "exec-opra-001", 1.0, 1.25, "BOT");
+
+    let resolved = client
+        .resolve_report_contract_instrument_id(&exec_data.contract)
+        .unwrap();
+
+    assert_eq!(resolved, instrument_id);
+}
+
+#[rstest]
 fn test_parse_historical_fill_report_uses_cached_bag_spread_id() {
     let (client, _, _) = create_test_execution_client();
     let spread = create_test_option_spread();
@@ -2081,6 +2097,76 @@ async fn test_handle_order_status_canceled_emits_canceled_event() {
             .lock()
             .unwrap()
             .contains_key(&order_id)
+    );
+}
+
+#[tokio::test]
+async fn test_opra_cancel_status_preserves_canonical_instrument_identity() {
+    let state = SubmitTrackingState::new();
+    let order_id = 7_002;
+    let client_order_id = ClientOrderId::from("O-OPRA-CANCEL-001");
+    let instrument_id = InstrumentId::from("SPY   250101C00400000.OPRA");
+    state.cache(
+        order_id,
+        client_order_id,
+        instrument_id,
+        TraderId::from("TRADER-001"),
+        StrategyId::from("STRATEGY-001"),
+    );
+
+    let instrument_provider = create_test_instrument_provider();
+    let order_avg_prices = Arc::new(Mutex::new(AHashMap::new()));
+    let pending_combo_fills = Arc::new(Mutex::new(AHashMap::new()));
+    let pending_combo_fill_avgs = Arc::new(Mutex::new(AHashMap::new()));
+    let order_fill_progress = Arc::new(Mutex::new(AHashMap::new()));
+    let pending_cancel_orders = Arc::new(Mutex::new(ahash::AHashSet::new()));
+    let spread_fill_tracking = Arc::new(Mutex::new(AHashMap::new()));
+    let (exec_sender, mut exec_receiver) = tokio::sync::mpsc::unbounded_channel();
+
+    InteractiveBrokersExecutionClient::handle_order_status(
+        &create_test_order_status(order_id, "Cancelled"),
+        &state.order_id_map,
+        &state.venue_order_id_map,
+        &instrument_provider,
+        &exec_sender,
+        UnixNanos::new(1),
+        AccountId::from("IB-001"),
+        &state.instrument_id_map,
+        &state.trader_id_map,
+        &state.strategy_id_map,
+        &state.active_order_contexts,
+        &state.terminal_order_contexts,
+        &order_avg_prices,
+        &pending_combo_fills,
+        &pending_combo_fill_avgs,
+        &order_fill_progress,
+        &pending_cancel_orders,
+        &spread_fill_tracking,
+    )
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        exec_receiver.try_recv().unwrap(),
+        ExecutionEvent::Order(OrderEventAny::Accepted(event))
+            if event.instrument_id == instrument_id
+    ));
+    assert!(matches!(
+        exec_receiver.try_recv().unwrap(),
+        ExecutionEvent::Order(OrderEventAny::Canceled(event))
+            if event.instrument_id == instrument_id
+                && event.client_order_id == client_order_id
+    ));
+    assert!(exec_receiver.try_recv().is_err());
+    assert_eq!(
+        state
+            .terminal_order_contexts
+            .lock()
+            .unwrap()
+            .get(&order_id)
+            .unwrap()
+            .instrument_id,
+        instrument_id
     );
 }
 

--- a/crates/adapters/interactive_brokers/src/providers/instruments.rs
+++ b/crates/adapters/interactive_brokers/src/providers/instruments.rs
@@ -2813,8 +2813,98 @@ mod tests {
         (provider, temp_dir)
     }
 
+    fn opra_option_contract_details(mut contract: Contract) -> ibapi::contracts::ContractDetails {
+        contract.contract_id = 12_345;
+        contract.symbol = ibapi::contracts::Symbol::from("AAPL");
+        contract.security_type = SecurityType::Option;
+        contract.exchange = Exchange::from("SMART");
+        contract.currency = ibapi::contracts::Currency::from("USD");
+        contract.local_symbol = "AAPL  270115P00155000".to_string();
+        contract.last_trade_date_or_contract_month = "20270115".to_string();
+        contract.strike = 155.0;
+        contract.right = Some(ibapi::contracts::OptionRight::Put);
+        contract.multiplier = "100".to_string();
+
+        ibapi::contracts::ContractDetails {
+            contract,
+            min_tick: 0.01,
+            under_symbol: "AAPL".to_string(),
+            under_security_type: "STK".to_string(),
+            valid_exchanges: vec!["SMART".to_string(), "CBOE".to_string()],
+            ..Default::default()
+        }
+    }
+
     fn create_test_instrument(instrument_id: InstrumentId) -> InstrumentAny {
         create_test_instrument_with_info(instrument_id, None)
+    }
+
+    #[rstest]
+    fn test_qualified_opra_details_preserve_canonical_instrument_identity() {
+        let provider = InteractiveBrokersInstrumentProvider::new(Default::default());
+        let requested_id = InstrumentId::from("AAPL  270115P00155000.OPRA");
+        let request = instrument_id_to_ib_contract(requested_id, None).unwrap();
+
+        assert_eq!(request.security_type, SecurityType::Option);
+        assert_eq!(request.exchange.as_str(), "SMART");
+        assert!(request.symbol.as_str().is_empty());
+        assert_eq!(request.currency.as_str(), "USD");
+        assert_eq!(request.local_symbol, "AAPL  270115P00155000");
+        assert!(request.last_trade_date_or_contract_month.is_empty());
+        assert!(request.right.is_none());
+        assert_eq!(request.strike, 0.0);
+
+        let details = opra_option_contract_details(request);
+        let loaded_id = provider
+            .process_contract_detail(&details, Some(requested_id.venue), false)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(loaded_id, requested_id);
+        assert_eq!(provider.count(), 1);
+        assert_eq!(
+            provider.get_instrument_id_by_contract_id(12_345),
+            Some(requested_id)
+        );
+        assert_eq!(
+            provider
+                .resolve_instrument_id_for_contract(&details.contract)
+                .unwrap(),
+            requested_id
+        );
+
+        let cached = provider.find(&requested_id).unwrap();
+        let InstrumentAny::OptionContract(option) = cached else {
+            panic!("expected option contract");
+        };
+        assert_eq!(option.id, requested_id);
+        assert_eq!(option.id.venue.as_str(), "OPRA");
+        assert!(
+            provider
+                .find(&InstrumentId::from("AAPL  270115P00155000.SMART"))
+                .is_none()
+        );
+
+        let cached_contract = provider
+            .instrument_id_to_ib_contract(&requested_id)
+            .unwrap();
+        assert_eq!(cached_contract.contract_id, 12_345);
+        assert_eq!(cached_contract.security_type, SecurityType::Option);
+        assert_eq!(cached_contract.exchange.as_str(), "SMART");
+
+        let resolved_contract = provider
+            .resolve_contract_for_instrument(requested_id)
+            .unwrap();
+        assert_eq!(resolved_contract, cached_contract);
+
+        let cached_details = provider
+            .instrument_id_to_ib_contract_details(&requested_id)
+            .unwrap();
+        assert_eq!(cached_details.contract.contract_id, 12_345);
+        assert_eq!(
+            cached_details.valid_exchanges,
+            vec!["SMART".to_string(), "CBOE".to_string()]
+        );
     }
 
     fn create_test_instrument_with_info(


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [ ] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [ ] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Treat canonical 21-character padded OCC `.OPRA` instrument IDs as IB option identities and qualify
them through SMART using the exact OCC local symbol. Preserve explicit routing overrides and retain
the canonical `.OPRA` identity across provider caches, contract ID mappings, cancellation events,
and report resolution.

Invalid simplified `.OPRA` symbols now fail closed, while existing SMART and EUREX behavior and
reverse venue mapping remain unchanged.

## Related issues/PRs

Related to #3451.

#3452 preserved OCC spacing in the legacy Python IB path, while #3605 changed Databento dataset
routing. This change addresses the Rust v2 IB contract qualification and execution identity path.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

None.

## Documentation

No documentation or public binding changes were required.

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Validation included:

- A red/green regression proving canonical `.OPRA` uses a local-symbol-only IB option query.
- 13 focused OPRA conversion, qualification, cache, cancel, and report tests.
- All 408 `nautilus-interactive-brokers` library tests.
- `make format`.
- `make pre-commit`.
