### PR TITLE
Persist resolved execution client origins

### DIFF
--- a/crates/common/src/cache/database.rs
+++ b/crates/common/src/cache/database.rs
@@ -492,6 +492,19 @@ pub trait CacheDatabaseAdapter {
         position_id: PositionId,
     ) -> anyhow::Result<()>;
 
+    /// Indexes order-client mappings as one batch operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if batch order-client indexing is unsupported or cannot be enqueued.
+    fn index_order_clients(&self, claims: &[(ClientOrderId, ClientId)]) -> anyhow::Result<()> {
+        if claims.is_empty() {
+            return Ok(());
+        }
+
+        anyhow::bail!("Batch order-client indexing is not supported by this cache database")
+    }
+
     /// Updates actor state in the cache.
     ///
     /// # Errors

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -4657,6 +4657,73 @@ impl Cache {
         Ok(())
     }
 
+    /// Claims the execution-client origin for one or more cached orders.
+    ///
+    /// Claims are write-once: an unclaimed order is assigned to `client_id`, a matching existing
+    /// claim is idempotent, and a conflicting claim is rejected. The complete batch is validated
+    /// and its persistence command is successfully enqueued before any in-memory index is
+    /// changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an order is not cached, an order is already claimed by another client,
+    /// the same order has conflicting claims in the batch, or persistence cannot be enqueued.
+    pub fn claim_order_clients(
+        &mut self,
+        claims: &[(ClientOrderId, ClientId)],
+    ) -> anyhow::Result<()> {
+        let mut requested = AHashMap::with_capacity(claims.len());
+        let mut ordered_claims = Vec::with_capacity(claims.len());
+
+        for (client_order_id, client_id) in claims {
+            if let Some(existing_client_id) = requested.get(client_order_id) {
+                if existing_client_id != client_id {
+                    anyhow::bail!(
+                        "Conflicting execution client claims for {client_order_id}: \
+                         {existing_client_id} and {client_id}"
+                    );
+                }
+                continue;
+            }
+
+            requested.insert(*client_order_id, *client_id);
+            ordered_claims.push((*client_order_id, *client_id));
+        }
+
+        let mut pending_claims = Vec::with_capacity(ordered_claims.len());
+        for (client_order_id, client_id) in ordered_claims {
+            if !self.orders.contains_key(&client_order_id) {
+                return Err(OrderLookupError::not_found(client_order_id).into());
+            }
+
+            match self.index.order_client.get(&client_order_id) {
+                Some(existing_client_id) if *existing_client_id == client_id => {}
+                Some(existing_client_id) => {
+                    anyhow::bail!(
+                        "Order {client_order_id} is already claimed by execution client \
+                         {existing_client_id} and cannot be claimed by {client_id}"
+                    );
+                }
+                None => pending_claims.push((client_order_id, client_id)),
+            }
+        }
+
+        if pending_claims.is_empty() {
+            return Ok(());
+        }
+
+        if let Some(database) = &self.database {
+            database.index_order_clients(&pending_claims)?;
+        }
+
+        for (client_order_id, client_id) in pending_claims {
+            self.index.order_client.insert(client_order_id, client_id);
+            log::debug!("Claimed {client_order_id} for execution client {client_id}");
+        }
+
+        Ok(())
+    }
+
     /// Adds the `order_list` to the cache.
     ///
     /// # Errors

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -15,9 +15,12 @@
 
 //! Tests module for `Cache`.
 
-#[cfg(feature = "defi")]
-use std::sync::Arc;
-use std::{borrow::Cow, cell::RefCell, rc::Rc};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 
 use ahash::{AHashMap, AHashSet, RandomState};
 use bytes::Bytes;
@@ -7401,15 +7404,19 @@ fn snapshot_test_position() -> Position {
     Position::new(&audusd_sim, fill.into())
 }
 
+type OrderClientClaimBatches = Arc<Mutex<Vec<Vec<(ClientOrderId, ClientId)>>>>;
+
 #[derive(Default)]
 struct SnapshotBlobTestDatabase {
     general: AHashMap<String, Bytes>,
     orders: AHashMap<ClientOrderId, OrderAny>,
     positions: AHashMap<PositionId, Position>,
     order_positions: AHashMap<ClientOrderId, PositionId>,
+    order_client_claims: OrderClientClaimBatches,
     fail_add: bool,
     fail_add_order: bool,
     fail_add_position: bool,
+    fail_index_order_clients: bool,
     fail_index_order_position: bool,
     fail_update_order: bool,
     fail_update_position: bool,
@@ -7465,6 +7472,20 @@ impl SnapshotBlobTestDatabase {
             fail_index_order_position: true,
             ..Default::default()
         }
+    }
+
+    fn order_client_claim_recorder(
+        fail_index_order_clients: bool,
+    ) -> (Self, OrderClientClaimBatches) {
+        let order_client_claims = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                order_client_claims: order_client_claims.clone(),
+                fail_index_order_clients,
+                ..Default::default()
+            },
+            order_client_claims,
+        )
     }
 
     fn fail_update_order() -> Self {
@@ -7730,6 +7751,18 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
         Ok(())
     }
 
+    fn index_order_clients(&self, claims: &[(ClientOrderId, ClientId)]) -> anyhow::Result<()> {
+        self.order_client_claims
+            .lock()
+            .unwrap()
+            .push(claims.to_vec());
+
+        if self.fail_index_order_clients {
+            anyhow::bail!("index order clients failed");
+        }
+        Ok(())
+    }
+
     fn update_actor(
         &self,
         _actor_id: &ActorId,
@@ -7780,6 +7813,162 @@ impl CacheDatabaseAdapter for SnapshotBlobTestDatabase {
     fn heartbeat(&self, _timestamp: UnixNanos) -> anyhow::Result<()> {
         Ok(())
     }
+}
+
+#[rstest]
+fn test_claim_order_clients_persists_one_batch_and_is_idempotent(audusd_sim: CurrencyPair) {
+    let (database, recorded_claims) = SnapshotBlobTestDatabase::order_client_claim_recorder(false);
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let client_id = ClientId::from("CLIENT-B");
+    let order_1 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id)
+        .client_order_id(ClientOrderId::from("O-CLAIM-001"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let order_2 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id)
+        .client_order_id(ClientOrderId::from("O-CLAIM-002"))
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let claims = [
+        (order_1.client_order_id(), client_id),
+        (order_2.client_order_id(), client_id),
+        (order_1.client_order_id(), client_id),
+    ];
+
+    cache.add_order(order_1.clone(), None, None, false).unwrap();
+    cache.add_order(order_2.clone(), None, None, false).unwrap();
+
+    cache.claim_order_clients(&claims).unwrap();
+    cache.claim_order_clients(&claims).unwrap();
+
+    assert_eq!(
+        cache.client_id(&order_1.client_order_id()).copied(),
+        Some(client_id),
+    );
+    assert_eq!(
+        cache.client_id(&order_2.client_order_id()).copied(),
+        Some(client_id),
+    );
+    assert_eq!(
+        recorded_claims.lock().unwrap().as_slice(),
+        &[vec![
+            (order_1.client_order_id(), client_id),
+            (order_2.client_order_id(), client_id),
+        ]],
+    );
+}
+
+#[rstest]
+fn test_claim_order_clients_rejects_conflict_without_partial_commit(audusd_sim: CurrencyPair) {
+    let (database, recorded_claims) = SnapshotBlobTestDatabase::order_client_claim_recorder(false);
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let existing_client_id = ClientId::from("CLIENT-A");
+    let claimant_client_id = ClientId::from("CLIENT-B");
+    let order_1 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id)
+        .client_order_id(ClientOrderId::from("O-CONFLICT-001"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let order_2 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id)
+        .client_order_id(ClientOrderId::from("O-CONFLICT-002"))
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .build();
+
+    cache.add_order(order_1.clone(), None, None, false).unwrap();
+    cache
+        .add_order(order_2.clone(), None, Some(existing_client_id), false)
+        .unwrap();
+
+    let error = cache
+        .claim_order_clients(&[
+            (order_1.client_order_id(), claimant_client_id),
+            (order_2.client_order_id(), claimant_client_id),
+        ])
+        .unwrap_err();
+
+    assert!(error.to_string().contains("already claimed"));
+    assert_eq!(cache.client_id(&order_1.client_order_id()), None);
+    assert_eq!(
+        cache.client_id(&order_2.client_order_id()).copied(),
+        Some(existing_client_id),
+    );
+    assert!(recorded_claims.lock().unwrap().is_empty());
+}
+
+#[rstest]
+fn test_claim_order_clients_rejects_invalid_batch_without_mutation(audusd_sim: CurrencyPair) {
+    let (database, recorded_claims) = SnapshotBlobTestDatabase::order_client_claim_recorder(false);
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let client_a = ClientId::from("CLIENT-A");
+    let client_b = ClientId::from("CLIENT-B");
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id)
+        .client_order_id(ClientOrderId::from("O-INVALID-BATCH-001"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+
+    cache.add_order(order.clone(), None, None, false).unwrap();
+
+    let conflicting_batch_error = cache
+        .claim_order_clients(&[
+            (order.client_order_id(), client_a),
+            (order.client_order_id(), client_b),
+        ])
+        .unwrap_err();
+    let missing_order_error = cache
+        .claim_order_clients(&[
+            (order.client_order_id(), client_a),
+            (ClientOrderId::from("O-MISSING"), client_a),
+        ])
+        .unwrap_err();
+
+    assert!(conflicting_batch_error.to_string().contains("Conflicting"));
+    assert!(missing_order_error.to_string().contains("order not found"));
+    assert_eq!(cache.client_id(&order.client_order_id()), None);
+    assert!(recorded_claims.lock().unwrap().is_empty());
+}
+
+#[rstest]
+fn test_claim_order_clients_database_error_leaves_memory_unmodified(audusd_sim: CurrencyPair) {
+    let (database, recorded_claims) = SnapshotBlobTestDatabase::order_client_claim_recorder(true);
+    let mut cache = Cache::new(None, Some(Box::new(database)));
+    let client_id = ClientId::from("CLIENT-B");
+    let order_1 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id)
+        .client_order_id(ClientOrderId::from("O-DB-FAIL-001"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let order_2 = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id)
+        .client_order_id(ClientOrderId::from("O-DB-FAIL-002"))
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let claims = [
+        (order_1.client_order_id(), client_id),
+        (order_2.client_order_id(), client_id),
+    ];
+
+    cache.add_order(order_1.clone(), None, None, false).unwrap();
+    cache.add_order(order_2.clone(), None, None, false).unwrap();
+
+    let error = cache.claim_order_clients(&claims).unwrap_err();
+
+    assert_eq!(error.to_string(), "index order clients failed");
+    assert_eq!(cache.client_id(&order_1.client_order_id()), None);
+    assert_eq!(cache.client_id(&order_2.client_order_id()), None);
+    assert_eq!(
+        recorded_claims.lock().unwrap().as_slice(),
+        &[claims.to_vec()]
+    );
 }
 
 #[rstest]

--- a/crates/event_store/src/replay.rs
+++ b/crates/event_store/src/replay.rs
@@ -2475,6 +2475,13 @@ mod tests {
             &[PAYLOAD_TYPE_ORDER_INITIALIZED],
         ),
         cache_mutation(
+            // Cache databases persist the resolved client index, but current EventStore
+            // command payloads do not carry the client selected by runtime routing.
+            "claim_order_clients",
+            CacheMutationRecoveryClass::MissingLiveRecovery,
+            &[],
+        ),
+        cache_mutation(
             "add_order_list",
             CacheMutationRecoveryClass::EventStoreCapturedAndReplayed,
             &[PAYLOAD_TYPE_SUBMIT_ORDER_LIST],

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -2078,8 +2078,7 @@ impl ExecutionEngine {
         let (order, added_to_cache) = match cached_order {
             Some(order) => (order, false),
             None => {
-                let Some(order) =
-                    self.add_order_from_init(&cmd.order_init, cmd.position_id, cmd.client_id, &cmd)
+                let Some(order) = self.add_order_from_init(&cmd.order_init, cmd.position_id, &cmd)
                 else {
                     return;
                 };
@@ -2132,6 +2131,25 @@ impl ExecutionEngine {
             }
         }
 
+        let client_id = client.client_id();
+        let claim_result = self
+            .cache
+            .borrow_mut()
+            .claim_order_clients(&[(client_order_id, client_id)]);
+
+        if let Err(e) = claim_result {
+            self.deny_order(
+                &order,
+                &OrderDeniedReason::ValidationFailed {
+                    detail: format!(
+                        "Failed to claim execution client {client_id} for {client_order_id}: {e}"
+                    ),
+                }
+                .to_string(),
+            );
+            return;
+        }
+
         if self.config.manage_own_order_books && should_handle_own_book_order(&order) {
             let mut own_book = self.get_or_init_own_order_book(&order.instrument_id());
             own_book.add(order.to_own_book_order());
@@ -2173,9 +2191,7 @@ impl ExecutionEngine {
                 continue;
             };
 
-            let Some(order) =
-                self.add_order_from_init(order_init, cmd.position_id, cmd.client_id, &cmd)
-            else {
+            let Some(order) = self.add_order_from_init(order_init, cmd.position_id, &cmd) else {
                 continue;
             };
 
@@ -2272,6 +2288,27 @@ impl ExecutionEngine {
             }
         }
 
+        let client_id = client.client_id();
+        let claims = orders
+            .iter()
+            .map(|order| (order.client_order_id(), client_id))
+            .collect::<Vec<_>>();
+        let claim_result = self.cache.borrow_mut().claim_order_clients(&claims);
+        if let Err(e) = claim_result {
+            let reason = OrderDeniedReason::ValidationFailed {
+                detail: format!(
+                    "Failed to claim execution client {client_id} for order list {}: {e}",
+                    cmd.order_list.id,
+                ),
+            }
+            .to_string();
+
+            for order in &orders {
+                self.deny_order(order, &reason);
+            }
+            return;
+        }
+
         if self.config.manage_own_order_books {
             for order in &orders {
                 if should_handle_own_book_order(order) {
@@ -2300,7 +2337,6 @@ impl ExecutionEngine {
         &self,
         order_init: &OrderInitialized,
         position_id: Option<PositionId>,
-        client_id: Option<ClientId>,
         context: &dyn Display,
     ) -> Option<OrderAny> {
         let client_order_id = order_init.client_order_id;
@@ -2316,10 +2352,10 @@ impl ExecutionEngine {
             }
         };
 
-        if let Err(e) =
-            self.cache
-                .borrow_mut()
-                .add_order(order.clone(), position_id, client_id, true)
+        if let Err(e) = self
+            .cache
+            .borrow_mut()
+            .add_order(order.clone(), position_id, None, true)
         {
             log::error!(
                 "Cannot add reconstructed order to cache for {client_order_id}: {e}, {context}"

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -15,6 +15,10 @@
 
 //! Tests module for `ExecutionEngine`.
 
+#[allow(dead_code)]
+#[path = "matching_engine/cache_database.rs"]
+mod cache_database;
+
 use std::{
     cell::RefCell,
     collections::HashSet,
@@ -26,6 +30,7 @@ use std::{
 };
 
 use ahash::AHashSet;
+use cache_database::FailNthAddOrderDatabase;
 use nautilus_common::{
     cache::{Cache, CacheSnapshotRef},
     clients::ExecutionClient,
@@ -3816,6 +3821,14 @@ fn test_submit_order_routes_to_default_client_when_no_client_id(
     assert_eq!(
         submitted_order_ids.borrow().as_slice(),
         &[order.client_order_id()],
+    );
+    assert_eq!(
+        execution_engine
+            .cache()
+            .borrow()
+            .client_id(&order.client_order_id())
+            .copied(),
+        Some(ClientId::from("IB")),
     );
 }
 
@@ -13844,6 +13857,332 @@ fn test_submit_order_routes_by_instrument_venue(mut execution_engine: ExecutionE
         submitted_order_ids.borrow().as_slice(),
         &[order.client_order_id()],
     );
+    assert_eq!(
+        execution_engine
+            .cache()
+            .borrow()
+            .client_id(&order.client_order_id())
+            .copied(),
+        Some(ClientId::from("SIM_CLIENT")),
+    );
+}
+
+#[rstest]
+fn test_submit_order_claims_venue_routed_client_origin(mut execution_engine: ExecutionEngine) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = futures_contract_xcme();
+    let client_id = ClientId::from("ROUTING");
+    let client = StubExecutionClient::new(
+        client_id,
+        AccountId::from("ROUTING-ACCOUNT"),
+        Venue::from("BROKER"),
+        OmsType::Netting,
+        None,
+    )
+    .with_handles_all_order_venues();
+    let submitted_order_ids = client.submitted_order_ids();
+    execution_engine.register_client(Box::new(client)).unwrap();
+    execution_engine
+        .register_venue_routing(client_id, instrument.id.venue)
+        .unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-ROUTED-ORIGIN-001"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(1))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, None, false)
+        .unwrap();
+
+    let submit_order = SubmitOrder {
+        trader_id,
+        strategy_id,
+        instrument_id: instrument.id,
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        position_id: None,
+        params: None,
+        client_id: None,
+        exec_algorithm_id: None,
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let cache = execution_engine.cache().borrow();
+    assert_eq!(
+        cache.client_id(&order.client_order_id()).copied(),
+        Some(client_id),
+    );
+    assert_eq!(
+        submitted_order_ids.borrow().as_slice(),
+        &[order.client_order_id()],
+    );
+}
+
+#[rstest]
+fn test_submit_order_rejects_conflicting_cached_client_origin(
+    mut execution_engine: ExecutionEngine,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+    let existing_client_id = ClientId::from("CLIENT_A");
+    let routed_client_id = ClientId::from("CLIENT_B");
+    let client = StubExecutionClient::new(
+        routed_client_id,
+        AccountId::from("CLIENT-B-ACCOUNT"),
+        instrument.id.venue,
+        OmsType::Netting,
+        None,
+    );
+    let submitted_order_ids = client.submitted_order_ids();
+    execution_engine.register_client(Box::new(client)).unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-CONFLICTING-ORIGIN-001"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(10))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(existing_client_id), false)
+        .unwrap();
+
+    let submit_order = SubmitOrder {
+        trader_id,
+        strategy_id,
+        instrument_id: instrument.id,
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        position_id: None,
+        params: None,
+        client_id: Some(routed_client_id),
+        exec_algorithm_id: None,
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let cache = execution_engine.cache().borrow();
+    assert_eq!(
+        cache.client_id(&order.client_order_id()).copied(),
+        Some(existing_client_id),
+    );
+    assert_eq!(
+        cache.order(&order.client_order_id()).unwrap().status(),
+        OrderStatus::Denied
+    );
+    assert!(submitted_order_ids.borrow().is_empty());
+}
+
+#[rstest]
+fn test_submit_order_does_not_transport_when_origin_persistence_cannot_be_enqueued(
+    mut execution_engine: ExecutionEngine,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+    let client_id = ClientId::from("CLIENT-B");
+    let client = StubExecutionClient::new(
+        client_id,
+        AccountId::from("CLIENT-B-ACCOUNT"),
+        instrument.id.venue,
+        OmsType::Netting,
+        None,
+    );
+    let submitted_order_ids = client.submitted_order_ids();
+    execution_engine.register_client(Box::new(client)).unwrap();
+    let (database, _control) = FailNthAddOrderDatabase::create();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .set_database(Box::new(database));
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-PERSISTENCE-FAIL-001"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(10))
+        .build();
+
+    let submit_order = SubmitOrder {
+        trader_id,
+        strategy_id,
+        instrument_id: instrument.id,
+        client_order_id: order.client_order_id(),
+        order_init: order.init_event().clone(),
+        position_id: None,
+        params: None,
+        client_id: Some(client_id),
+        exec_algorithm_id: None,
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    execution_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let cache = execution_engine.cache().borrow();
+    assert_eq!(cache.client_id(&order.client_order_id()), None);
+    assert_eq!(
+        cache.order(&order.client_order_id()).unwrap().status(),
+        OrderStatus::Denied
+    );
+    assert!(submitted_order_ids.borrow().is_empty());
+}
+
+#[rstest]
+#[case(false)]
+#[case(true)]
+fn test_submit_order_list_claims_are_atomic(
+    mut execution_engine: ExecutionEngine,
+    #[case] has_conflicting_origin: bool,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+    let existing_client_id = ClientId::from("CLIENT_A");
+    let routed_client_id = ClientId::from("CLIENT_B");
+    let client = StubExecutionClient::new(
+        routed_client_id,
+        AccountId::from("CLIENT-B-ACCOUNT"),
+        instrument.id.venue,
+        OmsType::Netting,
+        None,
+    );
+    let submitted_order_ids = client.submitted_order_ids();
+    execution_engine.register_client(Box::new(client)).unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let entry = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-LIST-ORIGIN-001"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let stop_loss = OrderTestBuilder::new(OrderType::StopMarket)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-LIST-ORIGIN-002"))
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(100_000))
+        .trigger_price(Price::from("0.50000"))
+        .build();
+    let orders = [entry.clone(), stop_loss.clone()];
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(entry.clone(), None, None, false)
+        .unwrap();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(
+            stop_loss.clone(),
+            None,
+            has_conflicting_origin.then_some(existing_client_id),
+            false,
+        )
+        .unwrap();
+
+    let order_list = OrderList::new(
+        OrderListId::from("L-ORIGIN-CLAIM"),
+        instrument.id,
+        strategy_id,
+        orders.iter().map(|order| order.client_order_id()).collect(),
+        UnixNanos::default(),
+    );
+    let submit_order_list = SubmitOrderList {
+        trader_id,
+        client_id: None,
+        strategy_id,
+        instrument_id: instrument.id,
+        order_list,
+        order_inits: orders
+            .iter()
+            .map(|order| order.init_event().clone())
+            .collect(),
+        exec_algorithm_id: None,
+        position_id: None,
+        params: None,
+        command_id: UUID4::new(),
+        ts_init: UnixNanos::default(),
+        correlation_id: None,
+        causation_id: None,
+    };
+
+    execution_engine.execute(TradingCommand::SubmitOrderList(submit_order_list));
+
+    let cache = execution_engine.cache().borrow();
+    if has_conflicting_origin {
+        assert_eq!(cache.client_id(&entry.client_order_id()), None);
+        assert_eq!(
+            cache.client_id(&stop_loss.client_order_id()).copied(),
+            Some(existing_client_id),
+        );
+        assert!(submitted_order_ids.borrow().is_empty());
+    } else {
+        for order in &orders {
+            assert_eq!(
+                cache.client_id(&order.client_order_id()).copied(),
+                Some(routed_client_id),
+            );
+        }
+        assert_eq!(
+            submitted_order_ids.borrow().as_slice(),
+            &[entry.client_order_id(), stop_loss.client_order_id()],
+        );
+    }
 }
 
 #[rstest]
@@ -13913,8 +14252,11 @@ fn test_submit_order_adds_missing_order_to_cache_from_init(mut execution_engine:
 }
 
 #[rstest]
-fn test_submit_order_list_adds_missing_orders_to_cache_from_inits(
+#[case::in_memory(false)]
+#[case::batch_enqueue_rejected(true)]
+fn test_submit_order_list_adds_missing_orders_then_claims_origin_atomically(
     mut execution_engine: ExecutionEngine,
+    #[case] reject_batch_enqueue: bool,
 ) {
     let trader_id = TraderId::test_default();
     let strategy_id = StrategyId::test_default();
@@ -13929,6 +14271,14 @@ fn test_submit_order_list_adds_missing_orders_to_cache_from_inits(
     );
     let submitted_order_ids = client.submitted_order_ids();
     execution_engine.register_client(Box::new(client)).unwrap();
+
+    if reject_batch_enqueue {
+        let (database, _control) = FailNthAddOrderDatabase::create();
+        execution_engine
+            .cache()
+            .borrow_mut()
+            .set_database(Box::new(database));
+    }
 
     execution_engine
         .cache()
@@ -13988,17 +14338,29 @@ fn test_submit_order_list_adds_missing_orders_to_cache_from_inits(
             .order(&order.client_order_id())
             .expect("Order should be cached from the order list initialization events");
 
-        assert_eq!(cached_order.status(), OrderStatus::Initialized);
+        assert_eq!(
+            cached_order.status(),
+            if reject_batch_enqueue {
+                OrderStatus::Denied
+            } else {
+                OrderStatus::Initialized
+            }
+        );
         assert_eq!(cached_order.instrument_id(), order.instrument_id());
         assert_eq!(
             cache.client_id(&order.client_order_id()).copied(),
-            Some(client_id)
+            (!reject_batch_enqueue).then_some(client_id)
         );
     }
-    assert_eq!(
-        submitted_order_ids.borrow().as_slice(),
-        &[entry.client_order_id(), stop_loss.client_order_id()],
-    );
+
+    if reject_batch_enqueue {
+        assert!(submitted_order_ids.borrow().is_empty());
+    } else {
+        assert_eq!(
+            submitted_order_ids.borrow().as_slice(),
+            &[entry.client_order_id(), stop_loss.client_order_id()],
+        );
+    }
 }
 
 #[rstest]

--- a/crates/infrastructure/src/redis/cache.rs
+++ b/crates/infrastructure/src/redis/cache.rs
@@ -969,8 +969,22 @@ fn insert_index(pipe: &mut Pipeline, key: &str, value: &[Bytes]) -> anyhow::Resu
             insert_set(pipe, key, value[0].as_ref());
             Ok(())
         }
-        INDEX_ORDER_POSITION | INDEX_ORDER_CLIENT => {
+        INDEX_ORDER_POSITION => {
             insert_hset(pipe, key, value[0].as_ref(), value[1].as_ref());
+            Ok(())
+        }
+        INDEX_ORDER_CLIENT => {
+            if !value.len().is_multiple_of(2) {
+                anyhow::bail!(
+                    "Invalid hash index payload for '{index_key}': expected field-value pairs"
+                );
+            }
+
+            let entries = value
+                .chunks_exact(2)
+                .map(|entry| (entry[0].as_ref(), entry[1].as_ref()))
+                .collect::<Vec<(&[u8], &[u8])>>();
+            pipe.hset_multiple(key, &entries);
             Ok(())
         }
         _ => anyhow::bail!("Index unknown '{index_key}' on insert"),
@@ -1783,6 +1797,21 @@ impl CacheDatabaseAdapter for RedisCacheDatabaseAdapter {
                 Bytes::from(position_id.to_string()),
             ]),
         )
+    }
+
+    fn index_order_clients(&self, claims: &[(ClientOrderId, ClientId)]) -> anyhow::Result<()> {
+        if claims.is_empty() {
+            return Ok(());
+        }
+
+        let mut payload = Vec::with_capacity(claims.len() * 2);
+        for (client_order_id, client_id) in claims {
+            payload.push(Bytes::from(client_order_id.to_string()));
+            payload.push(Bytes::from(client_id.to_string()));
+        }
+
+        self.database
+            .insert(INDEX_ORDER_CLIENT.to_string(), Some(payload))
     }
 
     fn update_actor(

--- a/crates/infrastructure/src/sql/cache.rs
+++ b/crates/infrastructure/src/sql/cache.rs
@@ -206,6 +206,7 @@ pub enum DatabaseQuery {
     UpdateOrder(OrderEventAny),
     UpdatePosition(OrderFilled),
     IndexOrderPosition(ClientOrderId, PositionId),
+    IndexOrderClients(Vec<(ClientOrderId, ClientId)>),
 }
 
 impl PostgresCacheDatabase {
@@ -1146,6 +1147,19 @@ impl CacheDatabaseAdapter for PostgresCacheDatabase {
         })
     }
 
+    fn index_order_clients(&self, claims: &[(ClientOrderId, ClientId)]) -> anyhow::Result<()> {
+        if claims.is_empty() {
+            return Ok(());
+        }
+
+        let query = DatabaseQuery::IndexOrderClients(claims.to_vec());
+        self.tx.send(query).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to send query index_order_clients to database message handler: {e}"
+            )
+        })
+    }
+
     fn update_actor(
         &self,
         actor_id: &ActorId,
@@ -1343,6 +1357,9 @@ async fn drain_buffer(pool: &PgPool, buffer: &mut VecDeque<DatabaseQuery>) {
             }
             DatabaseQuery::IndexOrderPosition(client_order_id, position_id) => {
                 DatabaseQueries::index_order_position(pool, client_order_id, position_id).await
+            }
+            DatabaseQuery::IndexOrderClients(claims) => {
+                DatabaseQueries::index_order_clients(pool, &claims).await
             }
         };
 

--- a/crates/infrastructure/src/sql/queries.rs
+++ b/crates/infrastructure/src/sql/queries.rs
@@ -1336,6 +1336,83 @@ impl DatabaseQueries {
         Ok(map)
     }
 
+    /// Claims execution-client origins for existing order events in one transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an order has no persisted events, an order is already claimed by a
+    /// different client, or any SQL operation fails. Any error rolls back the complete batch.
+    pub async fn index_order_clients(
+        pool: &PgPool,
+        claims: &[(ClientOrderId, ClientId)],
+    ) -> anyhow::Result<()> {
+        if claims.is_empty() {
+            return Ok(());
+        }
+
+        let mut transaction = pool.begin().await?;
+
+        for (client_order_id, client_id) in claims {
+            let conflicting_client_id = sqlx::query_scalar::<_, String>(
+                r#"
+                SELECT client_id
+                FROM "order_event"
+                WHERE client_order_id = $1
+                  AND client_id IS NOT NULL
+                  AND client_id <> $2
+                LIMIT 1
+            "#,
+            )
+            .bind(client_order_id.to_string())
+            .bind(client_id.to_string())
+            .fetch_optional(&mut *transaction)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to validate order client origin: {e}"))?;
+
+            if let Some(conflicting_client_id) = conflicting_client_id {
+                anyhow::bail!(
+                    "Order {client_order_id} is already claimed by execution client \
+                     {conflicting_client_id} and cannot be claimed by {client_id}"
+                );
+            }
+
+            sqlx::query(
+                r#"
+                INSERT INTO "client" (id)
+                VALUES ($1)
+                ON CONFLICT (id) DO NOTHING
+            "#,
+            )
+            .bind(client_id.to_string())
+            .execute(&mut *transaction)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to persist execution client {client_id}: {e}"))?;
+
+            let result = sqlx::query(
+                r#"
+                UPDATE "order_event"
+                SET client_id = $2
+                WHERE client_order_id = $1
+                  AND (client_id IS NULL OR client_id = $2)
+            "#,
+            )
+            .bind(client_order_id.to_string())
+            .bind(client_id.to_string())
+            .execute(&mut *transaction)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to index order client origin: {e}"))?;
+
+            if result.rows_affected() == 0 {
+                anyhow::bail!("No persisted order events found for {client_order_id}");
+            }
+        }
+
+        transaction
+            .commit()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to commit order client origins: {e}"))
+    }
+
     /// Inserts or updates an order ID to position ID index entry via the provided `pool`.
     ///
     /// # Errors

--- a/crates/infrastructure/tests/test_cache_database_postgres.rs
+++ b/crates/infrastructure/tests/test_cache_database_postgres.rs
@@ -563,6 +563,77 @@ mod serial_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_index_order_clients_conflict_rolls_back_batch() {
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
+        let instrument = currency_pair_ethusdt();
+        let existing_client = ClientId::new("CLIENT-EXISTING");
+        let conflicting_client = ClientId::new("CLIENT-CONFLICTING");
+        let unclaimed_order = OrderTestBuilder::new(OrderType::Market)
+            .client_order_id(ClientOrderId::new("O-PG-ORIGIN-ROLLBACK-001"))
+            .instrument_id(instrument.id())
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1.0"))
+            .build();
+        let claimed_order = OrderTestBuilder::new(OrderType::Market)
+            .client_order_id(ClientOrderId::new("O-PG-ORIGIN-ROLLBACK-002"))
+            .instrument_id(instrument.id())
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from("1.0"))
+            .build();
+
+        pg_cache
+            .add_currency(&instrument.base_currency().unwrap())
+            .unwrap();
+        pg_cache.add_currency(&instrument.quote_currency()).unwrap();
+        pg_cache
+            .add_instrument(&InstrumentAny::CurrencyPair(instrument))
+            .unwrap();
+        pg_cache.add_order(&unclaimed_order, None).unwrap();
+        pg_cache
+            .add_order(&claimed_order, Some(existing_client))
+            .unwrap();
+
+        wait_until_async(
+            || async {
+                let index = pg_cache.load_index_order_client().unwrap();
+                pg_cache
+                    .load_order(&unclaimed_order.client_order_id())
+                    .await
+                    .unwrap()
+                    .is_some()
+                    && index.get(&claimed_order.client_order_id()) == Some(&existing_client)
+            },
+            Duration::from_secs(5),
+        )
+        .await;
+
+        let error = DatabaseQueries::index_order_clients(
+            &pg_cache.pool,
+            &[
+                (unclaimed_order.client_order_id(), conflicting_client),
+                (claimed_order.client_order_id(), conflicting_client),
+            ],
+        )
+        .await
+        .unwrap_err();
+        let index_after_rollback = pg_cache.load_index_order_client().unwrap();
+
+        assert!(
+            error
+                .to_string()
+                .contains("already claimed by execution client")
+        );
+        assert!(!index_after_rollback.contains_key(&unclaimed_order.client_order_id()));
+        assert_eq!(
+            index_after_rollback.get(&claimed_order.client_order_id()),
+            Some(&existing_client)
+        );
+
+        pg_cache.flush().unwrap();
+        pg_cache.close().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_index_order_position_round_trip() {
         let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 

--- a/crates/infrastructure/tests/test_cache_database_postgres.rs
+++ b/crates/infrastructure/tests/test_cache_database_postgres.rs
@@ -22,7 +22,7 @@ mod serial_tests {
     use bytes::Bytes;
     use indexmap::indexmap;
     use nautilus_common::{
-        cache::database::CacheDatabaseAdapter,
+        cache::{Cache, database::CacheDatabaseAdapter},
         signal::Signal,
         testing::{wait_until, wait_until_async},
     };
@@ -466,6 +466,98 @@ mod serial_tests {
             vec![client_id].into_iter().collect::<HashSet<ClientId>>()
         );
 
+        pg_cache.flush().unwrap();
+        pg_cache.close().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_index_order_clients_batch_survives_restart() {
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
+        let instrument = currency_pair_ethusdt();
+        let client_a = ClientId::new("CLIENT-A");
+        let client_b = ClientId::new("CLIENT-B");
+        let order_1 = OrderTestBuilder::new(OrderType::Market)
+            .client_order_id(ClientOrderId::new("O-PG-ORIGIN-001"))
+            .instrument_id(instrument.id())
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1.0"))
+            .build();
+        let order_2 = OrderTestBuilder::new(OrderType::Market)
+            .client_order_id(ClientOrderId::new("O-PG-ORIGIN-002"))
+            .instrument_id(instrument.id())
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from("1.0"))
+            .build();
+        let claims = [
+            (order_1.client_order_id(), client_a),
+            (order_2.client_order_id(), client_b),
+        ];
+
+        pg_cache
+            .add_currency(&instrument.base_currency().unwrap())
+            .unwrap();
+        pg_cache.add_currency(&instrument.quote_currency()).unwrap();
+        pg_cache
+            .add_instrument(&InstrumentAny::CurrencyPair(instrument))
+            .unwrap();
+        pg_cache.add_order(&order_1, None).unwrap();
+        pg_cache.add_order(&order_2, None).unwrap();
+
+        wait_until_async(
+            || async {
+                pg_cache
+                    .load_order(&order_1.client_order_id())
+                    .await
+                    .unwrap()
+                    .is_some()
+                    && pg_cache
+                        .load_order(&order_2.client_order_id())
+                        .await
+                        .unwrap()
+                        .is_some()
+            },
+            Duration::from_secs(5),
+        )
+        .await;
+
+        let missing_order_id = ClientOrderId::new("O-PG-ORIGIN-MISSING");
+        let error = DatabaseQueries::index_order_clients(
+            &pg_cache.pool,
+            &[
+                (order_1.client_order_id(), client_a),
+                (missing_order_id, client_b),
+            ],
+        )
+        .await
+        .unwrap_err();
+        let index_after_rollback = pg_cache.load_index_order_client().unwrap();
+
+        assert!(error.to_string().contains("No persisted order events"));
+        assert!(!index_after_rollback.contains_key(&order_1.client_order_id()));
+        assert!(!index_after_rollback.contains_key(&missing_order_id));
+
+        pg_cache.index_order_clients(&claims).unwrap();
+        wait_until_async(
+            || async {
+                let index = pg_cache.load_index_order_client().unwrap();
+                index.get(&order_1.client_order_id()) == Some(&client_a)
+                    && index.get(&order_2.client_order_id()) == Some(&client_b)
+            },
+            Duration::from_secs(5),
+        )
+        .await;
+
+        let restarted_adapter = get_test_pg_cache_database().await.unwrap();
+        let mut cache = Cache::new(None, Some(Box::new(restarted_adapter)));
+        cache.cache_orders().await.unwrap();
+        cache.build_index();
+
+        assert!(cache.order(&order_1.client_order_id()).is_some());
+        assert!(cache.order(&order_2.client_order_id()).is_some());
+        assert_eq!(cache.client_id(&order_1.client_order_id()), Some(&client_a));
+        assert_eq!(cache.client_id(&order_2.client_order_id()), Some(&client_b));
+
+        cache.dispose();
         pg_cache.flush().unwrap();
         pg_cache.close().unwrap();
     }

--- a/crates/infrastructure/tests/test_cache_redis.rs
+++ b/crates/infrastructure/tests/test_cache_redis.rs
@@ -866,6 +866,74 @@ mod serial_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_index_order_clients_batch_survives_restart() {
+        let _guard = redis_test_mutex().lock().await;
+        let mut adapter = get_redis_cache_adapter()
+            .await
+            .expect("Failed to create adapter");
+        let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        let client_a = ClientId::new("CLIENT-A");
+        let client_b = ClientId::new("CLIENT-B");
+        let order_1 = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(instrument.id())
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1.0"))
+            .client_order_id(ClientOrderId::new("O-REDIS-ORIGIN-001"))
+            .build();
+        let order_2 = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(instrument.id())
+            .side(OrderSide::Sell)
+            .quantity(Quantity::from("1.0"))
+            .client_order_id(ClientOrderId::new("O-REDIS-ORIGIN-002"))
+            .build();
+        let claims = [
+            (order_1.client_order_id(), client_a),
+            (order_2.client_order_id(), client_b),
+        ];
+
+        adapter.add_instrument(&instrument).unwrap();
+        adapter.add_order(&order_1, None).unwrap();
+        adapter.add_order(&order_2, None).unwrap();
+        adapter.index_order_clients(&claims).unwrap();
+
+        wait_until_async(
+            || async {
+                let index = adapter.load_index_order_client().unwrap();
+                adapter
+                    .load_order(&order_1.client_order_id())
+                    .await
+                    .unwrap()
+                    .is_some()
+                    && adapter
+                        .load_order(&order_2.client_order_id())
+                        .await
+                        .unwrap()
+                        .is_some()
+                    && index.get(&order_1.client_order_id()) == Some(&client_a)
+                    && index.get(&order_2.client_order_id()) == Some(&client_b)
+            },
+            Duration::from_secs(5),
+        )
+        .await;
+
+        let restarted_adapter = connect_redis_cache_adapter()
+            .await
+            .expect("Failed to create adapter");
+        let mut cache = Cache::new(None, Some(Box::new(restarted_adapter)));
+        cache.cache_orders().await.unwrap();
+        cache.build_index();
+
+        assert!(cache.order(&order_1.client_order_id()).is_some());
+        assert!(cache.order(&order_2.client_order_id()).is_some());
+        assert_eq!(cache.client_id(&order_1.client_order_id()), Some(&client_a));
+        assert_eq!(cache.client_id(&order_2.client_order_id()), Some(&client_b));
+
+        cache.dispose();
+        adapter.flush().unwrap();
+        adapter.close().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_restart_recovery_restores_order_indexes() {
         let _guard = redis_test_mutex().lock().await;
         let adapter = get_redis_cache_adapter()


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [ ] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [ ] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed
- [x] I ran all relevant tests locally
- [x] I have not modified `RELEASES.md`

## Summary

Persist the execution client selected after routing and validation as a write-once cache origin
before an order reaches outbound transport. This prevents venue-routed orders without an explicit
`client_id` from remaining unowned and provides the prerequisite for strict runtime report source
validation in #4782. Order-list claims are validated and enqueued as one batch so conflicts or
persistence admission failures cannot partially update in-memory origins or reach transport.

## Related issues/PRs

Related to #4782

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [x] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Problem

An order can enter the cache before the execution engine resolves its final routing or default
client. If the command does not carry an explicit `client_id`, the selected client is not recorded
as the order's origin. This leaves later report validation without a trusted cached origin and can
cause subsequent multi-client routing to fall back to venue or default selection.

Order lists also require a batch contract: claiming each child independently could leave a
partially updated origin index when a later child conflicts or persistence cannot accept the
complete update.

## Solution

- Add `Cache::claim_order_clients` with write-once semantics: an unclaimed order is assigned,
  a matching claim is idempotent, and a conflicting or missing order is rejected.
- Validate the complete claim batch and enqueue its persistence operation before changing any
  in-memory origin.
- Claim the actual client selected after routing and venue validation, but before own-book or
  client transport side effects, for both single orders and order lists.
- Deny the submission without calling the execution client when a claim conflicts or the
  persistence command cannot be enqueued.
- Persist built-in Redis claims with one multi-field hash operation and PostgreSQL claims in one
  transaction, without changing the database schema.
- Record the new cache mutation in the EventStore recovery inventory without claiming that current
  command payloads can reconstruct a client selected only at runtime.

The asynchronous cache backends guarantee that the batch persistence command is accepted before
outbound transport. They retain their existing asynchronous failure model and do not claim durable
completion before transport.

## Stack and merge order

This is Stage 1 of the implementation agreed in #4782. It must land before the mandatory runtime
execution-report source migration because strict origin validation requires every newly submitted
order to have the resolved execution client recorded.

## Breaking change details

The new `CacheDatabaseAdapter::index_order_clients` method has a default implementation, so existing
third-party implementations remain Rust source-compatible. The default rejects non-empty claims,
however, because silently omitting origin persistence would violate the source-validation contract.

A custom cache database used for outbound live execution must therefore implement atomic batch
order-client indexing. Otherwise, affected submissions fail closed before transport. No migration
is required when no cache database is configured, and the built-in Redis and PostgreSQL adapters
implement the new operation.

## Documentation

- [x] Documentation changes follow the style guide (no documentation changed)
- [x] PyO3 stubs are unchanged because no bindings or wrapped Rust documentation changed

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed

Validation covered:

- write-once, idempotent, conflicting, duplicate, and missing-order cache claims;
- venue-routed single-order origin persistence;
- atomic order-list claims and no-transport failure paths;
- persistence enqueue failures leaving the in-memory origin index unchanged;
- Redis and PostgreSQL persistence and reload behavior;
- the full relevant `common`, `execution`, `infrastructure`, and `event_store` Rust test suites;
- formatting, workspace pre-commit checks, Clippy, and diff validation.
