### PR TITLE
Preserve client source during startup reconciliation

### DIFF
--- a/crates/execution/src/client/mod.rs
+++ b/crates/execution/src/client/mod.rs
@@ -165,7 +165,30 @@ impl ExecutionClientAdapter {
         &self,
         lookback_mins: Option<u64>,
     ) -> anyhow::Result<Option<ExecutionMassStatus>> {
-        self.client.generate_mass_status(lookback_mins).await
+        let mass_status = self.client.generate_mass_status(lookback_mins).await?;
+
+        if let Some(mass_status) = &mass_status {
+            anyhow::ensure!(
+                mass_status.client_id == self.client_id,
+                "Execution mass status client ID {} did not match source client {}",
+                mass_status.client_id,
+                self.client_id,
+            );
+            anyhow::ensure!(
+                mass_status.account_id == self.account_id,
+                "Execution mass status account ID {} did not match source account {}",
+                mass_status.account_id,
+                self.account_id,
+            );
+            anyhow::ensure!(
+                mass_status.venue == self.venue,
+                "Execution mass status venue {} did not match source venue {}",
+                mass_status.venue,
+                self.venue,
+            );
+        }
+
+        Ok(mass_status)
     }
 
     /// Forwards an instrument update to the underlying execution client.

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -515,6 +515,23 @@ impl ExecutionManager {
         mass_status: ExecutionMassStatus,
         exec_engine: Rc<RefCell<ExecutionEngine>>,
     ) -> ReconciliationResult {
+        if exec_engine
+            .borrow()
+            .get_client(&mass_status.client_id)
+            .is_none()
+        {
+            log::error!(
+                "Cannot reconcile ExecutionMassStatus from unknown client {}",
+                mass_status.client_id
+            );
+            return ReconciliationResult::default();
+        }
+
+        if let Err(e) = self.validate_mass_status_order_sources(&mass_status) {
+            log::error!("Cannot reconcile ExecutionMassStatus: {e}");
+            return ReconciliationResult::default();
+        }
+
         // Publish raw reports before any state mutation (including fill adjustment
         // below, which can synthesise replacement order/fill reports). The
         // execution engine's per-report `reconcile_*` entry points are bypassed by
@@ -541,6 +558,18 @@ impl ExecutionManager {
             for report in reports {
                 msgbus::publish_any(raw_position_topic, report);
             }
+        }
+
+        if exec_engine
+            .borrow()
+            .get_client(&mass_status.client_id)
+            .is_none()
+        {
+            log::error!(
+                "Execution client {} disappeared while publishing raw mass status reports",
+                mass_status.client_id
+            );
+            return ReconciliationResult::default();
         }
 
         let venue = mass_status.venue;
@@ -1574,6 +1603,56 @@ impl ExecutionManager {
         }
 
         result
+    }
+
+    pub(crate) fn validate_mass_status_order_sources(
+        &self,
+        mass_status: &ExecutionMassStatus,
+    ) -> anyhow::Result<()> {
+        let cache = self.cache.borrow();
+        let mut checked_client_order_ids = IndexSet::new();
+
+        let mut validate_report_source =
+            |direct_client_order_id: Option<ClientOrderId>, venue_order_id: VenueOrderId| {
+                let direct_client_order_id = direct_client_order_id
+                    .filter(|client_order_id| cache.order_exists(client_order_id));
+                let indexed_client_order_id = cache
+                    .client_order_id(&venue_order_id)
+                    .copied()
+                    .filter(|client_order_id| cache.order_exists(client_order_id));
+
+                for client_order_id in [direct_client_order_id, indexed_client_order_id]
+                    .into_iter()
+                    .flatten()
+                    .filter(|client_order_id| checked_client_order_ids.insert(*client_order_id))
+                {
+                    let cached_client_id = cache.client_id(&client_order_id).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Cached order {client_order_id} has no execution client origin"
+                        )
+                    })?;
+                    anyhow::ensure!(
+                        *cached_client_id == mass_status.client_id,
+                        "Cached order {client_order_id} belongs to execution client \
+                         {cached_client_id}, not mass status client {}",
+                        mass_status.client_id,
+                    );
+                }
+
+                Ok::<_, anyhow::Error>(())
+            };
+
+        for report in mass_status.order_reports().values() {
+            validate_report_source(report.client_order_id, report.venue_order_id)?;
+        }
+
+        for fills in mass_status.fill_reports().values() {
+            for fill in fills {
+                validate_report_source(fill.client_order_id, fill.venue_order_id)?;
+            }
+        }
+
+        Ok(())
     }
 
     fn filtered_open_orders_for_reconciliation(&self) -> Vec<OrderAny> {
@@ -4221,7 +4300,13 @@ impl ExecutionManager {
 
         {
             let mut cache = self.cache.borrow_mut();
-            if let Err(e) = cache.add_order(order.clone(), None, None, false) {
+            let source_client_id = if is_synthetic {
+                None
+            } else {
+                commission_client.map(ExecutionClient::client_id)
+            };
+
+            if let Err(e) = cache.add_order(order.clone(), None, source_client_id, false) {
                 // Deterministic synthetic reconciliation IDs hash the same logical event
                 // to the same client_order_id, so a restart replay can legitimately collide
                 // with a cached order. Differentiate expected dedup from stuck state.

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -817,6 +817,9 @@ impl LiveNode {
 
             match mass_status_result {
                 Ok(Some(mass_status)) => {
+                    self.exec_manager
+                        .validate_mass_status_order_sources(&mass_status)?;
+
                     log_info!(
                         "Reconciling ExecutionMassStatus for {}",
                         client_id,
@@ -829,6 +832,15 @@ impl LiveNode {
                         .exec_manager
                         .reconcile_execution_mass_status(mass_status, exec_engine_rc)
                         .await;
+
+                    anyhow::ensure!(
+                        self.kernel
+                            .exec_engine
+                            .borrow()
+                            .get_client(&client_id)
+                            .is_some(),
+                        "Execution client {client_id} disappeared during startup reconciliation",
+                    );
 
                     if result.events.is_empty() {
                         log_info!(
@@ -848,8 +860,14 @@ impl LiveNode {
                     // Register external orders with execution clients for tracking
                     if !result.external_orders.is_empty() {
                         let exec_engine = self.kernel.exec_engine.borrow();
+                        let source_client = exec_engine.get_client(&client_id).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Execution client {client_id} disappeared during startup reconciliation"
+                            )
+                        })?;
+
                         for external in result.external_orders {
-                            exec_engine.register_external_order(
+                            source_client.register_external_order(
                                 external.client_order_id,
                                 external.venue_order_id,
                                 external.instrument_id,

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -171,7 +171,7 @@ impl TestContext {
     fn add_order(&self, order: OrderAny) {
         self.cache
             .borrow_mut()
-            .add_order(order, None, None, false)
+            .add_order(order, None, Some(test_client_id()), false)
             .unwrap();
     }
 
@@ -693,6 +693,7 @@ async fn test_reconcile_mass_status_with_empty_reports() {
 async fn test_reconcile_mass_status_creates_external_order_accepted() {
     let mut ctx = TestContext::new();
     let instrument_id = test_instrument_id();
+    let client_id = test_client_id();
 
     ctx.add_instrument(test_instrument());
 
@@ -726,6 +727,166 @@ async fn test_reconcile_mass_status_creates_external_order_accepted() {
     let client_order_id = ClientOrderId::from("V-EXT-001");
     let order = ctx.get_order(&client_order_id);
     assert!(order.is_some());
+    assert_eq!(
+        ctx.cache.borrow().client_id(&client_order_id),
+        Some(&client_id)
+    );
+}
+
+#[rstest]
+#[case(None, true, false)]
+#[case(None, false, false)]
+#[case(Some("BINANCE"), true, true)]
+#[case(Some("BINANCE"), false, true)]
+#[case(Some("OTHER"), true, false)]
+#[case(Some("OTHER"), false, false)]
+#[tokio::test]
+async fn test_reconcile_mass_status_requires_matching_cached_client_origin(
+    #[case] cached_client_id: Option<&str>,
+    #[case] report_has_client_order_id: bool,
+    #[case] should_reconcile: bool,
+) {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let client_order_id = ClientOrderId::from("O-CACHED-SOURCE");
+    let venue_order_id = VenueOrderId::from("V-CACHED-SOURCE");
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .client_order_id(client_order_id)
+        .instrument_id(instrument_id)
+        .quantity(Quantity::from("1.0"))
+        .price(Price::from("3000.00"))
+        .build();
+    let submitted = TestOrderEventStubs::submitted(&order, test_account_id());
+    order.apply(submitted).unwrap();
+    let accepted = TestOrderEventStubs::accepted(&order, test_account_id(), venue_order_id);
+    order.apply(accepted).unwrap();
+
+    ctx.add_instrument(test_instrument());
+    ctx.cache
+        .borrow_mut()
+        .add_order(order, None, cached_client_id.map(ClientId::from), false)
+        .unwrap();
+
+    if !report_has_client_order_id {
+        ctx.cache
+            .borrow_mut()
+            .add_venue_order_id(&client_order_id, &venue_order_id, false)
+            .unwrap();
+    }
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_order_reports(vec![create_order_status_report(
+        report_has_client_order_id.then_some(client_order_id),
+        venue_order_id,
+        instrument_id,
+        OrderStatus::Canceled,
+        Quantity::from("1.0"),
+        Quantity::from("0"),
+    )]);
+
+    let raw_topic = MessagingSwitchboard::reconciliation_raw_order_status_report_topic();
+    let raw_pattern: msgbus::MStr<msgbus::Pattern> = raw_topic.into();
+    let (raw_handler, raw_saver) = get_any_saving_handler::<OrderStatusReport>(None);
+    msgbus::subscribe_any(raw_pattern, raw_handler.clone(), None);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+
+    assert_eq!(result.events.len(), usize::from(should_reconcile));
+    assert!(result.external_orders.is_empty());
+    assert_eq!(
+        ctx.get_order(&client_order_id).unwrap().status() == OrderStatus::Canceled,
+        should_reconcile,
+    );
+    assert_eq!(
+        raw_saver.get_messages().len(),
+        usize::from(should_reconcile)
+    );
+    assert_eq!(
+        ctx.cache.borrow().client_id(&client_order_id).copied(),
+        cached_client_id.map(ClientId::from),
+    );
+}
+
+#[tokio::test]
+async fn test_reconcile_mass_status_rejects_venue_only_fill_from_other_client() {
+    let mut ctx = TestContext::new();
+    let instrument_id = test_instrument_id();
+    let client_order_id = ClientOrderId::from("O-CACHED-FILL-SOURCE");
+    let venue_order_id = VenueOrderId::from("V-CACHED-FILL-SOURCE");
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .client_order_id(client_order_id)
+        .instrument_id(instrument_id)
+        .quantity(Quantity::from("1.0"))
+        .price(Price::from("3000.00"))
+        .build();
+    let submitted = TestOrderEventStubs::submitted(&order, test_account_id());
+    order.apply(submitted).unwrap();
+    let accepted = TestOrderEventStubs::accepted(&order, test_account_id(), venue_order_id);
+    order.apply(accepted).unwrap();
+
+    ctx.add_instrument(test_instrument());
+    ctx.cache
+        .borrow_mut()
+        .add_order(order, None, Some(ClientId::from("OTHER")), false)
+        .unwrap();
+    ctx.cache
+        .borrow_mut()
+        .add_venue_order_id(&client_order_id, &venue_order_id, false)
+        .unwrap();
+
+    let mut mass_status = ExecutionMassStatus::new(
+        test_client_id(),
+        test_account_id(),
+        test_venue(),
+        UnixNanos::default(),
+        Some(UUID4::new()),
+    );
+    mass_status.add_fill_reports(vec![FillReport::new(
+        test_account_id(),
+        instrument_id,
+        venue_order_id,
+        TradeId::from("T-CACHED-FILL-SOURCE"),
+        OrderSide::Buy,
+        Quantity::from("1.0"),
+        Price::from("3000.00"),
+        Money::from("0.50 USDT"),
+        LiquiditySide::Maker,
+        None,
+        None,
+        UnixNanos::from(1_000_000),
+        UnixNanos::from(1_000_000),
+        None,
+    )]);
+
+    let raw_topic = MessagingSwitchboard::reconciliation_raw_fill_report_topic();
+    let raw_pattern: msgbus::MStr<msgbus::Pattern> = raw_topic.into();
+    let (raw_handler, raw_saver) = get_any_saving_handler::<FillReport>(None);
+    msgbus::subscribe_any(raw_pattern, raw_handler.clone(), None);
+
+    let result = ctx
+        .manager
+        .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())
+        .await;
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+
+    assert!(result.events.is_empty());
+    assert!(result.external_orders.is_empty());
+    assert!(raw_saver.get_messages().is_empty());
+    let cached_order = ctx.get_order(&client_order_id).unwrap();
+    assert_eq!(cached_order.status(), OrderStatus::Accepted);
+    assert!(cached_order.filled_qty().is_zero());
 }
 
 #[rstest]
@@ -1626,6 +1787,9 @@ async fn test_synthetic_orders_bypass_filter_unclaimed_external() {
     } else {
         panic!("Expected Accepted event first, was {:?}", result.events[0]);
     }
+
+    let client_order_id = result.events[0].client_order_id();
+    assert_eq!(ctx.cache.borrow().client_id(&client_order_id), None);
 }
 
 #[tokio::test]
@@ -11317,7 +11481,10 @@ async fn test_check_open_orders_queries_oversized_responsible_client_group() {
         .price(Price::from("100.0"))
         .build();
     let submitted = TestOrderEventStubs::submitted(&order, test_account_id());
-    ctx.add_order(order);
+    ctx.cache
+        .borrow_mut()
+        .add_order(order, None, None, false)
+        .unwrap();
     let order = ctx.cache.borrow_mut().update_order(&submitted).unwrap();
     let accepted = TestOrderEventStubs::accepted(&order, test_account_id(), venue_order_id);
     ctx.cache.borrow_mut().update_order(&accepted).unwrap();

--- a/crates/live/tests/node.rs
+++ b/crates/live/tests/node.rs
@@ -59,6 +59,7 @@ use nautilus_live::{
 use nautilus_model::{
     accounts::AccountAny,
     enums::{OmsType, OrderSide, OrderStatus, OrderType, TimeInForce},
+    events::OrderEventAny,
     identifiers::{
         AccountId, ClientId, ClientOrderId, ExecAlgorithmId, InstrumentId, StrategyId, TraderId,
         Venue, VenueOrderId,
@@ -301,6 +302,8 @@ mod serial_tests {
         connected: Arc<AtomicBool>,
         disconnect_attempted: Arc<AtomicBool>,
         mass_status_requested: Arc<AtomicBool>,
+        mass_status: Arc<Mutex<Option<ExecutionMassStatus>>>,
+        registered_external_orders: Arc<Mutex<Vec<ClientOrderId>>>,
         cancel_all_orders_received: Arc<AtomicUsize>,
         cancel_all_orders_while_connected: Arc<AtomicBool>,
     }
@@ -329,6 +332,7 @@ mod serial_tests {
 
     #[derive(Clone, Copy, Debug)]
     enum StartupMassStatusBehavior {
+        Available,
         Unavailable,
         Error,
         Pending,
@@ -337,6 +341,10 @@ mod serial_tests {
     struct StartupMassStatusExecutionClient {
         state: StartupMassStatusClientState,
         behavior: StartupMassStatusBehavior,
+        client_id: ClientId,
+        account_id: AccountId,
+        venue: Venue,
+        handles_all_order_venues: bool,
     }
 
     struct FailingDisconnectDataClient {
@@ -356,8 +364,22 @@ mod serial_tests {
     impl StartupMassStatusExecutionClient {
         const CLIENT_ID: &'static str = "STARTUP-MASS-STATUS";
 
-        fn new(state: StartupMassStatusClientState, behavior: StartupMassStatusBehavior) -> Self {
-            Self { state, behavior }
+        fn new(
+            state: StartupMassStatusClientState,
+            behavior: StartupMassStatusBehavior,
+            client_id: ClientId,
+            account_id: AccountId,
+            venue: Venue,
+            handles_all_order_venues: bool,
+        ) -> Self {
+            Self {
+                state,
+                behavior,
+                client_id,
+                account_id,
+                venue,
+                handles_all_order_venues,
+            }
         }
     }
 
@@ -409,6 +431,10 @@ mod serial_tests {
     struct StartupMassStatusExecutionClientFactory {
         state: StartupMassStatusClientState,
         behavior: StartupMassStatusBehavior,
+        client_id: ClientId,
+        account_id: AccountId,
+        venue: Venue,
+        handles_all_order_venues: bool,
     }
 
     #[derive(Debug)]
@@ -430,7 +456,31 @@ mod serial_tests {
 
     impl StartupMassStatusExecutionClientFactory {
         fn new(state: StartupMassStatusClientState, behavior: StartupMassStatusBehavior) -> Self {
-            Self { state, behavior }
+            Self {
+                state,
+                behavior,
+                client_id: ClientId::from(StartupMassStatusExecutionClient::CLIENT_ID),
+                account_id: AccountId::from("STARTUP-MASS-STATUS-001"),
+                venue: crypto_perpetual_ethusdt().id().venue,
+                handles_all_order_venues: false,
+            }
+        }
+
+        fn with_identity(
+            mut self,
+            client_id: ClientId,
+            account_id: AccountId,
+            venue: Venue,
+        ) -> Self {
+            self.client_id = client_id;
+            self.account_id = account_id;
+            self.venue = venue;
+            self
+        }
+
+        fn with_handles_all_order_venues(mut self) -> Self {
+            self.handles_all_order_venues = true;
+            self
         }
     }
 
@@ -462,6 +512,10 @@ mod serial_tests {
             Ok(Box::new(StartupMassStatusExecutionClient::new(
                 self.state.clone(),
                 self.behavior,
+                self.client_id,
+                self.account_id,
+                self.venue,
+                self.handles_all_order_venues,
             )))
         }
 
@@ -688,15 +742,19 @@ mod serial_tests {
         }
 
         fn client_id(&self) -> ClientId {
-            ClientId::from(Self::CLIENT_ID)
+            self.client_id
         }
 
         fn account_id(&self) -> AccountId {
-            AccountId::from("STARTUP-MASS-STATUS-001")
+            self.account_id
         }
 
         fn venue(&self) -> Venue {
-            crypto_perpetual_ethusdt().id().venue
+            self.venue
+        }
+
+        fn handles_order_venue(&self, venue: Venue) -> bool {
+            self.handles_all_order_venues || self.venue == venue
         }
 
         fn oms_type(&self) -> OmsType {
@@ -759,12 +817,33 @@ mod serial_tests {
                 .store(true, Ordering::Relaxed);
 
             match self.behavior {
+                StartupMassStatusBehavior::Available => Ok(self
+                    .state
+                    .mass_status
+                    .lock()
+                    .expect("mass status lock poisoned")
+                    .clone()),
                 StartupMassStatusBehavior::Unavailable => Ok(None),
                 StartupMassStatusBehavior::Error => Err(anyhow::anyhow!("mass status failed")),
                 StartupMassStatusBehavior::Pending => {
                     std::future::pending::<anyhow::Result<Option<ExecutionMassStatus>>>().await
                 }
             }
+        }
+
+        fn register_external_order(
+            &self,
+            client_order_id: ClientOrderId,
+            _venue_order_id: VenueOrderId,
+            _instrument_id: InstrumentId,
+            _strategy_id: StrategyId,
+            _ts_init: UnixNanos,
+        ) {
+            self.state
+                .registered_external_orders
+                .lock()
+                .expect("registered external orders lock poisoned")
+                .push(client_order_id);
         }
     }
 
@@ -1254,6 +1333,15 @@ mod serial_tests {
         venue_order_id: VenueOrderId,
         client_id: ClientId,
     ) {
+        add_accepted_test_order_with_origin(node, client_order_id, venue_order_id, Some(client_id));
+    }
+
+    fn add_accepted_test_order_with_origin(
+        node: &LiveNode,
+        client_order_id: ClientOrderId,
+        venue_order_id: VenueOrderId,
+        client_id: Option<ClientId>,
+    ) {
         let instrument_id = crypto_perpetual_ethusdt().id();
         let account_id = AccountId::from("BLOCKING-REPORT-001");
         let order = OrderTestBuilder::new(OrderType::Limit)
@@ -1266,7 +1354,7 @@ mod serial_tests {
         node.kernel()
             .cache
             .borrow_mut()
-            .add_order(order, None, Some(client_id), false)
+            .add_order(order, None, client_id, false)
             .unwrap();
         let order = node
             .kernel()
@@ -1317,6 +1405,47 @@ mod serial_tests {
             None,
         )
         .with_price(Price::from("100.0"))
+    }
+
+    fn live_node_with_available_mass_status(
+        name: &str,
+        state: StartupMassStatusClientState,
+        client_id: ClientId,
+        account_id: AccountId,
+        venue: Venue,
+    ) -> LiveNode {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: true,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let factory = StartupMassStatusExecutionClientFactory::new(
+            state,
+            StartupMassStatusBehavior::Available,
+        )
+        .with_identity(client_id, account_id, venue)
+        .with_handles_all_order_venues();
+        let node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name(name)
+            .add_exec_client(
+                Some("source-client".to_string()),
+                Box::new(factory),
+                Box::new(StartupMassStatusExecutionClientConfig),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        node.kernel()
+            .cache()
+            .borrow_mut()
+            .add_instrument(InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt()))
+            .unwrap();
+        node
     }
 
     #[rstest]
@@ -2175,6 +2304,341 @@ mod serial_tests {
         assert!(!state.connected.load(Ordering::Relaxed));
         assert!(node.kernel().trader().borrow().is_disposed());
         assert_eq!(node.kernel().trader().borrow().component_count(), 0);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_startup_mass_status_registers_external_order_with_source_client() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                reconciliation: true,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            timeout_disconnection: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let instrument = crypto_perpetual_ethusdt();
+        let instrument_id = instrument.id();
+        let venue_client_id = ClientId::from("VENUE-CLIENT");
+        let source_client_id = ClientId::from("ROUTING-CLIENT");
+        let source_account_id = AccountId::from("ROUTING-001");
+        let source_venue = Venue::from("ROUTING");
+        let client_order_id = ClientOrderId::from("O-EXT-SOURCE");
+        let venue_order_id = VenueOrderId::from("V-EXT-SOURCE");
+        let venue_state = StartupMassStatusClientState::default();
+        let source_state = StartupMassStatusClientState::default();
+        let report = test_order_report(
+            source_account_id,
+            client_order_id,
+            venue_order_id,
+            OrderStatus::Accepted,
+        );
+        let mut mass_status = ExecutionMassStatus::new(
+            source_client_id,
+            source_account_id,
+            source_venue,
+            UnixNanos::default(),
+            None,
+        );
+        mass_status.add_order_reports(vec![report]);
+        *source_state
+            .mass_status
+            .lock()
+            .expect("mass status lock poisoned") = Some(mass_status);
+
+        let venue_factory = StartupMassStatusExecutionClientFactory::new(
+            venue_state.clone(),
+            StartupMassStatusBehavior::Unavailable,
+        )
+        .with_identity(
+            venue_client_id,
+            AccountId::from("VENUE-001"),
+            instrument_id.venue,
+        )
+        .with_handles_all_order_venues();
+        let source_factory = StartupMassStatusExecutionClientFactory::new(
+            source_state.clone(),
+            StartupMassStatusBehavior::Available,
+        )
+        .with_identity(source_client_id, source_account_id, source_venue)
+        .with_handles_all_order_venues();
+        let mut node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name("StartupMassStatusSourceNode")
+            .add_exec_client(
+                Some("venue-client".to_string()),
+                Box::new(venue_factory),
+                Box::new(StartupMassStatusExecutionClientConfig),
+            )
+            .unwrap()
+            .add_exec_client(
+                Some("source-client".to_string()),
+                Box::new(source_factory),
+                Box::new(StartupMassStatusExecutionClientConfig),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
+        node.kernel()
+            .cache()
+            .borrow_mut()
+            .add_instrument(InstrumentAny::CryptoPerpetual(instrument))
+            .unwrap();
+
+        node.start().await.unwrap();
+
+        assert_eq!(
+            node.kernel()
+                .cache()
+                .borrow()
+                .client_id(&client_order_id)
+                .copied(),
+            Some(source_client_id)
+        );
+        assert!(
+            venue_state
+                .registered_external_orders
+                .lock()
+                .expect("registered external orders lock poisoned")
+                .is_empty()
+        );
+        assert_eq!(
+            *source_state
+                .registered_external_orders
+                .lock()
+                .expect("registered external orders lock poisoned"),
+            vec![client_order_id]
+        );
+
+        node.stop().await.unwrap();
+        node.dispose();
+    }
+
+    #[rstest]
+    #[case("OTHER", "SOURCE-001", "SOURCE", "client ID")]
+    #[case("SOURCE", "OTHER-001", "SOURCE", "account ID")]
+    #[case("SOURCE", "SOURCE-001", "OTHER", "venue")]
+    #[tokio::test]
+    async fn test_startup_mass_status_rejects_mismatched_source_identity(
+        #[case] reported_client_id: &str,
+        #[case] reported_account_id: &str,
+        #[case] reported_venue: &str,
+        #[case] expected_error: &str,
+    ) {
+        let source_client_id = ClientId::from("SOURCE");
+        let source_account_id = AccountId::from("SOURCE-001");
+        let source_venue = Venue::from("SOURCE");
+        let client_order_id = ClientOrderId::from("O-MISMATCHED-SOURCE");
+        let venue_order_id = VenueOrderId::from("V-MISMATCHED-SOURCE");
+        let state = StartupMassStatusClientState::default();
+        let mut mass_status = ExecutionMassStatus::new(
+            ClientId::from(reported_client_id),
+            AccountId::from(reported_account_id),
+            Venue::from(reported_venue),
+            UnixNanos::default(),
+            None,
+        );
+        mass_status.add_order_reports(vec![test_order_report(
+            AccountId::from(reported_account_id),
+            client_order_id,
+            venue_order_id,
+            OrderStatus::Accepted,
+        )]);
+        *state.mass_status.lock().expect("mass status lock poisoned") = Some(mass_status);
+        let mut node = live_node_with_available_mass_status(
+            "StartupMassStatusIdentityNode",
+            state.clone(),
+            source_client_id,
+            source_account_id,
+            source_venue,
+        );
+        let raw_topic = MessagingSwitchboard::reconciliation_raw_order_status_report_topic();
+        let raw_pattern: msgbus::MStr<msgbus::Pattern> = raw_topic.into();
+        let (raw_handler, raw_saver) =
+            nautilus_common::msgbus::stubs::get_any_saving_handler::<OrderStatusReport>(None);
+        msgbus::subscribe_any(raw_pattern, raw_handler.clone(), None);
+        let event_topic = switchboard::get_event_order_topic(StrategyId::from("EXTERNAL"));
+        let (event_handler, event_saver) =
+            nautilus_common::msgbus::stubs::get_typed_message_saving_handler::<OrderEventAny>(None);
+        msgbus::subscribe_order_events(event_topic.into(), event_handler.clone(), None);
+
+        let result = node.start().await;
+
+        msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+        msgbus::unsubscribe_order_events(event_topic.into(), &event_handler);
+        let error = result.expect_err("mismatched mass status identity should abort startup");
+
+        assert!(
+            format!("{error:#}").contains(expected_error),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(node.state(), NodeState::Stopped);
+        assert!(raw_saver.get_messages().is_empty());
+        assert!(event_saver.get_messages().is_empty());
+        assert!(
+            node.kernel()
+                .cache()
+                .borrow()
+                .order(&client_order_id)
+                .is_none()
+        );
+        assert!(
+            state
+                .registered_external_orders
+                .lock()
+                .expect("registered external orders lock poisoned")
+                .is_empty()
+        );
+        node.dispose();
+    }
+
+    #[rstest]
+    #[case(None, "has no execution client origin")]
+    #[case(Some("OTHER"), "belongs to execution client OTHER")]
+    #[tokio::test]
+    async fn test_startup_mass_status_rejects_untrusted_cached_order_origin(
+        #[case] cached_client_id: Option<&str>,
+        #[case] expected_error: &str,
+    ) {
+        let source_client_id = ClientId::from("SOURCE-CLIENT");
+        let source_account_id = AccountId::from("BLOCKING-REPORT-001");
+        let source_venue = Venue::from("SOURCE");
+        let client_order_id = ClientOrderId::from("O-UNTRUSTED-SOURCE");
+        let venue_order_id = VenueOrderId::from("V-UNTRUSTED-SOURCE");
+        let state = StartupMassStatusClientState::default();
+        let mut mass_status = ExecutionMassStatus::new(
+            source_client_id,
+            source_account_id,
+            source_venue,
+            UnixNanos::default(),
+            None,
+        );
+        mass_status.add_order_reports(vec![test_order_report(
+            source_account_id,
+            client_order_id,
+            venue_order_id,
+            OrderStatus::Canceled,
+        )]);
+        *state.mass_status.lock().expect("mass status lock poisoned") = Some(mass_status);
+        let mut node = live_node_with_available_mass_status(
+            "StartupMassStatusUntrustedOriginNode",
+            state.clone(),
+            source_client_id,
+            source_account_id,
+            source_venue,
+        );
+        add_accepted_test_order_with_origin(
+            &node,
+            client_order_id,
+            venue_order_id,
+            cached_client_id.map(ClientId::from),
+        );
+
+        let error = node
+            .start()
+            .await
+            .expect_err("untrusted cached order origin should abort startup");
+
+        assert!(
+            error.to_string().contains(expected_error),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(node.state(), NodeState::Stopped);
+        assert!(
+            state
+                .registered_external_orders
+                .lock()
+                .expect("registered external orders lock poisoned")
+                .is_empty()
+        );
+        let cache = node.kernel().cache();
+        let cache = cache.borrow();
+        assert_eq!(
+            cache.order(&client_order_id).unwrap().status(),
+            OrderStatus::Accepted
+        );
+        assert_eq!(
+            cache.client_id(&client_order_id).copied(),
+            cached_client_id.map(ClientId::from)
+        );
+        drop(cache);
+
+        node.dispose();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_startup_mass_status_aborts_if_source_disappears_during_raw_publish() {
+        let source_client_id = ClientId::from("SOURCE-CLIENT");
+        let source_account_id = AccountId::from("BLOCKING-REPORT-001");
+        let source_venue = Venue::from("SOURCE");
+        let client_order_id = ClientOrderId::from("O-DISAPPEARING-SOURCE");
+        let venue_order_id = VenueOrderId::from("V-DISAPPEARING-SOURCE");
+        let state = StartupMassStatusClientState::default();
+        let mut mass_status = ExecutionMassStatus::new(
+            source_client_id,
+            source_account_id,
+            source_venue,
+            UnixNanos::default(),
+            None,
+        );
+        mass_status.add_order_reports(vec![test_order_report(
+            source_account_id,
+            client_order_id,
+            venue_order_id,
+            OrderStatus::Canceled,
+        )]);
+        *state.mass_status.lock().expect("mass status lock poisoned") = Some(mass_status);
+        let mut node = live_node_with_available_mass_status(
+            "StartupMassStatusDisappearingSourceNode",
+            state.clone(),
+            source_client_id,
+            source_account_id,
+            source_venue,
+        );
+        add_accepted_test_order(&node, client_order_id, venue_order_id, source_client_id);
+
+        let exec_engine = node.kernel().exec_engine().clone();
+        let handler = ShareableMessageHandler::from_typed(move |_report: &OrderStatusReport| {
+            exec_engine
+                .borrow_mut()
+                .deregister_client(source_client_id)
+                .expect("source execution client should still be registered");
+        });
+        let raw_pattern: msgbus::MStr<msgbus::Pattern> =
+            MessagingSwitchboard::reconciliation_raw_order_status_report_topic().into();
+        msgbus::subscribe_any(raw_pattern, handler.clone(), None);
+
+        let result = node.start().await;
+
+        msgbus::unsubscribe_any(raw_pattern, &handler);
+        let error = result.expect_err("disappearing source client should abort startup");
+        assert!(
+            error
+                .to_string()
+                .contains("disappeared during startup reconciliation"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(node.state(), NodeState::Stopped);
+        assert!(
+            state
+                .registered_external_orders
+                .lock()
+                .expect("registered external orders lock poisoned")
+                .is_empty()
+        );
+        assert_eq!(
+            node.kernel()
+                .cache()
+                .borrow()
+                .order(&client_order_id)
+                .unwrap()
+                .status(),
+            OrderStatus::Accepted
+        );
+
+        node.dispose();
     }
 
     #[rstest]


### PR DESCRIPTION
# Pull Request

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

> External contributions must not modify files under `.github/workflows` or `.github/actions`;
> workflow changes are maintainer-only.

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [ ] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [ ] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Startup reconciliation polls each execution client separately, but the source client was lost when
external orders were materialized, allowing venue/default routing to claim an order from another
client. This validates mass-status client, account, and venue identity before reconciliation,
preserves the exact source as the cache origin and registration target, and fails closed when a
cached origin conflicts or the source client disappears. Runtime execution-report transport is
intentionally unchanged.

## Related issues/PRs

- Related to #4408
- Related to #4479
- Related to #4490

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

No public API changes. As a safety tightening, a cached external order without an execution-client
origin now makes the relevant startup reconciliation fail closed instead of being re-attributed by
venue/default routing.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Validated with the complete `make pre-commit` suite, all 582 `nautilus-execution` library tests,
all 266 `nautilus-live` library tests, all 252 execution-manager integration tests, and all 72
LiveNode integration tests.
