### PR TITLE
Fix Binance Futures USD-M testnet WS host mismatch

### DIFF
--- a/crates/adapters/binance/src/common/consts.rs
+++ b/crates/adapters/binance/src/common/consts.rs
@@ -147,7 +147,7 @@ pub const BINANCE_FUTURES_USD_DEMO_WS_URL: &str = "wss://demo-fstream.binance.co
 pub const BINANCE_FUTURES_COIN_DEMO_WS_URL: &str = "wss://demo-dstream.binance.com/ws";
 
 /// Binance USD-M Futures WebSocket base URL (testnet).
-pub const BINANCE_FUTURES_USD_TESTNET_WS_URL: &str = "wss://fstream.binancefuture.com/ws";
+pub const BINANCE_FUTURES_USD_TESTNET_WS_URL: &str = "wss://demo-fstream.binance.com/ws";
 
 /// Binance COIN-M Futures WebSocket base URL (testnet).
 pub const BINANCE_FUTURES_COIN_TESTNET_WS_URL: &str = "wss://dstream.binancefuture.com/ws";

--- a/crates/adapters/binance/src/common/urls.rs
+++ b/crates/adapters/binance/src/common/urls.rs
@@ -401,8 +401,11 @@ mod tests {
 
     #[rstest]
     fn test_ws_url_usdm_testnet() {
+        // USD-M testnet HTTP is paired with the Demo host (`demo-fapi.binance.com`), so the
+        // private WS stream must resolve to the matching Demo WS host as well, otherwise the
+        // listen key signed against the Demo account is rejected by the legacy WS host.
         let url = get_ws_base_url(BinanceProductType::UsdM, BinanceEnvironment::Testnet);
-        assert_eq!(url, "wss://fstream.binancefuture.com/ws");
+        assert_eq!(url, "wss://demo-fstream.binance.com/ws");
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

Fixes #4733.

The USD-M futures testnet HTTP host was migrated to `demo-fapi.binance.com` (see the earlier commit that fixed the WS subdomain typo and moved HTTP to the Demo infra), but the corresponding WS host was left on the legacy `fstream.binancefuture.com` domain. A listen key created via `create_listen_key` is signed against the Demo account (since HTTP goes to `demo-fapi.binance.com`), but the private user-data WS stream then connects to a different backend (`fstream.binancefuture.com`) that rejects that key — breaking the private WebSocket stream on testnet.

`docs/integrations/binance.md` already documents that testnet futures endpoints route through the Demo infrastructure, and its Demo table gives USD-M WS as `demo-fstream.binance.com` — confirming this is the correct pairing, not a revert of the earlier HTTP migration.

## Changes

- `crates/adapters/binance/src/common/consts.rs`: `BINANCE_FUTURES_USD_TESTNET_WS_URL` now points at `wss://demo-fstream.binance.com/ws` (previously `wss://fstream.binancefuture.com/ws`), aliasing Demo like the HTTP host already does.
- `crates/adapters/binance/src/common/urls.rs`: updated `test_ws_url_usdm_testnet` to assert the corrected host, with a comment explaining why Testnet == Demo for USD-M WS.

## Testing

`cargo test -p nautilus-binance --lib common::urls::tests` — 52 passed, 0 failed.