### PR TITLE
Expose submit order handoff outcome

### DIFF
--- a/crates/trading/src/lib.rs
+++ b/crates/trading/src/lib.rs
@@ -112,7 +112,7 @@ pub use algorithm::{
 pub use controller::ImportableControllerConfig;
 pub use strategy::{
     ImportableStrategyConfig, Strategy, StrategyConfig, StrategyCore, StrategyNative,
-    SubmitOrderError, SubmitOrderHandoff,
+    StrategySubmitOrderExt, SubmitOrderError, SubmitOrderHandoff,
 };
 
 #[cfg(feature = "python")]

--- a/crates/trading/src/lib.rs
+++ b/crates/trading/src/lib.rs
@@ -112,6 +112,7 @@ pub use algorithm::{
 pub use controller::ImportableControllerConfig;
 pub use strategy::{
     ImportableStrategyConfig, Strategy, StrategyConfig, StrategyCore, StrategyNative,
+    SubmitOrderError, SubmitOrderHandoff,
 };
 
 #[cfg(feature = "python")]

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -65,6 +65,63 @@ pub type BatchModifyOrder = (
     Option<Price>,
 );
 
+/// Describes whether an order submission crossed into NT command routing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SubmitOrderHandoff {
+    /// No command was handed to an NT execution route.
+    NotHandedOff,
+    /// The command was handed to an NT execution route.
+    HandedOff {
+        /// The routed command identifier.
+        command_id: UUID4,
+    },
+}
+
+/// Error returned when order submission fails before or after NT command routing.
+#[derive(Debug)]
+pub struct SubmitOrderError {
+    handoff: SubmitOrderHandoff,
+    source: anyhow::Error,
+}
+
+impl SubmitOrderError {
+    /// Creates an error for a submission which did not enter NT command routing.
+    #[must_use]
+    pub fn not_handed_off(source: anyhow::Error) -> Self {
+        Self {
+            handoff: SubmitOrderHandoff::NotHandedOff,
+            source,
+        }
+    }
+
+    /// Creates an error for a submission which entered NT command routing.
+    #[must_use]
+    pub fn handed_off(command_id: UUID4, source: anyhow::Error) -> Self {
+        Self {
+            handoff: SubmitOrderHandoff::HandedOff { command_id },
+            source,
+        }
+    }
+
+    /// Returns whether the command crossed into NT routing before the failure.
+    #[must_use]
+    pub const fn handoff(&self) -> SubmitOrderHandoff {
+        self.handoff
+    }
+}
+
+impl std::fmt::Display for SubmitOrderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(f)
+    }
+}
+
+impl std::error::Error for SubmitOrderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
 /// Core trait for implementing trading strategies in NautilusTrader.
 ///
 /// Strategies are specialized [`DataActor`]s that combine data ingestion capabilities with
@@ -150,17 +207,39 @@ pub trait Strategy: DataActor {
     where
         Self: StrategyNative,
     {
+        self.submit_order_with_handoff(order, position_id, client_id, params)
+            .map(|_| ())
+            .map_err(Into::into)
+    }
+
+    /// Submits an order and reports whether it crossed into NT command routing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error carrying the handoff state if the strategy is not registered or order
+    /// submission fails.
+    fn submit_order_with_handoff(
+        &mut self,
+        order: OrderAny,
+        position_id: Option<PositionId>,
+        client_id: Option<ClientId>,
+        params: Option<Params>,
+    ) -> Result<SubmitOrderHandoff, SubmitOrderError>
+    where
+        Self: StrategyNative,
+    {
         let core = StrategyNative::strategy_core_mut(self);
 
-        let trader_id = registered_trader_id(core)?;
-        let strategy_id = registered_strategy_id(core)?;
+        let trader_id = registered_trader_id(core).map_err(SubmitOrderError::not_handed_off)?;
+        let strategy_id =
+            registered_strategy_id(core).map_err(SubmitOrderError::not_handed_off)?;
         let ts_init = core.clock_mut().timestamp_ns();
 
         if order.status() != OrderStatus::Initialized {
-            anyhow::bail!(
+            return Err(SubmitOrderError::not_handed_off(anyhow::anyhow!(
                 "Order denied: invalid status for {}, expected INITIALIZED",
                 order.client_order_id()
-            );
+            )));
         }
 
         let market_exit_tag = core.market_exit_tag;
@@ -172,7 +251,7 @@ pub trait Strategy: DataActor {
 
         if should_deny_for_market_exit {
             self.deny_order(&order, Ustr::from("MARKET_EXIT_IN_PROGRESS"));
-            return Ok(());
+            return Ok(SubmitOrderHandoff::NotHandedOff);
         }
 
         let core = StrategyNative::strategy_core_mut(self);
@@ -181,12 +260,14 @@ pub trait Strategy: DataActor {
         {
             let cache_rc = core.cache_rc();
             let mut cache = cache_rc.try_borrow_mut().map_err(|_| {
-                anyhow::anyhow!(
+                SubmitOrderError::not_handed_off(anyhow::anyhow!(
                     "Cannot submit order {}: cache is currently borrowed",
                     order.client_order_id()
-                )
+                ))
             })?;
-            cache.add_order(order.clone(), position_id, client_id, true)?;
+            cache
+                .add_order(order.clone(), position_id, client_id, true)
+                .map_err(SubmitOrderError::not_handed_off)?;
         }
 
         publish_order_initialized(&order);
@@ -205,6 +286,7 @@ pub trait Strategy: DataActor {
             ts_init,
             None, // correlation_id
         );
+        let command_id = command.command_id;
 
         if matches!(order.emulation_trigger(), Some(trigger) if trigger != TriggerType::NoTrigger) {
             send_emulator_command(TradingCommand::SubmitOrder(command));
@@ -214,8 +296,9 @@ pub trait Strategy: DataActor {
             send_risk_command(TradingCommand::SubmitOrder(command));
         }
 
-        self.set_gtd_expiry(&order)?;
-        Ok(())
+        self.set_gtd_expiry(&order)
+            .map_err(|source| SubmitOrderError::handed_off(command_id, source))?;
+        Ok(SubmitOrderHandoff::HandedOff { command_id })
     }
 
     /// Submits an order list.
@@ -2929,6 +3012,7 @@ mod tests {
         let cache_rc = strategy.core.cache_rc();
         let timeline = Rc::new(RefCell::new(Vec::new()));
         let event_messages = Rc::new(RefCell::new(Vec::new()));
+        let routed_command_id = Rc::new(RefCell::new(None));
 
         let event_handler = {
             let event_messages = event_messages.clone();
@@ -2942,10 +3026,14 @@ mod tests {
         };
         let risk_handler = {
             let timeline = timeline.clone();
+            let routed_command_id = routed_command_id.clone();
             TypedIntoHandler::from_with_id(
                 "RiskEngine.queue_execute",
                 move |command: TradingCommand| {
-                    assert!(matches!(command, TradingCommand::SubmitOrder(_)));
+                    let TradingCommand::SubmitOrder(command) = command else {
+                        panic!("expected SubmitOrder command");
+                    };
+                    *routed_command_id.borrow_mut() = Some(command.command_id);
                     timeline.borrow_mut().push("command");
                 },
             )
@@ -2958,8 +3046,8 @@ mod tests {
         let topic = format!("events.order.{}", order.strategy_id());
         msgbus::subscribe_order_events(topic.clone().into(), event_handler.clone(), None);
 
-        strategy
-            .submit_order(order.clone(), None, None, None)
+        let handoff = strategy
+            .submit_order_with_handoff(order.clone(), None, None, None)
             .unwrap();
 
         msgbus::unsubscribe_order_events(topic.into(), &event_handler);
@@ -2971,6 +3059,12 @@ mod tests {
             OrderEventAny::Initialized(order.init_event().clone())
         );
         assert_eq!(timeline.borrow().as_slice(), &["init", "command"]);
+        assert_eq!(
+            handoff,
+            SubmitOrderHandoff::HandedOff {
+                command_id: routed_command_id.borrow().unwrap(),
+            },
+        );
     }
 
     #[rstest]
@@ -3019,11 +3113,70 @@ mod tests {
         let order = make_initialized_market_order("O-20250208-UNREGISTERED-001");
 
         let err = strategy
-            .submit_order(order, None, None, None)
-            .unwrap_err()
-            .to_string();
+            .submit_order_with_handoff(order, None, None, None)
+            .unwrap_err();
 
-        assert_eq!(err, "Strategy not registered: trader_id is not set");
+        assert_eq!(err.handoff(), SubmitOrderHandoff::NotHandedOff);
+        assert_eq!(
+            err.to_string(),
+            "Strategy not registered: trader_id is not set"
+        );
+    }
+
+    #[rstest]
+    fn test_submit_order_error_reports_handoff_after_command_routing() {
+        let config = StrategyConfig {
+            strategy_id: Some(StrategyId::from("TEST-001")),
+            order_id_tag: Some("001".to_string()),
+            manage_gtd_expiry: true,
+            ..Default::default()
+        };
+        let mut strategy = TestStrategy::new(config);
+        let trader_id = TraderId::from("TRADER-001");
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let portfolio = Rc::new(RefCell::new(Portfolio::new(
+            clock.clone(),
+            cache.clone(),
+            None,
+        )));
+        strategy
+            .core
+            .register(trader_id, clock.clone(), cache, portfolio)
+            .unwrap();
+        strategy.initialize().unwrap();
+        clock.borrow_mut().cancel_callbacks();
+
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .instrument_id(InstrumentId::from("BTCUSDT.BINANCE"))
+            .client_order_id(ClientOrderId::from("O-20250208-GTD-HANDOFF-001"))
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from(100_000))
+            .price(Price::from("1.00000"))
+            .time_in_force(TimeInForce::Gtd)
+            .expire_time(UnixNanos::from(1))
+            .build();
+
+        let err = strategy
+            .submit_order_with_handoff(order, None, None, None)
+            .unwrap_err();
+        let commands = risk_messages.get_messages();
+        let Some(TradingCommand::SubmitOrder(command)) = commands.first() else {
+            panic!("expected routed SubmitOrder command");
+        };
+
+        assert_eq!(
+            err.handoff(),
+            SubmitOrderHandoff::HandedOff {
+                command_id: command.command_id,
+            },
+        );
     }
 
     #[rstest]
@@ -4684,11 +4837,11 @@ mod tests {
         let topic = format!("events.order.{}", order.strategy_id());
         msgbus::subscribe_order_events(topic.clone().into(), event_handler.clone(), None);
         let client_order_id = order.client_order_id();
-        let result = strategy.submit_order(order.clone(), None, None, None);
+        let result = strategy.submit_order_with_handoff(order.clone(), None, None, None);
 
         msgbus::unsubscribe_order_events(topic.into(), &event_handler);
 
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), SubmitOrderHandoff::NotHandedOff,);
         let cache = strategy.cache();
         let cached_order = cache.order(&client_order_id).unwrap();
         assert_eq!(cached_order.status(), OrderStatus::Denied);

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -220,7 +220,7 @@ pub trait Strategy: DataActor {
             position_id,
             client_id,
             params,
-            |strategy, order, reason| strategy.deny_order(order, reason),
+            Self::deny_order,
         )
         .map(|_| ())
         .map_err(SubmitOrderError::into_source)

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -2606,6 +2606,11 @@ mod tests {
     }
 
     fn register_strategy(strategy: &mut TestStrategy) {
+        register_strategy_core(&mut strategy.core);
+        strategy.initialize().unwrap();
+    }
+
+    fn register_strategy_core(core: &mut StrategyCore) -> Rc<RefCell<TestClock>> {
         let trader_id = TraderId::from("TRADER-001");
         let clock = Rc::new(RefCell::new(TestClock::new()));
         let cache = Rc::new(RefCell::new(Cache::default()));
@@ -2615,11 +2620,9 @@ mod tests {
             None,
         )));
 
-        strategy
-            .core
-            .register(trader_id, clock, cache, portfolio)
+        core.register(trader_id, clock.clone(), cache, portfolio)
             .unwrap();
-        strategy.initialize().unwrap();
+        clock
     }
 
     fn start_strategy(strategy: &mut TestStrategy) {
@@ -3215,7 +3218,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_submit_order_handoff_extension_bypasses_legacy_override() {
+    fn test_submit_order_handoff_extension_bypasses_legacy_overrides() {
         let config = StrategyConfig {
             strategy_id: Some(StrategyId::from("TEST-001")),
             order_id_tag: Some("001".to_string()),
@@ -3224,19 +3227,13 @@ mod tests {
         let mut strategy = LegacySubmitOverrideStrategy {
             core: StrategyCore::new(config),
         };
-        let trader_id = TraderId::from("TRADER-001");
-        let clock = Rc::new(RefCell::new(TestClock::new()));
-        let cache = Rc::new(RefCell::new(Cache::default()));
-        let portfolio = Rc::new(RefCell::new(Portfolio::new(
-            clock.clone(),
-            cache.clone(),
-            None,
-        )));
-        strategy
-            .core
-            .register(trader_id, clock, cache, portfolio)
-            .unwrap();
+        register_strategy_core(&mut strategy.core);
         strategy.initialize().unwrap();
+
+        let legacy_order = make_initialized_market_order("O-20250208-LEGACY-FACADE-001");
+        let legacy_error =
+            Strategy::submit_order(&mut strategy, legacy_order, None, None, None).unwrap_err();
+        assert_eq!(legacy_error.to_string(), "legacy submit override called");
 
         let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
             get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
@@ -3265,31 +3262,7 @@ mod tests {
                 command_id: command.command_id,
             },
         );
-    }
 
-    #[rstest]
-    fn test_submit_order_handoff_extension_bypasses_legacy_denial_override() {
-        let config = StrategyConfig {
-            strategy_id: Some(StrategyId::from("TEST-001")),
-            order_id_tag: Some("001".to_string()),
-            ..Default::default()
-        };
-        let mut strategy = LegacySubmitOverrideStrategy {
-            core: StrategyCore::new(config),
-        };
-        let trader_id = TraderId::from("TRADER-001");
-        let clock = Rc::new(RefCell::new(TestClock::new()));
-        let cache = Rc::new(RefCell::new(Cache::default()));
-        let portfolio = Rc::new(RefCell::new(Portfolio::new(
-            clock.clone(),
-            cache.clone(),
-            None,
-        )));
-        strategy
-            .core
-            .register(trader_id, clock, cache, portfolio)
-            .unwrap();
-        strategy.initialize().unwrap();
         strategy.core.is_exiting = true;
         let order = make_initialized_market_order("O-20250208-LEGACY-DENY-001");
 
@@ -3314,18 +3287,7 @@ mod tests {
             ..Default::default()
         };
         let mut strategy = TestStrategy::new(config);
-        let trader_id = TraderId::from("TRADER-001");
-        let clock = Rc::new(RefCell::new(TestClock::new()));
-        let cache = Rc::new(RefCell::new(Cache::default()));
-        let portfolio = Rc::new(RefCell::new(Portfolio::new(
-            clock.clone(),
-            cache.clone(),
-            None,
-        )));
-        strategy
-            .core
-            .register(trader_id, clock.clone(), cache, portfolio)
-            .unwrap();
+        let clock = register_strategy_core(&mut strategy.core);
         strategy.initialize().unwrap();
         clock.borrow_mut().cancel_callbacks();
 

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -1982,75 +1982,7 @@ pub trait Strategy: DataActor {
     where
         Self: StrategyNative,
     {
-        let core = StrategyNative::strategy_core_mut(self);
-        let Some(trader_id) = core.trader_id() else {
-            log::error!(
-                "Cannot deny order {}: trader_id is not set",
-                order.client_order_id()
-            );
-            return;
-        };
-        let Some(strategy_id) = core.strategy_id() else {
-            log::error!(
-                "Cannot deny order {}: strategy_id is not set",
-                order.client_order_id()
-            );
-            return;
-        };
-        let ts_now = core.clock_mut().timestamp_ns();
-
-        let event = OrderDenied::new(
-            trader_id,
-            strategy_id,
-            order.instrument_id(),
-            order.client_order_id(),
-            reason,
-            UUID4::new(),
-            ts_now,
-            ts_now,
-        );
-
-        log::warn!(
-            "{strategy_id} Order {} denied: {reason}",
-            order.client_order_id()
-        );
-
-        let publish_initialized = {
-            let cache_rc = core.cache_rc();
-            let mut cache = cache_rc.borrow_mut();
-            if cache.order_exists(&order.client_order_id()) {
-                false
-            } else {
-                match cache.add_order(order.clone(), None, None, true) {
-                    Ok(()) => true,
-                    Err(e) => {
-                        log::warn!("Failed to add denied order to cache: {e}");
-                        false
-                    }
-                }
-            }
-        };
-
-        if publish_initialized {
-            publish_order_initialized(order);
-        }
-
-        let event = OrderEventAny::Denied(event);
-        let applied = {
-            let cache_rc = core.cache_rc();
-            let mut cache = cache_rc.borrow_mut();
-            if let Err(e) = cache.update_order(&event) {
-                log::warn!("Failed to apply OrderDenied event: {e}");
-                false
-            } else {
-                true
-            }
-        };
-
-        if applied {
-            let topic = format!("events.order.{strategy_id}");
-            msgbus::publish_order_event(topic.into(), &event);
-        }
+        deny_order_impl(StrategyNative::strategy_core_mut(self), order, reason);
     }
 
     /// Denies all orders in an order list.
@@ -2286,7 +2218,11 @@ where
         core.is_exiting && !order.is_reduce_only() && !is_market_exit_order;
 
     if should_deny_for_market_exit {
-        strategy.deny_order(order, Ustr::from("MARKET_EXIT_IN_PROGRESS"));
+        deny_order_impl(
+            StrategyNative::strategy_core_mut(strategy),
+            order,
+            Ustr::from("MARKET_EXIT_IN_PROGRESS"),
+        );
         return Ok(SubmitOrderHandoff::NotHandedOff);
     }
 
@@ -2336,6 +2272,77 @@ where
         .set_gtd_expiry(order)
         .map_err(|source| SubmitOrderError::handed_off(command_id, source))?;
     Ok(SubmitOrderHandoff::HandedOff { command_id })
+}
+
+fn deny_order_impl(core: &mut StrategyCore, order: &OrderAny, reason: Ustr) {
+    let Some(trader_id) = core.trader_id() else {
+        log::error!(
+            "Cannot deny order {}: trader_id is not set",
+            order.client_order_id()
+        );
+        return;
+    };
+    let Some(strategy_id) = core.strategy_id() else {
+        log::error!(
+            "Cannot deny order {}: strategy_id is not set",
+            order.client_order_id()
+        );
+        return;
+    };
+    let ts_now = core.clock_mut().timestamp_ns();
+
+    let event = OrderDenied::new(
+        trader_id,
+        strategy_id,
+        order.instrument_id(),
+        order.client_order_id(),
+        reason,
+        UUID4::new(),
+        ts_now,
+        ts_now,
+    );
+
+    log::warn!(
+        "{strategy_id} Order {} denied: {reason}",
+        order.client_order_id()
+    );
+
+    let publish_initialized = {
+        let cache_rc = core.cache_rc();
+        let mut cache = cache_rc.borrow_mut();
+        if cache.order_exists(&order.client_order_id()) {
+            false
+        } else {
+            match cache.add_order(order.clone(), None, None, true) {
+                Ok(()) => true,
+                Err(e) => {
+                    log::warn!("Failed to add denied order to cache: {e}");
+                    false
+                }
+            }
+        }
+    };
+
+    if publish_initialized {
+        publish_order_initialized(order);
+    }
+
+    let event = OrderEventAny::Denied(event);
+    let applied = {
+        let cache_rc = core.cache_rc();
+        let mut cache = cache_rc.borrow_mut();
+        if let Err(e) = cache.update_order(&event) {
+            log::warn!("Failed to apply OrderDenied event: {e}");
+            false
+        } else {
+            true
+        }
+    };
+
+    if applied {
+        let topic = format!("events.order.{strategy_id}");
+        msgbus::publish_order_event(topic.into(), &event);
+    }
 }
 
 fn publish_order_initialized(order: &OrderAny) {
@@ -2515,6 +2522,10 @@ mod tests {
             _params: Option<Params>,
         ) -> anyhow::Result<()> {
             anyhow::bail!("legacy submit override called")
+        }
+
+        fn deny_order(&mut self, _order: &OrderAny, _reason: Ustr) {
+            panic!("legacy deny override called")
         }
     });
 
@@ -3254,6 +3265,44 @@ mod tests {
                 command_id: command.command_id,
             },
         );
+    }
+
+    #[rstest]
+    fn test_submit_order_handoff_extension_bypasses_legacy_denial_override() {
+        let config = StrategyConfig {
+            strategy_id: Some(StrategyId::from("TEST-001")),
+            order_id_tag: Some("001".to_string()),
+            ..Default::default()
+        };
+        let mut strategy = LegacySubmitOverrideStrategy {
+            core: StrategyCore::new(config),
+        };
+        let trader_id = TraderId::from("TRADER-001");
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let portfolio = Rc::new(RefCell::new(Portfolio::new(
+            clock.clone(),
+            cache.clone(),
+            None,
+        )));
+        strategy
+            .core
+            .register(trader_id, clock, cache, portfolio)
+            .unwrap();
+        strategy.initialize().unwrap();
+        strategy.core.is_exiting = true;
+        let order = make_initialized_market_order("O-20250208-LEGACY-DENY-001");
+
+        let handoff = StrategySubmitOrderExt::submit_order_with_handoff(
+            &mut strategy,
+            order,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(handoff, SubmitOrderHandoff::NotHandedOff);
     }
 
     #[rstest]

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -214,9 +214,16 @@ pub trait Strategy: DataActor {
     where
         Self: StrategyNative,
     {
-        submit_order_with_handoff_impl(self, &order, position_id, client_id, params)
-            .map(|_| ())
-            .map_err(SubmitOrderError::into_source)
+        submit_order_with_handoff_impl(
+            self,
+            &order,
+            position_id,
+            client_id,
+            params,
+            |strategy, order, reason| strategy.deny_order(order, reason),
+        )
+        .map(|_| ())
+        .map_err(SubmitOrderError::into_source)
     }
 
     /// Submits an order list.
@@ -2183,19 +2190,30 @@ where
         client_id: Option<ClientId>,
         params: Option<Params>,
     ) -> Result<SubmitOrderHandoff, SubmitOrderError> {
-        submit_order_with_handoff_impl(self, &order, position_id, client_id, params)
+        submit_order_with_handoff_impl(
+            self,
+            &order,
+            position_id,
+            client_id,
+            params,
+            |strategy, order, reason| {
+                deny_order_impl(StrategyNative::strategy_core_mut(strategy), order, reason);
+            },
+        )
     }
 }
 
-fn submit_order_with_handoff_impl<S>(
+fn submit_order_with_handoff_impl<S, D>(
     strategy: &mut S,
     order: &OrderAny,
     position_id: Option<PositionId>,
     client_id: Option<ClientId>,
     params: Option<Params>,
+    deny_order: D,
 ) -> Result<SubmitOrderHandoff, SubmitOrderError>
 where
     S: Strategy + StrategyNative + ?Sized,
+    D: FnOnce(&mut S, &OrderAny, Ustr),
 {
     let core = StrategyNative::strategy_core_mut(strategy);
 
@@ -2218,11 +2236,7 @@ where
         core.is_exiting && !order.is_reduce_only() && !is_market_exit_order;
 
     if should_deny_for_market_exit {
-        deny_order_impl(
-            StrategyNative::strategy_core_mut(strategy),
-            order,
-            Ustr::from("MARKET_EXIT_IN_PROGRESS"),
-        );
+        deny_order(strategy, order, Ustr::from("MARKET_EXIT_IN_PROGRESS"));
         return Ok(SubmitOrderHandoff::NotHandedOff);
     }
 
@@ -2478,6 +2492,12 @@ mod tests {
         core: StrategyCore,
     }
 
+    #[derive(Debug)]
+    struct LegacyDenialOverrideStrategy {
+        core: StrategyCore,
+        denial_called: bool,
+    }
+
     impl Component for CoreFreeStrategy {
         fn component_id(&self) -> ComponentId {
             ComponentId::new("CoreFreeStrategy")
@@ -2526,6 +2546,14 @@ mod tests {
 
         fn deny_order(&mut self, _order: &OrderAny, _reason: Ustr) {
             panic!("legacy deny override called")
+        }
+    });
+
+    impl DataActor for LegacyDenialOverrideStrategy {}
+
+    nautilus_strategy!(LegacyDenialOverrideStrategy, {
+        fn deny_order(&mut self, _order: &OrderAny, _reason: Ustr) {
+            self.denial_called = true;
         }
     });
 
@@ -3276,6 +3304,40 @@ mod tests {
         .unwrap();
 
         assert_eq!(handoff, SubmitOrderHandoff::NotHandedOff);
+    }
+
+    #[rstest]
+    fn test_submit_order_facades_classify_legacy_denial_override_explicitly() {
+        let config = StrategyConfig {
+            strategy_id: Some(StrategyId::from("TEST-001")),
+            order_id_tag: Some("001".to_string()),
+            ..Default::default()
+        };
+        let mut strategy = LegacyDenialOverrideStrategy {
+            core: StrategyCore::new(config),
+            denial_called: false,
+        };
+        register_strategy_core(&mut strategy.core);
+        strategy.initialize().unwrap();
+        strategy.core.is_exiting = true;
+
+        let legacy_order = make_initialized_market_order("O-20250208-LEGACY-DENY-FACADE-001");
+        Strategy::submit_order(&mut strategy, legacy_order, None, None, None).unwrap();
+        assert!(strategy.denial_called);
+
+        strategy.denial_called = false;
+        let canonical_order = make_initialized_market_order("O-20250208-CANONICAL-DENY-001");
+        let handoff = StrategySubmitOrderExt::submit_order_with_handoff(
+            &mut strategy,
+            canonical_order,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(handoff, SubmitOrderHandoff::NotHandedOff);
+        assert!(!strategy.denial_called);
     }
 
     #[rstest]

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -108,6 +108,12 @@ impl SubmitOrderError {
     pub const fn handoff(&self) -> SubmitOrderHandoff {
         self.handoff
     }
+
+    /// Returns the original submission error without adding a wrapper layer.
+    #[must_use]
+    pub fn into_source(self) -> anyhow::Error {
+        self.source
+    }
 }
 
 impl std::fmt::Display for SubmitOrderError {
@@ -118,7 +124,8 @@ impl std::fmt::Display for SubmitOrderError {
 
 impl std::error::Error for SubmitOrderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.source.as_ref())
+        let source: &(dyn std::error::Error + 'static) = self.source.as_ref();
+        source.source()
     }
 }
 
@@ -207,98 +214,9 @@ pub trait Strategy: DataActor {
     where
         Self: StrategyNative,
     {
-        self.submit_order_with_handoff(order, position_id, client_id, params)
+        submit_order_with_handoff_impl(self, &order, position_id, client_id, params)
             .map(|_| ())
-            .map_err(Into::into)
-    }
-
-    /// Submits an order and reports whether it crossed into NT command routing.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error carrying the handoff state if the strategy is not registered or order
-    /// submission fails.
-    fn submit_order_with_handoff(
-        &mut self,
-        order: OrderAny,
-        position_id: Option<PositionId>,
-        client_id: Option<ClientId>,
-        params: Option<Params>,
-    ) -> Result<SubmitOrderHandoff, SubmitOrderError>
-    where
-        Self: StrategyNative,
-    {
-        let core = StrategyNative::strategy_core_mut(self);
-
-        let trader_id = registered_trader_id(core).map_err(SubmitOrderError::not_handed_off)?;
-        let strategy_id =
-            registered_strategy_id(core).map_err(SubmitOrderError::not_handed_off)?;
-        let ts_init = core.clock_mut().timestamp_ns();
-
-        if order.status() != OrderStatus::Initialized {
-            return Err(SubmitOrderError::not_handed_off(anyhow::anyhow!(
-                "Order denied: invalid status for {}, expected INITIALIZED",
-                order.client_order_id()
-            )));
-        }
-
-        let market_exit_tag = core.market_exit_tag;
-        let is_market_exit_order = order
-            .tags()
-            .is_some_and(|tags| tags.contains(&market_exit_tag));
-        let should_deny_for_market_exit =
-            core.is_exiting && !order.is_reduce_only() && !is_market_exit_order;
-
-        if should_deny_for_market_exit {
-            self.deny_order(&order, Ustr::from("MARKET_EXIT_IN_PROGRESS"));
-            return Ok(SubmitOrderHandoff::NotHandedOff);
-        }
-
-        let core = StrategyNative::strategy_core_mut(self);
-        let params = params.filter(|params| !params.is_empty());
-
-        {
-            let cache_rc = core.cache_rc();
-            let mut cache = cache_rc.try_borrow_mut().map_err(|_| {
-                SubmitOrderError::not_handed_off(anyhow::anyhow!(
-                    "Cannot submit order {}: cache is currently borrowed",
-                    order.client_order_id()
-                ))
-            })?;
-            cache
-                .add_order(order.clone(), position_id, client_id, true)
-                .map_err(SubmitOrderError::not_handed_off)?;
-        }
-
-        publish_order_initialized(&order);
-
-        let command = SubmitOrder::new(
-            trader_id,
-            client_id,
-            strategy_id,
-            order.instrument_id(),
-            order.client_order_id(),
-            order.init_event().clone(),
-            order.exec_algorithm_id(),
-            position_id,
-            params,
-            UUID4::new(),
-            ts_init,
-            None, // correlation_id
-        );
-        let command_id = command.command_id;
-
-        if matches!(order.emulation_trigger(), Some(trigger) if trigger != TriggerType::NoTrigger) {
-            send_emulator_command(TradingCommand::SubmitOrder(command));
-        } else if let Some(exec_algorithm_id) = order.exec_algorithm_id() {
-            send_algo_command(command, exec_algorithm_id);
-        } else {
-            send_risk_command(TradingCommand::SubmitOrder(command));
-        }
-
-        self.set_gtd_expiry(&order)
-            .map_err(|source| SubmitOrderError::handed_off(command_id, source))?;
-        Ok(SubmitOrderHandoff::HandedOff { command_id })
+            .map_err(SubmitOrderError::into_source)
     }
 
     /// Submits an order list.
@@ -2293,6 +2211,133 @@ pub trait Strategy: DataActor {
     }
 }
 
+mod strategy_submit_order_sealed {
+    pub trait Sealed {}
+
+    impl<T> Sealed for T where T: super::Strategy + super::StrategyNative + ?Sized {}
+}
+
+/// Adds the canonical NT submit operation with explicit command-handoff reporting.
+///
+/// This extension is blanket-implemented and sealed so strategy implementations cannot replace
+/// the handoff classification. It invokes the standard NT implementation directly rather than an
+/// override of the legacy [`Strategy::submit_order`] facade.
+pub trait StrategySubmitOrderExt:
+    Strategy + StrategyNative + strategy_submit_order_sealed::Sealed
+{
+    /// Submits an order and reports whether it crossed into NT command routing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error carrying the handoff state if the strategy is not registered or order
+    /// submission fails.
+    fn submit_order_with_handoff(
+        &mut self,
+        order: OrderAny,
+        position_id: Option<PositionId>,
+        client_id: Option<ClientId>,
+        params: Option<Params>,
+    ) -> Result<SubmitOrderHandoff, SubmitOrderError>;
+}
+
+impl<T> StrategySubmitOrderExt for T
+where
+    T: Strategy + StrategyNative + ?Sized,
+{
+    fn submit_order_with_handoff(
+        &mut self,
+        order: OrderAny,
+        position_id: Option<PositionId>,
+        client_id: Option<ClientId>,
+        params: Option<Params>,
+    ) -> Result<SubmitOrderHandoff, SubmitOrderError> {
+        submit_order_with_handoff_impl(self, &order, position_id, client_id, params)
+    }
+}
+
+fn submit_order_with_handoff_impl<S>(
+    strategy: &mut S,
+    order: &OrderAny,
+    position_id: Option<PositionId>,
+    client_id: Option<ClientId>,
+    params: Option<Params>,
+) -> Result<SubmitOrderHandoff, SubmitOrderError>
+where
+    S: Strategy + StrategyNative + ?Sized,
+{
+    let core = StrategyNative::strategy_core_mut(strategy);
+
+    let trader_id = registered_trader_id(core).map_err(SubmitOrderError::not_handed_off)?;
+    let strategy_id = registered_strategy_id(core).map_err(SubmitOrderError::not_handed_off)?;
+    let ts_init = core.clock_mut().timestamp_ns();
+
+    if order.status() != OrderStatus::Initialized {
+        return Err(SubmitOrderError::not_handed_off(anyhow::anyhow!(
+            "Order denied: invalid status for {}, expected INITIALIZED",
+            order.client_order_id()
+        )));
+    }
+
+    let market_exit_tag = core.market_exit_tag;
+    let is_market_exit_order = order
+        .tags()
+        .is_some_and(|tags| tags.contains(&market_exit_tag));
+    let should_deny_for_market_exit =
+        core.is_exiting && !order.is_reduce_only() && !is_market_exit_order;
+
+    if should_deny_for_market_exit {
+        strategy.deny_order(order, Ustr::from("MARKET_EXIT_IN_PROGRESS"));
+        return Ok(SubmitOrderHandoff::NotHandedOff);
+    }
+
+    let core = StrategyNative::strategy_core_mut(strategy);
+    let params = params.filter(|params| !params.is_empty());
+
+    {
+        let cache_rc = core.cache_rc();
+        let mut cache = cache_rc.try_borrow_mut().map_err(|_| {
+            SubmitOrderError::not_handed_off(anyhow::anyhow!(
+                "Cannot submit order {}: cache is currently borrowed",
+                order.client_order_id()
+            ))
+        })?;
+        cache
+            .add_order((*order).clone(), position_id, client_id, true)
+            .map_err(SubmitOrderError::not_handed_off)?;
+    }
+
+    publish_order_initialized(order);
+
+    let command = SubmitOrder::new(
+        trader_id,
+        client_id,
+        strategy_id,
+        order.instrument_id(),
+        order.client_order_id(),
+        order.init_event().clone(),
+        order.exec_algorithm_id(),
+        position_id,
+        params,
+        UUID4::new(),
+        ts_init,
+        None, // correlation_id
+    );
+    let command_id = command.command_id;
+
+    if matches!(order.emulation_trigger(), Some(trigger) if trigger != TriggerType::NoTrigger) {
+        send_emulator_command(TradingCommand::SubmitOrder(command));
+    } else if let Some(exec_algorithm_id) = order.exec_algorithm_id() {
+        send_algo_command(command, exec_algorithm_id);
+    } else {
+        send_risk_command(TradingCommand::SubmitOrder(command));
+    }
+
+    strategy
+        .set_gtd_expiry(order)
+        .map_err(|source| SubmitOrderError::handed_off(command_id, source))?;
+    Ok(SubmitOrderHandoff::HandedOff { command_id })
+}
+
 fn publish_order_initialized(order: &OrderAny) {
     let topic = format!("events.order.{}", order.strategy_id());
     let event = OrderEventAny::Initialized(order.init_event().clone());
@@ -2421,6 +2466,11 @@ mod tests {
         started: bool,
     }
 
+    #[derive(Debug)]
+    struct LegacySubmitOverrideStrategy {
+        core: StrategyCore,
+    }
+
     impl Component for CoreFreeStrategy {
         fn component_id(&self) -> ComponentId {
             ComponentId::new("CoreFreeStrategy")
@@ -2453,6 +2503,20 @@ mod tests {
     }
 
     impl Strategy for CoreFreeStrategy {}
+
+    impl DataActor for LegacySubmitOverrideStrategy {}
+
+    nautilus_strategy!(LegacySubmitOverrideStrategy, {
+        fn submit_order(
+            &mut self,
+            _order: OrderAny,
+            _position_id: Option<PositionId>,
+            _client_id: Option<ClientId>,
+            _params: Option<Params>,
+        ) -> anyhow::Result<()> {
+            anyhow::bail!("legacy submit override called")
+        }
+    });
 
     impl TestStrategy {
         fn new(config: StrategyConfig) -> Self {
@@ -3120,6 +3184,75 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "Strategy not registered: trader_id is not set"
+        );
+        assert!(std::error::Error::source(&err).is_none());
+    }
+
+    #[rstest]
+    fn test_submit_order_compatibility_wrapper_preserves_original_error() {
+        let mut strategy = create_test_strategy();
+        let order = make_initialized_market_order("O-20250208-UNREGISTERED-LEGACY-001");
+
+        let err = strategy.submit_order(order, None, None, None).unwrap_err();
+
+        assert_eq!(
+            format!("{err:#}"),
+            "Strategy not registered: trader_id is not set"
+        );
+        assert_eq!(err.chain().count(), 1);
+        assert!(err.is::<&str>());
+    }
+
+    #[rstest]
+    fn test_submit_order_handoff_extension_bypasses_legacy_override() {
+        let config = StrategyConfig {
+            strategy_id: Some(StrategyId::from("TEST-001")),
+            order_id_tag: Some("001".to_string()),
+            ..Default::default()
+        };
+        let mut strategy = LegacySubmitOverrideStrategy {
+            core: StrategyCore::new(config),
+        };
+        let trader_id = TraderId::from("TRADER-001");
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let portfolio = Rc::new(RefCell::new(Portfolio::new(
+            clock.clone(),
+            cache.clone(),
+            None,
+        )));
+        strategy
+            .core
+            .register(trader_id, clock, cache, portfolio)
+            .unwrap();
+        strategy.initialize().unwrap();
+
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let order = make_initialized_market_order("O-20250208-LEGACY-OVERRIDE-001");
+
+        let handoff = StrategySubmitOrderExt::submit_order_with_handoff(
+            &mut strategy,
+            order,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let commands = risk_messages.get_messages();
+        let Some(TradingCommand::SubmitOrder(command)) = commands.first() else {
+            panic!("expected routed SubmitOrder command");
+        };
+
+        assert_eq!(
+            handoff,
+            SubmitOrderHandoff::HandedOff {
+                command_id: command.command_id,
+            },
         );
     }
 
@@ -4835,6 +4968,12 @@ mod tests {
             None,
         ));
         let topic = format!("events.order.{}", order.strategy_id());
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
         msgbus::subscribe_order_events(topic.clone().into(), event_handler.clone(), None);
         let client_order_id = order.client_order_id();
         let result = strategy.submit_order_with_handoff(order.clone(), None, None, None);
@@ -4842,6 +4981,7 @@ mod tests {
         msgbus::unsubscribe_order_events(topic.into(), &event_handler);
 
         assert_eq!(result.unwrap(), SubmitOrderHandoff::NotHandedOff,);
+        assert!(risk_messages.get_messages().is_empty());
         let cache = strategy.cache();
         let cached_order = cache.order(&client_order_id).unwrap();
         assert_eq!(cached_order.status(), OrderStatus::Denied);

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -18,7 +18,10 @@ pub mod config;
 pub mod core;
 
 pub use core::{StrategyCore, StrategyNative};
-use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::{
+    fmt::Display,
+    panic::{AssertUnwindSafe, catch_unwind},
+};
 
 use ahash::AHashSet;
 pub use api::{OrderApi, PortfolioApi};
@@ -116,7 +119,7 @@ impl SubmitOrderError {
     }
 }
 
-impl std::fmt::Display for SubmitOrderError {
+impl Display for SubmitOrderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.source.fmt(f)
     }


### PR DESCRIPTION
## Summary

- add a typed submit API reporting whether an order crossed into NT command routing
- preserve the existing `Strategy::submit_order` signature, behavior, error identity, and legitimate overrides
- keep command construction and routing in one shared implementation
- seal the canonical handoff classification so downstream implementations cannot fabricate it

## Motivation

Callers that hold reservations or other submission authority need to distinguish a failure before routing from one after NT accepted the command for routing. The existing `anyhow::Result<()>` cannot express that boundary without callers duplicating NT execution behavior.

Closes #4790.

## Behavior

- `NotHandedOff` covers validation, cache, and market-exit denial paths before message-bus routing.
- `HandedOff { command_id }` covers successful routing and failures occurring afterward, including GTD timer setup.
- Handoff means entry into NT message-bus routing; it does not imply endpoint delivery or venue acceptance.
- The legacy facade returns the original `anyhow::Error`, preserving formatting, chains, type identity, and downcasting.

## Verification

- `cargo test -p nautilus-trading --lib`
- `cargo clippy -p nautilus-trading --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo doc -p nautilus-trading --no-deps`
- `git diff --check`

Behavior coverage includes pre-route denial with zero escaped commands, post-route failure, exact routed command IDs, legacy override compatibility, sealed canonical dispatch, and original error identity.
