### PR TITLE
Fix Binance Futures execution report resolution

### DIFF
--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -2350,9 +2350,10 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
             .map(|report| report.instrument_id)
             .chain(position_reports.iter().map(|report| report.instrument_id))
             .collect();
+        let mut retained_instrument_ids = Vec::new();
         {
             let cache = self.core.cache();
-            instrument_ids.extend(
+            retained_instrument_ids.extend(
                 cache
                     .orders_open(
                         Some(&BINANCE_VENUE),
@@ -2364,7 +2365,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                     .into_iter()
                     .map(|order| order.instrument_id()),
             );
-            instrument_ids.extend(
+            retained_instrument_ids.extend(
                 cache
                     .orders_inflight(
                         Some(&BINANCE_VENUE),
@@ -2376,7 +2377,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                     .into_iter()
                     .map(|order| order.instrument_id()),
             );
-            instrument_ids.extend(
+            retained_instrument_ids.extend(
                 cache
                     .positions_open(
                         Some(&BINANCE_VENUE),
@@ -2388,12 +2389,13 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                     .into_iter()
                     .map(|position| position.instrument_id),
             );
-            instrument_ids.retain(|instrument_id| {
+            retained_instrument_ids.retain(|instrument_id| {
                 cache.instrument(instrument_id).is_some_and(|instrument| {
                     is_instrument_for_product(instrument, self.product_type)
                 })
             });
         }
+        instrument_ids.extend(retained_instrument_ids);
         let instruments_cache = self.http_client.instruments_cache();
         instrument_ids.retain(|instrument_id| {
             let symbol = format_binance_symbol(instrument_id);

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -1890,8 +1890,19 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
 
             for order in orders {
                 if let Some(instrument_id) = cmd.instrument_id {
-                    let (price_precision, size_precision) =
-                        self.get_instrument_precision(instrument_id)?;
+                    let Some((_, price_precision, size_precision)) =
+                        self.resolve_cached_instrument(&format_binance_symbol(&instrument_id))?
+                    else {
+                        if self.is_out_of_scope(instrument_id) {
+                            log::debug!(
+                                "Dropping out-of-scope Binance Futures open order for instrument {instrument_id}"
+                            );
+                            continue;
+                        }
+                        anyhow::bail!(
+                            "Binance Futures open order has unresolved instrument {instrument_id}"
+                        );
+                    };
 
                     if let Ok(report) = order.to_order_status_report(
                         self.core.account_id,
@@ -1935,8 +1946,19 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
 
             for algo_order in algo_orders {
                 if let Some(instrument_id) = cmd.instrument_id {
-                    let (price_precision, size_precision) =
-                        self.get_instrument_precision(instrument_id)?;
+                    let Some((_, price_precision, size_precision)) =
+                        self.resolve_cached_instrument(&format_binance_symbol(&instrument_id))?
+                    else {
+                        if self.is_out_of_scope(instrument_id) {
+                            log::debug!(
+                                "Dropping out-of-scope Binance Futures open algo order for instrument {instrument_id}"
+                            );
+                            continue;
+                        }
+                        anyhow::bail!(
+                            "Binance Futures open algo order has unresolved instrument {instrument_id}"
+                        );
+                    };
 
                     if let Ok(report) = algo_order.to_order_status_report(
                         self.core.account_id,
@@ -2334,7 +2356,18 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         let instruments_cache = self.http_client.instruments_cache();
         instrument_ids.retain(|instrument_id| {
             let symbol = format_binance_symbol(instrument_id);
-            instruments_cache.contains_key(&Ustr::from(symbol.as_str()))
+            if instruments_cache.contains_key(&Ustr::from(symbol.as_str())) {
+                return true;
+            }
+
+            if self.is_out_of_scope(*instrument_id) {
+                log::debug!(
+                    "Dropping out-of-scope Binance Futures retained instrument {instrument_id}"
+                );
+                return false;
+            }
+
+            true
         });
         instrument_ids.sort_unstable();
         instrument_ids.dedup();

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -984,7 +984,7 @@ impl BinanceFuturesExecutionClient {
             return false;
         };
 
-        let contract_type = instrument_contract_type(&instrument);
+        let contract_type = instrument_contract_type(instrument);
         let mut selector_config = provider.clone();
         let contract_filter = selector_config.filters.remove("contract_types");
         let Ok(selector) = BinanceInstrumentSelector::new(&selector_config) else {

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -57,6 +57,7 @@ use nautilus_model::{
         OrderRejected, OrderUpdated,
     },
     identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, Venue, VenueOrderId},
+    instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
     types::{AccountBalance, Currency, MarginBalance, Money, Quantity},
@@ -106,6 +107,7 @@ use crate::{
             BinanceEnvironment, BinanceFuturesOrderType, BinancePositionSide, BinancePriceMatch,
             BinanceProductType, BinanceSide, BinanceTimeInForce, BinanceWorkingType,
         },
+        instruments::BinanceInstrumentSelector,
         symbol::{format_binance_symbol, format_instrument_id},
         urls::{get_usdm_ws_route_base_url, get_ws_private_base_url},
     },
@@ -960,12 +962,65 @@ impl BinanceFuturesExecutionClient {
 
     fn is_out_of_scope(&self, instrument_id: InstrumentId) -> bool {
         let provider = &self.config.instrument_provider;
-        !provider.load_all
+        if !provider.load_all
             && provider.load_ids.as_ref().is_none_or(|load_ids| {
                 load_ids
                     .iter()
                     .all(|raw_id| InstrumentId::from(raw_id.as_str()) != instrument_id)
             })
+        {
+            return true;
+        }
+
+        let Some(instrument) = self.core.cache().instrument(&instrument_id) else {
+            // A record with no shared-cache definition cannot be proven to be outside a
+            // filter. Keep it in scope so reconciliation reports the missing definition.
+            if let Some(values) = provider.filters.get("symbols")
+                && !filter_values_contain(values, &format_binance_symbol(&instrument_id))
+            {
+                return true;
+            }
+            return false;
+        };
+
+        let contract_type = instrument_contract_type(&instrument);
+        let mut selector_config = provider.clone();
+        let contract_filter = selector_config.filters.remove("contract_types");
+        let Ok(selector) = BinanceInstrumentSelector::new(&selector_config) else {
+            return false;
+        };
+
+        if !selector.includes(
+            instrument_id,
+            instrument.raw_symbol().as_str(),
+            instrument
+                .base_currency()
+                .map_or("", |currency| currency.code.as_str()),
+            instrument.quote_currency().code.as_str(),
+            contract_type,
+        ) {
+            return true;
+        }
+
+        let Some(contract_filter) = contract_filter else {
+            return false;
+        };
+
+        match contract_type {
+            Some(contract_type) => !filter_values_contain(&contract_filter, contract_type),
+            // The model retains delivery expiry but not Binance's current/next-quarter label.
+            // Treat a delivery contract as potentially selected when any delivery label is
+            // configured, while still classifying it out of scope for perpetual-only filters.
+            None => !filter_values_contain_any(
+                &contract_filter,
+                [
+                    "CURRENT_MONTH",
+                    "NEXT_MONTH",
+                    "CURRENT_QUARTER",
+                    "NEXT_QUARTER",
+                ],
+            ),
+        }
     }
 
     /// Creates a position status report from Binance position risk data.
@@ -2046,6 +2101,21 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         };
 
         let symbol = format_binance_symbol(&instrument_id);
+        let Some((_, price_precision, size_precision)) = self
+            .resolve_cached_instrument(&symbol)?
+        else {
+            if self.is_out_of_scope(instrument_id) {
+                log::debug!(
+                    "Dropping out-of-scope Binance Futures fills for instrument {instrument_id}"
+                );
+            } else {
+                log::warn!(
+                    "Dropping historical Binance Futures fills for unresolved instrument {instrument_id}"
+                );
+            }
+            return Ok(Vec::new());
+        };
+
         let mut trades = Vec::new();
         let mut seen_trade_ids = AHashSet::new();
         let requested_end_time = cmd
@@ -2158,7 +2228,6 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         }
 
         trades.sort_unstable_by_key(|trade| (trade.time, trade.id));
-        let (price_precision, size_precision) = self.get_instrument_precision(instrument_id)?;
         let ts_init = self.clock.get_time_ns();
 
         let mut reports = Vec::new();
@@ -2319,6 +2388,11 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                     .into_iter()
                     .map(|position| position.instrument_id),
             );
+            instrument_ids.retain(|instrument_id| {
+                cache.instrument(instrument_id).is_some_and(|instrument| {
+                    is_instrument_for_product(instrument, self.product_type)
+                })
+            });
         }
         let instruments_cache = self.http_client.instruments_cache();
         instrument_ids.retain(|instrument_id| {
@@ -3198,8 +3272,65 @@ fn cancel_venue_order_id(
     }
 }
 
+fn is_instrument_for_product(instrument: &InstrumentAny, product_type: BinanceProductType) -> bool {
+    match product_type {
+        BinanceProductType::UsdM => {
+            matches!(
+                instrument,
+                InstrumentAny::CryptoFuture(_)
+                    | InstrumentAny::CryptoPerpetual(_)
+                    | InstrumentAny::PerpetualContract(_)
+            ) && !instrument.is_inverse()
+        }
+        BinanceProductType::CoinM => {
+            matches!(
+                instrument,
+                InstrumentAny::CryptoFuture(_) | InstrumentAny::CryptoPerpetual(_)
+            ) && instrument.is_inverse()
+        }
+        _ => false,
+    }
+}
+
+fn instrument_contract_type(instrument: &InstrumentAny) -> Option<&'static str> {
+    match instrument {
+        InstrumentAny::CryptoPerpetual(_) => Some("PERPETUAL"),
+        InstrumentAny::PerpetualContract(_) => Some("TRADIFI_PERPETUAL"),
+        InstrumentAny::CryptoFuture(_) => None,
+        _ => None,
+    }
+}
+
+fn filter_values_contain(value: &serde_json::Value, expected: &str) -> bool {
+    match value {
+        serde_json::Value::String(value) => value.trim().eq_ignore_ascii_case(expected),
+        serde_json::Value::Array(values) => values.iter().any(|value| {
+            value
+                .as_str()
+                .is_some_and(|value| value.trim().eq_ignore_ascii_case(expected))
+        }),
+        _ => false,
+    }
+}
+
+fn filter_values_contain_any<const N: usize>(
+    value: &serde_json::Value,
+    expected: [&str; N],
+) -> bool {
+    expected
+        .iter()
+        .any(|expected| filter_values_contain(value, expected))
+}
+
 #[cfg(test)]
 mod tests {
+    use nautilus_model::{
+        instruments::stubs::{
+            crypto_future_btcusdt, crypto_perpetual_ethusdt, currency_pair_btcusdt,
+            perpetual_contract_eurusd, xbtusd_bitmex,
+        },
+        types::Price,
+    };
     use rstest::rstest;
 
     use super::*;
@@ -3481,6 +3612,51 @@ mod tests {
         let err = http_error(BINANCE_GTX_ORDER_REJECT_CODE);
         assert!(!is_ambiguous_submit_error(&err));
         assert!(is_structured_venue_rejection(&err));
+    }
+
+    #[rstest]
+    fn test_instrument_product_matching_distinguishes_futures_products_from_spot() {
+        let usdm = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        let generic_perpetual = InstrumentAny::PerpetualContract(perpetual_contract_eurusd());
+        let coinm = InstrumentAny::CryptoPerpetual(xbtusd_bitmex());
+        let delivery =
+            || crypto_future_btcusdt(2, 6, Price::from("0.01"), Quantity::from("0.000001"));
+        let usdm_delivery = InstrumentAny::CryptoFuture(delivery());
+        let mut coinm_delivery = delivery();
+        coinm_delivery.is_inverse = true;
+        let coinm_delivery = InstrumentAny::CryptoFuture(coinm_delivery);
+        let spot = InstrumentAny::CurrencyPair(currency_pair_btcusdt());
+
+        assert!(is_instrument_for_product(&usdm, BinanceProductType::UsdM));
+        assert!(!is_instrument_for_product(&usdm, BinanceProductType::CoinM));
+        assert!(is_instrument_for_product(
+            &generic_perpetual,
+            BinanceProductType::UsdM
+        ));
+        assert!(!is_instrument_for_product(
+            &generic_perpetual,
+            BinanceProductType::CoinM
+        ));
+        assert!(is_instrument_for_product(&coinm, BinanceProductType::CoinM));
+        assert!(!is_instrument_for_product(&coinm, BinanceProductType::UsdM));
+        assert!(is_instrument_for_product(
+            &usdm_delivery,
+            BinanceProductType::UsdM
+        ));
+        assert!(!is_instrument_for_product(
+            &usdm_delivery,
+            BinanceProductType::CoinM
+        ));
+        assert!(is_instrument_for_product(
+            &coinm_delivery,
+            BinanceProductType::CoinM
+        ));
+        assert!(!is_instrument_for_product(
+            &coinm_delivery,
+            BinanceProductType::UsdM
+        ));
+        assert!(!is_instrument_for_product(&spot, BinanceProductType::UsdM));
+        assert!(!is_instrument_for_product(&spot, BinanceProductType::CoinM));
     }
 
 }

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -57,7 +57,6 @@ use nautilus_model::{
         OrderRejected, OrderUpdated,
     },
     identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, Venue, VenueOrderId},
-    instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
     types::{AccountBalance, Currency, MarginBalance, Money, Quantity},
@@ -65,6 +64,7 @@ use nautilus_model::{
 use rust_decimal::Decimal;
 use tokio::{sync::Mutex as TokioMutex, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
+use ustr::Ustr;
 
 use super::{
     http::{
@@ -106,7 +106,7 @@ use crate::{
             BinanceEnvironment, BinanceFuturesOrderType, BinancePositionSide, BinancePriceMatch,
             BinanceProductType, BinanceSide, BinanceTimeInForce, BinanceWorkingType,
         },
-        symbol::format_binance_symbol,
+        symbol::{format_binance_symbol, format_instrument_id},
         urls::{get_usdm_ws_route_base_url, get_ws_private_base_url},
     },
     config::BinanceExecClientConfig,
@@ -925,12 +925,47 @@ impl BinanceFuturesExecutionClient {
         crate::common::execution::abort_pending_tasks(&self.pending_tasks);
     }
 
+    /// Resolves a parsed instrument from the execution client's catalogue.
+    fn resolve_cached_instrument(
+        &self,
+        symbol: &str,
+    ) -> anyhow::Result<Option<(InstrumentId, u8, u8)>> {
+        let cache = self.http_client.instruments_cache();
+        let Some(instrument) = cache.get(&Ustr::from(symbol)) else {
+            return Ok(None);
+        };
+
+        let price_precision = u8::try_from(instrument.price_precision())
+            .context("invalid Binance Futures price precision")?;
+        let size_precision = u8::try_from(instrument.quantity_precision())
+            .context("invalid Binance Futures quantity precision")?;
+
+        Ok(Some((
+            instrument.id(),
+            price_precision,
+            size_precision,
+        )))
+    }
+
     /// Returns the (price_precision, size_precision) for an instrument.
-    fn get_instrument_precision(&self, instrument_id: InstrumentId) -> (u8, u8) {
-        let cache = self.core.cache();
-        cache
-            .instrument(&instrument_id)
-            .map_or((8, 8), |i| (i.price_precision(), i.size_precision()))
+    fn get_instrument_precision(&self, instrument_id: InstrumentId) -> anyhow::Result<(u8, u8)> {
+        self.resolve_cached_instrument(&format_binance_symbol(&instrument_id))?
+            .map(|(_, price_precision, size_precision)| (price_precision, size_precision))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Binance Futures instrument {instrument_id} is not loaded in the execution client"
+                )
+            })
+    }
+
+    fn is_out_of_scope(&self, instrument_id: InstrumentId) -> bool {
+        let provider = &self.config.instrument_provider;
+        !provider.load_all
+            && provider.load_ids.as_ref().is_none_or(|load_ids| {
+                load_ids
+                    .iter()
+                    .all(|raw_id| InstrumentId::from(raw_id.as_str()) != instrument_id)
+            })
     }
 
     /// Creates a position status report from Binance position risk data.
@@ -1748,7 +1783,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         }
         let params = builder.build().map_err(|e| anyhow::anyhow!("{e}"))?;
 
-        let (price_precision, size_precision) = self.get_instrument_precision(instrument_id);
+        let (price_precision, size_precision) = self.get_instrument_precision(instrument_id)?;
         let ts_init = self.clock.get_time_ns();
         let algo_lookup = self.resolve_algo_lookup(cmd.client_order_id, cmd.params.as_ref());
 
@@ -1859,7 +1894,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
             for order in orders {
                 if let Some(instrument_id) = cmd.instrument_id {
                     let (price_precision, size_precision) =
-                        self.get_instrument_precision(instrument_id);
+                        self.get_instrument_precision(instrument_id)?;
 
                     if let Ok(report) = order.to_order_status_report(
                         self.core.account_id,
@@ -1872,24 +1907,33 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                         reports.push(report);
                     }
                 } else {
-                    let cache = self.core.cache();
-                    if let Some(instrument) = cache
-                        .instruments(&BINANCE_VENUE, None)
-                        .into_iter()
-                        .find(|instrument| {
-                            instrument.raw_symbol().as_str() == order.symbol.as_str()
-                                && is_instrument_for_product(instrument, self.product_type)
-                        })
-                        && let Ok(report) = order.to_order_status_report(
-                            self.core.account_id,
-                            instrument.id(),
-                            instrument.price_precision(),
-                            instrument.size_precision(),
-                            self.config.treat_expired_as_canceled,
-                            ts_init,
-                        )
-                    {
-                        reports.push(report);
+                    let instrument_id = format_instrument_id(
+                        &Ustr::from(order.symbol.as_str()),
+                        self.product_type,
+                    );
+                    match self.resolve_cached_instrument(order.symbol.as_str())? {
+                        Some((resolved_id, price_precision, size_precision)) => {
+                            if let Ok(report) = order.to_order_status_report(
+                                self.core.account_id,
+                                resolved_id,
+                                price_precision,
+                                size_precision,
+                                self.config.treat_expired_as_canceled,
+                                ts_init,
+                            ) {
+                                reports.push(report);
+                            }
+                        }
+                        None if self.is_out_of_scope(instrument_id) => {
+                            log::debug!(
+                                "Dropping out-of-scope Binance Futures open order for instrument {instrument_id}"
+                            );
+                        }
+                        None => {
+                            anyhow::bail!(
+                                "Binance Futures open order has unresolved instrument {instrument_id}"
+                            );
+                        }
                     }
                 }
             }
@@ -1897,7 +1941,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
             for algo_order in algo_orders {
                 if let Some(instrument_id) = cmd.instrument_id {
                     let (price_precision, size_precision) =
-                        self.get_instrument_precision(instrument_id);
+                        self.get_instrument_precision(instrument_id)?;
 
                     if let Ok(report) = algo_order.to_order_status_report(
                         self.core.account_id,
@@ -1909,23 +1953,32 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                         reports.push(report);
                     }
                 } else {
-                    let cache = self.core.cache();
-                    if let Some(instrument) = cache
-                        .instruments(&BINANCE_VENUE, None)
-                        .into_iter()
-                        .find(|instrument| {
-                            instrument.raw_symbol().as_str() == algo_order.symbol.as_str()
-                                && is_instrument_for_product(instrument, self.product_type)
-                        })
-                        && let Ok(report) = algo_order.to_order_status_report(
-                            self.core.account_id,
-                            instrument.id(),
-                            instrument.price_precision(),
-                            instrument.size_precision(),
-                            ts_init,
-                        )
-                    {
-                        reports.push(report);
+                    let instrument_id = format_instrument_id(
+                        &Ustr::from(algo_order.symbol.as_str()),
+                        self.product_type,
+                    );
+                    match self.resolve_cached_instrument(algo_order.symbol.as_str())? {
+                        Some((resolved_id, price_precision, size_precision)) => {
+                            if let Ok(report) = algo_order.to_order_status_report(
+                                self.core.account_id,
+                                resolved_id,
+                                price_precision,
+                                size_precision,
+                                ts_init,
+                            ) {
+                                reports.push(report);
+                            }
+                        }
+                        None if self.is_out_of_scope(instrument_id) => {
+                            log::debug!(
+                                "Dropping out-of-scope Binance Futures algo order for instrument {instrument_id}"
+                            );
+                        }
+                        None => {
+                            anyhow::bail!(
+                                "Binance Futures open algo order has unresolved instrument {instrument_id}"
+                            );
+                        }
                     }
                 }
             }
@@ -1951,7 +2004,20 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
             let params = builder.build().map_err(|e| anyhow::anyhow!("{e}"))?;
 
             let orders = self.http_client.query_all_orders(&params).await?;
-            let (price_precision, size_precision) = self.get_instrument_precision(instrument_id);
+            let Some((_, price_precision, size_precision)) = self
+                .resolve_cached_instrument(&format_binance_symbol(&instrument_id))?
+            else {
+                if self.is_out_of_scope(instrument_id) {
+                    log::debug!(
+                        "Dropping out-of-scope historical Binance Futures orders for instrument {instrument_id}"
+                    );
+                } else {
+                    log::warn!(
+                        "Dropping historical Binance Futures orders for unresolved instrument {instrument_id}"
+                    );
+                }
+                return Ok(reports);
+            };
 
             for order in orders {
                 if let Ok(report) = order.to_order_status_report(
@@ -2092,7 +2158,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         }
 
         trades.sort_unstable_by_key(|trade| (trade.time, trade.id));
-        let (price_precision, size_precision) = self.get_instrument_precision(instrument_id);
+        let (price_precision, size_precision) = self.get_instrument_precision(instrument_id)?;
         let ts_init = self.clock.get_time_ns();
 
         let mut reports = Vec::new();
@@ -2144,28 +2210,31 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                 continue;
             }
 
-            let cache = self.core.cache();
-            if let Some(instrument) =
-                cache
-                    .instruments(&BINANCE_VENUE, None)
-                    .into_iter()
-                    .find(|instrument| {
-                        instrument.raw_symbol().as_str() == position.symbol.as_str()
-                            && is_instrument_for_product(instrument, self.product_type)
-                    })
-            {
-                match self.create_position_report(
-                    &position,
-                    instrument.id(),
-                    instrument.size_precision(),
-                ) {
-                    Ok(report) => reports.push(report),
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to create Futures position report for symbol={}: {e}",
-                            position.symbol
-                        );
+            let instrument_id = format_instrument_id(
+                &Ustr::from(position.symbol.as_str()),
+                self.product_type,
+            );
+            match self.resolve_cached_instrument(position.symbol.as_str())? {
+                Some((resolved_id, _, size_precision)) => {
+                    match self.create_position_report(&position, resolved_id, size_precision) {
+                        Ok(report) => reports.push(report),
+                        Err(e) => {
+                            log::warn!(
+                                "Failed to create Futures position report for symbol={}: {e}",
+                                position.symbol
+                            );
+                        }
                     }
+                }
+                None if self.is_out_of_scope(instrument_id) => {
+                    log::debug!(
+                        "Dropping out-of-scope Binance Futures position for instrument {instrument_id}"
+                    );
+                }
+                None => {
+                    anyhow::bail!(
+                        "Binance Futures position has unresolved instrument {instrument_id}"
+                    );
                 }
             }
         }
@@ -2250,12 +2319,12 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                     .into_iter()
                     .map(|position| position.instrument_id),
             );
-            instrument_ids.retain(|instrument_id| {
-                cache.instrument(instrument_id).is_some_and(|instrument| {
-                    is_instrument_for_product(instrument, self.product_type)
-                })
-            });
         }
+        let instruments_cache = self.http_client.instruments_cache();
+        instrument_ids.retain(|instrument_id| {
+            let symbol = format_binance_symbol(instrument_id);
+            instruments_cache.contains_key(&Ustr::from(symbol.as_str()))
+        });
         instrument_ids.sort_unstable();
         instrument_ids.dedup();
 
@@ -2319,7 +2388,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
             BINANCE_NAUTILUS_FUTURES_BROKER_ID,
         ));
         let (price_precision, size_precision) =
-            self.get_instrument_precision(command.instrument_id);
+            self.get_instrument_precision(command.instrument_id)?;
         let treat_expired_as_canceled = self.config.treat_expired_as_canceled;
 
         self.spawn_task("query_order", async move {
@@ -3129,35 +3198,8 @@ fn cancel_venue_order_id(
     }
 }
 
-fn is_instrument_for_product(instrument: &InstrumentAny, product_type: BinanceProductType) -> bool {
-    match product_type {
-        BinanceProductType::UsdM => {
-            matches!(
-                instrument,
-                InstrumentAny::CryptoFuture(_)
-                    | InstrumentAny::CryptoPerpetual(_)
-                    | InstrumentAny::PerpetualContract(_)
-            ) && !instrument.is_inverse()
-        }
-        BinanceProductType::CoinM => {
-            matches!(
-                instrument,
-                InstrumentAny::CryptoFuture(_) | InstrumentAny::CryptoPerpetual(_)
-            ) && instrument.is_inverse()
-        }
-        _ => false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use nautilus_model::{
-        instruments::stubs::{
-            crypto_future_btcusdt, crypto_perpetual_ethusdt, currency_pair_btcusdt,
-            perpetual_contract_eurusd, xbtusd_bitmex,
-        },
-        types::Price,
-    };
     use rstest::rstest;
 
     use super::*;
@@ -3441,48 +3483,4 @@ mod tests {
         assert!(is_structured_venue_rejection(&err));
     }
 
-    #[rstest]
-    fn test_instrument_product_matching_distinguishes_futures_products_from_spot() {
-        let usdm = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
-        let generic_perpetual = InstrumentAny::PerpetualContract(perpetual_contract_eurusd());
-        let coinm = InstrumentAny::CryptoPerpetual(xbtusd_bitmex());
-        let delivery =
-            || crypto_future_btcusdt(2, 6, Price::from("0.01"), Quantity::from("0.000001"));
-        let usdm_delivery = InstrumentAny::CryptoFuture(delivery());
-        let mut coinm_delivery = delivery();
-        coinm_delivery.is_inverse = true;
-        let coinm_delivery = InstrumentAny::CryptoFuture(coinm_delivery);
-        let spot = InstrumentAny::CurrencyPair(currency_pair_btcusdt());
-
-        assert!(is_instrument_for_product(&usdm, BinanceProductType::UsdM));
-        assert!(!is_instrument_for_product(&usdm, BinanceProductType::CoinM));
-        assert!(is_instrument_for_product(
-            &generic_perpetual,
-            BinanceProductType::UsdM
-        ));
-        assert!(!is_instrument_for_product(
-            &generic_perpetual,
-            BinanceProductType::CoinM
-        ));
-        assert!(is_instrument_for_product(&coinm, BinanceProductType::CoinM));
-        assert!(!is_instrument_for_product(&coinm, BinanceProductType::UsdM));
-        assert!(is_instrument_for_product(
-            &usdm_delivery,
-            BinanceProductType::UsdM
-        ));
-        assert!(!is_instrument_for_product(
-            &usdm_delivery,
-            BinanceProductType::CoinM
-        ));
-        assert!(is_instrument_for_product(
-            &coinm_delivery,
-            BinanceProductType::CoinM
-        ));
-        assert!(!is_instrument_for_product(
-            &coinm_delivery,
-            BinanceProductType::UsdM
-        ));
-        assert!(!is_instrument_for_product(&spot, BinanceProductType::UsdM));
-        assert!(!is_instrument_for_product(&spot, BinanceProductType::CoinM));
-    }
 }

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -107,7 +107,6 @@ use crate::{
             BinanceEnvironment, BinanceFuturesOrderType, BinancePositionSide, BinancePriceMatch,
             BinanceProductType, BinanceSide, BinanceTimeInForce, BinanceWorkingType,
         },
-        instruments::BinanceInstrumentSelector,
         symbol::{format_binance_symbol, format_instrument_id},
         urls::{get_usdm_ws_route_base_url, get_ws_private_base_url},
     },
@@ -962,66 +961,12 @@ impl BinanceFuturesExecutionClient {
 
     fn is_out_of_scope(&self, instrument_id: InstrumentId) -> bool {
         let provider = &self.config.instrument_provider;
-        if !provider.load_all
-            && provider.load_ids.as_ref().is_none_or(|load_ids| {
+        !provider.load_all
+            && provider.load_ids.as_ref().is_some_and(|load_ids| {
                 load_ids
                     .iter()
                     .all(|raw_id| InstrumentId::from(raw_id.as_str()) != instrument_id)
             })
-        {
-            return true;
-        }
-
-        let cache = self.core.cache();
-        let Some(instrument) = cache.instrument(&instrument_id) else {
-            // A record with no shared-cache definition cannot be proven to be outside a
-            // filter. Keep it in scope so reconciliation reports the missing definition.
-            if let Some(values) = provider.filters.get("symbols")
-                && !filter_values_contain(values, &format_binance_symbol(&instrument_id))
-            {
-                return true;
-            }
-            return false;
-        };
-
-        let contract_type = instrument_contract_type(instrument);
-        let mut selector_config = provider.clone();
-        let contract_filter = selector_config.filters.remove("contract_types");
-        let Ok(selector) = BinanceInstrumentSelector::new(&selector_config) else {
-            return false;
-        };
-
-        if !selector.includes(
-            instrument_id,
-            instrument.raw_symbol().as_str(),
-            instrument
-                .base_currency()
-                .map_or("", |currency| currency.code.as_str()),
-            instrument.quote_currency().code.as_str(),
-            contract_type,
-        ) {
-            return true;
-        }
-
-        let Some(contract_filter) = contract_filter else {
-            return false;
-        };
-
-        match contract_type {
-            Some(contract_type) => !filter_values_contain(&contract_filter, contract_type),
-            // The model retains delivery expiry but not Binance's current/next-quarter label.
-            // Treat a delivery contract as potentially selected when any delivery label is
-            // configured, while still classifying it out of scope for perpetual-only filters.
-            None => !filter_values_contain_any(
-                &contract_filter,
-                [
-                    "CURRENT_MONTH",
-                    "NEXT_MONTH",
-                    "CURRENT_QUARTER",
-                    "NEXT_QUARTER",
-                ],
-            ),
-        }
     }
 
     /// Creates a position status report from Binance position risk data.
@@ -3293,36 +3238,6 @@ fn is_instrument_for_product(instrument: &InstrumentAny, product_type: BinancePr
         }
         _ => false,
     }
-}
-
-fn instrument_contract_type(instrument: &InstrumentAny) -> Option<&'static str> {
-    match instrument {
-        InstrumentAny::CryptoPerpetual(_) => Some("PERPETUAL"),
-        InstrumentAny::PerpetualContract(_) => Some("TRADIFI_PERPETUAL"),
-        InstrumentAny::CryptoFuture(_) => None,
-        _ => None,
-    }
-}
-
-fn filter_values_contain(value: &serde_json::Value, expected: &str) -> bool {
-    match value {
-        serde_json::Value::String(value) => value.trim().eq_ignore_ascii_case(expected),
-        serde_json::Value::Array(values) => values.iter().any(|value| {
-            value
-                .as_str()
-                .is_some_and(|value| value.trim().eq_ignore_ascii_case(expected))
-        }),
-        _ => false,
-    }
-}
-
-fn filter_values_contain_any<const N: usize>(
-    value: &serde_json::Value,
-    expected: [&str; N],
-) -> bool {
-    expected
-        .iter()
-        .any(|expected| filter_values_contain(value, expected))
 }
 
 #[cfg(test)]

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -2533,24 +2533,6 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         self.emitter.set_sender(get_exec_event_sender());
         self.core.set_started();
 
-        let http_client = self.http_client.clone();
-        let provider = self.config.instrument_provider.clone();
-
-        get_runtime().spawn(async move {
-            match http_client.request_instruments_with_config(&provider).await {
-                Ok(instruments) => {
-                    if instruments.is_empty() {
-                        log::warn!("No instruments returned for Binance Futures");
-                    } else {
-                        log::debug!("Loaded {} Futures instruments", instruments.len());
-                    }
-                }
-                Err(e) => {
-                    log::error!("Failed to request Binance Futures instruments: {e}");
-                }
-            }
-        });
-
         log::info!(
             "Started: client_id={}, account_id={}, account_type={:?}, environment={:?}",
             self.core.client_id,

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -941,11 +941,7 @@ impl BinanceFuturesExecutionClient {
         let size_precision = u8::try_from(instrument.quantity_precision())
             .context("invalid Binance Futures quantity precision")?;
 
-        Ok(Some((
-            instrument.id(),
-            price_precision,
-            size_precision,
-        )))
+        Ok(Some((instrument.id(), price_precision, size_precision)))
     }
 
     /// Returns the (price_precision, size_precision) for an instrument.
@@ -1908,10 +1904,8 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                         reports.push(report);
                     }
                 } else {
-                    let instrument_id = format_instrument_id(
-                        &Ustr::from(order.symbol.as_str()),
-                        self.product_type,
-                    );
+                    let instrument_id = format_instrument_id(&order.symbol, self.product_type);
+
                     match self.resolve_cached_instrument(order.symbol.as_str())? {
                         Some((resolved_id, price_precision, size_precision)) => {
                             if let Ok(report) = order.to_order_status_report(
@@ -1954,10 +1948,8 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                         reports.push(report);
                     }
                 } else {
-                    let instrument_id = format_instrument_id(
-                        &Ustr::from(algo_order.symbol.as_str()),
-                        self.product_type,
-                    );
+                    let instrument_id = format_instrument_id(&algo_order.symbol, self.product_type);
+
                     match self.resolve_cached_instrument(algo_order.symbol.as_str())? {
                         Some((resolved_id, price_precision, size_precision)) => {
                             if let Ok(report) = algo_order.to_order_status_report(
@@ -2005,8 +1997,8 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
             let params = builder.build().map_err(|e| anyhow::anyhow!("{e}"))?;
 
             let orders = self.http_client.query_all_orders(&params).await?;
-            let Some((_, price_precision, size_precision)) = self
-                .resolve_cached_instrument(&format_binance_symbol(&instrument_id))?
+            let Some((_, price_precision, size_precision)) =
+                self.resolve_cached_instrument(&format_binance_symbol(&instrument_id))?
             else {
                 if self.is_out_of_scope(instrument_id) {
                     log::debug!(
@@ -2047,8 +2039,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
         };
 
         let symbol = format_binance_symbol(&instrument_id);
-        let Some((_, price_precision, size_precision)) = self
-            .resolve_cached_instrument(&symbol)?
+        let Some((_, price_precision, size_precision)) = self.resolve_cached_instrument(&symbol)?
         else {
             if self.is_out_of_scope(instrument_id) {
                 log::debug!(
@@ -2225,10 +2216,8 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
                 continue;
             }
 
-            let instrument_id = format_instrument_id(
-                &Ustr::from(position.symbol.as_str()),
-                self.product_type,
-            );
+            let instrument_id = format_instrument_id(&position.symbol, self.product_type);
+
             match self.resolve_cached_instrument(position.symbol.as_str())? {
                 Some((resolved_id, _, size_precision)) => {
                     match self.create_position_report(&position, resolved_id, size_precision) {
@@ -3576,5 +3565,4 @@ mod tests {
         assert!(!is_instrument_for_product(&spot, BinanceProductType::UsdM));
         assert!(!is_instrument_for_product(&spot, BinanceProductType::CoinM));
     }
-
 }

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -972,7 +972,8 @@ impl BinanceFuturesExecutionClient {
             return true;
         }
 
-        let Some(instrument) = self.core.cache().instrument(&instrument_id) else {
+        let cache = self.core.cache();
+        let Some(instrument) = cache.instrument(&instrument_id) else {
             // A record with no shared-cache definition cannot be proven to be outside a
             // filter. Keep it in scope so reconciliation reports the missing definition.
             if let Some(values) = provider.filters.get("symbols")

--- a/crates/adapters/binance/src/futures/http/client.rs
+++ b/crates/adapters/binance/src/futures/http/client.rs
@@ -1738,12 +1738,14 @@ impl BinanceFuturesHttpClient {
                         ts_init,
                         ts_init,
                     ) {
-                        Ok(instrument) => instruments.push(instrument),
+                        Ok(instrument) => {
+                            cache.push((symbol.symbol, BinanceFuturesInstrument::UsdM(symbol)));
+                            instruments.push(instrument);
+                        }
                         Err(e) => {
                             log_futures_instrument_parse_error(config, &symbol.symbol, &e);
                         }
                     }
-                    cache.push((symbol.symbol, BinanceFuturesInstrument::UsdM(symbol)));
                 }
 
                 log::debug!(
@@ -1784,12 +1786,14 @@ impl BinanceFuturesHttpClient {
                         ts_init,
                         ts_init,
                     ) {
-                        Ok(instrument) => instruments.push(instrument),
+                        Ok(instrument) => {
+                            cache.push((symbol.symbol, BinanceFuturesInstrument::CoinM(symbol)));
+                            instruments.push(instrument);
+                        }
                         Err(e) => {
                             log_futures_instrument_parse_error(config, &symbol.symbol, &e);
                         }
                     }
-                    cache.push((symbol.symbol, BinanceFuturesInstrument::CoinM(symbol)));
                 }
 
                 log::debug!(

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -2876,11 +2876,14 @@ async fn test_delivery_reconciliation_emits_open_order_and_position_reports() {
 }
 
 #[rstest]
-#[case::in_scope(vec!["BTCUSDT-PERP.BINANCE"], true)]
-#[case::out_of_scope(vec!["XAUUSDT-PERP.BINANCE"], false)]
+#[case::explicitly_in_scope(false, Some(vec!["BTCUSDT-PERP.BINANCE"]), true)]
+#[case::explicitly_out_of_scope(false, Some(vec!["XAUUSDT-PERP.BINANCE"]), false)]
+#[case::no_explicit_ids(false, None, true)]
+#[case::load_all_ignores_ids(true, Some(vec!["XAUUSDT-PERP.BINANCE"]), true)]
 #[tokio::test]
 async fn test_reconciliation_respects_load_id_scope(
-    #[case] load_ids: Vec<&str>,
+    #[case] load_all: bool,
+    #[case] load_ids: Option<Vec<&str>>,
     #[case] in_scope: bool,
 ) {
     let (addr, _captured_queries) = start_exec_test_server_with_query_capture_and_responses(
@@ -2891,8 +2894,8 @@ async fn test_reconciliation_respects_load_id_scope(
     let base_url_http = format!("http://{addr}");
     let base_url_ws = format!("ws://{addr}/ws");
     let provider = BinanceInstrumentProviderConfig {
-        load_all: false,
-        load_ids: Some(load_ids.into_iter().map(str::to_string).collect()),
+        load_all,
+        load_ids: load_ids.map(|ids| ids.into_iter().map(str::to_string).collect()),
         ..Default::default()
     };
     let (mut client, _rx, cache) =
@@ -2919,9 +2922,11 @@ async fn test_reconciliation_respects_load_id_scope(
 
     if in_scope {
         let error = result.unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("open order has unresolved instrument"));
+        assert!(
+            error
+                .to_string()
+                .contains("open order has unresolved instrument")
+        );
     } else {
         assert!(result.unwrap().is_empty());
     }
@@ -2929,7 +2934,7 @@ async fn test_reconciliation_respects_load_id_scope(
 
 #[rstest]
 #[tokio::test]
-async fn test_reconciliation_filters_out_delivery_instruments() {
+async fn test_reconciliation_filter_mismatch_remains_in_scope() {
     let (addr, _captured_queries) = start_exec_test_server_with_query_capture_and_responses(
         CommandResponses::default(),
         ReportFixtureMode::Delivery,
@@ -2949,7 +2954,7 @@ async fn test_reconciliation_filters_out_delivery_instruments() {
     client.start().unwrap();
     client.connect().await.unwrap();
 
-    let positions = client
+    let error = client
         .generate_position_status_reports(&GeneratePositionStatusReports::new(
             nautilus_core::UUID4::new(),
             UnixNanos::default(),
@@ -2960,9 +2965,13 @@ async fn test_reconciliation_filters_out_delivery_instruments() {
             None,
         ))
         .await
-        .unwrap();
+        .unwrap_err();
 
-    assert!(positions.is_empty());
+    assert!(
+        error
+            .to_string()
+            .contains("position has unresolved instrument")
+    );
 }
 
 #[rstest]

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -2929,6 +2929,46 @@ async fn test_reconciliation_respects_load_id_scope(
 
 #[rstest]
 #[tokio::test]
+async fn test_explicit_open_order_scope_classification() {
+    let (addr, _captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses::default(),
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+    let provider = BinanceInstrumentProviderConfig {
+        load_all: false,
+        load_ids: Some(vec!["XAUUSDT-PERP.BINANCE".to_string()]),
+        ..Default::default()
+    };
+    let (mut client, _rx, cache) =
+        create_test_execution_client_with_provider(base_url_http, base_url_ws, provider);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    add_test_instrument_to_cache(&cache);
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+    client.instruments_cache().clear();
+
+    let reports = client
+        .generate_order_status_reports(&GenerateOrderStatusReports::new(
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            true,
+            Some(test_instrument_id()),
+            None,
+            None,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    assert!(reports.is_empty());
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_reconciliation_filter_mismatch_remains_in_scope() {
     let (addr, _captured_queries) = start_exec_test_server_with_query_capture_and_responses(
         CommandResponses::default(),

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -47,7 +47,7 @@ use nautilus_binance::{
         enums::BinanceProductType,
         parse::parse_usdm_instrument,
     },
-    config::BinanceExecClientConfig,
+    config::{BinanceExecClientConfig, BinanceInstrumentProviderConfig},
     futures::{
         execution::{BINANCE_VENUE_ORDER_ID_IS_ALGO_ID_PARAM, BinanceFuturesExecutionClient},
         http::models::BinanceFuturesUsdExchangeInfo,
@@ -1281,6 +1281,41 @@ fn create_test_execution_client_with_leverages(
     tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
     Rc<RefCell<Cache>>,
 ) {
+    create_test_execution_client_with_options(
+        base_url_http,
+        base_url_ws,
+        futures_leverages,
+        BinanceInstrumentProviderConfig::default(),
+    )
+}
+
+fn create_test_execution_client_with_provider(
+    base_url_http: String,
+    base_url_ws: String,
+    instrument_provider: BinanceInstrumentProviderConfig,
+) -> (
+    BinanceFuturesExecutionClient,
+    tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    Rc<RefCell<Cache>>,
+) {
+    create_test_execution_client_with_options(
+        base_url_http,
+        base_url_ws,
+        None,
+        instrument_provider,
+    )
+}
+
+fn create_test_execution_client_with_options(
+    base_url_http: String,
+    base_url_ws: String,
+    futures_leverages: Option<HashMap<String, u32>>,
+    instrument_provider: BinanceInstrumentProviderConfig,
+) -> (
+    BinanceFuturesExecutionClient,
+    tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    Rc<RefCell<Cache>>,
+) {
     let trader_id = TraderId::from("TESTER-001");
     let account_id = AccountId::from("BINANCE-001");
     let client_id = *BINANCE_CLIENT_ID;
@@ -1308,6 +1343,7 @@ fn create_test_execution_client_with_leverages(
         api_key: Some("test_api_key".to_string()),
         api_secret: Some("test_api_secret".to_string()),
         futures_leverages,
+        instrument_provider,
         ..Default::default()
     };
 
@@ -1344,6 +1380,20 @@ fn add_test_instrument_to_cache(cache: &Rc<RefCell<Cache>>) {
     let exchange_info: BinanceFuturesUsdExchangeInfo =
         serde_json::from_value(exchange_info_response()).unwrap();
     let symbol = exchange_info.symbols.first().unwrap();
+    let instrument =
+        parse_usdm_instrument(symbol, UnixNanos::default(), UnixNanos::default()).unwrap();
+
+    cache.borrow_mut().add_instrument(instrument).unwrap();
+}
+
+fn add_delivery_instrument_to_cache(cache: &Rc<RefCell<Cache>>) {
+    let exchange_info: BinanceFuturesUsdExchangeInfo =
+        serde_json::from_value(exchange_info_response()).unwrap();
+    let symbol = exchange_info
+        .symbols
+        .iter()
+        .find(|symbol| symbol.symbol.as_str() == "BTCUSDT_260925")
+        .unwrap();
     let instrument =
         parse_usdm_instrument(symbol, UnixNanos::default(), UnixNanos::default()).unwrap();
 
@@ -2826,6 +2876,96 @@ async fn test_delivery_reconciliation_emits_open_order_and_position_reports() {
 }
 
 #[rstest]
+#[case::in_scope(vec!["BTCUSDT-PERP.BINANCE"], true)]
+#[case::out_of_scope(vec!["XAUUSDT-PERP.BINANCE"], false)]
+#[tokio::test]
+async fn test_reconciliation_respects_load_id_scope(
+    #[case] load_ids: Vec<&str>,
+    #[case] in_scope: bool,
+) {
+    let (addr, _captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses::default(),
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+    let provider = BinanceInstrumentProviderConfig {
+        load_all: false,
+        load_ids: Some(load_ids.into_iter().map(str::to_string).collect()),
+        ..Default::default()
+    };
+    let (mut client, _rx, cache) =
+        create_test_execution_client_with_provider(base_url_http, base_url_ws, provider);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    add_test_instrument_to_cache(&cache);
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+    client.instruments_cache().clear();
+
+    let result = client
+        .generate_order_status_reports(&GenerateOrderStatusReports::new(
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ))
+        .await;
+
+    if in_scope {
+        let error = result.unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("open order has unresolved instrument"));
+    } else {
+        assert!(result.unwrap().is_empty());
+    }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_reconciliation_filters_out_delivery_instruments() {
+    let (addr, _captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses::default(),
+        ReportFixtureMode::Delivery,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+    let provider = BinanceInstrumentProviderConfig {
+        filters: HashMap::from([("contract_types".to_string(), json!("PERPETUAL"))]),
+        ..Default::default()
+    };
+    let (mut client, _rx, cache) =
+        create_test_execution_client_with_provider(base_url_http, base_url_ws, provider);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    add_delivery_instrument_to_cache(&cache);
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let positions = client
+        .generate_position_status_reports(&GeneratePositionStatusReports::new(
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    assert!(positions.is_empty());
+}
+
+#[rstest]
 #[tokio::test]
 async fn test_reconciliation_fails_when_execution_instrument_catalogue_cannot_resolve() {
     let (addr, _captured_queries) = start_exec_test_server_with_query_capture_and_responses(
@@ -2874,6 +3014,21 @@ async fn test_reconciliation_fails_when_execution_instrument_catalogue_cannot_re
     assert!(position_error
         .to_string()
         .contains("position has unresolved instrument"));
+
+    let fills = client
+        .generate_fill_reports(GenerateFillReports::new(
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            Some(test_instrument_id()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ))
+        .await
+        .unwrap();
+    assert!(fills.is_empty());
 }
 
 #[rstest]

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -1298,12 +1298,7 @@ fn create_test_execution_client_with_provider(
     tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
     Rc<RefCell<Cache>>,
 ) {
-    create_test_execution_client_with_options(
-        base_url_http,
-        base_url_ws,
-        None,
-        instrument_provider,
-    )
+    create_test_execution_client_with_options(base_url_http, base_url_ws, None, instrument_provider)
 }
 
 fn create_test_execution_client_with_options(
@@ -3004,9 +2999,11 @@ async fn test_reconciliation_fails_when_execution_instrument_catalogue_cannot_re
         ))
         .await
         .unwrap_err();
-    assert!(order_error
-        .to_string()
-        .contains("open order has unresolved instrument"));
+    assert!(
+        order_error
+            .to_string()
+            .contains("open order has unresolved instrument")
+    );
 
     let position_error = client
         .generate_position_status_reports(&GeneratePositionStatusReports::new(
@@ -3020,9 +3017,11 @@ async fn test_reconciliation_fails_when_execution_instrument_catalogue_cannot_re
         ))
         .await
         .unwrap_err();
-    assert!(position_error
-        .to_string()
-        .contains("position has unresolved instrument"));
+    assert!(
+        position_error
+            .to_string()
+            .contains("position has unresolved instrument")
+    );
 
     let fills = client
         .generate_fill_reports(GenerateFillReports::new(

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -1350,20 +1350,6 @@ fn add_test_instrument_to_cache(cache: &Rc<RefCell<Cache>>) {
     cache.borrow_mut().add_instrument(instrument).unwrap();
 }
 
-fn add_delivery_instrument_to_cache(cache: &Rc<RefCell<Cache>>) {
-    let exchange_info: BinanceFuturesUsdExchangeInfo =
-        serde_json::from_value(exchange_info_response()).unwrap();
-    let symbol = exchange_info
-        .symbols
-        .iter()
-        .find(|symbol| symbol.symbol == "BTCUSDT_260925")
-        .unwrap();
-    let instrument =
-        parse_usdm_instrument(symbol, UnixNanos::default(), UnixNanos::default()).unwrap();
-
-    cache.borrow_mut().add_instrument(instrument).unwrap();
-}
-
 #[rstest]
 #[tokio::test]
 async fn test_client_creation() {
@@ -2799,7 +2785,6 @@ async fn test_delivery_reconciliation_emits_open_order_and_position_reports() {
     let base_url_ws = format!("ws://{addr}/ws");
     let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
     add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
-    add_delivery_instrument_to_cache(&cache);
     let instrument_id = InstrumentId::from("BTCUSDT_260925.BINANCE");
 
     client.start().unwrap();
@@ -2838,6 +2823,57 @@ async fn test_delivery_reconciliation_emits_open_order_and_position_reports() {
     );
     assert_eq!(positions.len(), 1);
     assert_eq!(positions[0].instrument_id, instrument_id);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_reconciliation_fails_when_execution_instrument_catalogue_cannot_resolve() {
+    let (addr, _captured_queries) = start_exec_test_server_with_query_capture_and_responses(
+        CommandResponses::default(),
+        ReportFixtureMode::Populated,
+    )
+    .await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+    client.instruments_cache().clear();
+
+    let order_error = client
+        .generate_order_status_reports(&GenerateOrderStatusReports::new(
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            true,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ))
+        .await
+        .unwrap_err();
+    assert!(order_error
+        .to_string()
+        .contains("open order has unresolved instrument"));
+
+    let position_error = client
+        .generate_position_status_reports(&GeneratePositionStatusReports::new(
+            nautilus_core::UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ))
+        .await
+        .unwrap_err();
+    assert!(position_error
+        .to_string()
+        .contains("position has unresolved instrument"));
 }
 
 #[rstest]
@@ -3960,11 +3996,6 @@ async fn test_report_generation_without_instrument_matches_raw_symbol_responses(
 
     client.start().unwrap();
     client.connect().await.unwrap();
-    add_test_instrument_to_cache(&cache);
-    cache
-        .borrow_mut()
-        .add_instrument(InstrumentAny::CurrencyPair(currency_pair_btcusdt()))
-        .unwrap();
 
     let open_orders = GenerateOrderStatusReports::new(
         nautilus_core::UUID4::new(),

--- a/crates/adapters/binance/tests/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/futures/exec_client.rs
@@ -2960,6 +2960,7 @@ async fn test_explicit_open_order_scope_classification() {
             None,
             None,
             None,
+            None,
         ))
         .await
         .unwrap();

--- a/crates/adapters/binance/tests/futures/http.rs
+++ b/crates/adapters/binance/tests/futures/http.rs
@@ -68,6 +68,7 @@ struct TestServerState {
     request_count: Arc<AtomicUsize>,
     rate_limit_threshold: usize,
     last_query: Arc<Mutex<Option<String>>>,
+    rejected_instrument_product: Option<BinanceProductType>,
 }
 
 impl Default for TestServerState {
@@ -76,6 +77,7 @@ impl Default for TestServerState {
             request_count: Arc::new(AtomicUsize::new(0)),
             rate_limit_threshold: usize::MAX,
             last_query: Arc::new(Mutex::new(None)),
+            rejected_instrument_product: None,
         }
     }
 }
@@ -83,6 +85,11 @@ impl Default for TestServerState {
 impl TestServerState {
     fn with_rate_limit(mut self, limit: usize) -> Self {
         self.rate_limit_threshold = limit;
+        self
+    }
+
+    fn with_rejected_instrument(mut self, product_type: BinanceProductType) -> Self {
+        self.rejected_instrument_product = Some(product_type);
         self
     }
 
@@ -139,12 +146,20 @@ async fn handle_time() -> Response {
     json_response(&json!({"serverTime": 1700000000000_i64}))
 }
 
-async fn handle_exchange_info() -> Response {
-    json_response(&load_fixture("exchange_info_usdm.json"))
+async fn handle_exchange_info(State(state): State<TestServerState>) -> Response {
+    let mut exchange_info = load_fixture("exchange_info_usdm.json");
+    if state.rejected_instrument_product == Some(BinanceProductType::UsdM) {
+        exchange_info["symbols"][0]["status"] = json!("PENDING_TRADING");
+    }
+    json_response(&exchange_info)
 }
 
-async fn handle_coinm_exchange_info() -> Response {
-    json_response(&load_fixture("exchange_info_delivery_coinm.json"))
+async fn handle_coinm_exchange_info(State(state): State<TestServerState>) -> Response {
+    let mut exchange_info = load_fixture("exchange_info_delivery_coinm.json");
+    if state.rejected_instrument_product == Some(BinanceProductType::CoinM) {
+        exchange_info["symbols"][0]["contractStatus"] = json!("PENDING_TRADING");
+    }
+    json_response(&exchange_info)
 }
 
 async fn handle_depth() -> Response {
@@ -604,6 +619,29 @@ async fn test_request_delivery_instrument_populates_cache_and_status(
         statuses.get(&raw_symbol),
         Some(&MarketStatusAction::Trading),
     );
+}
+
+#[rstest]
+#[case::usdm(BinanceProductType::UsdM, "BTCUSDT")]
+#[case::coinm(BinanceProductType::CoinM, "BTCUSD_260925")]
+#[tokio::test]
+async fn test_request_instruments_does_not_cache_rejected_instrument(
+    #[case] product_type: BinanceProductType,
+    #[case] raw_symbol: &str,
+) {
+    let state = TestServerState::default().with_rejected_instrument(product_type);
+    let addr = start_test_server(state).await.unwrap();
+    let client = create_domain_client(&addr, product_type);
+    let raw_symbol = Ustr::from(raw_symbol);
+
+    let instruments = client.request_instruments().await.unwrap();
+
+    assert!(
+        instruments
+            .iter()
+            .all(|instrument| instrument.raw_symbol().inner() != raw_symbol)
+    );
+    assert!(!client.instruments_cache().contains_key(&raw_symbol));
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

- Resolve Binance Futures order and position reports from the execution client’s parsed instrument catalogue.
- Fail reconciliation for in-scope open records that cannot resolve an instrument, while dropping configured out-of-scope records at debug level.
- Remove the guessed `(8, 8)` precision fallback and warn when historical records cannot be resolved.
- Add regression coverage for execution-only reconciliation without a shared data-client cache.

Fixes #4772

## Validation

- `git diff --check` passed.
- Rust tests and formatting could not be run locally because Cargo/Rust is not installed in this environment.
