### PR TITLE
Commit cached add transaction state before persisting it

### DIFF
--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -4490,7 +4490,10 @@ impl Cache {
     ///
     /// # Errors
     ///
-    /// Returns an error if not `replace_existing` and the `order.client_order_id` is already contained in the cache.
+    /// Returns an error if not `replace_existing` and the `order.client_order_id` is already contained in the cache,
+    /// or if persisting the order to the backing database fails. The order and every index are
+    /// committed to memory before persistence is attempted, so a persistence error leaves the
+    /// cache internally consistent.
     pub fn add_order(
         &mut self,
         order: OrderAny,
@@ -4585,12 +4588,12 @@ impl Cache {
 
         // Index position ID if provided
         if let Some(position_id) = position_id {
-            self.add_position_id(
+            self.index_position_id_in_memory(
                 &position_id,
                 &order.instrument_id().venue,
                 &client_order_id,
                 &strategy_id,
-            )?;
+            );
         }
 
         // Index client ID if provided
@@ -4599,21 +4602,27 @@ impl Cache {
             log::debug!("Indexed {client_id:?}");
         }
 
+        // Reuse the existing cell on replace so the canonical entry stays in place
+        // rather than orphaning a stale cell.
+        let order_cell = if let Some(order_cell) = self.orders.get(&client_order_id) {
+            *order_cell.borrow_mut() = order;
+            order_cell.clone()
+        } else {
+            let order_cell = SharedCell::new(order);
+            self.orders.insert(client_order_id, order_cell.clone());
+            order_cell
+        };
+
+        if let Some(position_id) = position_id {
+            self.persist_position_id(&position_id, &client_order_id)?;
+        }
+
         if let Some(database) = &mut self.database {
-            database.add_order(&order, client_id)?;
+            database.add_order(&order_cell.borrow(), client_id)?;
             // TODO: Implement
             // if self.config.snapshot_orders {
             //     database.snapshot_order_state(order)?;
             // }
-        }
-
-        match self.orders.get(&client_order_id) {
-            // Reuse the existing cell on replace so the canonical entry stays in place
-            // rather than orphaning a stale cell.
-            Some(order_cell) => *order_cell.borrow_mut() = order,
-            None => {
-                self.orders.insert(client_order_id, SharedCell::new(order));
-            }
         }
 
         Ok(())
@@ -4642,7 +4651,9 @@ impl Cache {
     ///
     /// # Errors
     ///
-    /// Returns an error if indexing position ID in the backing database fails.
+    /// Returns an error if indexing position ID in the backing database fails. The complete index
+    /// operation is committed to memory before persistence is attempted, so a persistence error
+    /// leaves the cache internally consistent.
     pub fn add_position_id(
         &mut self,
         position_id: &PositionId,
@@ -4650,21 +4661,36 @@ impl Cache {
         client_order_id: &ClientOrderId,
         strategy_id: &StrategyId,
     ) -> anyhow::Result<()> {
+        self.index_position_id_in_memory(position_id, venue, client_order_id, strategy_id);
+        self.persist_position_id(position_id, client_order_id)
+    }
+
+    fn index_position_id_in_memory(
+        &mut self,
+        position_id: &PositionId,
+        venue: &Venue,
+        client_order_id: &ClientOrderId,
+        strategy_id: &StrategyId,
+    ) {
         self.index
             .order_position
             .insert(*client_order_id, *position_id);
-
-        // Index: ClientOrderId -> PositionId
-        if let Some(database) = &mut self.database {
-            database.index_order_position(*client_order_id, *position_id)?;
-        }
-
         self.index_position(position_id, venue, strategy_id);
         self.index
             .position_orders
             .entry(*position_id)
             .or_default()
             .insert(*client_order_id);
+    }
+
+    fn persist_position_id(
+        &mut self,
+        position_id: &PositionId,
+        client_order_id: &ClientOrderId,
+    ) -> anyhow::Result<()> {
+        if let Some(database) = &mut self.database {
+            database.index_order_position(*client_order_id, *position_id)?;
+        }
 
         Ok(())
     }
@@ -4757,7 +4783,9 @@ impl Cache {
     ///
     /// # Errors
     ///
-    /// Returns an error if persisting the position to the backing database fails.
+    /// Returns an error if persisting the position to the backing database fails. After
+    /// serialization succeeds, the complete operation is committed to memory before persistence
+    /// is attempted, so a persistence error leaves the cache internally consistent.
     pub fn add_position(&mut self, position: &Position, oms_type: OmsType) -> anyhow::Result<()> {
         self.add_position_inner(position, oms_type, true)
     }
@@ -4766,7 +4794,9 @@ impl Cache {
     ///
     /// # Errors
     ///
-    /// Returns an error if persisting the position to the backing database fails.
+    /// Returns an error if persisting the position to the backing database fails. After
+    /// serialization succeeds, the complete operation is committed to memory before persistence
+    /// is attempted, so a persistence error leaves the cache internally consistent.
     pub fn add_position_without_order(
         &mut self,
         position: &Position,
@@ -4781,6 +4811,13 @@ impl Cache {
         oms_type: OmsType,
         index_order: bool,
     ) -> anyhow::Result<()> {
+        // Validate and serialize the OMS entry up front: both are construction failures, and
+        // committing the position before they run would leave the cache mutated by one.
+        let key = position_oms_key(position.id);
+        check_valid_string_ascii(&key, stringify!(key))?;
+        let value = Bytes::from(serde_json::to_vec(&oms_type)?);
+        check_predicate_false(value.is_empty(), stringify!(value))?;
+
         self.positions
             .insert(position.id, SharedCell::new(position.clone()));
         self.index.position_oms.insert(position.id, oms_type);
@@ -4796,12 +4833,12 @@ impl Cache {
         log::debug!("Adding {position}");
 
         if index_order {
-            self.add_position_id(
+            self.index_position_id_in_memory(
                 &position.id,
                 &position.instrument_id.venue,
                 &position.opening_order_id,
                 &position.strategy_id,
-            )?;
+            );
         } else {
             self.index_position(
                 &position.id,
@@ -4834,6 +4871,13 @@ impl Cache {
             .or_default()
             .insert(position.id);
 
+        log::debug!("Adding general {key}");
+        self.general.insert(key.clone(), value.clone());
+
+        if index_order {
+            self.persist_position_id(&position.id, &position.opening_order_id)?;
+        }
+
         if let Some(database) = &mut self.database {
             database.add_position(position)?;
             // TODO: Implement position snapshots
@@ -4844,11 +4888,8 @@ impl Cache {
             //         self.calculate_unrealized_pnl(&position),
             //     )?;
             // }
+            database.add(key, value)?;
         }
-
-        let key = position_oms_key(position.id);
-        let value = Bytes::from(serde_json::to_vec(&oms_type)?);
-        self.add(&key, value)?;
 
         Ok(())
     }
@@ -4965,11 +5006,15 @@ impl Cache {
     ///
     /// # Errors
     ///
-    /// Returns an error if updating the order indexes or database fails.
+    /// Returns an error if validation or persistence fails. After validation succeeds, the
+    /// canonical order is committed to memory before its indexes and database are refreshed, so a
+    /// persistence error leaves the cache internally consistent.
     pub fn replace_order(&mut self, order: &OrderAny) -> anyhow::Result<()> {
-        self.refresh_order(order)?;
-
         let client_order_id = order.client_order_id();
+        if let Some(venue_order_id) = order.venue_order_id() {
+            self.validate_venue_order_id_ownership(&client_order_id, &venue_order_id)?;
+        }
+
         match self.orders.get(&client_order_id) {
             // Reuse the existing cell so the canonical entry stays in place rather than
             // orphaning a stale cell.
@@ -4980,7 +5025,7 @@ impl Cache {
             }
         }
 
-        Ok(())
+        self.refresh_order(order)
     }
 
     /// Updates the cached order by applying an event and refreshing derived cache state.

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -7241,6 +7241,9 @@ struct SnapshotBlobTestDatabase {
     positions: AHashMap<PositionId, Position>,
     order_positions: AHashMap<ClientOrderId, PositionId>,
     fail_add: bool,
+    fail_add_order: bool,
+    fail_add_position: bool,
+    fail_index_order_position: bool,
     fail_update_order: bool,
     fail_update_position: bool,
 }
@@ -7272,6 +7275,27 @@ impl SnapshotBlobTestDatabase {
     fn fail_add() -> Self {
         Self {
             fail_add: true,
+            ..Default::default()
+        }
+    }
+
+    fn fail_add_order() -> Self {
+        Self {
+            fail_add_order: true,
+            ..Default::default()
+        }
+    }
+
+    fn fail_add_position() -> Self {
+        Self {
+            fail_add_position: true,
+            ..Default::default()
+        }
+    }
+
+    fn fail_index_order_position() -> Self {
+        Self {
+            fail_index_order_position: true,
             ..Default::default()
         }
     }
@@ -7451,6 +7475,9 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
     }
 
     fn add_order(&self, _order: &OrderAny, _client_id: Option<ClientId>) -> anyhow::Result<()> {
+        if self.fail_add_order {
+            anyhow::bail!("add order failed");
+        }
         Ok(())
     }
 
@@ -7459,6 +7486,9 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
     }
 
     fn add_position(&self, _position: &Position) -> anyhow::Result<()> {
+        if self.fail_add_position {
+            anyhow::bail!("add position failed");
+        }
         Ok(())
     }
 
@@ -7527,6 +7557,9 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
         _client_order_id: ClientOrderId,
         _position_id: PositionId,
     ) -> anyhow::Result<()> {
+        if self.fail_index_order_position {
+            anyhow::bail!("index order position failed");
+        }
         Ok(())
     }
 
@@ -7580,6 +7613,273 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
     fn heartbeat(&self, _timestamp: UnixNanos) -> anyhow::Result<()> {
         Ok(())
     }
+}
+
+#[rstest]
+fn test_add_order_commits_memory_when_database_add_fails(audusd_sim: CurrencyPair) {
+    let database = SnapshotBlobTestDatabase::fail_add_order();
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(audusd_sim.id)
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00000"))
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+
+    let error = cache
+        .add_order(order.clone(), None, None, false)
+        .unwrap_err();
+
+    assert_eq!(error.to_string(), "add order failed");
+    let cached = cache.order(&client_order_id).unwrap();
+    assert_eq!(
+        serde_json::to_value(&*cached).unwrap(),
+        serde_json::to_value(&order).unwrap(),
+    );
+    drop(cached);
+    assert!(cache.index.orders.contains(&client_order_id));
+    assert!(cache.index.orders_active_local.contains(&client_order_id));
+    assert_eq!(
+        cache.index.order_strategy.get(&client_order_id),
+        Some(&order.strategy_id()),
+    );
+    assert!(
+        cache
+            .index
+            .venue_orders
+            .get(&audusd_sim.id.venue)
+            .unwrap()
+            .contains(&client_order_id)
+    );
+    assert!(
+        cache
+            .index
+            .instrument_orders
+            .get(&audusd_sim.id)
+            .unwrap()
+            .contains(&client_order_id)
+    );
+    assert!(
+        cache
+            .index
+            .strategy_orders
+            .get(&order.strategy_id())
+            .unwrap()
+            .contains(&client_order_id)
+    );
+    assert!(cache.check_integrity());
+}
+
+#[rstest]
+fn test_add_order_commits_position_indexes_when_database_index_fails(audusd_sim: CurrencyPair) {
+    let database = SnapshotBlobTestDatabase::fail_index_order_position();
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(audusd_sim.id)
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00000"))
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    let position_id = PositionId::new("P-INDEX-FAILURE");
+
+    let error = cache
+        .add_order(order.clone(), Some(position_id), None, false)
+        .unwrap_err();
+
+    assert_eq!(error.to_string(), "index order position failed");
+    assert_eq!(cache.position_id(&client_order_id), Some(&position_id));
+    // `OrderAny` compares on `client_order_id` alone, so compare structurally.
+    let related = cache.orders_for_position(&position_id);
+    assert_eq!(related.len(), 1);
+    assert_eq!(
+        serde_json::to_value(&*related[0]).unwrap(),
+        serde_json::to_value(&order).unwrap(),
+    );
+    assert_eq!(
+        cache.index.position_strategy.get(&position_id),
+        Some(&order.strategy_id()),
+    );
+    assert!(
+        cache
+            .index
+            .venue_positions
+            .get(&audusd_sim.id.venue)
+            .unwrap()
+            .contains(&position_id)
+    );
+    assert!(
+        cache
+            .index
+            .strategy_positions
+            .get(&order.strategy_id())
+            .unwrap()
+            .contains(&position_id)
+    );
+}
+
+#[rstest]
+fn test_add_position_commits_memory_when_database_add_fails(audusd_sim: CurrencyPair) {
+    let database = SnapshotBlobTestDatabase::fail_add_position();
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(TradeId::new("T-ADD-POSITION-FAILURE")),
+        Some(PositionId::new("P-ADD-POSITION-FAILURE")),
+        Some(Price::from("1.00000")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let position = Position::new(&instrument, fill.into());
+    let position_id = position.id;
+
+    let error = cache.add_position(&position, OmsType::Netting).unwrap_err();
+
+    assert_eq!(error.to_string(), "add position failed");
+    let cached = cache.position(&position_id).unwrap();
+    assert_eq!(
+        serde_json::to_value(&*cached).unwrap(),
+        serde_json::to_value(&position).unwrap(),
+    );
+    drop(cached);
+    assert!(
+        cache
+            .position_ids(Some(&position.instrument_id.venue), None, None, None)
+            .contains(&position_id)
+    );
+    assert!(
+        cache
+            .position_ids(None, Some(&position.instrument_id), None, None)
+            .contains(&position_id)
+    );
+    assert!(
+        cache
+            .position_ids(None, None, None, Some(&position.account_id))
+            .contains(&position_id)
+    );
+    let key = super::position_oms_key(position_id);
+    assert_eq!(
+        cache.get(&key).unwrap(),
+        Some(&Bytes::from(serde_json::to_vec(&OmsType::Netting).unwrap())),
+    );
+}
+
+/// Pins the earliest persistence boundary in `add_position_inner`: `index_order_position` is
+/// its FIRST database call, so every memory mutation must already be committed when it fails.
+#[rstest]
+fn test_add_position_commits_memory_when_database_index_fails(audusd_sim: CurrencyPair) {
+    let database = SnapshotBlobTestDatabase::fail_index_order_position();
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &instrument,
+        Some(TradeId::new("T-INDEX-FAILURE")),
+        Some(PositionId::new("P-INDEX-FAILURE")),
+        Some(Price::from("1.00000")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let position = Position::new(&instrument, fill.into());
+    let position_id = position.id;
+
+    let error = cache.add_position(&position, OmsType::Netting).unwrap_err();
+
+    assert_eq!(error.to_string(), "index order position failed");
+    let cached = cache.position(&position_id).unwrap();
+    assert_eq!(
+        serde_json::to_value(&*cached).unwrap(),
+        serde_json::to_value(&position).unwrap(),
+    );
+    drop(cached);
+    // The opening-order relationship in both directions.
+    assert_eq!(
+        cache.position_id(&position.opening_order_id),
+        Some(&position_id),
+    );
+    assert!(
+        cache
+            .index
+            .position_orders
+            .get(&position_id)
+            .unwrap()
+            .contains(&position.opening_order_id)
+    );
+    assert_eq!(
+        cache.index.position_strategy.get(&position_id),
+        Some(&position.strategy_id),
+    );
+    assert!(
+        cache
+            .position_ids(Some(&position.instrument_id.venue), None, None, None)
+            .contains(&position_id)
+    );
+    assert!(
+        cache
+            .position_ids(None, Some(&position.instrument_id), None, None)
+            .contains(&position_id)
+    );
+    assert!(
+        cache
+            .position_ids(None, None, Some(&position.strategy_id), None)
+            .contains(&position_id)
+    );
+    assert!(
+        cache
+            .position_ids(None, None, None, Some(&position.account_id))
+            .contains(&position_id)
+    );
+    let key = super::position_oms_key(position_id);
+    assert_eq!(
+        cache.get(&key).unwrap(),
+        Some(&Bytes::from(serde_json::to_vec(&OmsType::Netting).unwrap())),
+    );
+}
+
+#[rstest]
+fn test_replace_order_commits_canonical_state_when_database_update_fails(audusd_sim: CurrencyPair) {
+    let database = SnapshotBlobTestDatabase::fail_update_order();
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(audusd_sim.id)
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00000"))
+        .quantity(Quantity::from(100_000))
+        .build();
+    let client_order_id = order.client_order_id();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+    let mut replacement = order;
+    let submitted = TestOrderEventStubs::submitted(&replacement, AccountId::new("SIM-001"));
+    replacement.apply(submitted).unwrap();
+
+    let error = cache.replace_order(&replacement).unwrap_err();
+
+    assert_eq!(error.to_string(), "update order failed");
+    let cached = cache.order(&client_order_id).unwrap();
+    assert_eq!(
+        serde_json::to_value(&*cached).unwrap(),
+        serde_json::to_value(&replacement).unwrap(),
+    );
+    assert_eq!(cached.status(), OrderStatus::Submitted);
 }
 
 #[rstest]

--- a/crates/common/src/python/cache.rs
+++ b/crates/common/src/python/cache.rs
@@ -1561,7 +1561,10 @@ impl Cache {
     ///
     /// # Errors
     ///
-    /// Returns an error if not `replace_existing` and the `order.client_order_id` is already contained in the cache.
+    /// Returns an error if not `replace_existing` and the `order.client_order_id` is already contained in the cache,
+    /// or if persisting the order to the backing database fails. The order and every index are
+    /// committed to memory before persistence is attempted, so a persistence error leaves the
+    /// cache internally consistent.
     #[pyo3(name = "add_order")]
     fn py_add_order(
         &mut self,
@@ -1727,7 +1730,9 @@ impl Cache {
     ///
     /// # Errors
     ///
-    /// Returns an error if persisting the position to the backing database fails.
+    /// Returns an error if persisting the position to the backing database fails. After
+    /// serialization succeeds, the complete operation is committed to memory before persistence
+    /// is attempted, so a persistence error leaves the cache internally consistent.
     #[pyo3(name = "add_position")]
     #[expect(clippy::needless_pass_by_value)]
     fn py_add_position(

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -13552,24 +13552,21 @@ fn test_option_physical_settlement_second_registration_failure_dispatches_nothin
         "Failed settlement plan must expose both indexed settlement order IDs",
     );
     let cache_ref = cache.borrow();
-    let registered_order_ids: Vec<ClientOrderId> = added_order_ids
+    let registered_order_count = added_order_ids
         .iter()
-        .copied()
         .filter(|client_order_id| cache_ref.order(client_order_id).is_some())
-        .collect();
+        .count();
     assert_eq!(
-        registered_order_ids.len(),
-        1,
-        "Only the successfully registered close leg must resolve to an order object",
+        registered_order_count, 2,
+        "Both settlement legs must resolve to order objects after registration failure",
     );
-    let registered_order_id = registered_order_ids[0];
     assert_eq!(
         added_order_ids
             .iter()
             .filter(|client_order_id| cache_ref.order(client_order_id).is_none())
             .count(),
-        1,
-        "The failed second leg must leave one stale order ID index",
+        0,
+        "Registration failure must not leave a stale order ID index",
     );
     drop(cache_ref);
     assert!(
@@ -13580,20 +13577,37 @@ fn test_option_physical_settlement_second_registration_failure_dispatches_nothin
         .difference(&position_order_ids_before_failure)
         .copied()
         .collect();
+    let cache_ref = cache.borrow();
+    // Identify the legs by instrument rather than by set size: only the option close leg
+    // carries a position ID, the underlying open leg is planned with `position_id: None`.
+    let close_order_id = added_order_ids
+        .iter()
+        .copied()
+        .find(|client_order_id| {
+            cache_ref
+                .order(client_order_id)
+                .is_some_and(|order| order.instrument_id() == option_id)
+        })
+        .expect("option close settlement order");
+    let open_order_id = added_order_ids
+        .iter()
+        .copied()
+        .find(|client_order_id| *client_order_id != close_order_id)
+        .expect("underlying open settlement order");
     assert_eq!(
         added_position_order_ids,
-        HashSet::from([registered_order_id]),
-        "Successfully registered close leg must retain its position relationship",
-    );
-    let cache_ref = cache.borrow();
-    assert!(
-        cache_ref.order(&registered_order_id).is_some(),
-        "Registered settlement order ID must resolve to an order object",
+        HashSet::from([close_order_id]),
+        "Only the option close leg must retain the option position relationship",
     );
     assert_eq!(
-        cache_ref.position_id(&registered_order_id),
+        cache_ref.position_id(&close_order_id),
         Some(&option_position.id),
-        "Registered settlement order must resolve to its option position",
+        "The option close leg must resolve to its option position",
+    );
+    assert_eq!(
+        cache_ref.position_id(&open_order_id),
+        None,
+        "The underlying open leg is planned without a position ID",
     );
     drop(cache_ref);
 


### PR DESCRIPTION
A follow-up to the position write ordering in #4767, covering the add transaction and the two companion paths you named on that thread.

## The add transaction

`Cache::add_order` populated every index, then called `database.add_order`, then wrote the canonical cell. A persistence failure returned between the second and third, so `order_exists` and `client_order_ids` reported the order while `order(&id)` returned `None`. `add_position_id` had the same split internally: it inserted `index.order_position`, persisted, then filled `index_position` and `position_orders`, leaving the forward mapping without its reverse. `add_position_inner` inherited that through its nested call and added two more fallible writes between the index families, so an early return left `venue_positions`, `instrument_positions`, `instrument_orders` and `account_positions` unset on a position already present in `positions` and `positions_open`.

`add_position_id` now splits into a private memory half and a persistence half, so `add_order` and `add_position_inner` commit their whole logical operation, canonical cell included, before any database call. Splitting only at the public boundary would not have been enough: calling the public form from either caller still puts a database write inside their memory transaction. The three writes in `add_position_inner` stay fail-fast in their existing order, since persisting a position whose order-position association has already failed would let the database load a position with no opening-order relationship. Its OMS entry no longer goes through `Cache::add`, which is memory-first on its own; the general insert moves into the commit phase and the database write joins the others, with the key and value validated and serialized up front where a construction failure cannot leave the cache mutated.

## `replace_order`

`replace_order` called `refresh_order` and only then wrote the cell, so a failed persistence left the derived index state updated and the canonical entry stale. `update_order` has done the opposite since #4767. This aligns the two on ordering: the venue order ID ownership check is preflighted, then the cell is committed, then the refresh runs. It keeps propagating the error rather than logging it as `update_order` does, because callers use that signal.

The contract these paths now state in their rustdoc is that memory is committed before persistence is attempted, so a persistence failure leaves the cache internally self-consistent and returns to the caller. Memory and the database can still disagree; that is a durability failure and not something the cache can resolve.

## Testing

`test_add_order_commits_memory_when_database_add_fails` pins the canonical order and every index that names it after a failed `add_order`, with `check_integrity`. `test_add_order_commits_position_indexes_when_database_index_fails` pins the forward and reverse position relationship. `test_add_position_commits_memory_when_database_index_fails` pins the earliest boundary in the position path, `index_order_position`, asserting the canonical position, both relationship directions, the strategy, venue, instrument and account indexes, and the OMS entry; `test_add_position_commits_memory_when_database_add_fails` covers the later boundary. `test_replace_order_commits_canonical_state_when_database_update_fails` pins the replacement in the cell.

Each compares structurally with `serde_json` rather than through `PartialEq`, which for `Position` and `OrderAny` compares identifiers alone and would pass against the old ordering. Each was run against the unfixed ordering and fails there.

`test_option_physical_settlement_second_registration_failure_dispatches_nothing` asserted the old shape directly, requiring exactly one of two settlement legs to resolve to an order and one stale index entry to remain. Those assertions now expect both legs committed and no stale entry. What the test pins otherwise is unchanged: registration failure still aborts the plan, still dispatches no acceptance or fill, and still cancels the resting order. The relationship assertion is tightened while it is open, identifying the option close leg by its instrument and asserting the underlying open leg carries no position ID, since only the close leg is planned with one.
