### PR TITLE
Route an active-local modify to its execution algorithm

### DIFF
--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -322,7 +322,7 @@ pub trait ExecutionAlgorithm: DataActor {
     where
         Self: ExecutionAlgorithmNative,
     {
-        let order = {
+        let (is_closed, is_active_local) = {
             let cache = ExecutionAlgorithmNative::exec_algorithm_core_mut(self).cache_ref();
 
             let Some(order) = cache.order(&command.client_order_id) else {
@@ -333,15 +333,15 @@ pub trait ExecutionAlgorithm: DataActor {
                 return Ok(());
             };
 
-            order.clone()
+            (order.is_closed(), order.is_active_local())
         };
 
-        if order.is_closed() {
+        if is_closed {
             log::warn!("Order already closed for {command:?}");
             return Ok(());
         }
 
-        if order.is_active_local() {
+        if is_active_local {
             log::warn!(
                 "Cannot modify {}: order is being executed by this algorithm",
                 command.client_order_id

--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -141,6 +141,7 @@ pub trait ExecutionAlgorithm: DataActor {
                 let orders = core.get_orders_for_list(&cmd.order_list)?;
                 self.on_order_list(cmd.order_list, orders)
             }
+            TradingCommand::ModifyOrder(cmd) => self.handle_modify_order(cmd),
             TradingCommand::CancelOrder(cmd) => self.handle_cancel_order(cmd),
             _ => {
                 log::warn!("Unhandled command type: {command:?}");
@@ -307,6 +308,52 @@ pub trait ExecutionAlgorithm: DataActor {
             &event,
         );
 
+        Ok(())
+    }
+
+    /// Handles a modify order command for algorithm-managed orders.
+    ///
+    /// Active-local orders are left unchanged because the algorithm owns their execution state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if command handling fails.
+    fn handle_modify_order(&mut self, command: ModifyOrder) -> anyhow::Result<()>
+    where
+        Self: ExecutionAlgorithmNative,
+    {
+        let order = {
+            let cache = ExecutionAlgorithmNative::exec_algorithm_core_mut(self).cache_ref();
+
+            let Some(order) = cache.order(&command.client_order_id) else {
+                log::warn!(
+                    "Cannot modify order: {} not found in cache",
+                    command.client_order_id
+                );
+                return Ok(());
+            };
+
+            order.clone()
+        };
+
+        if order.is_closed() {
+            log::warn!("Order already closed for {command:?}");
+            return Ok(());
+        }
+
+        if order.is_active_local() {
+            log::warn!(
+                "Cannot modify {}: order is being executed by this algorithm",
+                command.client_order_id
+            );
+            return Ok(());
+        }
+
+        // A venue-active order is routed to the execution path, not here
+        log::warn!(
+            "Cannot modify {}: order is not active-local",
+            command.client_order_id
+        );
         Ok(())
     }
 
@@ -1499,6 +1546,12 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct ModifyDispatchAlgorithm {
+        core: ExecutionAlgorithmCore,
+        modify_client_order_ids: Vec<ClientOrderId>,
+    }
+
+    #[derive(Debug)]
     struct CoreFreeExecutionAlgorithm {
         orders_seen: usize,
     }
@@ -1539,6 +1592,28 @@ mod tests {
     nautilus_execution_algorithm!(TestAlgorithm, {
         fn on_order(&mut self, order: OrderAny) -> anyhow::Result<()> {
             self.order_client_ids.push(order.client_order_id());
+            Ok(())
+        }
+    });
+
+    impl ModifyDispatchAlgorithm {
+        fn new(config: ExecutionAlgorithmConfig) -> Self {
+            Self {
+                core: ExecutionAlgorithmCore::new(config),
+                modify_client_order_ids: Vec::new(),
+            }
+        }
+    }
+
+    impl DataActor for ModifyDispatchAlgorithm {}
+
+    nautilus_execution_algorithm!(ModifyDispatchAlgorithm, {
+        fn on_order(&mut self, _order: OrderAny) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn handle_modify_order(&mut self, command: ModifyOrder) -> anyhow::Result<()> {
+            self.modify_client_order_ids.push(command.client_order_id);
             Ok(())
         }
     });
@@ -2868,6 +2943,96 @@ mod tests {
         assert!(matches!(received[0], OrderEventAny::Canceled(_)));
         assert_eq!(received[0].client_order_id(), order.client_order_id());
         assert_eq!(received[0].instrument_id(), instrument_id);
+    }
+
+    #[rstest]
+    fn test_algorithm_execute_dispatches_modify_order_to_handler() {
+        let unique_id = format!("TEST-{}", UUID4::new());
+        let config = ExecutionAlgorithmConfig {
+            exec_algorithm_id: Some(ExecAlgorithmId::new(&unique_id)),
+            ..Default::default()
+        };
+        let mut algo = ModifyDispatchAlgorithm::new(config);
+        algo.core
+            .register(
+                TraderId::from("TRADER-001"),
+                Rc::new(RefCell::new(TestClock::new())),
+                Rc::new(RefCell::new(Cache::default())),
+            )
+            .unwrap();
+        algo.transition_state(ComponentTrigger::Initialize).unwrap();
+        algo.transition_state(ComponentTrigger::Start).unwrap();
+        algo.transition_state(ComponentTrigger::StartCompleted)
+            .unwrap();
+
+        let client_order_id = ClientOrderId::from("O-ALGO-DISPATCH");
+        let command = ModifyOrder::new(
+            TraderId::from("TRADER-001"),
+            None,
+            StrategyId::from("STRAT-ALGO-DISPATCH"),
+            InstrumentId::from("BTC/USDT.BINANCE"),
+            client_order_id,
+            None,
+            Some(Quantity::from("0.5")),
+            None,
+            None,
+            UUID4::new(),
+            0.into(),
+            None,
+            None,
+        );
+
+        algo.execute(TradingCommand::ModifyOrder(command)).unwrap();
+
+        assert_eq!(algo.modify_client_order_ids, vec![client_order_id]);
+    }
+
+    #[rstest]
+    fn test_algorithm_handle_modify_order_refuses_active_local_order_without_events() {
+        let mut algo = create_test_algorithm();
+        register_algorithm(&mut algo);
+
+        let strategy_id = StrategyId::from("STRAT-ALGO-MODIFY");
+        let order = OrderTestBuilder::new(OrderType::Market)
+            .trader_id(TraderId::from("TRADER-001"))
+            .strategy_id(strategy_id)
+            .instrument_id(InstrumentId::from("BTC/USDT.BINANCE"))
+            .client_order_id(ClientOrderId::from("O-ALGO-MODIFY"))
+            .quantity(Quantity::from("1.0"))
+            .exec_algorithm_id(algo.id())
+            .exec_spawn_id(ClientOrderId::from("O-ALGO-MODIFY"))
+            .build();
+        {
+            let cache_rc = algo.core.cache_rc();
+            cache_rc
+                .borrow_mut()
+                .add_order(order.clone(), None, None, false)
+                .unwrap();
+        }
+        let (handler, events) = subscribe_order_topic(strategy_id);
+        let command = ModifyOrder::new(
+            order.trader_id(),
+            None,
+            strategy_id,
+            order.instrument_id(),
+            order.client_order_id(),
+            None,
+            Some(Quantity::from("0.5")),
+            None,
+            None,
+            UUID4::new(),
+            0.into(),
+            None,
+            None,
+        );
+
+        algo.execute(TradingCommand::ModifyOrder(command)).unwrap();
+
+        msgbus::unsubscribe_order_events(format!("events.order.{strategy_id}").into(), &handler);
+        let cached_order = algo.cache().order(&order.client_order_id()).unwrap();
+        assert_eq!(cached_order.status(), OrderStatus::Initialized);
+        assert_eq!(cached_order.quantity(), Quantity::from("1.0"));
+        assert!(events.borrow().is_empty());
     }
 
     #[rstest]

--- a/crates/trading/src/algorithm/twap.rs
+++ b/crates/trading/src/algorithm/twap.rs
@@ -515,7 +515,7 @@ mod tests {
         clock::{Clock, TestClock},
         component::Component,
         enums::ComponentTrigger,
-        messages::execution::{SubmitOrder, TradingCommand},
+        messages::execution::{ModifyOrder, SubmitOrder, TradingCommand},
         msgbus::{self, MessagingSwitchboard, TypedHandler},
     };
     use nautilus_core::{Params, UUID4, UnixNanos};
@@ -927,6 +927,47 @@ mod tests {
         assert_eq!(primary.quantity(), Quantity::from("0.6"));
         assert_eq!(spawned.quantity(), Quantity::from("0.6"));
         assert_eq!(spawned.exec_spawn_id(), Some(primary_id));
+    }
+
+    #[rstest]
+    fn test_twap_refused_modify_preserves_remaining_quantity_schedule() {
+        let mut algo = create_twap_algorithm();
+        register_algorithm(&mut algo);
+        add_instrument_to_cache(&algo);
+
+        let mut params = IndexMap::new();
+        params.insert(Ustr::from("horizon_secs"), Ustr::from("60"));
+        params.insert(Ustr::from("interval_secs"), Ustr::from("20"));
+        let order = create_market_order_with_params_and_qty(params, Quantity::from("1.2"));
+        let primary_id = order.client_order_id();
+        algo.on_order(order).unwrap();
+
+        let command = ModifyOrder::new(
+            TraderId::from("TRADER-001"),
+            None,
+            StrategyId::from("STRAT-001"),
+            InstrumentId::from("ETHUSDT-PERP.BINANCE"),
+            primary_id,
+            None,
+            Some(Quantity::from("0.4")),
+            None,
+            None,
+            UUID4::new(),
+            0.into(),
+            None,
+            None,
+        );
+
+        algo.handle_modify_order(command).unwrap();
+
+        let primary_quantity = algo.cache().order(&primary_id).unwrap().quantity();
+        let scheduled_quantity = algo.scheduled_sizes[&primary_id]
+            .iter()
+            .fold(Decimal::ZERO, |total, quantity| {
+                total + quantity.as_decimal()
+            });
+        assert_eq!(primary_quantity.as_decimal(), scheduled_quantity);
+        assert_eq!(primary_quantity, Quantity::from("0.8"));
     }
 
     #[rstest]

--- a/crates/trading/src/algorithm/twap.rs
+++ b/crates/trading/src/algorithm/twap.rs
@@ -961,7 +961,8 @@ mod tests {
         algo.handle_modify_order(command).unwrap();
 
         let primary_quantity = algo.cache().order(&primary_id).unwrap().quantity();
-        let scheduled_quantity = algo.scheduled_sizes[&primary_id]
+        let scheduled_quantity = algo.scheduled_orders[&primary_id]
+            .remaining_sizes
             .iter()
             .fold(Decimal::ZERO, |total, quantity| {
                 total + quantity.as_decimal()

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -463,6 +463,12 @@ pub trait Strategy: DataActor {
 
         if order.is_emulated() {
             send_emulator_command(TradingCommand::ModifyOrder(command));
+        } else if let Some(algo_id) = order
+            .exec_algorithm_id()
+            .filter(|_| order.is_active_local())
+        {
+            let endpoint = format!("{algo_id}.execute");
+            msgbus::send_any(endpoint.into(), &TradingCommand::ModifyOrder(command));
         } else {
             send_risk_command(TradingCommand::ModifyOrder(command));
         }
@@ -2339,8 +2345,8 @@ mod tests {
         events::{
             OrderAccepted, OrderCanceled, OrderFilled, OrderRejected, PositionAdjusted,
             order::spec::{
-                OrderAcceptedSpec, OrderCanceledSpec, OrderExpiredSpec, OrderFillVoidedSpec,
-                OrderFilledSpec, OrderRejectedSpec,
+                OrderAcceptedSpec, OrderCanceledSpec, OrderEmulatedSpec, OrderExpiredSpec,
+                OrderFillVoidedSpec, OrderFilledSpec, OrderRejectedSpec,
             },
         },
         identifiers::{
@@ -2682,6 +2688,30 @@ mod tests {
             None,
             None,
             None,
+            None,
+        ))
+    }
+
+    fn make_initialized_algorithm_order(client_order_id: &str) -> OrderAny {
+        OrderAny::Market(MarketOrder::new(
+            TraderId::from("TRADER-001"),
+            StrategyId::from("TEST-001"),
+            InstrumentId::from("BTCUSDT.BINANCE"),
+            ClientOrderId::from(client_order_id),
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            TimeInForce::Gtc,
+            UUID4::new(),
+            UnixNanos::default(),
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            Some(ExecAlgorithmId::from("TWAP")),
+            None,
+            Some(ClientOrderId::from(client_order_id)),
             None,
         ))
     }
@@ -3471,6 +3501,172 @@ mod tests {
             Some(TradingCommand::ModifyOrder(_))
         ));
         assert!(exec_messages.is_empty());
+    }
+
+    #[rstest]
+    fn test_modify_order_routes_active_local_algorithm_order_to_algorithm() {
+        let mut strategy = create_test_strategy();
+        register_strategy(&mut strategy);
+
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let (exec_handler, exec_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("ExecEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::exec_engine_queue_execute(),
+            exec_handler,
+        );
+        let (algo_handler, algo_messages) =
+            get_any_saving_handler::<TradingCommand>(Some(Ustr::from("TWAP.execute")));
+        msgbus::register_any("TWAP.execute".into(), algo_handler);
+
+        let order = make_initialized_algorithm_order("O-20250208-ALGO-MODIFY-001");
+        add_order_to_cache(&strategy, &order);
+
+        strategy
+            .modify_order(
+                order.client_order_id(),
+                Some(Quantity::from(200_000)),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let algo_messages = algo_messages.get_messages();
+        assert_eq!(algo_messages.len(), 1);
+        assert!(matches!(
+            algo_messages.first(),
+            Some(TradingCommand::ModifyOrder(command))
+                if command.client_order_id == order.client_order_id()
+        ));
+        assert!(risk_messages.get_messages().is_empty());
+        assert!(exec_messages.get_messages().is_empty());
+    }
+
+    #[rstest]
+    fn test_modify_order_routes_accepted_algorithm_order_to_risk() {
+        let mut strategy = create_test_strategy();
+        register_strategy(&mut strategy);
+
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let (algo_handler, algo_messages) =
+            get_any_saving_handler::<TradingCommand>(Some(Ustr::from("TWAP.execute")));
+        msgbus::register_any("TWAP.execute".into(), algo_handler);
+
+        let mut order = make_initialized_algorithm_order("O-20250208-ALGO-MODIFY-002");
+        let account_id = AccountId::from("ACC-001");
+        order
+            .apply(TestOrderEventStubs::submitted(&order, account_id))
+            .unwrap();
+        order
+            .apply(TestOrderEventStubs::accepted(
+                &order,
+                account_id,
+                VenueOrderId::from("O-20250208-ALGO-MODIFY-002"),
+            ))
+            .unwrap();
+        add_order_to_cache(&strategy, &order);
+
+        strategy
+            .modify_order(
+                order.client_order_id(),
+                Some(Quantity::from(200_000)),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+
+        let risk_messages = risk_messages.get_messages();
+        assert_eq!(risk_messages.len(), 1);
+        assert!(matches!(
+            risk_messages.first(),
+            Some(TradingCommand::ModifyOrder(command))
+                if command.client_order_id == order.client_order_id()
+        ));
+        assert!(algo_messages.get_messages().is_empty());
+        assert_eq!(
+            strategy
+                .cache()
+                .order(&order.client_order_id())
+                .unwrap()
+                .status(),
+            OrderStatus::PendingUpdate
+        );
+    }
+
+    #[rstest]
+    fn test_modify_order_routes_emulated_order_to_order_emulator() {
+        let mut strategy = create_test_strategy();
+        register_strategy(&mut strategy);
+
+        let (emulator_handler, emulator_messages): (
+            _,
+            TypedIntoMessageSavingHandler<TradingCommand>,
+        ) = get_typed_into_message_saving_handler(Some(Ustr::from("OrderEmulator.execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::order_emulator_execute(),
+            emulator_handler,
+        );
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let mut order = OrderTestBuilder::new(OrderType::StopMarket)
+            .trader_id(TraderId::from("TRADER-001"))
+            .strategy_id(StrategyId::from("TEST-001"))
+            .instrument_id(InstrumentId::from("BTCUSDT.BINANCE"))
+            .client_order_id(ClientOrderId::from("O-20250208-EMULATED-MODIFY-001"))
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("51000.0"))
+            .quantity(Quantity::from(100_000))
+            .emulation_trigger(TriggerType::BidAsk)
+            .build();
+        order
+            .apply(OrderEventAny::Emulated(
+                OrderEmulatedSpec::builder()
+                    .trader_id(order.trader_id())
+                    .strategy_id(order.strategy_id())
+                    .instrument_id(order.instrument_id())
+                    .client_order_id(order.client_order_id())
+                    .build(),
+            ))
+            .unwrap();
+        add_order_to_cache(&strategy, &order);
+
+        strategy
+            .modify_order(
+                order.client_order_id(),
+                None,
+                None,
+                Some(Price::from("52000.0")),
+                None,
+                None,
+            )
+            .unwrap();
+
+        let emulator_messages = emulator_messages.get_messages();
+        assert_eq!(emulator_messages.len(), 1);
+        assert!(matches!(
+            emulator_messages.first(),
+            Some(TradingCommand::ModifyOrder(command))
+                if command.client_order_id == order.client_order_id()
+        ));
+        assert!(risk_messages.get_messages().is_empty());
     }
 
     #[rstest]

--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -3670,6 +3670,82 @@ mod tests {
     }
 
     #[rstest]
+    fn test_modify_order_prefers_emulator_over_algorithm_for_emulated_algorithm_order() {
+        let mut strategy = create_test_strategy();
+        register_strategy(&mut strategy);
+
+        let (emulator_handler, emulator_messages): (
+            _,
+            TypedIntoMessageSavingHandler<TradingCommand>,
+        ) = get_typed_into_message_saving_handler(Some(Ustr::from("OrderEmulator.execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::order_emulator_execute(),
+            emulator_handler,
+        );
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let (algo_handler, algo_messages) =
+            get_any_saving_handler::<TradingCommand>(Some(Ustr::from("TWAP.execute")));
+        msgbus::register_any("TWAP.execute".into(), algo_handler);
+
+        let mut order = OrderTestBuilder::new(OrderType::StopMarket)
+            .trader_id(TraderId::from("TRADER-001"))
+            .strategy_id(StrategyId::from("TEST-001"))
+            .instrument_id(InstrumentId::from("BTCUSDT.BINANCE"))
+            .client_order_id(ClientOrderId::from("O-20250208-EMULATED-ALGO-MODIFY-001"))
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("51000.0"))
+            .quantity(Quantity::from(100_000))
+            .emulation_trigger(TriggerType::BidAsk)
+            .exec_algorithm_id(ExecAlgorithmId::from("TWAP"))
+            .exec_spawn_id(ClientOrderId::from("O-20250208-EMULATED-ALGO-MODIFY-001"))
+            .build();
+        order
+            .apply(OrderEventAny::Emulated(
+                OrderEmulatedSpec::builder()
+                    .trader_id(order.trader_id())
+                    .strategy_id(order.strategy_id())
+                    .instrument_id(order.instrument_id())
+                    .client_order_id(order.client_order_id())
+                    .build(),
+            ))
+            .unwrap();
+
+        // An `Emulated` order satisfies both `is_emulated` and `is_active_local`, so this
+        // order matches the emulator branch and the algorithm branch at once.
+        assert!(order.is_emulated());
+        assert!(order.is_active_local());
+        assert!(order.exec_algorithm_id().is_some());
+
+        add_order_to_cache(&strategy, &order);
+
+        strategy
+            .modify_order(
+                order.client_order_id(),
+                None,
+                None,
+                Some(Price::from("52000.0")),
+                None,
+                None,
+            )
+            .unwrap();
+
+        let emulator_messages = emulator_messages.get_messages();
+        assert_eq!(emulator_messages.len(), 1);
+        assert!(matches!(
+            emulator_messages.first(),
+            Some(TradingCommand::ModifyOrder(command))
+                if command.client_order_id == order.client_order_id()
+        ));
+        assert!(algo_messages.get_messages().is_empty());
+        assert!(risk_messages.get_messages().is_empty());
+    }
+
+    #[rstest]
     fn test_modify_order_marks_order_pending_update_locally_before_send() {
         let mut strategy = create_test_strategy();
         register_strategy(&mut strategy);

--- a/docs/concepts/execution.md
+++ b/docs/concepts/execution.md
@@ -37,8 +37,9 @@ Commands follow different routes:
   `exec_algorithm_id` is set, and to the `RiskEngine` otherwise.
 - `submit_order_list(...)` follows the same branching behavior based on emulation and
   `exec_algorithm_id`.
-- `modify_order(...)` routes to the `OrderEmulator` for emulated orders and to the `RiskEngine`
-  otherwise.
+- `modify_order(...)` routes to the `OrderEmulator` for emulated orders, to an `ExecutionAlgorithm`
+  when the order has an `exec_algorithm_id` and is still active within the local system, and to the
+  `RiskEngine` otherwise.
 - Cancel and query commands can route directly to the `OrderEmulator`, `ExecutionAlgorithm`, or
   `ExecutionEngine`, depending on the command and order state.
 

--- a/docs/concepts/strategies.md
+++ b/docs/concepts/strategies.md
@@ -626,10 +626,15 @@ At least one value must differ from the original order for the command to be val
 The component a `ModifyOrder` command will flow to for execution depends on the following:
 
 - If the order is currently emulated, the command will *firstly* be sent to the `OrderEmulator`.
+- Otherwise, if the order has an `exec_algorithm_id` and is still active within the local system, the
+  command will be sent to the relevant `ExecutionAlgorithm`.
 - Otherwise, the order will *firstly* be sent to the `RiskEngine`.
 
 :::info
-Unlike `CancelOrder`, a `ModifyOrder` command never routes to an execution algorithm.
+An `ExecutionAlgorithm` refuses a `ModifyOrder` for a primary order that is still active locally, and
+logs a warning without emitting an event. The algorithm's schedule is keyed to the quantity it
+computed, so applying the modification in place would break that state; the primary order is left
+unchanged.
 :::
 
 The following shows how to modify the size of `LIMIT` BUY order currently *open* on a venue:


### PR DESCRIPTION
# Route an active-local modify to its execution algorithm

A follow-up to the TWAP execution-schedule work in #4786.

## Routing

`Strategy::submit_order` and `Strategy::cancel_order` both recognize that an execution algorithm owns its primary order while that order is active local: submit routes on `exec_algorithm_id`, and cancel routes on `exec_algorithm_id().filter(|_| order.is_active_local())`, both to the `{algo_id}.execute` endpoint. `Strategy::modify_order` branches only on `is_emulated()` and sends everything else to the risk engine. Since the primary has never reached the venue, `ExecutionEngine::handle_modify_order` - which applies no active-local guard - hands the command to the execution client for an order the venue does not know, while the algorithm's schedule is never told the quantity was meant to change.

The modify path now carries the same predicate as `cancel_order`. The emulator branch keeps precedence and everything else still falls through to the risk engine.

## Handling

`ExecutionAlgorithm::execute` matches `SubmitOrder`, `SubmitOrderList` and `CancelOrder`; `ModifyOrder` reaches the catch-all that logs `"Unhandled command type"` and returns `Ok(())`. Routing alone would exchange a command sent to the wrong destination for one that is silently dropped, so this adds a `ModifyOrder` arm and a `handle_modify_order` built like `handle_cancel_order`.

It refuses an active-local order: the algorithm holds private execution state keyed to the quantity it computed, and `TwapAlgorithm` maintains `primary.quantity == sum of the scheduled slice quantities` by reducing both together on every spawn. Applying an external modify in place breaks that equality, and a later slice can then exceed the primary's `leaves_qty` and trip the assertion in `reduce_primary_order`. Re-slicing instead would be new execution policy - what an updated quantity means for spawned or filled volume, cadence and horizon - rather than a routing repair. The handler emits no event, mutates no cache state and sends no downstream command. A venue-active order arriving at the algorithm endpoint is refused for the same reason: the endpoint is an ownership boundary, not a second route to risk.

The refusal is a logged no-op rather than an `OrderModifyRejected`, since no `PendingUpdate` precedes it - `mark_order_pending_update` already skips active-local orders - and there is no pending state for such an event to resolve.

## Testing

`test_modify_order_routes_active_local_algorithm_order_to_algorithm` asserts the command reaches `{algo_id}.execute` and that the risk and execution endpoints receive nothing. `test_modify_order_routes_accepted_algorithm_order_to_risk` pins the unchanged path for a venue-active order, including its `PendingUpdate`, and `test_modify_order_routes_emulated_order_to_order_emulator` pins the emulator branch; both pass against the unfixed code by design, since they guard behaviour this change must not move. `test_algorithm_execute_dispatches_modify_order_to_handler` drives `execute` on an algorithm that records receipt, proving the match arm independently of what the handler does. `test_algorithm_handle_modify_order_refuses_active_local_order_without_events` asserts unchanged status, unchanged quantity and no published events. `test_twap_refused_modify_preserves_remaining_quantity_schedule` asserts the quantity equality above still holds after a refused modify.

Three mutations were run against the new tests, each an assertion failure rather than a compilation error: applying the modify in place instead of refusing breaks the TWAP equality (0.4 against 0.800); removing the dispatch arm leaves the recording algorithm empty; and dropping `.filter(|_| order.is_active_local())` diverts a venue-active modify away from the risk engine.
