### PR TITLE
Fix MovingAverageConvergenceDivergence input count

### DIFF
--- a/crates/indicators/src/momentum/macd.rs
+++ b/crates/indicators/src/momentum/macd.rs
@@ -90,6 +90,7 @@ impl Indicator for MovingAverageConvergenceDivergence {
 
     fn reset(&mut self) {
         self.value = 0.0;
+        self.count = 0;
         self.fast_ma.reset();
         self.slow_ma.reset();
         self.has_inputs = false;
@@ -140,6 +141,7 @@ impl MovingAverage for MovingAverageConvergenceDivergence {
         self.fast_ma.update_raw(close);
         self.slow_ma.update_raw(close);
         self.value = self.fast_ma.value() - self.slow_ma.value();
+        self.count += 1;
 
         // Initialization logic
         if !self.initialized {
@@ -250,9 +252,20 @@ mod tests {
         macd_10.update_raw(1.0);
         macd_10.reset();
         assert_eq!(macd_10.value, 0.0);
+        assert_eq!(macd_10.count, 0);
         assert_eq!(macd_10.fast_ma.value(), 0.0);
         assert_eq!(macd_10.slow_ma.value(), 0.0);
         assert!(!macd_10.has_inputs);
         assert!(!macd_10.initialized);
+    }
+
+    #[rstest]
+    fn count_matches_inputs(mut macd_10: MovingAverageConvergenceDivergence) {
+        assert_eq!(macd_10.count(), 0);
+
+        for i in 1..=12 {
+            macd_10.update_raw(f64::from(i));
+            assert_eq!(macd_10.count(), i as usize);
+        }
     }
 }


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self‑contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`MovingAverageConvergenceDivergence.count` is never assigned after `new`. `update_raw` does not
increment it and `reset` does not clear it, so `count()` returns 0 for the life of the object.

It is public in three places: the field, `MovingAverage::count`, and `count` on the pyo3 class,
which `python/nautilus_trader/indicators/__init__.pyi` publishes as `def count(self) -> int`.

`DoubleExponentialMovingAverage` is the same shape, a composite of two moving averages holding its
own count, and it does `self.count += 1` in `update_raw` and `self.count = 0` in `reset`. This is
those two lines. Every other struct in the crate with a `count` field already maintains it;
`RelativeStrengthIndex` delegates with `self.count = self.average_gain.count()`.

Nothing the indicator reports moves. `initialized` reads `fast_ma.initialized() &&
slow_ma.initialized()` and never consults `count`.

## Related issues/PRs

None.

## Type of change

- [x] Bug fix (non-breaking)

## Documentation

No documentation or binding change, so no stub regeneration.

## Testing

- [x] I added/updated tests to cover new or changed logic

`count_matches_inputs` follows `wma.rs`'s `count_matches_inputs_and_has_inputs`, and `test_reset`
gains one line. Removing the increment turns the first red at 0 against 1; removing the reset turns
`test_reset` red at 1 against 0.

551 tests pass in `nautilus-indicators`, `cargo fmt` is clean on stable and nightly, and `cargo
clippy --all-targets` is clean. `prek run` scoped to the changed file is 32 passed, 34 skipped
for having no matching files, 0 failed. I did not let `--all-files` finish, so that is the run
I am reporting.
