### PR TITLE
Refuse a cache position update for an unknown ID

### DIFF
--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -5118,15 +5118,20 @@ impl Cache {
             .insert(order.client_order_id());
     }
 
-    /// Updates the `position` in the cache.
+    /// Updates a `position` already held in the cache.
     ///
-    /// Reuses the existing cell when present so any held [`PositionRef`] handles continue to point
-    /// at the canonical entry; only inserts a new cell when the position is unknown.
+    /// Reuses the existing cell so any held [`PositionRef`] handles continue to point at the
+    /// canonical entry.
     ///
     /// # Errors
     ///
-    /// Returns an error if updating the position in the database fails.
+    /// Returns an error if the position is not already held in the cache, or if updating the
+    /// position in the database fails.
     pub fn update_position(&mut self, position: &Position) -> anyhow::Result<()> {
+        let Some(position_cell) = self.positions.get(&position.id).cloned() else {
+            anyhow::bail!("Cannot update position {}: not found in cache", position.id);
+        };
+
         // Update open/closed state
 
         if position.is_open() {
@@ -5137,13 +5142,7 @@ impl Cache {
             self.index.positions_open.remove(&position.id);
         }
 
-        match self.positions.get(&position.id) {
-            Some(position_cell) => *position_cell.borrow_mut() = position.clone(),
-            None => {
-                self.positions
-                    .insert(position.id, SharedCell::new(position.clone()));
-            }
-        }
+        *position_cell.borrow_mut() = position.clone();
 
         if let Some(database) = &mut self.database {
             database.update_position(position)?;

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -2843,6 +2843,180 @@ fn test_update_position_reuses_existing_cell(mut cache: Cache, audusd_sim: Curre
     );
 }
 
+#[rstest]
+fn test_update_position_refuses_purged_position(mut cache: Cache, audusd_sim: CurrencyPair) {
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim);
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        &audusd_sim,
+        None,
+        Some(PositionId::new("P-PURGED-UPDATE")),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let mut position = Position::new(&audusd_sim, filled.into());
+    let position_id = position.id;
+    let venue = position.instrument_id.venue;
+    let instrument_id = position.instrument_id;
+    let strategy_id = position.strategy_id;
+    let account_id = position.account_id;
+    cache.add_position(&position, OmsType::Netting).unwrap();
+
+    let close_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new("O-19700101-000000-001-001-2"))
+        .build();
+    let close_filled = TestOrderEventStubs::filled(
+        &close_order,
+        &audusd_sim,
+        Some(TradeId::new("T-PURGED-UPDATE-CLOSE")),
+        Some(position_id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    position.apply(&close_filled.into());
+    cache.update_position(&position).unwrap();
+    cache.purge_position(position_id);
+
+    let error = cache.update_position(&position).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        format!("Cannot update position {position_id}: not found in cache")
+    );
+    assert!(cache.position(&position_id).is_none());
+    assert!(!cache.index.positions.contains(&position_id));
+    assert!(!cache.index.positions_open.contains(&position_id));
+    assert!(!cache.index.positions_closed.contains(&position_id));
+    assert!(
+        cache
+            .positions(Some(&venue), None, None, None, None)
+            .is_empty()
+    );
+    assert!(
+        cache
+            .positions(None, Some(&instrument_id), None, None, None)
+            .is_empty()
+    );
+    assert!(
+        cache
+            .positions(None, None, Some(&strategy_id), None, None)
+            .is_empty()
+    );
+    assert!(
+        cache
+            .positions(None, None, None, Some(&account_id), None)
+            .is_empty()
+    );
+    assert!(cache.check_integrity());
+}
+
+#[rstest]
+fn test_update_position_refuses_never_added_position(mut cache: Cache, audusd_sim: CurrencyPair) {
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim);
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        &audusd_sim,
+        None,
+        Some(PositionId::new("P-NEVER-ADDED")),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let position = Position::new(&audusd_sim, filled.into());
+    let position_id = position.id;
+
+    let error = cache.update_position(&position).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        format!("Cannot update position {position_id}: not found in cache")
+    );
+    assert!(cache.positions.is_empty());
+    assert!(cache.index.positions.is_empty());
+    assert!(cache.index.positions_open.is_empty());
+    assert!(cache.index.positions_closed.is_empty());
+    assert!(cache.check_integrity());
+}
+
+#[rstest]
+fn test_update_position_moves_held_position_to_closed_index(
+    mut cache: Cache,
+    audusd_sim: CurrencyPair,
+) {
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim);
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let filled = TestOrderEventStubs::filled(
+        &order,
+        &audusd_sim,
+        None,
+        Some(PositionId::new("P-HELD-UPDATE")),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let mut position = Position::new(&audusd_sim, filled.into());
+    let position_id = position.id;
+
+    cache.add_position(&position, OmsType::Netting).unwrap();
+
+    let close_order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .client_order_id(ClientOrderId::new("O-19700101-000000-001-001-3"))
+        .build();
+    let close_filled = TestOrderEventStubs::filled(
+        &close_order,
+        &audusd_sim,
+        Some(TradeId::new("T-HELD-UPDATE-CLOSE")),
+        Some(position_id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    position.apply(&close_filled.into());
+
+    cache.update_position(&position).unwrap();
+
+    assert!(cache.position(&position_id).unwrap().is_closed());
+    assert!(!cache.index.positions_open.contains(&position_id));
+    assert!(cache.index.positions_closed.contains(&position_id));
+}
+
 // -- DATA ------------------------------------------------------------------------------------
 
 #[rstest]


### PR DESCRIPTION
`Cache::update_position` treats an unknown position ID as a creation instruction, which reverses a purge into a half-indexed entry.

## The unknown-ID insertion

`update_position` moves the ID between `positions_open` and `positions_closed`, writes the canonical cell, and persists. Its cell write has two arms, and the second inserts a new `SharedCell` when the ID is absent. That arm is not a creation path anyone asks for: `add_position` and `add_position_without_order` are the creation APIs, and every in-tree caller of `update_position` already holds a position obtained from the cache. `ExecutionEngine::handle_position_update` reaches it only through its `Some` arm, routing the `None` arm to `open_position` and `add_position`; the `event_store` replay calls all fetch first and skip absent IDs; the backtest funding path updates clones drawn from cached positions.

`purge_position` removes a closed position from `self.positions`, from `venue_positions`, `instrument_positions`, `strategy_positions` and `account_positions`, and from `position_strategy`, `position_oms`, `position_orders`, `index.positions`, both open/closed sets and the `order_position` reverse mappings. A later `update_position` for that ID restores exactly two of those: the canonical cell and `positions_closed`.

The result is a position that `position(&id)` and `is_position_closed(&id)` both report and that no bucket query can see. `positions(Some(&venue), ..)` and the instrument, strategy and account forms all return empty for it, and `check_integrity` fails on three counts, since it requires `position_strategy`, `position_orders` and `index.positions` for every canonical position. This was measured against the unfixed code rather than inferred.

`update_position` now returns an error when the ID is absent, before touching the open/closed index sets, the cell, or the database, so a refusal leaves the position absent everywhere. The existing-cell arm is unchanged, and so is the memory-before-persistence ordering from #4767.

A purged position is the concrete way to reach this, but the arm accepts any unknown ID; the fix is stated as the contract, which is that this method updates a position the cache already holds.

## Testing

`test_update_position_refuses_purged_position` adds a position, closes it, purges it, and asserts the update is refused, that the ID is absent from the canonical map, `index.positions` and both open/closed sets, that all four bucket queries stay empty, and that `check_integrity` holds. `test_update_position_refuses_never_added_position` covers a first-ever update on the same contract. `test_update_position_moves_held_position_to_closed_index` pins the ordinary path, asserting the cached position is closed afterwards rather than merely present, since `Position` compares on ID alone.

All three fail against the unfixed code. Restoring the insertion arm additionally reproduces the described state exactly: canonical cell present, `positions_closed` repopulated, `index.positions`, `position_strategy` and `position_orders` absent, all four bucket queries blind, and `check_integrity` false.
