### PR TITLE
Resume a stopped TWAP execution schedule

### DIFF
--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -1308,6 +1308,15 @@ pub trait ExecutionAlgorithm: DataActor {
         Ok(())
     }
 
+    /// Called when the algorithm is resumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if resume fails.
+    fn on_resume(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Called when the algorithm is reset.
     ///
     /// # Errors

--- a/crates/trading/src/algorithm/twap.rs
+++ b/crates/trading/src/algorithm/twap.rs
@@ -65,8 +65,8 @@ pub type TwapAlgorithmConfig = ExecutionAlgorithmConfig;
 pub struct TwapAlgorithm {
     /// The algorithm core.
     pub core: ExecutionAlgorithmCore,
-    /// Scheduled sizes for each primary order.
-    scheduled_sizes: AHashMap<ClientOrderId, Vec<Quantity>>,
+    /// Schedules for each primary order.
+    scheduled_orders: AHashMap<ClientOrderId, TwapSchedule>,
 }
 
 impl TwapAlgorithm {
@@ -75,7 +75,7 @@ impl TwapAlgorithm {
     pub fn new(config: TwapAlgorithmConfig) -> Self {
         Self {
             core: ExecutionAlgorithmCore::new(config),
-            scheduled_sizes: AHashMap::new(),
+            scheduled_orders: AHashMap::new(),
         }
     }
 
@@ -87,7 +87,7 @@ impl TwapAlgorithm {
             core.clock_mut().cancel_timer(timer_name);
         }
         core.remove_submit_params(&primary_id);
-        self.scheduled_sizes.remove(&primary_id);
+        self.scheduled_orders.remove(&primary_id);
         log::info!("Completed TWAP execution for {primary_id}");
     }
 }
@@ -103,6 +103,10 @@ impl DataActor for TwapAlgorithm {
         ExecutionAlgorithm::on_stop(self)
     }
 
+    fn on_resume(&mut self) -> anyhow::Result<()> {
+        ExecutionAlgorithm::on_resume(self)
+    }
+
     fn on_reset(&mut self) -> anyhow::Result<()> {
         ExecutionAlgorithm::on_reset(self)
     }
@@ -112,7 +116,7 @@ nautilus_execution_algorithm!(TwapAlgorithm, {
     fn on_order(&mut self, order: OrderAny) -> anyhow::Result<()> {
         let primary_id = order.client_order_id();
 
-        if self.scheduled_sizes.contains_key(&primary_id) {
+        if self.scheduled_orders.contains_key(&primary_id) {
             anyhow::bail!("Order {primary_id} already being executed");
         }
 
@@ -336,14 +340,20 @@ nautilus_execution_algorithm!(TwapAlgorithm, {
             }
         }
 
-        self.scheduled_sizes
-            .insert(primary_id, scheduled_sizes.clone());
+        self.scheduled_orders.insert(
+            primary_id,
+            TwapSchedule {
+                remaining_sizes: scheduled_sizes.clone(),
+                interval,
+            },
+        );
 
-        let first_qty = self.scheduled_sizes.get_mut(&primary_id).unwrap().remove(0);
+        let schedule = self.scheduled_orders.get_mut(&primary_id).unwrap();
+        let first_qty = schedule.remaining_sizes.remove(0);
         let is_single_slice = self
-            .scheduled_sizes
+            .scheduled_orders
             .get(&primary_id)
-            .is_some_and(Vec::is_empty);
+            .is_some_and(|schedule| schedule.remaining_sizes.is_empty());
 
         // Single slice: submit the primary order directly
         if is_single_slice {
@@ -390,6 +400,7 @@ nautilus_execution_algorithm!(TwapAlgorithm, {
 
         let Some(primary) = primary else {
             log::error!("Cannot find primary order for exec_spawn_id={primary_id}");
+            self.complete_sequence(primary_id);
             return Ok(());
         };
 
@@ -398,18 +409,18 @@ nautilus_execution_algorithm!(TwapAlgorithm, {
             return Ok(());
         }
 
-        let Some(scheduled_sizes) = self.scheduled_sizes.get_mut(&primary_id) else {
+        let Some(schedule) = self.scheduled_orders.get_mut(&primary_id) else {
             log::error!("Cannot find scheduled sizes for exec_spawn_id={primary_id}");
             return Ok(());
         };
 
-        if scheduled_sizes.is_empty() {
+        if schedule.remaining_sizes.is_empty() {
             log::warn!("No more size to execute for exec_spawn_id={primary_id}");
             return Ok(());
         }
 
-        let quantity = scheduled_sizes.remove(0);
-        let is_final_slice = scheduled_sizes.is_empty();
+        let quantity = schedule.remaining_sizes.remove(0);
+        let is_final_slice = schedule.remaining_sizes.is_empty();
 
         // Final slice: submit the primary order (already reduced to remaining quantity)
         if is_final_slice {
@@ -443,13 +454,48 @@ nautilus_execution_algorithm!(TwapAlgorithm, {
         Ok(())
     }
 
+    fn on_resume(&mut self) -> anyhow::Result<()> {
+        let primary_ids: Vec<ClientOrderId> = self.scheduled_orders.keys().copied().collect();
+
+        for primary_id in primary_ids {
+            let primary_is_open = {
+                let cache = ExecutionAlgorithmNative::exec_algorithm_core(self).cache_ref();
+                cache.order(&primary_id).map(|primary| !primary.is_closed())
+            };
+
+            if primary_is_open.is_none() {
+                log::error!("Cannot find primary order for exec_spawn_id={primary_id}");
+            }
+            let interval = self.scheduled_orders.get(&primary_id).and_then(|schedule| {
+                (!schedule.remaining_sizes.is_empty()).then_some(schedule.interval)
+            });
+
+            let Some(interval) = interval.filter(|_| primary_is_open == Some(true)) else {
+                self.complete_sequence(primary_id);
+                continue;
+            };
+
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+                .clock_mut()
+                .set_timer(primary_id.as_str(), interval, None, None, None, None, None)?;
+        }
+
+        Ok(())
+    }
+
     fn on_reset(&mut self) -> anyhow::Result<()> {
         self.unsubscribe_all_strategy_events();
         ExecutionAlgorithmNative::exec_algorithm_core_mut(self).reset();
-        self.scheduled_sizes.clear();
+        self.scheduled_orders.clear();
         Ok(())
     }
 });
+
+#[derive(Debug)]
+struct TwapSchedule {
+    remaining_sizes: Vec<Quantity>,
+    interval: Duration,
+}
 
 fn validation_failed(detail: impl Into<String>) -> Ustr {
     let reason = OrderDeniedReason::ValidationFailed {
@@ -495,7 +541,7 @@ mod tests {
         TwapAlgorithm::new(config)
     }
 
-    fn register_algorithm(algo: &mut TwapAlgorithm) {
+    fn register_algorithm_with_clock(algo: &mut TwapAlgorithm) -> Rc<RefCell<TestClock>> {
         use nautilus_common::timer::TimeEventCallback;
 
         let trader_id = TraderId::from("TRADER-001");
@@ -507,13 +553,19 @@ mod tests {
             .borrow_mut()
             .register_default_handler(TimeEventCallback::Rust(std::sync::Arc::new(|_| {})));
 
-        algo.core.register(trader_id, clock, cache).unwrap();
+        algo.core.register(trader_id, clock.clone(), cache).unwrap();
 
         // Transition to Running state for tests
         algo.transition_state(ComponentTrigger::Initialize).unwrap();
         algo.transition_state(ComponentTrigger::Start).unwrap();
         algo.transition_state(ComponentTrigger::StartCompleted)
             .unwrap();
+
+        clock
+    }
+
+    fn register_algorithm(algo: &mut TwapAlgorithm) {
+        let _ = register_algorithm_with_clock(algo);
     }
 
     fn add_instrument_to_cache(algo: &TwapAlgorithm) {
@@ -592,7 +644,7 @@ mod tests {
                     && event.strategy_id == strategy_id
                     && event.client_order_id == order.client_order_id()
         ));
-        assert!(algo.scheduled_sizes.is_empty());
+        assert!(algo.scheduled_orders.is_empty());
         assert!(algo.clock().timer_names().is_empty());
     }
 
@@ -600,7 +652,7 @@ mod tests {
     fn test_twap_creation() {
         let algo = create_twap_algorithm();
         assert!(algo.id().inner().starts_with("TWAP"));
-        assert!(algo.scheduled_sizes.is_empty());
+        assert!(algo.scheduled_orders.is_empty());
     }
 
     #[rstest]
@@ -614,17 +666,27 @@ mod tests {
     #[rstest]
     fn test_twap_reset_clears_scheduled_sizes() {
         let mut algo = create_twap_algorithm();
-        let primary_id = ClientOrderId::new("O-001");
+        algo.scheduled_orders.insert(
+            ClientOrderId::new("O-001"),
+            TwapSchedule {
+                remaining_sizes: vec![Quantity::from("1.0")],
+                interval: Duration::from_secs(1),
+            },
+        );
+        algo.scheduled_orders.insert(
+            ClientOrderId::new("O-002"),
+            TwapSchedule {
+                remaining_sizes: vec![Quantity::from("2.0")],
+                interval: Duration::from_secs(2),
+            },
+        );
 
-        algo.scheduled_sizes
-            .insert(primary_id, vec![Quantity::from("1.0")]);
-
-        assert!(!algo.scheduled_sizes.is_empty());
+        assert!(!algo.scheduled_orders.is_empty());
 
         // Dispatch through the DataActor entry point the component lifecycle uses
         DataActor::on_reset(&mut algo).unwrap();
 
-        assert!(algo.scheduled_sizes.is_empty());
+        assert!(algo.scheduled_orders.is_empty());
     }
 
     #[rstest]
@@ -830,7 +892,11 @@ mod tests {
         algo.on_order(order).unwrap();
 
         // First slice spawned immediately, remaining 2 slices scheduled (no remainder)
-        let remaining = algo.scheduled_sizes.get(&primary_id).unwrap();
+        let remaining = &algo
+            .scheduled_orders
+            .get(&primary_id)
+            .unwrap()
+            .remaining_sizes;
         assert_eq!(remaining.len(), 2);
 
         for qty in remaining {
@@ -886,7 +952,7 @@ mod tests {
 
         algo.on_order(order).unwrap();
 
-        assert_eq!(algo.scheduled_sizes.get(&primary_id).unwrap().len(), 2);
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 2);
     }
 
     #[rstest]
@@ -908,7 +974,11 @@ mod tests {
         algo.on_order(order).unwrap();
 
         // First slice spawned, 3 remaining (2 regular + 1 remainder)
-        let remaining = algo.scheduled_sizes.get(&primary_id).unwrap();
+        let remaining = &algo
+            .scheduled_orders
+            .get(&primary_id)
+            .unwrap()
+            .remaining_sizes;
         assert_eq!(remaining.len(), 3);
         assert_eq!(
             remaining,
@@ -959,7 +1029,8 @@ mod tests {
             .quantity();
         assert_eq!(spawned.precision, instrument.size_precision());
         assert!(
-            algo.scheduled_sizes[&primary_id]
+            algo.scheduled_orders[&primary_id]
+                .remaining_sizes
                 .iter()
                 .all(|quantity| quantity.precision == instrument.size_precision())
         );
@@ -990,14 +1061,14 @@ mod tests {
         algo.on_order(order).unwrap();
 
         // Verify 2 slices remain after first spawn (no remainder)
-        assert_eq!(algo.scheduled_sizes.get(&primary_id).unwrap().len(), 2);
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 2);
 
         // Simulate timer firing
         let event = TimeEvent::new(primary_id.inner(), UUID4::new(), 0.into(), 0.into());
         ExecutionAlgorithm::on_time_event(&mut algo, &event).unwrap();
 
         // One slice consumed
-        assert_eq!(algo.scheduled_sizes.get(&primary_id).unwrap().len(), 1);
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 1);
         assert_eq!(algo.core.submit_params(&primary_id), Some(submit_params));
     }
 
@@ -1016,13 +1087,13 @@ mod tests {
         let primary_id = order.client_order_id();
 
         algo.on_order(order).unwrap();
-        assert_eq!(algo.scheduled_sizes.get(&primary_id).unwrap().len(), 2);
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 2);
 
         // Dispatch through the DataActor entry point the clock callback uses
         let event = TimeEvent::new(primary_id.inner(), UUID4::new(), 0.into(), 0.into());
         algo.handle_time_event(&event);
 
-        assert_eq!(algo.scheduled_sizes.get(&primary_id).unwrap().len(), 1);
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 1);
     }
 
     #[rstest]
@@ -1048,7 +1119,7 @@ mod tests {
             .remember_submit_params(primary_id, Some(submit_params.clone()));
 
         algo.on_order(order).unwrap();
-        assert_eq!(algo.scheduled_sizes.get(&primary_id).unwrap().len(), 1);
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 1);
         assert_eq!(
             algo.core.submit_params(&primary_id),
             Some(submit_params.clone())
@@ -1073,7 +1144,7 @@ mod tests {
         ExecutionAlgorithm::on_time_event(&mut algo, &event).unwrap();
 
         // Sequence completed, scheduled_sizes removed
-        assert!(algo.scheduled_sizes.get(&primary_id).is_none());
+        assert!(algo.scheduled_orders.get(&primary_id).is_none());
         assert_eq!(
             received
                 .borrow()
@@ -1106,7 +1177,7 @@ mod tests {
             .remember_submit_params(primary_id, Some(submit_params));
 
         algo.on_order(order).unwrap();
-        assert_eq!(algo.scheduled_sizes.get(&primary_id).unwrap().len(), 2);
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 2);
 
         // Mark primary order as closed (canceled)
         {
@@ -1130,8 +1201,47 @@ mod tests {
         ExecutionAlgorithm::on_time_event(&mut algo, &event).unwrap();
 
         // Sequence should complete early since primary is closed
-        assert!(algo.scheduled_sizes.get(&primary_id).is_none());
+        assert!(algo.scheduled_orders.get(&primary_id).is_none());
         assert_eq!(algo.core.submit_params(&primary_id), None);
+    }
+
+    #[rstest]
+    fn test_twap_on_time_event_completes_when_primary_missing() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+        add_instrument_to_cache(&algo);
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("60"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("20"));
+
+        let order = create_market_order_with_params_and_qty(params, Quantity::from("1.2"));
+        let primary_id = order.client_order_id();
+        algo.on_order(order).unwrap();
+
+        {
+            let cache_rc = algo.core.cache_rc();
+            let mut cache = cache_rc.borrow_mut();
+            let primary = cache.order(&primary_id).map(|order| order.clone()).unwrap();
+            let canceled = OrderCanceledSpec::builder()
+                .trader_id(primary.trader_id())
+                .strategy_id(primary.strategy_id())
+                .instrument_id(primary.instrument_id())
+                .client_order_id(primary.client_order_id())
+                .build();
+            cache
+                .update_order(&OrderEventAny::Canceled(canceled))
+                .unwrap();
+            cache.purge_order(primary_id);
+        }
+        assert!(algo.cache().order(&primary_id).is_none());
+
+        let event = TimeEvent::new(primary_id.inner(), UUID4::new(), 0.into(), 0.into());
+        ExecutionAlgorithm::on_time_event(&mut algo, &event).unwrap();
+
+        // A vanished primary is terminal: the schedule must not outlive it and block the ID
+        assert!(algo.scheduled_orders.get(&primary_id).is_none());
+        assert!(algo.clock().timer_names().is_empty());
     }
 
     #[rstest]
@@ -1163,6 +1273,162 @@ mod tests {
 
         // Timer should be canceled
         assert!(algo.clock().timer_names().is_empty());
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 3);
+    }
+
+    #[rstest]
+    fn test_twap_on_resume_rearms_timer_without_submitting() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+        add_instrument_to_cache(&algo);
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("60"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("20"));
+
+        let order = create_market_order_with_params(params);
+        let primary_id = order.client_order_id();
+        algo.on_order(order).unwrap();
+        let order_count = algo
+            .cache()
+            .orders_total_count(None, None, None, None, None);
+
+        Component::stop(&mut algo).unwrap();
+
+        // Observe the command bus directly: resubmitting the already-cached primary would
+        // leave the order count unchanged, so the count alone cannot prove nothing was sent.
+        let received = Rc::new(RefCell::new(None::<SubmitOrder>));
+        let handler = msgbus::TypedIntoHandler::from({
+            let captured = received.clone();
+            move |cmd: TradingCommand| {
+                if let TradingCommand::SubmitOrder(cmd) = cmd {
+                    *captured.borrow_mut() = Some(cmd);
+                }
+            }
+        });
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            handler,
+        );
+
+        let resume_time = algo.clock().timestamp_ns();
+        Component::resume(&mut algo).unwrap();
+
+        assert!(received.borrow().is_none());
+        assert_eq!(algo.clock().timer_count(), 1);
+        assert_eq!(
+            algo.clock().next_time_ns(primary_id.as_str()),
+            Some(resume_time + 20_000_000_000)
+        );
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 3);
+        assert_eq!(
+            algo.cache()
+                .orders_total_count(None, None, None, None, None),
+            order_count
+        );
+    }
+
+    #[rstest]
+    fn test_twap_on_resume_executes_remaining_slices() {
+        let mut algo = create_twap_algorithm();
+        let clock = register_algorithm_with_clock(&mut algo);
+        add_instrument_to_cache(&algo);
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("60"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("20"));
+
+        let order = create_market_order_with_params_and_qty(params, Quantity::from("1.2"));
+        let primary_id = order.client_order_id();
+        algo.on_order(order).unwrap();
+
+        Component::stop(&mut algo).unwrap();
+        Component::resume(&mut algo).unwrap();
+        assert_eq!(algo.clock().timer_count(), 1);
+
+        let first_events = clock.borrow_mut().advance_time(20_000_000_000.into(), true);
+        assert_eq!(first_events.len(), 1);
+        algo.handle_time_event(&first_events[0]);
+        assert_eq!(algo.scheduled_orders[&primary_id].remaining_sizes.len(), 1);
+
+        let final_events = clock.borrow_mut().advance_time(40_000_000_000.into(), true);
+        assert_eq!(final_events.len(), 1);
+        algo.handle_time_event(&final_events[0]);
+        assert!(algo.scheduled_orders.get(&primary_id).is_none());
+    }
+
+    #[rstest]
+    fn test_twap_on_resume_completes_closed_primary() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+        add_instrument_to_cache(&algo);
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("60"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("20"));
+
+        let order = create_market_order_with_params_and_qty(params, Quantity::from("1.2"));
+        let primary_id = order.client_order_id();
+        algo.on_order(order).unwrap();
+        Component::stop(&mut algo).unwrap();
+
+        {
+            let cache_rc = algo.core.cache_rc();
+            let mut cache = cache_rc.borrow_mut();
+            let primary = cache.order(&primary_id).map(|order| order.clone()).unwrap();
+            let canceled = OrderCanceledSpec::builder()
+                .trader_id(primary.trader_id())
+                .strategy_id(primary.strategy_id())
+                .instrument_id(primary.instrument_id())
+                .client_order_id(primary.client_order_id())
+                .build();
+            cache
+                .update_order(&OrderEventAny::Canceled(canceled))
+                .unwrap();
+        }
+
+        Component::resume(&mut algo).unwrap();
+
+        assert!(algo.scheduled_orders.get(&primary_id).is_none());
+        assert_eq!(algo.clock().timer_count(), 0);
+    }
+
+    #[rstest]
+    fn test_twap_on_resume_completes_missing_primary() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+        add_instrument_to_cache(&algo);
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("60"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("20"));
+
+        let order = create_market_order_with_params_and_qty(params, Quantity::from("1.2"));
+        let primary_id = order.client_order_id();
+        algo.on_order(order).unwrap();
+        Component::stop(&mut algo).unwrap();
+
+        {
+            let cache_rc = algo.core.cache_rc();
+            let mut cache = cache_rc.borrow_mut();
+            let primary = cache.order(&primary_id).map(|order| order.clone()).unwrap();
+            let canceled = OrderCanceledSpec::builder()
+                .trader_id(primary.trader_id())
+                .strategy_id(primary.strategy_id())
+                .instrument_id(primary.instrument_id())
+                .client_order_id(primary.client_order_id())
+                .build();
+            cache
+                .update_order(&OrderEventAny::Canceled(canceled))
+                .unwrap();
+            cache.purge_order(primary_id);
+        }
+
+        assert!(algo.cache().order(&primary_id).is_none());
+        Component::resume(&mut algo).unwrap();
+
+        assert!(algo.scheduled_orders.get(&primary_id).is_none());
+        assert_eq!(algo.clock().timer_count(), 0);
     }
 
     #[rstest]
@@ -1184,7 +1450,11 @@ mod tests {
         algo.on_order(order).unwrap();
 
         // 3 / 0.5 = 6 intervals, first spawned immediately, 5 remaining (plus possible remainder)
-        let remaining = algo.scheduled_sizes.get(&primary_id).unwrap();
+        let remaining = &algo
+            .scheduled_orders
+            .get(&primary_id)
+            .unwrap()
+            .remaining_sizes;
         assert!(remaining.len() >= 5);
     }
 
@@ -1246,7 +1516,7 @@ mod tests {
         algo.on_order(order).unwrap();
 
         // Should submit entire size directly (no scheduling)
-        assert!(algo.scheduled_sizes.get(&primary_id).is_none());
+        assert!(algo.scheduled_orders.get(&primary_id).is_none());
         assert_eq!(algo.core.submit_params(&primary_id), None);
     }
 
@@ -1283,7 +1553,7 @@ mod tests {
 
         algo.on_order(order).unwrap();
 
-        assert!(algo.scheduled_sizes.get(&primary_id).is_none());
+        assert!(algo.scheduled_orders.get(&primary_id).is_none());
         assert_eq!(algo.core.submit_params(&primary_id), None);
     }
 

--- a/crates/trading/src/python/algorithm.rs
+++ b/crates/trading/src/python/algorithm.rs
@@ -59,7 +59,7 @@ use crate::algorithm::{
     ImportableExecAlgorithmConfig,
 };
 
-/// Inner state of `PyExecutionAlgorithm`, shared between Python and Rust registries.
+/// Inner state of `PyExecutionAlgorithm`, shared by the Python and Rust registries.
 pub struct PyExecutionAlgorithmInner {
     core: ExecutionAlgorithmCore,
     py_self: Option<Py<PyWeakrefReference>>,
@@ -554,6 +554,7 @@ impl DataActor for PyExecutionAlgorithm {
     }
 
     fn on_resume(&mut self) -> anyhow::Result<()> {
+        ExecutionAlgorithm::on_resume(self)?;
         self.dispatch_no_args("on_resume")
             .map_err(|e| anyhow::anyhow!("Python on_resume failed: {e}"))
     }


### PR DESCRIPTION
`TwapAlgorithm` retains its remaining schedule across a stop, which is what the component contract asks for, but nothing ever resumes it.

## The missing half of the lifecycle

`on_stop` cancels the algorithm's clock timers and leaves `scheduled_sizes` populated. That is correct: `Component::stop` and `Component::resume` are distinct transitions, `on_reset` is the state-clearing operation, and `Controller` follows the same shape by deregistering its endpoint on stop and restoring it on resume.

What is absent is the resume half. `TwapAlgorithm` forwards `on_time_event`, `on_stop` and `on_reset` through its `DataActor` implementation and implements no `on_resume`, so a resume reaches the default handler, which logs that the handler was not overridden and returns. The timer that would deliver the remaining slices was cancelled on stop and nothing re-arms it, so the schedule is never delivered and `on_order` keeps rejecting that primary order ID with "already being executed".

The asymmetry is already visible at the Python boundary: `PyExecutionAlgorithm` calls `ExecutionAlgorithm::on_stop` and `on_reset` before dispatching to Python, while its `on_resume` only dispatches, because the trait has no resume hook to call.

`ExecutionAlgorithm` now carries a defaulted `on_resume`, forwarded from `DataActor` by `TwapAlgorithm` and called by the Python bridge alongside the other two. Being defaulted, it is not a breaking change for any implementor.

## Resuming at the original interval

`scheduled_sizes` held only quantities, so the interval had to come from somewhere on resume. It is now a `TwapSchedule` record holding the remaining sizes and the validated `Duration`, which keeps the schedule a complete description of what it takes to resume rather than requiring the cached primary's `exec_algorithm_params` to be reparsed.

`on_resume` walks the retained schedules and arms one repeating timer per live sequence at the stored interval. Because `set_timer` first fires one full interval after resume, slices whose nominal times passed while stopped are not delivered as a burst; the sequence continues at its original cadence and the effective horizon extends by the stopped duration. This is the only semantic the stored state supports, since no absolute per-slice deadlines are recorded, and it is the one I would argue for anyway. Say the word if you want elapsed slices treated as due instead and I will follow up.

A sequence whose primary is closed, missing from the cache, or out of remaining sizes is completed instead of re-armed. A primary that closes while stopped can then be purged by the periodic closed-order purge, and a schedule left behind for an order that no longer exists would block its ID permanently. `on_time_event` gets the same treatment for the same reason: it previously logged the missing primary and returned, leaving the schedule in place.

`on_start` is untouched. The component FSM permits `Ready -> Start` and `Stopped -> Resume` but not `Stopped -> Start`, so restoring schedules there would only obscure an invalid transition.

## Testing

Resume arms exactly one timer whose next fire time equals the resume timestamp plus one interval, submits no `SubmitOrder` (observed on the risk-engine command endpoint, since resubmitting the already-cached primary would leave the order count unchanged), and consumes no slice. Advancing the clock one interval then delivers the next slice, and the following interval completes the sequence. Resume with a closed primary, and with a purged one, clears the schedule and arms nothing; the timer path is covered separately for the missing case.

Two tests pin contracts this change deliberately does not move: stop still retains the schedule while cancelling timers, and reset still clears it. Those two pass against the unfixed code, which is the point of them - they guard against the two tempting alternatives, clearing on stop or retaining through reset. Every other new assertion fails against the unfixed code.
