### PR TITLE
Skip unknown Polymarket user channel event types

### DIFF
--- a/crates/adapters/polymarket/src/websocket/messages.rs
+++ b/crates/adapters/polymarket/src/websocket/messages.rs
@@ -24,6 +24,7 @@ use serde::{
         value::{BorrowedStrDeserializer, MapAccessDeserializer},
     },
 };
+use serde_json::value::RawValue;
 use ustr::Ustr;
 
 use crate::common::{
@@ -569,11 +570,38 @@ impl UserWsMessage {
 
     /// Parses a batch of user-channel JSON messages.
     ///
+    /// Elements carrying an unrecognized `event_type` are skipped so that a single unknown
+    /// message cannot discard the valid `order` and `trade` messages batched alongside it.
+    ///
     /// # Errors
     ///
     /// Returns [`serde_json::Error`] when `text` is not a valid user-message batch.
     pub fn parse_batch(text: &str) -> serde_json::Result<Vec<Self>> {
-        serde_json::from_str(text)
+        /// Reads only the tag, to classify an element before deserializing it.
+        #[derive(Deserialize)]
+        struct EventTypeTag {
+            event_type: Option<String>,
+        }
+
+        // Elements stay raw so the derived impl parses each one and rejects a duplicated
+        // `event_type`; `serde_json::Value` would silently keep the last occurrence.
+        let elements: Vec<&RawValue> = serde_json::from_str(text)?;
+        let mut messages = Vec::with_capacity(elements.len());
+        let mut skipped = 0usize;
+
+        for element in elements {
+            let tag: EventTypeTag = serde_json::from_str(element.get())?;
+            match tag.event_type.as_deref() {
+                Some(event_type) if !matches!(event_type, "order" | "trade") => skipped += 1,
+                _ => messages.push(serde_json::from_str(element.get())?),
+            }
+        }
+
+        if skipped > 0 {
+            log::debug!("Skipped {skipped} user WS message(s) with an unrecognized event_type");
+        }
+
+        Ok(messages)
     }
 
     fn parse_reordered(text: &str) -> serde_json::Result<Self> {
@@ -682,6 +710,26 @@ mod tests {
     fn load_text(filename: &str) -> String {
         let path = format!("test_data/{filename}");
         std::fs::read_to_string(path).expect("Failed to read test data")
+    }
+
+    /// An `auto_redeem` user-channel event as observed from the venue, which is undocumented and
+    /// not modelled by [`UserWsMessage`].
+    fn auto_redeem_element() -> serde_json::Value {
+        serde_json::json!({
+            "event_type": "auto_redeem",
+            "proxy_wallet": "0x0000000000000000000000000000000000000000",
+            "txn_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "amount": "70",
+            "condition_id": "0xb88862256916cb0c82e72667bd43f3e6cfe94cd7d5cda0bf763ec82394021e07",
+            "question": "Bitcoin Up or Down - August 17, 9:35AM-9:40AM ET",
+            "slug": "btc-updown-5m-1786973700",
+            "neg_risk": false,
+            "timestamp": "1786974414920",
+            "position_id": "",
+            "outcome_index": 0,
+            "legs": 0,
+            "owner": "00000000-0000-0000-0000-000000000000",
+        })
     }
 
     #[rstest]
@@ -1179,6 +1227,52 @@ mod tests {
         let text = serde_json::to_string(&value).expect("user batch fixture should serialize");
 
         assert!(UserWsMessage::parse_batch(&text).is_err());
+    }
+
+    /// A duplicated `event_type` is malformed and must be rejected, matching
+    /// [`UserWsMessage::parse`].
+    #[rstest]
+    fn test_user_ws_message_parse_batch_rejects_duplicate_event_type() {
+        let element = load_text("ws_user_order_msg.json").replacen(
+            r#""event_type": "order""#,
+            r#""event_type": "order", "event_type": "order""#,
+            1,
+        );
+        let text = format!("[{element}]");
+
+        assert!(UserWsMessage::parse_batch(&text).is_err());
+    }
+
+    /// Polymarket emits undocumented user-channel events such as `auto_redeem`, which must not
+    /// discard the `order` and `trade` messages batched alongside them.
+    #[rstest]
+    fn test_user_ws_message_parse_batch_skips_unknown_event_type() {
+        let expected: Vec<UserWsMessage> = load("ws_user_batch_msg.json");
+        let mut value: serde_json::Value = load("ws_user_batch_msg.json");
+        let elements = value
+            .as_array_mut()
+            .expect("user batch fixture should be an array");
+        elements.insert(1, auto_redeem_element());
+        let text = serde_json::to_string(&value).expect("user batch fixture should serialize");
+
+        let actual =
+            UserWsMessage::parse_batch(&text).expect("batch with unknown event_type should parse");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    fn test_user_ws_message_parse_batch_all_unknown_event_types() {
+        let text = serde_json::to_string(&serde_json::Value::Array(vec![
+            auto_redeem_element(),
+            auto_redeem_element(),
+        ]))
+        .expect("unknown batch should serialize");
+
+        let actual =
+            UserWsMessage::parse_batch(&text).expect("batch of unknown event types should parse");
+
+        assert!(actual.is_empty());
     }
 
     #[rstest]


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self‑contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Polymarket emits undocumented user-channel events such as `auto_redeem`. `UserWsMessage::parse_batch`
used serde's all-or-nothing `Vec` deserialization, so one unrecognized element failed the entire
array; the single-message fallback then also failed (the payload is an array, not an object) and the
handler returned `vec![]`, discarding every message in that batch including valid `order` and `trade`
siblings.

Each element is now parsed individually, skipping those that carry an unrecognized `event_type` and
logging a count at debug level. Malformed elements (for example a missing `event_type`) still surface
as an error, so the existing contract is unchanged.

Per the issue discussion, `auto_redeem` itself is not modelled.

## Related issues/PRs

Resolves #4788

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation changes. No PyO3 bindings or wrapped Rust docs were touched, so `make py-stubs` does
not apply.

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Two `#[rstest]` cases were added next to the existing batch tests, built from the existing
`ws_user_batch_msg.json` fixture:

- `test_user_ws_message_parse_batch_skips_unknown_event_type` injects an `auto_redeem` element
  between the valid `order` and `trade` elements and asserts both siblings still parse.
- `test_user_ws_message_parse_batch_all_unknown_event_types` asserts a batch of only unknown event
  types yields an empty `Vec` rather than an error.

Both fail against the previous implementation and pass with this change. The existing
`test_user_ws_message_parse_batch_rejects_invalid_element` is unchanged and still passes, pinning the
boundary between an unknown and a malformed element.

`cargo nextest run -p nautilus-polymarket` passes (1570 tests).