### PR TITLE
Validate purge retention minutes and remove purge panics

### DIFF
--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -60,7 +60,7 @@ use nautilus_core::{
         check_key_not_in_map, check_predicate_false, check_slice_not_empty,
         check_valid_string_ascii,
     },
-    datetime::secs_to_nanos_unchecked,
+    datetime::secs_to_nanos,
 };
 #[cfg(feature = "defi")]
 use nautilus_model::defi::{Pool, PoolProfiler};
@@ -3279,7 +3279,13 @@ impl Cache {
             }
         );
 
-        let buffer_ns = secs_to_nanos_unchecked(buffer_secs as f64);
+        let Ok(buffer_ns) = secs_to_nanos(buffer_secs as f64) else {
+            log::warn!(
+                "Cannot purge closed orders: buffer_secs {buffer_secs} is not representable in `u64` nanoseconds"
+            );
+            return;
+        };
+        let purge_cutoff = ts_now.checked_sub(buffer_ns);
 
         let mut affected_order_list_ids: AHashSet<OrderListId> = AHashSet::new();
 
@@ -3288,7 +3294,7 @@ impl Cache {
                 let order = order_cell.borrow();
                 if order.is_closed()
                     && let Some(ts_closed) = order.ts_closed()
-                    && ts_closed + buffer_ns <= ts_now
+                    && purge_cutoff.is_some_and(|cutoff| ts_closed <= cutoff)
                 {
                     let linked = order.linked_order_ids().map(<[_]>::to_vec);
                     let order_list_id = order.order_list_id();
@@ -3347,15 +3353,21 @@ impl Cache {
             }
         );
 
-        let buffer_ns = secs_to_nanos_unchecked(buffer_secs as f64);
+        let Ok(buffer_ns) = secs_to_nanos(buffer_secs as f64) else {
+            log::warn!(
+                "Cannot purge closed positions: buffer_secs {buffer_secs} is not representable in `u64` nanoseconds"
+            );
+            return;
+        };
+        let purge_cutoff = ts_now.checked_sub(buffer_ns);
 
         for position_id in self.index.positions_closed.clone() {
             let should_purge = self.positions.get(&position_id).is_some_and(|cell| {
                 let position = cell.borrow();
                 position.is_closed()
-                    && position
-                        .ts_closed
-                        .is_some_and(|ts_closed| ts_closed + buffer_ns <= ts_now)
+                    && position.ts_closed.is_some_and(|ts_closed| {
+                        purge_cutoff.is_some_and(|cutoff| ts_closed <= cutoff)
+                    })
             });
 
             if should_purge {

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -210,6 +210,96 @@ fn orders_contains(actual: &[OrderRef<'_>], expected: &OrderAny) -> bool {
     actual.iter().any(|r| r == expected)
 }
 
+/// Adds a filled, and therefore closed, order to the `cache` and returns it.
+fn closed_order_in_cache(
+    cache: &mut Cache,
+    instrument: &InstrumentAny,
+    client_order_id: &str,
+) -> OrderAny {
+    let account_id = AccountId::new("SIM-001");
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00000"))
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new(client_order_id))
+        .build();
+    cache.add_order(order.clone(), None, None, false).unwrap();
+
+    let submitted = TestOrderEventStubs::submitted(&order, account_id);
+    update_order_with_event(cache, &mut order, submitted);
+    let accepted =
+        TestOrderEventStubs::accepted(&order, account_id, VenueOrderId::new("V-CLOSED-1"));
+    update_order_with_event(cache, &mut order, accepted);
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        instrument,
+        Some(TradeId::new("T-CLOSED-1")),
+        None,
+        Some(Price::from("1.00000")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    update_order_with_event(cache, &mut order, filled);
+
+    assert!(order.is_closed());
+    order
+}
+
+/// Adds an opened-then-flattened, and therefore closed, position to the `cache`.
+fn closed_position_in_cache(
+    cache: &mut Cache,
+    instrument: &InstrumentAny,
+    position_id: &str,
+) -> PositionId {
+    let position_id = PositionId::new(position_id);
+    let open_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let open_fill = TestOrderEventStubs::filled(
+        &open_order,
+        instrument,
+        Some(TradeId::new("T-OPEN-1")),
+        Some(position_id),
+        Some(Price::from("1.00000")),
+        None,
+        None,
+        None,
+        Some(UnixNanos::from(1_000_000_000)),
+        None,
+    );
+    let mut position = Position::new(instrument, open_fill.into());
+    cache.add_position(&position, OmsType::Netting).unwrap();
+
+    let close_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let close_fill = TestOrderEventStubs::filled(
+        &close_order,
+        instrument,
+        Some(TradeId::new("T-CLOSE-1")),
+        Some(position_id),
+        Some(Price::from("1.00010")),
+        None,
+        None,
+        None,
+        Some(UnixNanos::from(2_000_000_000)),
+        None,
+    );
+    position.apply(&close_fill.into());
+    cache.update_position(&position).unwrap();
+
+    assert!(position.is_closed());
+    position_id
+}
+
 #[rstest]
 fn test_cache_view_borrows_same_cache(audusd_sim: CurrencyPair) {
     let cache = Rc::new(RefCell::new(Cache::default()));
@@ -6376,6 +6466,60 @@ fn test_purge_closed_orders_does_not_purge_order_list_with_open_orders() {
     assert!(!cache.order_exists(&order1.client_order_id()));
     assert!(cache.order_exists(&order2.client_order_id()));
     assert!(cache.order_list_exists(&order_list_id));
+}
+
+#[rstest]
+fn test_purge_closed_orders_retains_closed_order_for_overflowing_buffer(audusd_sim: CurrencyPair) {
+    let mut cache = Cache::default();
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim);
+    let order = closed_order_in_cache(&mut cache, &audusd_sim, "O-OVERFLOW-BUFFER");
+    let client_order_id = order.client_order_id();
+    assert!(cache.is_order_closed(&client_order_id));
+
+    cache.purge_closed_orders(UnixNanos::from(u64::MAX), u64::MAX);
+
+    assert!(
+        cache.order(&client_order_id).is_some(),
+        "an unrepresentable buffer must retain, not purge",
+    );
+
+    // Purgeable under a representable buffer, so the retention above is the overflow handling.
+    cache.purge_closed_orders(UnixNanos::from(u64::MAX), 0);
+    assert!(cache.order(&client_order_id).is_none());
+}
+
+#[rstest]
+fn test_purge_closed_positions_retains_closed_position_for_overflowing_buffer(
+    audusd_sim: CurrencyPair,
+) {
+    let mut cache = Cache::default();
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim);
+    let position_id = closed_position_in_cache(&mut cache, &audusd_sim, "P-OVERFLOW-BUFFER");
+    assert!(cache.is_position_closed(&position_id));
+
+    cache.purge_closed_positions(UnixNanos::from(u64::MAX), u64::MAX);
+
+    assert!(
+        cache.position_exists(&position_id),
+        "an unrepresentable buffer must retain, not purge",
+    );
+
+    cache.purge_closed_positions(UnixNanos::from(u64::MAX), 0);
+    assert!(!cache.position_exists(&position_id));
+}
+
+#[rstest]
+fn test_purge_closed_positions_retains_position_closed_near_u64_max(audusd_sim: CurrencyPair) {
+    let mut cache = Cache::default();
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim);
+    let position_id = closed_position_in_cache(&mut cache, &audusd_sim, "P-NEAR-MAX");
+    let mut position = cache.position(&position_id).unwrap().clone();
+    position.ts_closed = Some(UnixNanos::from(u64::MAX - 1));
+    cache.update_position(&position).unwrap();
+
+    cache.purge_closed_positions(UnixNanos::from(u64::MAX), 60);
+
+    assert!(cache.position_exists(&position_id));
 }
 
 #[rstest]

--- a/crates/execution/src/engine/config.rs
+++ b/crates/execution/src/engine/config.rs
@@ -163,6 +163,31 @@ impl ExecutionEngineConfig {
             }
         }
 
+        for (field, value) in [
+            (
+                "purge_closed_orders_buffer_mins",
+                self.purge_closed_orders_buffer_mins,
+            ),
+            (
+                "purge_closed_positions_buffer_mins",
+                self.purge_closed_positions_buffer_mins,
+            ),
+            (
+                "purge_account_events_lookback_mins",
+                self.purge_account_events_lookback_mins,
+            ),
+        ] {
+            if let Some(mins) = value {
+                errors.check(
+                    checked_mins_to_nanos(u64::from(mins)).is_some(),
+                    ConfigError::range(
+                        field,
+                        format!("must fit in `u64` nanoseconds, was {mins} minutes"),
+                    ),
+                );
+            }
+        }
+
         errors.into_result()
     }
 }
@@ -291,6 +316,58 @@ mod tests {
                 ],
             }
         );
+    }
+
+    #[rstest]
+    #[case("purge_closed_orders_buffer_mins", 0)]
+    #[case("purge_closed_orders_buffer_mins", 307_445_734)]
+    #[case("purge_closed_positions_buffer_mins", 0)]
+    #[case("purge_closed_positions_buffer_mins", 307_445_734)]
+    #[case("purge_account_events_lookback_mins", 0)]
+    #[case("purge_account_events_lookback_mins", 307_445_734)]
+    fn test_purge_retention_minute_boundaries_accepted(#[case] field: &str, #[case] mins: u32) {
+        let mut config = ExecutionEngineConfig::default();
+
+        match field {
+            "purge_closed_orders_buffer_mins" => {
+                config.purge_closed_orders_buffer_mins = Some(mins);
+            }
+            "purge_closed_positions_buffer_mins" => {
+                config.purge_closed_positions_buffer_mins = Some(mins);
+            }
+            "purge_account_events_lookback_mins" => {
+                config.purge_account_events_lookback_mins = Some(mins);
+            }
+            _ => unreachable!(),
+        }
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[rstest]
+    #[case("purge_closed_orders_buffer_mins")]
+    #[case("purge_closed_positions_buffer_mins")]
+    #[case("purge_account_events_lookback_mins")]
+    fn test_overflowing_purge_retention_minutes_rejected(#[case] field: &str) {
+        let mut config = ExecutionEngineConfig::default();
+
+        match field {
+            "purge_closed_orders_buffer_mins" => {
+                config.purge_closed_orders_buffer_mins = Some(307_445_735);
+            }
+            "purge_closed_positions_buffer_mins" => {
+                config.purge_closed_positions_buffer_mins = Some(307_445_735);
+            }
+            "purge_account_events_lookback_mins" => {
+                config.purge_account_events_lookback_mins = Some(307_445_735);
+            }
+            _ => unreachable!(),
+        }
+
+        assert!(matches!(
+            config.validate(),
+            Err(ConfigError::Range { field: error_field, .. }) if error_field == field
+        ));
     }
 
     #[rstest]

--- a/crates/live/src/node/config.rs
+++ b/crates/live/src/node/config.rs
@@ -1018,6 +1018,18 @@ impl LiveExecEngineConfig {
                 "LiveExecEngineConfig.purge_account_events_interval_mins",
                 self.purge_account_events_interval_mins,
             ),
+            (
+                "LiveExecEngineConfig.purge_closed_orders_buffer_mins",
+                self.purge_closed_orders_buffer_mins,
+            ),
+            (
+                "LiveExecEngineConfig.purge_closed_positions_buffer_mins",
+                self.purge_closed_positions_buffer_mins,
+            ),
+            (
+                "LiveExecEngineConfig.purge_account_events_lookback_mins",
+                self.purge_account_events_lookback_mins,
+            ),
         ] {
             if let Some(mins) = value {
                 collector.collect(check_range(
@@ -1635,6 +1647,52 @@ mean_dispatch_ns_clear = 700
                 ],
             }
         );
+    }
+
+    #[rstest]
+    #[case(0)]
+    #[case(307_445_734)]
+    fn test_validate_runtime_support_accepts_purge_retention_boundaries(#[case] mins: u32) {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                purge_closed_orders_buffer_mins: Some(mins),
+                purge_closed_positions_buffer_mins: Some(mins),
+                purge_account_events_lookback_mins: Some(mins),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(config.validate_runtime_support().is_ok());
+    }
+
+    #[rstest]
+    fn test_validate_runtime_support_rejects_overflowing_purge_retention_minutes() {
+        let config = LiveNodeConfig {
+            exec_engine: LiveExecEngineConfig {
+                purge_closed_orders_buffer_mins: Some(307_445_735),
+                purge_closed_positions_buffer_mins: Some(307_445_735),
+                purge_account_events_lookback_mins: Some(307_445_735),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let error = config.validate_runtime_support().unwrap_err();
+        let ConfigError::Multiple { errors } = error else {
+            panic!("Expected multiple config errors, received {error:?}");
+        };
+        assert_eq!(errors.len(), 3);
+
+        for field in [
+            "LiveExecEngineConfig.purge_closed_orders_buffer_mins",
+            "LiveExecEngineConfig.purge_closed_positions_buffer_mins",
+            "LiveExecEngineConfig.purge_account_events_lookback_mins",
+        ] {
+            assert!(errors.iter().any(
+                |e| matches!(e, ConfigError::Range { field: error_field, .. } if error_field == field)
+            ));
+        }
     }
 
     #[rstest]

--- a/crates/model/src/accounts/base.rs
+++ b/crates/model/src/accounts/base.rs
@@ -26,7 +26,7 @@ use nautilus_core::{
         CorrectnessError, CorrectnessResult, FAILED, check_equal, check_predicate_false,
         check_predicate_true,
     },
-    datetime::secs_to_nanos_unchecked,
+    datetime::secs_to_nanos,
 };
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -238,12 +238,18 @@ impl BaseAccount {
     ///
     /// Panics if the purging implementation is changed and all events are purged.
     pub fn base_purge_account_events(&mut self, ts_now: UnixNanos, lookback_secs: u64) {
-        let lookback_ns = UnixNanos::from(secs_to_nanos_unchecked(lookback_secs as f64));
+        let Ok(lookback_ns) = secs_to_nanos(lookback_secs as f64) else {
+            log::warn!(
+                "Cannot purge account events: lookback_secs {lookback_secs} is not representable in `u64` nanoseconds"
+            );
+            return;
+        };
+        let purge_cutoff = ts_now.checked_sub(lookback_ns);
 
         let mut retained_events = Vec::new();
 
         for event in &self.events {
-            if event.ts_event + lookback_ns > ts_now {
+            if purge_cutoff.is_none_or(|cutoff| event.ts_event > cutoff) {
                 retained_events.push(event.clone());
             }
         }
@@ -597,6 +603,29 @@ mod tests {
         assert_eq!(account.events.len(), 1);
         assert_eq!(account.events[0].ts_event, event3.ts_event);
         assert_eq!(account.base_last_event().unwrap().ts_event, event3.ts_event);
+    }
+
+    #[rstest]
+    fn test_base_purge_account_events_retains_all_for_overflowing_lookback() {
+        let mut account = BaseAccount::new(cash_account_state(), true);
+        let mut event = cash_account_state();
+        event.ts_event = UnixNanos::from(1);
+        account.base_apply(event);
+
+        account.base_purge_account_events(UnixNanos::from(u64::MAX), u64::MAX);
+
+        assert_eq!(account.events.len(), 2);
+    }
+
+    #[rstest]
+    fn test_base_purge_account_events_retains_future_event_without_overflow() {
+        let mut event = cash_account_state();
+        event.ts_event = UnixNanos::from(u64::MAX - 1);
+        let mut account = BaseAccount::new(event, true);
+
+        account.base_purge_account_events(UnixNanos::from(u64::MAX), 60);
+
+        assert_eq!(account.events.len(), 1);
     }
 
     #[rstest]


### PR DESCRIPTION
The purge retention fields are the only members of their config group without the nanosecond overflow guard their sibling interval fields carry, and the arithmetic they reach panics rather than erroring.

## The unguarded fields

`ExecutionEngineConfig::validate` walks `purge_closed_orders_interval_mins`, `purge_closed_positions_interval_mins` and `purge_account_events_interval_mins` and rejects any value where `checked_mins_to_nanos` returns `None`, with `test_overflowing_purge_intervals_rejected` pinning that at `u32::MAX`. The three fields that pair with them - `purge_closed_orders_buffer_mins`, `purge_closed_positions_buffer_mins` and `purge_account_events_lookback_mins` - are unchecked, and `LiveExecEngineConfig::validate_runtime_support` repeats the omission while guarding `open_check_lookback_mins`.

An accepted buffer reaches `mins_to_secs` in `start_purge_timers` and then `Cache::purge_closed_orders`, which converts with `secs_to_nanos_unchecked` - a bare `expect`. Past 307,445,734 minutes the product exceeds `u64::MAX` nanoseconds and the timer callback panics. The same shape reaches `purge_closed_positions` and, through `AccountAny`, `BaseAccount::base_purge_account_events`.

That threshold is roughly 584 years, and `u32::MAX` minutes is about 8,000. No one arrives there by mistyping a retention window. A sentinel does - `u32::MAX` for "effectively never purge" - which is the value upstream's own test already passes to the sibling fields and which the interval guard already rejects. The claim here is not that a live node is hitting this; it is that a config value out of range should be a `ConfigError`, and that a purge routine should not have a panic reachable from its public arguments at all.

Both `validate` paths now reject an overflowing value for all three fields with a `ConfigError::Range` naming the field. Zero is untouched: unlike an interval, a zero buffer means "no retention window" and stays valid. The guard uses the same `checked_mins_to_nanos` the runtime arithmetic overflows on, so it trips at exactly the value that would have panicked - 307,445,734 minutes accepted, 307,445,735 rejected.

## The purge arithmetic

These functions are also reached without a validated config: `ExecutionEngine::new` stores a supplied config without validating it, struct literals bypass the builder, and the pyo3 methods on `Cache` and on the four account types take the duration directly as `u64` seconds, where the equivalent value is far easier to reach than through a minutes field.

Each of the three now obtains its offset through the fallible `secs_to_nanos` and retains everything when the duration is unrepresentable, and the age test becomes `ts_closed <= ts_now - buffer_ns` by checked subtraction instead of `ts_closed + buffer_ns <= ts_now`. Subtraction preserves the original predicate exactly: when the cutoff is not representable no `ts_now` can satisfy it, so retaining is that predicate's result over the type's domain rather than a new policy, and saturating the addition to `u64::MAX` would instead purge at `ts_now == u64::MAX`. It also removes a second `expect` - `UnixNanos::Add` - which a `ts_closed` near the top of the `u64` range reaches under any buffer. That timestamp is a representable state rather than one a live node produces; it is fixed here because the rewrite covers it, not because it is reachable in practice.

A conversion failure now logs a warning naming the rejected value. An unrepresentable cutoff is still a no-op, but no longer a silent one.

## Testing

Config, both layers: 307,445,734 accepted and 307,445,735 rejected for each of the three fields, and zero still accepted. Purge paths, called directly rather than through a config: `purge_closed_orders` and `purge_closed_positions` with `u64::MAX` seconds retain an order and a position closed through fill transitions, each then purged under a representable buffer in the same test so the retention is the overflow handling rather than the entity being too young; a position closed at `u64::MAX - 1` is retained under a 60 second buffer; and `base_purge_account_events` with `u64::MAX` seconds retains its events with the at-least-one-event guarantee intact.

Every new assertion was run against the unfixed code. The conversion sites fail in `secs_to_nanos_unchecked` and the near-maximum timestamp case fails in `UnixNanos::Add`, which are the two distinct panics this change removes; the config cases fail on the absent `ConfigError::Range`.
