### PR TITLE
Map partial Polymarket GTC fills to terminal status

### DIFF
--- a/crates/adapters/polymarket/src/execution/parse.rs
+++ b/crates/adapters/polymarket/src/execution/parse.rs
@@ -35,7 +35,7 @@ use crate::{
         consts::{DUST_SNAP_THRESHOLD_DEC, USDC_DECIMALS},
         enums::{
             PolymarketEventType, PolymarketLiquiditySide, PolymarketOrderSide,
-            PolymarketOrderStatus, PolymarketOrderType,
+            PolymarketOrderStatus,
         },
         models::PolymarketMakerOrder,
     },
@@ -130,18 +130,16 @@ pub fn parse_order_status_report(
     let venue_order_id = VenueOrderId::from(order.id.as_str());
     let order_side = OrderSide::from(order.side);
     let time_in_force = TimeInForce::from(order.order_type);
-    let order_status = if order.status == PolymarketOrderStatus::Matched
-        && order.order_type == PolymarketOrderType::FAK
-        && order.size_matched < order.original_size
-    {
-        OrderStatus::Canceled
-    } else {
-        OrderStatus::from(order.status)
-    };
     let quantity = Quantity::from_decimal_dp(order.original_size, size_precision)
         .unwrap_or_else(|_| Quantity::zero(size_precision));
     let raw_filled_qty = Quantity::from_decimal_dp(order.size_matched, size_precision)
         .unwrap_or_else(|_| Quantity::zero(size_precision));
+    // `Matched` does not mean fully filled, so resolve the status from the filled quantity.
+    let order_status = if order.status == PolymarketOrderStatus::Matched {
+        recovered_terminal_order_status(time_in_force, quantity, raw_filled_qty)
+    } else {
+        OrderStatus::from(order.status)
+    };
     let filled_qty = snap_filled_qty_to_quantity(quantity, raw_filled_qty, order_status);
     let price = Price::from_decimal_dp(order.price, price_precision)
         .unwrap_or_else(|_| Price::zero(price_precision));
@@ -467,6 +465,27 @@ pub(crate) fn weighted_average_price(
         .map(|f| f.last_qty.as_decimal() * f.last_px.as_decimal())
         .sum();
     Some(weighted / total_filled)
+}
+
+/// Resolves the terminal status of a venue-terminal order from its filled quantity.
+///
+/// Polymarket reports a terminated order as `MATCHED` whether or not it filled completely: an IOC
+/// underfill was killed, any other non-dust remainder was canceled. Dust remainders stay `Filled`.
+pub(crate) fn recovered_terminal_order_status(
+    time_in_force: TimeInForce,
+    quantity: Quantity,
+    filled_qty: Quantity,
+) -> OrderStatus {
+    if time_in_force == TimeInForce::Ioc && filled_qty < quantity {
+        return OrderStatus::Canceled;
+    }
+
+    let dust_diff = (quantity.as_decimal() - filled_qty.as_decimal()).abs();
+    if filled_qty >= quantity || dust_diff < DUST_SNAP_THRESHOLD_DEC {
+        OrderStatus::Filled
+    } else {
+        OrderStatus::Canceled
+    }
 }
 
 /// At terminal `Filled` status, snap `filled_qty` to `quantity` when the
@@ -1347,6 +1366,62 @@ mod tests {
             report.quantity,
             Quantity::new(original_size.try_into().unwrap_or(0.0), 6)
         );
+    }
+
+    /// A `MATCHED` underfill must reach a terminal status, and `Filled` must never carry
+    /// `filled_qty < quantity`. Dust remainders still resolve as `Filled` (see #3728).
+    #[rstest]
+    // Partially filled then canceled: terminal, not `Filled`.
+    #[case::gtc_real_partial(PolymarketOrderType::GTC, dec!(10), dec!(7), OrderStatus::Canceled)]
+    // Dust underfill: stays `Filled`, `filled_qty` snaps up to `quantity`.
+    #[case::gtc_dust_underfill(PolymarketOrderType::GTC, dec!(100), dec!(99.997714), OrderStatus::Filled)]
+    // GTC exact fill.
+    #[case::gtc_exact(PolymarketOrderType::GTC, dec!(10), dec!(10), OrderStatus::Filled)]
+    // FAK underfill is killed by the venue: unchanged.
+    #[case::fak_partial(PolymarketOrderType::FAK, dec!(30), dec!(20), OrderStatus::Canceled)]
+    fn test_parse_order_status_report_matched_resolves_terminal_status(
+        #[case] order_type: PolymarketOrderType,
+        #[case] original_size: Decimal,
+        #[case] size_matched: Decimal,
+        #[case] expected_status: OrderStatus,
+    ) {
+        let order = PolymarketOpenOrder {
+            associate_trades: None,
+            id: "0xterminal".to_string(),
+            status: PolymarketOrderStatus::Matched,
+            market: Ustr::from("0xmarket"),
+            original_size,
+            outcome: PolymarketOutcome::yes(),
+            maker_address: "0xmaker".to_string(),
+            owner: "owner".to_string(),
+            price: dec!(0.5),
+            side: PolymarketOrderSide::Buy,
+            size_matched,
+            asset_id: Ustr::from("token"),
+            expiration: None,
+            order_type,
+            created_at: 1_784_118_677,
+        };
+
+        let report = parse_order_status_report(
+            &order,
+            InstrumentId::from("TEST-TOKEN.POLYMARKET"),
+            AccountId::from("POLYMARKET-001"),
+            None,
+            3,
+            6,
+            UnixNanos::from(1_000_000_000u64),
+        );
+
+        assert_eq!(report.order_status, expected_status);
+        if report.order_status == OrderStatus::Filled {
+            assert!(
+                report.filled_qty >= report.quantity,
+                "a Filled report must not carry filled_qty < quantity, was filled_qty={} quantity={}",
+                report.filled_qty,
+                report.quantity
+            );
+        }
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/execution/reports.rs
+++ b/crates/adapters/polymarket/src/execution/reports.rs
@@ -34,8 +34,8 @@ use ustr::Ustr;
 use super::{
     PolymarketExecutionClient,
     parse::{
-        parse_balance_allowance, parse_order_status_report, sum_filled_quantity,
-        weighted_average_price,
+        parse_balance_allowance, parse_order_status_report, recovered_terminal_order_status,
+        sum_filled_quantity, weighted_average_price,
     },
     reconciliation::{
         FillContext, apply_fill_filters, build_fill_reports_from_trades, build_position_reports,
@@ -44,7 +44,7 @@ use super::{
     },
 };
 use crate::{
-    common::{consts::DUST_SNAP_THRESHOLD_DEC, enums::SignatureType},
+    common::enums::SignatureType,
     http::{
         clob::PolymarketClobHttpClient,
         query::{GetBalanceAllowanceParams, GetTradesParams},
@@ -600,23 +600,6 @@ impl PolymarketExecutionClient {
             lookback_mins,
         )
         .await
-    }
-}
-
-fn recovered_terminal_order_status(
-    time_in_force: TimeInForce,
-    quantity: Quantity,
-    filled_qty: Quantity,
-) -> OrderStatus {
-    if time_in_force == TimeInForce::Ioc && filled_qty < quantity {
-        return OrderStatus::Canceled;
-    }
-
-    let dust_diff = (quantity.as_decimal() - filled_qty.as_decimal()).abs();
-    if filled_qty >= quantity || dust_diff < DUST_SNAP_THRESHOLD_DEC {
-        OrderStatus::Filled
-    } else {
-        OrderStatus::Canceled
     }
 }
 


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self‑contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Polymarket reports a terminated order as `MATCHED` whether or not it filled completely.
`parse_order_status_report` mapped that straight to `Filled` unless the order was FAK, so a GTC
order that was partially filled and then canceled produced a report with `filled_qty < quantity`.
Reconciliation cannot act on that combination (there is no missing fill to synthesize, and no
quantity or price drift), so it logs a warning and returns without emitting a corrective event,
leaving the local order stuck in `PENDING_CANCEL` and its strategy leg unable to cancel again.

The terminal status is now resolved from the filled quantity for any `MATCHED` order, reusing
`recovered_terminal_order_status`, which the trade-history recovery path already applied to the same
question. That helper moved from `reports.rs` into `parse.rs` next to `snap_filled_qty_to_quantity`
and is now shared, so the two paths cannot diverge again. Dust remainders left by venue-side
rounding still resolve as `Filled` (#3728), and `snap_filled_qty_to_quantity` continues to raise
`filled_qty` to `quantity` in that case, so a `Filled` report never carries `filled_qty < quantity`.

Statuses other than `MATCHED` are unchanged. The other two `OrderStatus::from` call sites
(`resolve_order_status` and the FOK REST resolution in `responses.rs`) are left alone to keep this
change focused.

## Related issues/PRs

Resolves #4787
Related to #3728 (dust underfills, whose behavior this preserves)

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation changes. No PyO3 bindings or wrapped Rust docs were touched, so `make py-stubs` does
not apply.

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

`test_parse_order_status_report_matched_resolves_terminal_status` was added with four `#[rstest]`
cases asserting `order_status` directly, plus an assertion that any `Filled` report satisfies
`filled_qty >= quantity`:

- GTC `10 / 7` resolves to `Canceled` (the reported bug).
- GTC `100 / 99.997714` stays `Filled` with `filled_qty` snapped to `quantity` (#3728).
- GTC `10 / 10` resolves to `Filled`.
- FAK `30 / 20` resolves to `Canceled` (unchanged).

Only the first case fails against the previous implementation, so it pins the new behavior without
altering the rest. The existing `test_recovered_terminal_order_status` in `reports.rs` and
`test_parse_order_status_report_maps_partial_fak_match_to_canceled` are unchanged and still pass.

One existing case changes behavior without changing its assertions:
`test_parse_order_status_report_snaps_dust_filled_qty::matched_real_partial` (GTC `100 / 99`) now
resolves to `Canceled` rather than `Filled`. It still passes because it asserts only `filled_qty`
and `quantity`, never `order_status`, so the suite did not previously pin that status.

`cargo nextest run -p nautilus-polymarket` passes (1572 tests).

