### PR TITLE
Centralize Polymarket pagination operations

### DIFF
--- a/crates/adapters/polymarket/src/http/clob.rs
+++ b/crates/adapters/polymarket/src/http/clob.rs
@@ -45,6 +45,7 @@ use crate::{
             ClobBookResponse, ClobMarketResponse, FeeRateResponse, PolymarketOpenOrder,
             PolymarketOrder, PolymarketTradeReport, TickSizeResponse,
         },
+        pagination::{CursorKey, PaginationGuard},
         query::{
             BalanceAllowance, BatchCancelResponse, CancelMarketOrdersParams, CancelResponse,
             ClobVersionResponse, GetBalanceAllowanceParams, GetOrdersParams, GetTradesParams,
@@ -455,18 +456,22 @@ impl PolymarketClobHttpClient {
         mut params: GetOrdersParams,
     ) -> Result<Vec<PolymarketOpenOrder>> {
         let mut all = Vec::new();
+        let mut cursor = params
+            .next_cursor
+            .clone()
+            .unwrap_or_else(|| CURSOR_START.to_string());
+        params.next_cursor = Some(cursor.clone());
+        let mut pagination = CursorPagination::new(PATH_ORDERS, cursor.clone());
 
         loop {
-            let cursor = params
-                .next_cursor
-                .get_or_insert_with(|| CURSOR_START.to_string())
-                .clone();
             let page: PaginatedResponse<PolymarketOpenOrder> =
                 self.send_get(PATH_ORDERS, Some(&params), true).await?;
+            let page_len = page.data.len();
             all.extend(page.data);
-            let Some(next_cursor) = cursor_next(PATH_ORDERS, &cursor, page.next_cursor)? else {
+            let Some(next_cursor) = pagination.next(page_len, &cursor, page.next_cursor)? else {
                 break;
             };
+            cursor.clone_from(&next_cursor);
             params.next_cursor = Some(next_cursor);
         }
         Ok(all)
@@ -494,18 +499,22 @@ impl PolymarketClobHttpClient {
         mut params: GetTradesParams,
     ) -> Result<Vec<PolymarketTradeReport>> {
         let mut all = Vec::new();
+        let mut cursor = params
+            .next_cursor
+            .clone()
+            .unwrap_or_else(|| CURSOR_START.to_string());
+        params.next_cursor = Some(cursor.clone());
+        let mut pagination = CursorPagination::new(PATH_TRADES, cursor.clone());
 
         loop {
-            let cursor = params
-                .next_cursor
-                .get_or_insert_with(|| CURSOR_START.to_string())
-                .clone();
             let page: PaginatedResponse<PolymarketTradeReport> =
                 self.send_get(PATH_TRADES, Some(&params), true).await?;
+            let page_len = page.data.len();
             all.extend(page.data);
-            let Some(next_cursor) = cursor_next(PATH_TRADES, &cursor, page.next_cursor)? else {
+            let Some(next_cursor) = pagination.next(page_len, &cursor, page.next_cursor)? else {
                 break;
             };
+            cursor.clone_from(&next_cursor);
             params.next_cursor = Some(next_cursor);
         }
         Ok(all)
@@ -770,21 +779,46 @@ impl PolymarketClobPublicClient {
     }
 }
 
-fn cursor_next(
+struct CursorPagination {
     endpoint: &'static str,
-    cursor: &str,
-    next_cursor: Option<String>,
-) -> Result<Option<String>> {
-    let next_cursor = next_cursor
-        .ok_or_else(|| Error::decode(format!("{endpoint} response omitted next_cursor")))?;
-    if next_cursor.is_empty() || next_cursor == CURSOR_END {
-        Ok(None)
-    } else if next_cursor == cursor {
-        Err(Error::decode(format!(
-            "{endpoint} pagination cursor did not advance from {cursor:?}"
-        )))
-    } else {
-        Ok(Some(next_cursor))
+    guard: PaginationGuard<CursorKey>,
+}
+
+impl CursorPagination {
+    fn new(endpoint: &'static str, initial_cursor: String) -> Self {
+        let mut guard = PaginationGuard::new(endpoint);
+        guard.seed(CursorKey::new(initial_cursor));
+        Self { endpoint, guard }
+    }
+
+    fn next(
+        &mut self,
+        rows: usize,
+        cursor: &str,
+        next_cursor: Option<String>,
+    ) -> Result<Option<String>> {
+        let next_cursor = next_cursor.ok_or_else(|| {
+            Error::decode(format!("{} response omitted next_cursor", self.endpoint))
+        })?;
+
+        match next_cursor {
+            next if next.is_empty() || next == CURSOR_END => {
+                self.guard
+                    .advance(rows, None)
+                    .map_err(|e| Error::decode(e.to_string()))?;
+                Ok(None)
+            }
+            next if next == cursor => Err(Error::decode(format!(
+                "{} pagination cursor did not advance from {cursor:?}",
+                self.endpoint
+            ))),
+            next => {
+                self.guard
+                    .advance(rows, Some(CursorKey::new(next.clone())))
+                    .map_err(|e| Error::decode(e.to_string()))?;
+                Ok(Some(next))
+            }
+        }
     }
 }
 

--- a/crates/adapters/polymarket/src/http/clob.rs
+++ b/crates/adapters/polymarket/src/http/clob.rs
@@ -15,7 +15,10 @@
 
 //! Provides the HTTP client for the Polymarket CLOB REST API.
 
-use std::{collections::HashMap, result::Result as StdResult, str::from_utf8, sync::Arc};
+use std::{
+    collections::HashMap, convert::Infallible, result::Result as StdResult, str::from_utf8,
+    sync::Arc,
+};
 
 use nautilus_core::{
     consts::NAUTILUS_USER_AGENT,
@@ -45,7 +48,7 @@ use crate::{
             ClobBookResponse, ClobMarketResponse, FeeRateResponse, PolymarketOpenOrder,
             PolymarketOrder, PolymarketTradeReport, TickSizeResponse,
         },
-        pagination::{CursorKey, PaginationGuard},
+        pagination::{CollectAll, Completion, CursorProtocol, FetchOutcome, Paginator},
         query::{
             BalanceAllowance, BatchCancelResponse, CancelMarketOrdersParams, CancelResponse,
             ClobVersionResponse, GetBalanceAllowanceParams, GetOrdersParams, GetTradesParams,
@@ -451,30 +454,37 @@ impl PolymarketClobHttpClient {
     }
 
     /// Fetches all open orders matching the given parameters (auto-paginated).
-    pub async fn get_orders(
-        &self,
-        mut params: GetOrdersParams,
-    ) -> Result<Vec<PolymarketOpenOrder>> {
-        let mut all = Vec::new();
-        let mut cursor = params
+    pub async fn get_orders(&self, params: GetOrdersParams) -> Result<Vec<PolymarketOpenOrder>> {
+        let initial_cursor = params
             .next_cursor
             .clone()
             .unwrap_or_else(|| CURSOR_START.to_string());
-        params.next_cursor = Some(cursor.clone());
-        let mut pagination = CursorPagination::new(PATH_ORDERS, cursor.clone());
+        let protocol = CursorProtocol::<Infallible>::clob(PATH_ORDERS, initial_cursor, CURSOR_END)
+            .map_err(|e| Error::decode(e.to_string()))?;
+        let paginator = Paginator::new(PATH_ORDERS, protocol, CollectAll::new());
+        let completed = paginator
+            .run(
+                |position| {
+                    let mut request = params.clone();
+                    request.next_cursor =
+                        position.as_ref().map(|cursor| cursor.as_ref().to_string());
+                    async move {
+                        let page: PaginatedResponse<PolymarketOpenOrder> =
+                            self.send_get(PATH_ORDERS, Some(&request), true).await?;
+                        Ok(FetchOutcome::Page {
+                            rows: page.data,
+                            wire: page.next_cursor,
+                        })
+                    }
+                },
+                |e| Error::decode(e.to_string()),
+            )
+            .await?;
 
-        loop {
-            let page: PaginatedResponse<PolymarketOpenOrder> =
-                self.send_get(PATH_ORDERS, Some(&params), true).await?;
-            let page_len = page.data.len();
-            all.extend(page.data);
-            let Some(next_cursor) = pagination.next(page_len, &cursor, page.next_cursor)? else {
-                break;
-            };
-            cursor.clone_from(&next_cursor);
-            params.next_cursor = Some(next_cursor);
+        match completed.completion {
+            Completion::WireComplete => Ok(completed.output),
+            Completion::Stopped(never) => match never {},
         }
-        Ok(all)
     }
 
     /// Fetches a single order by ID, returning `None` for empty/null responses.
@@ -494,30 +504,37 @@ impl PolymarketClobHttpClient {
     }
 
     /// Fetches all trades matching the given parameters (auto-paginated).
-    pub async fn get_trades(
-        &self,
-        mut params: GetTradesParams,
-    ) -> Result<Vec<PolymarketTradeReport>> {
-        let mut all = Vec::new();
-        let mut cursor = params
+    pub async fn get_trades(&self, params: GetTradesParams) -> Result<Vec<PolymarketTradeReport>> {
+        let initial_cursor = params
             .next_cursor
             .clone()
             .unwrap_or_else(|| CURSOR_START.to_string());
-        params.next_cursor = Some(cursor.clone());
-        let mut pagination = CursorPagination::new(PATH_TRADES, cursor.clone());
+        let protocol = CursorProtocol::<Infallible>::clob(PATH_TRADES, initial_cursor, CURSOR_END)
+            .map_err(|e| Error::decode(e.to_string()))?;
+        let paginator = Paginator::new(PATH_TRADES, protocol, CollectAll::new());
+        let completed = paginator
+            .run(
+                |position| {
+                    let mut request = params.clone();
+                    request.next_cursor =
+                        position.as_ref().map(|cursor| cursor.as_ref().to_string());
+                    async move {
+                        let page: PaginatedResponse<PolymarketTradeReport> =
+                            self.send_get(PATH_TRADES, Some(&request), true).await?;
+                        Ok(FetchOutcome::Page {
+                            rows: page.data,
+                            wire: page.next_cursor,
+                        })
+                    }
+                },
+                |e| Error::decode(e.to_string()),
+            )
+            .await?;
 
-        loop {
-            let page: PaginatedResponse<PolymarketTradeReport> =
-                self.send_get(PATH_TRADES, Some(&params), true).await?;
-            let page_len = page.data.len();
-            all.extend(page.data);
-            let Some(next_cursor) = pagination.next(page_len, &cursor, page.next_cursor)? else {
-                break;
-            };
-            cursor.clone_from(&next_cursor);
-            params.next_cursor = Some(next_cursor);
+        match completed.completion {
+            Completion::WireComplete => Ok(completed.output),
+            Completion::Stopped(never) => match never {},
         }
-        Ok(all)
     }
 
     /// Fetches strict V2 balance and allowance evidence for the given parameters.
@@ -776,49 +793,6 @@ impl PolymarketClobPublicClient {
         );
 
         Ok(book)
-    }
-}
-
-struct CursorPagination {
-    endpoint: &'static str,
-    guard: PaginationGuard<CursorKey>,
-}
-
-impl CursorPagination {
-    fn new(endpoint: &'static str, initial_cursor: String) -> Self {
-        let mut guard = PaginationGuard::new(endpoint);
-        guard.seed(CursorKey::new(initial_cursor));
-        Self { endpoint, guard }
-    }
-
-    fn next(
-        &mut self,
-        rows: usize,
-        cursor: &str,
-        next_cursor: Option<String>,
-    ) -> Result<Option<String>> {
-        let next_cursor = next_cursor.ok_or_else(|| {
-            Error::decode(format!("{} response omitted next_cursor", self.endpoint))
-        })?;
-
-        match next_cursor {
-            next if next.is_empty() || next == CURSOR_END => {
-                self.guard
-                    .advance(rows, None)
-                    .map_err(|e| Error::decode(e.to_string()))?;
-                Ok(None)
-            }
-            next if next == cursor => Err(Error::decode(format!(
-                "{} pagination cursor did not advance from {cursor:?}",
-                self.endpoint
-            ))),
-            next => {
-                self.guard
-                    .advance(rows, Some(CursorKey::new(next.clone())))
-                    .map_err(|e| Error::decode(e.to_string()))?;
-                Ok(Some(next))
-            }
-        }
     }
 }
 

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -15,7 +15,7 @@
 
 //! Provides the HTTP client for the Polymarket Data API.
 
-use std::{collections::HashMap, fmt::Debug, result::Result as StdResult};
+use std::{collections::HashMap, convert::Infallible, result::Result as StdResult};
 
 use anyhow::Context;
 use nautilus_core::{UnixNanos, consts::NAUTILUS_USER_AGENT};
@@ -36,7 +36,10 @@ use crate::{
     http::{
         error::{Error, Result},
         models::{DataApiPosition, DataApiTrade},
-        pagination::PaginationGuard,
+        pagination::{
+            CollectAll, Completion, FetchOutcome, OffsetProtocol, PageFingerprint, PageReducer,
+            Paginator, encode_length_prefixed, fingerprint_multiset,
+        },
     },
 };
 
@@ -74,12 +77,121 @@ pub(crate) fn build_polymarket_trade_id(transaction_hash: &str, asset: &str, seq
 
 const POLYMARKET_DATA_API_URL: &str = "https://data-api.polymarket.com";
 
-#[derive(Eq, Hash, PartialEq)]
-struct PositionPage(Vec<u8>);
+fn position_page_fingerprint(rows: &[DataApiPosition]) -> PageFingerprint {
+    let descriptors = rows
+        .iter()
+        .map(|position| {
+            let mut descriptor = Vec::new();
+            encode_length_prefixed(&mut descriptor, position.condition_id.as_bytes());
+            encode_length_prefixed(&mut descriptor, position.asset.as_bytes());
+            descriptor
+        })
+        .collect();
+    fingerprint_multiset(1, descriptors)
+}
 
-impl Debug for PositionPage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("a full page")
+fn trade_page_fingerprint(rows: &[DataApiTrade]) -> PageFingerprint {
+    let descriptors = rows
+        .iter()
+        .map(|trade| {
+            let mut descriptor = Vec::new();
+            encode_length_prefixed(&mut descriptor, trade.transaction_hash.as_bytes());
+            encode_length_prefixed(&mut descriptor, trade.asset.as_bytes());
+            descriptor.push(match trade.side {
+                PolymarketOrderSide::Buy => 0,
+                PolymarketOrderSide::Sell => 1,
+            });
+            encode_decimal(&mut descriptor, trade.price);
+            encode_decimal(&mut descriptor, trade.size);
+            descriptor.extend_from_slice(&trade.timestamp.to_be_bytes());
+            descriptor
+        })
+        .collect();
+    fingerprint_multiset(2, descriptors)
+}
+
+fn encode_decimal(output: &mut Vec<u8>, value: Decimal) {
+    let normalized = value.normalize();
+    output.extend_from_slice(&normalized.mantissa().to_be_bytes());
+    output.extend_from_slice(&normalized.scale().to_be_bytes());
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TradeTickStop {
+    CallerCapped,
+    VenueOffsetCeiling(OffsetCeilingSource),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum OffsetCeilingSource {
+    Local,
+    Remote(String),
+}
+
+struct TradeTickReducer {
+    rows: Vec<DataApiTrade>,
+    instrument_id: InstrumentId,
+    token_id: String,
+    price_precision: u8,
+    size_precision: u8,
+    start: Option<UnixNanos>,
+    end: Option<UnixNanos>,
+    limit: Option<usize>,
+}
+
+impl PageReducer<DataApiTrade, anyhow::Error> for TradeTickReducer {
+    type Output = Vec<TradeTick>;
+    type Stop = TradeTickStop;
+
+    fn consume(&mut self, rows: Vec<DataApiTrade>) -> anyhow::Result<Option<Self::Stop>> {
+        self.rows.extend(rows);
+        let capped = self.start.is_none()
+            && self.limit.is_some_and(|target| {
+                count_matching_trades_within_end(&self.rows, &self.token_id, self.end) >= target
+            });
+        Ok(capped.then_some(TradeTickStop::CallerCapped))
+    }
+
+    fn finish(self, completion: &Completion<Self::Stop>) -> anyhow::Result<Self::Output> {
+        if self.start.is_some()
+            && matches!(
+                completion,
+                Completion::Stopped(TradeTickStop::VenueOffsetCeiling(_))
+            )
+        {
+            return Ok(Vec::new());
+        }
+
+        let start_secs = self
+            .start
+            .map(|value| (value.as_u64() / 1_000_000_000) as i64);
+        let end_secs = self
+            .end
+            .map(|value| (value.as_u64() / 1_000_000_000) as i64);
+        let mut trades = parse_trade_ticks(
+            self.rows,
+            self.instrument_id,
+            &self.token_id,
+            self.price_precision,
+            self.size_precision,
+        )?;
+        trades.retain(|trade| {
+            let event_secs = trade.ts_event.as_u64() / 1_000_000_000;
+            start_secs.is_none_or(|start| event_secs >= start as u64)
+                && end_secs.is_none_or(|end| event_secs <= end as u64)
+        });
+
+        if let Some(target) = self.limit
+            && trades.len() > target
+        {
+            if self.start.is_some() {
+                trades.truncate(target);
+            } else {
+                trades.drain(..trades.len() - target);
+            }
+        }
+
+        Ok(trades)
     }
 }
 
@@ -136,57 +248,59 @@ impl PolymarketDataApiHttpClient {
     /// Paginates through `GET /positions?user={address}&sizeThreshold=0`
     /// until a partial page is returned.
     pub async fn get_positions(&self, user_address: &str) -> Result<Vec<DataApiPosition>> {
-        const PAGE_SIZE: u32 = 100;
+        const PAGE_SIZE: usize = 100;
 
-        let mut all_positions: Vec<DataApiPosition> = Vec::new();
-        let mut offset: u32 = 0;
-        let mut pagination = PaginationGuard::new("/positions");
+        let protocol = OffsetProtocol::<DataApiPosition, Infallible>::new(
+            "/positions",
+            PAGE_SIZE,
+            position_page_fingerprint,
+            None,
+        );
+        let paginator = Paginator::new("/positions", protocol, CollectAll::new());
+        let completed = paginator
+            .run(
+                |offset| async move {
+                    let params = vec![
+                        ("user".to_string(), user_address.to_string()),
+                        ("limit".to_string(), PAGE_SIZE.to_string()),
+                        ("offset".to_string(), offset.to_string()),
+                        ("sizeThreshold".to_string(), "0".to_string()),
+                        ("sortBy".to_string(), "TOKENS".to_string()),
+                        ("sortDirection".to_string(), "DESC".to_string()),
+                    ];
+                    let url = format!("{}/positions", self.base_url);
+                    let response = self
+                        .client
+                        .request_with_params(
+                            Method::GET,
+                            url,
+                            Some(&params),
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .await
+                        .map_err(Error::from_http_client)?;
 
-        loop {
-            let params = vec![
-                ("user".to_string(), user_address.to_string()),
-                ("limit".to_string(), PAGE_SIZE.to_string()),
-                ("offset".to_string(), offset.to_string()),
-                ("sizeThreshold".to_string(), "0".to_string()),
-                ("sortBy".to_string(), "TOKENS".to_string()),
-                ("sortDirection".to_string(), "DESC".to_string()),
-            ];
+                    if response.status.is_success() {
+                        let rows = serde_json::from_slice(&response.body).map_err(Error::Serde)?;
+                        Ok(FetchOutcome::Page { rows, wire: () })
+                    } else {
+                        Err(Error::from_status_code(
+                            response.status.as_u16(),
+                            &response.body,
+                        ))
+                    }
+                },
+                |e| Error::decode(e.to_string()),
+            )
+            .await?;
 
-            let url = format!("{}/positions", self.base_url);
-            let response = self
-                .client
-                .request_with_params(Method::GET, url, Some(&params), None, None, None, None)
-                .await
-                .map_err(Error::from_http_client)?;
-
-            if response.status.is_success() {
-                let page_body = PositionPage(response.body.to_vec());
-                let page: Vec<DataApiPosition> =
-                    serde_json::from_slice(&response.body).map_err(Error::Serde)?;
-                let page_len = page.len();
-                let count = u32::try_from(page_len)
-                    .map_err(|_| Error::decode("/positions page length exceeds u32"))?;
-                let progress = (count >= PAGE_SIZE).then_some(page_body);
-                pagination
-                    .advance(page_len, progress)
-                    .map_err(|e| Error::decode(e.to_string()))?;
-                all_positions.extend(page);
-
-                if count < PAGE_SIZE {
-                    break;
-                }
-                offset = offset
-                    .checked_add(count)
-                    .ok_or_else(|| Error::decode("/positions pagination offset overflowed u32"))?;
-            } else {
-                return Err(Error::from_status_code(
-                    response.status.as_u16(),
-                    &response.body,
-                ));
-            }
+        match completed.completion {
+            Completion::WireComplete => Ok(completed.output),
+            Completion::Stopped(never) => match never {},
         }
-
-        Ok(all_positions)
     }
 
     /// Fetches trades from the Data API for the given condition ID.
@@ -281,93 +395,84 @@ impl PolymarketDataApiHttpClient {
 
         let start_secs = start.map(|value| (value.as_u64() / 1_000_000_000) as i64);
         let end_secs = end.map(|value| (value.as_u64() / 1_000_000_000) as i64);
-        let page_size = PAGE_SIZE;
-        let mut all_trades: Vec<DataApiTrade> = Vec::new();
-        let mut offset: u32 = 0;
-        let mut offset_ceiling_reached = false;
-
-        loop {
-            let page = match self
-                .get_trades_in_window(
-                    condition_id,
-                    Some(page_size),
-                    Some(offset),
-                    start_secs,
-                    end_secs,
-                )
-                .await
-            {
-                Ok(page) => page,
-                Err(e) => {
-                    if format!("{e}").contains("max historical activity offset") {
-                        // Public API caps pagination depth; warn and return partial
-                        log::warn!(
-                            "Polymarket public trades API hit its historical offset \
-                             ceiling for condition {condition_id}; returning partial \
-                            results: {e}",
-                        );
-                        offset_ceiling_reached = true;
-                        break;
+        let reducer = TradeTickReducer {
+            rows: Vec::new(),
+            instrument_id,
+            token_id: token_id.to_string(),
+            price_precision,
+            size_precision,
+            start,
+            end,
+            limit: limit.map(|value| value as usize),
+        };
+        let protocol = OffsetProtocol::new(
+            "/trades",
+            PAGE_SIZE as usize,
+            trade_page_fingerprint,
+            Some((
+                MAX_OFFSET,
+                TradeTickStop::VenueOffsetCeiling(OffsetCeilingSource::Local),
+            )),
+        );
+        let paginator = Paginator::new("/trades", protocol, reducer);
+        let completed = paginator
+            .run(
+                |offset| async move {
+                    match self
+                        .get_trades_in_window(
+                            condition_id,
+                            Some(PAGE_SIZE),
+                            Some(offset),
+                            start_secs,
+                            end_secs,
+                        )
+                        .await
+                    {
+                        Ok(rows) => Ok(FetchOutcome::Page { rows, wire: () }),
+                        Err(e) if is_historical_offset_ceiling(&e) => {
+                            Ok(FetchOutcome::Stop(TradeTickStop::VenueOffsetCeiling(
+                                OffsetCeilingSource::Remote(e.to_string()),
+                            )))
+                        }
+                        Err(e) => Err(anyhow::Error::new(e)),
                     }
-                    anyhow::bail!(e);
-                }
-            };
+                },
+                anyhow::Error::new,
+            )
+            .await?;
 
-            let count = page.len() as u32;
-            all_trades.extend(page);
-
-            if count < page_size {
-                break;
+        match completed.completion {
+            Completion::WireComplete | Completion::Stopped(TradeTickStop::CallerCapped) => {
+                Ok(completed.output)
             }
-
-            if start.is_none()
-                && limit.is_some_and(|target| {
-                    count_matching_trades_within_end(&all_trades, token_id, end) >= target as usize
-                })
-            {
-                break;
+            Completion::Stopped(TradeTickStop::VenueOffsetCeiling(_)) if start.is_some() => {
+                anyhow::bail!(
+                    "Polymarket public trades API reached the historical offset ceiling for condition {condition_id}; cannot guarantee complete start-anchored results, narrow the time window"
+                )
             }
-            offset += count;
-            if offset >= MAX_OFFSET {
+            Completion::Stopped(TradeTickStop::VenueOffsetCeiling(OffsetCeilingSource::Local)) => {
                 log::warn!(
                     "Polymarket public trades API reached the historical offset ceiling for condition {condition_id}; returning partial results"
                 );
-                offset_ceiling_reached = true;
-                break;
+                Ok(completed.output)
+            }
+            Completion::Stopped(TradeTickStop::VenueOffsetCeiling(
+                OffsetCeilingSource::Remote(error),
+            )) => {
+                log::warn!(
+                    "Polymarket public trades API hit its historical offset ceiling for condition {condition_id}; returning partial results: {error}"
+                );
+                Ok(completed.output)
             }
         }
-
-        if offset_ceiling_reached && start.is_some() {
-            anyhow::bail!(
-                "Polymarket public trades API reached the historical offset ceiling for condition {condition_id}; cannot guarantee complete start-anchored results, narrow the time window"
-            );
-        }
-
-        let mut trades = parse_trade_ticks(
-            all_trades,
-            instrument_id,
-            token_id,
-            price_precision,
-            size_precision,
-        )?;
-        trades.retain(|trade| {
-            let event_secs = trade.ts_event.as_u64() / 1_000_000_000;
-            start_secs.is_none_or(|start| event_secs >= start as u64)
-                && end_secs.is_none_or(|end| event_secs <= end as u64)
-        });
-
-        if let Some(target) = limit.map(|value| value as usize)
-            && trades.len() > target
-        {
-            if start.is_some() {
-                trades.truncate(target);
-            } else {
-                trades.drain(..trades.len() - target);
-            }
-        }
-
-        Ok(trades)
     }
+}
+
+fn is_historical_offset_ceiling(error: &Error) -> bool {
+    matches!(
+        error,
+        Error::Http { message, .. } if message.contains("max historical activity offset")
+    )
 }
 
 fn count_matching_trades_within_end(
@@ -705,6 +810,106 @@ mod tests {
             profile_image_optimized: None,
             transaction_hash: transaction_hash.to_string(),
         }
+    }
+
+    #[rstest]
+    fn test_position_page_fingerprint_uses_identity_multiset_only() {
+        let first = vec![
+            DataApiPosition {
+                asset: "asset-a".to_string(),
+                condition_id: "condition-a".to_string(),
+                size: dec!(1),
+                avg_price: Some(dec!(0.5)),
+            },
+            DataApiPosition {
+                asset: "asset-b".to_string(),
+                condition_id: "condition-b".to_string(),
+                size: dec!(2),
+                avg_price: Some(dec!(0.6)),
+            },
+        ];
+        let reordered_with_new_values = vec![
+            DataApiPosition {
+                asset: "asset-b".to_string(),
+                condition_id: "condition-b".to_string(),
+                size: dec!(20),
+                avg_price: Some(dec!(0.9)),
+            },
+            DataApiPosition {
+                asset: "asset-a".to_string(),
+                condition_id: "condition-a".to_string(),
+                size: dec!(10),
+                avg_price: None,
+            },
+        ];
+
+        assert_eq!(
+            position_page_fingerprint(&first),
+            position_page_fingerprint(&reordered_with_new_values)
+        );
+    }
+
+    #[rstest]
+    fn test_trade_page_fingerprint_uses_normalized_economic_multiset() {
+        let mut first = make_trade(
+            1_710_000_000,
+            "transaction-a",
+            "asset-a",
+            PolymarketOrderSide::Buy,
+            0.5,
+            1.0,
+        );
+        first.condition_id = "condition-a".to_string();
+        first.title = Some("first title".to_string());
+        let mut restamped = make_trade(
+            1_710_000_000,
+            "transaction-a",
+            "asset-a",
+            PolymarketOrderSide::Buy,
+            0.5,
+            1.0,
+        );
+        restamped.condition_id = "condition-b".to_string();
+        restamped.title = Some("second title".to_string());
+        restamped.price = Decimal::from_str_exact("0.5000").unwrap();
+        restamped.size = Decimal::from_str_exact("1.000").unwrap();
+
+        assert_eq!(
+            trade_page_fingerprint(&[first]),
+            trade_page_fingerprint(&[restamped])
+        );
+
+        let duplicate = vec![
+            make_trade(
+                1_710_000_000,
+                "transaction-a",
+                "asset-a",
+                PolymarketOrderSide::Buy,
+                0.5,
+                1.0,
+            ),
+            make_trade(
+                1_710_000_000,
+                "transaction-a",
+                "asset-a",
+                PolymarketOrderSide::Buy,
+                0.5,
+                1.0,
+            ),
+        ];
+        let single = vec![make_trade(
+            1_710_000_000,
+            "transaction-a",
+            "asset-a",
+            PolymarketOrderSide::Buy,
+            0.5,
+            1.0,
+        )];
+
+        assert_ne!(
+            trade_page_fingerprint(&duplicate),
+            trade_page_fingerprint(&single)
+        );
     }
 
     fn test_instrument_id() -> InstrumentId {

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -15,7 +15,7 @@
 
 //! Provides the HTTP client for the Polymarket Data API.
 
-use std::{collections::HashMap, result::Result as StdResult};
+use std::{collections::HashMap, fmt::Debug, result::Result as StdResult};
 
 use anyhow::Context;
 use nautilus_core::{UnixNanos, consts::NAUTILUS_USER_AGENT};
@@ -36,6 +36,7 @@ use crate::{
     http::{
         error::{Error, Result},
         models::{DataApiPosition, DataApiTrade},
+        pagination::PaginationGuard,
     },
 };
 
@@ -72,6 +73,15 @@ pub(crate) fn build_polymarket_trade_id(transaction_hash: &str, asset: &str, seq
 }
 
 const POLYMARKET_DATA_API_URL: &str = "https://data-api.polymarket.com";
+
+#[derive(Eq, Hash, PartialEq)]
+struct PositionPage(Vec<u8>);
+
+impl Debug for PositionPage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("a full page")
+    }
+}
 
 /// Provides an unauthenticated HTTP client for the Polymarket Data API.
 ///
@@ -130,6 +140,7 @@ impl PolymarketDataApiHttpClient {
 
         let mut all_positions: Vec<DataApiPosition> = Vec::new();
         let mut offset: u32 = 0;
+        let mut pagination = PaginationGuard::new("/positions");
 
         loop {
             let params = vec![
@@ -149,15 +160,24 @@ impl PolymarketDataApiHttpClient {
                 .map_err(Error::from_http_client)?;
 
             if response.status.is_success() {
+                let page_body = PositionPage(response.body.to_vec());
                 let page: Vec<DataApiPosition> =
                     serde_json::from_slice(&response.body).map_err(Error::Serde)?;
-                let count = page.len() as u32;
+                let page_len = page.len();
+                let count = u32::try_from(page_len)
+                    .map_err(|_| Error::decode("/positions page length exceeds u32"))?;
+                let progress = (count >= PAGE_SIZE).then_some(page_body);
+                pagination
+                    .advance(page_len, progress)
+                    .map_err(|e| Error::decode(e.to_string()))?;
                 all_positions.extend(page);
 
                 if count < PAGE_SIZE {
                     break;
                 }
-                offset += count;
+                offset = offset
+                    .checked_add(count)
+                    .ok_or_else(|| Error::decode("/positions pagination offset overflowed u32"))?;
             } else {
                 return Err(Error::from_status_code(
                     response.status.as_u16(),

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -110,6 +110,22 @@ fn trade_page_fingerprint(rows: &[DataApiTrade]) -> PageFingerprint {
     fingerprint_multiset(2, descriptors)
 }
 
+fn validate_trade_page_scope(
+    rows: Vec<DataApiTrade>,
+    expected_condition_id: &str,
+) -> anyhow::Result<Vec<DataApiTrade>> {
+    match rows
+        .iter()
+        .find(|trade| trade.condition_id != expected_condition_id)
+    {
+        Some(trade) => anyhow::bail!(
+            "Polymarket Data API returned trade for condition {} while requesting {expected_condition_id}",
+            trade.condition_id
+        ),
+        None => Ok(rows),
+    }
+}
+
 fn encode_decimal(output: &mut Vec<u8>, value: Decimal) {
     let normalized = value.normalize();
     output.extend_from_slice(&normalized.mantissa().to_be_bytes());
@@ -428,7 +444,10 @@ impl PolymarketDataApiHttpClient {
                         )
                         .await
                     {
-                        Ok(rows) => Ok(FetchOutcome::Page { rows, wire: () }),
+                        Ok(rows) => Ok(FetchOutcome::Page {
+                            rows: validate_trade_page_scope(rows, condition_id)?,
+                            wire: (),
+                        }),
                         Err(e) if is_historical_offset_ceiling(&e) => {
                             Ok(FetchOutcome::Stop(TradeTickStop::VenueOffsetCeiling(
                                 OffsetCeilingSource::Remote(e.to_string()),
@@ -469,10 +488,12 @@ impl PolymarketDataApiHttpClient {
 }
 
 fn is_historical_offset_ceiling(error: &Error) -> bool {
-    matches!(
-        error,
-        Error::Http { message, .. } if message.contains("max historical activity offset")
-    )
+    match error {
+        Error::Http { message, .. } | Error::RateLimit { message, .. } => {
+            message.contains("max historical activity offset")
+        }
+        _ => false,
+    }
 }
 
 fn count_matching_trades_within_end(

--- a/crates/adapters/polymarket/src/http/gamma.rs
+++ b/crates/adapters/polymarket/src/http/gamma.rs
@@ -47,7 +47,7 @@ use crate::{
     http::{
         error::{Error, Result},
         models::{GammaEvent, GammaMarket, GammaTag, SearchResponse},
-        pagination::{CursorKey, PaginationGuard},
+        pagination::{Completion, CursorProtocol, FetchOutcome, Paginator, WindowedCollect},
         parse::{create_instrument_from_def, parse_gamma_market},
         query::{GetGammaEventsParams, GetGammaMarketsParams, GetSearchParams},
         rate_limits::POLYMARKET_GAMMA_REST_QUOTA,
@@ -56,6 +56,11 @@ use crate::{
 
 const GAMMA_MARKETS_KEYSET_PAGE_LIMIT: u32 = 100;
 const GAMMA_EVENTS_KEYSET_PAGE_LIMIT: u32 = 500;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GammaStop {
+    CallerCapped,
+}
 
 /// Provides a raw HTTP client for the Polymarket Gamma API.
 ///
@@ -500,51 +505,42 @@ impl PolymarketGammaHttpClient {
             .limit
             .unwrap_or(GAMMA_MARKETS_KEYSET_PAGE_LIMIT)
             .min(GAMMA_MARKETS_KEYSET_PAGE_LIMIT);
-        let max_markets = base_params.max_markets;
-        let mut all_markets = Vec::new();
-        let mut remaining_offset = base_params.offset.unwrap_or(0);
-        let mut after_cursor = None;
-        let mut pagination = PaginationGuard::new("Gamma market");
-        let mut page_num = 0u32;
+        let protocol = CursorProtocol::<GammaStop>::gamma("Gamma market");
+        let reducer = WindowedCollect::new(
+            base_params.offset.unwrap_or(0) as usize,
+            base_params.max_markets.map(|value| value as usize),
+            GammaStop::CallerCapped,
+        );
+        let paginator = Paginator::new("Gamma market", protocol, reducer);
+        let completed = paginator
+            .run(
+                |position| {
+                    let after_cursor = position.map(|cursor| cursor.as_ref().to_string());
+                    let params = GetGammaMarketsParams {
+                        limit: Some(page_size),
+                        offset: None,
+                        ..base_params.clone()
+                    };
+                    async move {
+                        let response = self
+                            .inner
+                            .get_gamma_markets_keyset(params, after_cursor.as_deref())
+                            .await?;
+                        Ok::<_, anyhow::Error>(FetchOutcome::Page {
+                            rows: response.markets,
+                            wire: response.next_cursor,
+                        })
+                    }
+                },
+                anyhow::Error::new,
+            )
+            .await?;
 
-        loop {
-            let params = GetGammaMarketsParams {
-                limit: Some(page_size),
-                offset: None,
-                ..base_params.clone()
-            };
-
-            let response = self
-                .inner
-                .get_gamma_markets_keyset(params, after_cursor.as_deref())
-                .await?;
-            let page_rows = response.markets.len();
-            let page_len = page_rows as u32;
-            let skipped = remaining_offset.min(page_len) as usize;
-            remaining_offset -= skipped as u32;
-            page_num += 1;
-            all_markets.extend(response.markets.into_iter().skip(skipped));
-
-            log::debug!(
-                "Fetched markets page {page_num}: {page_len} markets (total: {})",
-                all_markets.len(),
-            );
-
-            if let Some(cap) = max_markets
-                && all_markets.len() as u32 >= cap
-            {
-                all_markets.truncate(cap as usize);
-                break;
+        match completed.completion {
+            Completion::WireComplete | Completion::Stopped(GammaStop::CallerCapped) => {
+                Ok(completed.output)
             }
-
-            pagination.advance(page_rows, response.next_cursor.clone().map(CursorKey::new))?;
-            let Some(next_cursor) = response.next_cursor else {
-                break;
-            };
-            after_cursor = Some(next_cursor);
         }
-
-        Ok(all_markets)
     }
 
     /// Fetches all active markets from the Gamma API, paginating automatically.
@@ -868,52 +864,42 @@ impl PolymarketGammaHttpClient {
             .limit
             .unwrap_or(GAMMA_EVENTS_KEYSET_PAGE_LIMIT)
             .min(GAMMA_EVENTS_KEYSET_PAGE_LIMIT);
-        let max_events = base_params.max_events;
-        let mut all_events = Vec::new();
-        let mut remaining_offset = base_params.offset.unwrap_or(0);
-        let mut after_cursor = None;
-        let mut pagination = PaginationGuard::new("Gamma event");
-        let mut page_num = 0u32;
+        let protocol = CursorProtocol::<GammaStop>::gamma("Gamma event");
+        let reducer = WindowedCollect::new(
+            base_params.offset.unwrap_or(0) as usize,
+            base_params.max_events.map(|value| value as usize),
+            GammaStop::CallerCapped,
+        );
+        let paginator = Paginator::new("Gamma event", protocol, reducer);
+        let completed = paginator
+            .run(
+                |position| {
+                    let after_cursor = position.map(|cursor| cursor.as_ref().to_string());
+                    let params = GetGammaEventsParams {
+                        limit: Some(page_size),
+                        offset: None,
+                        ..base_params.clone()
+                    };
+                    async move {
+                        let response = self
+                            .inner
+                            .get_gamma_events_keyset(params, after_cursor.as_deref())
+                            .await?;
+                        Ok::<_, anyhow::Error>(FetchOutcome::Page {
+                            rows: response.events,
+                            wire: response.next_cursor,
+                        })
+                    }
+                },
+                anyhow::Error::new,
+            )
+            .await?;
 
-        loop {
-            let params = GetGammaEventsParams {
-                limit: Some(page_size),
-                offset: None,
-                ..base_params.clone()
-            };
-
-            let response = self
-                .inner
-                .get_gamma_events_keyset(params, after_cursor.as_deref())
-                .await?;
-            let page_rows = response.events.len();
-            let page_len = page_rows as u32;
-            let skipped = remaining_offset.min(page_len) as usize;
-            remaining_offset -= skipped as u32;
-            page_num += 1;
-            let market_count: usize = response.events.iter().map(|e| e.markets.len()).sum();
-            all_events.extend(response.events.into_iter().skip(skipped));
-
-            log::debug!(
-                "Fetched events page {page_num}: {page_len} events, {market_count} markets (total events: {})",
-                all_events.len(),
-            );
-
-            if let Some(cap) = max_events
-                && all_events.len() as u32 >= cap
-            {
-                all_events.truncate(cap as usize);
-                break;
+        match completed.completion {
+            Completion::WireComplete | Completion::Stopped(GammaStop::CallerCapped) => {
+                Ok(completed.output)
             }
-
-            pagination.advance(page_rows, response.next_cursor.clone().map(CursorKey::new))?;
-            let Some(next_cursor) = response.next_cursor else {
-                break;
-            };
-            after_cursor = Some(next_cursor);
         }
-
-        Ok(all_events)
     }
 
     /// Fetches instruments from events matching full query params (paginated).

--- a/crates/adapters/polymarket/src/http/gamma.rs
+++ b/crates/adapters/polymarket/src/http/gamma.rs
@@ -27,7 +27,6 @@
 
 use std::{collections::HashMap, result::Result as StdResult, sync::Arc};
 
-use ahash::AHashSet;
 use nautilus_core::{
     UnixNanos,
     consts::NAUTILUS_USER_AGENT,
@@ -48,6 +47,7 @@ use crate::{
     http::{
         error::{Error, Result},
         models::{GammaEvent, GammaMarket, GammaTag, SearchResponse},
+        pagination::{CursorKey, PaginationGuard},
         parse::{create_instrument_from_def, parse_gamma_market},
         query::{GetGammaEventsParams, GetGammaMarketsParams, GetSearchParams},
         rate_limits::POLYMARKET_GAMMA_REST_QUOTA,
@@ -504,7 +504,7 @@ impl PolymarketGammaHttpClient {
         let mut all_markets = Vec::new();
         let mut remaining_offset = base_params.offset.unwrap_or(0);
         let mut after_cursor = None;
-        let mut seen_cursors = AHashSet::new();
+        let mut pagination = PaginationGuard::new("Gamma market");
         let mut page_num = 0u32;
 
         loop {
@@ -518,7 +518,8 @@ impl PolymarketGammaHttpClient {
                 .inner
                 .get_gamma_markets_keyset(params, after_cursor.as_deref())
                 .await?;
-            let page_len = response.markets.len() as u32;
+            let page_rows = response.markets.len();
+            let page_len = page_rows as u32;
             let skipped = remaining_offset.min(page_len) as usize;
             remaining_offset -= skipped as u32;
             page_num += 1;
@@ -536,14 +537,10 @@ impl PolymarketGammaHttpClient {
                 break;
             }
 
+            pagination.advance(page_rows, response.next_cursor.clone().map(CursorKey::new))?;
             let Some(next_cursor) = response.next_cursor else {
                 break;
             };
-
-            anyhow::ensure!(
-                seen_cursors.insert(next_cursor.clone()),
-                "Gamma market pagination repeated cursor {next_cursor:?}",
-            );
             after_cursor = Some(next_cursor);
         }
 
@@ -875,7 +872,7 @@ impl PolymarketGammaHttpClient {
         let mut all_events = Vec::new();
         let mut remaining_offset = base_params.offset.unwrap_or(0);
         let mut after_cursor = None;
-        let mut seen_cursors = AHashSet::new();
+        let mut pagination = PaginationGuard::new("Gamma event");
         let mut page_num = 0u32;
 
         loop {
@@ -889,7 +886,8 @@ impl PolymarketGammaHttpClient {
                 .inner
                 .get_gamma_events_keyset(params, after_cursor.as_deref())
                 .await?;
-            let page_len = response.events.len() as u32;
+            let page_rows = response.events.len();
+            let page_len = page_rows as u32;
             let skipped = remaining_offset.min(page_len) as usize;
             remaining_offset -= skipped as u32;
             page_num += 1;
@@ -908,14 +906,10 @@ impl PolymarketGammaHttpClient {
                 break;
             }
 
+            pagination.advance(page_rows, response.next_cursor.clone().map(CursorKey::new))?;
             let Some(next_cursor) = response.next_cursor else {
                 break;
             };
-
-            anyhow::ensure!(
-                seen_cursors.insert(next_cursor.clone()),
-                "Gamma event pagination repeated cursor {next_cursor:?}",
-            );
             after_cursor = Some(next_cursor);
         }
 

--- a/crates/adapters/polymarket/src/http/mod.rs
+++ b/crates/adapters/polymarket/src/http/mod.rs
@@ -24,3 +24,5 @@ pub mod models;
 pub mod parse;
 pub mod query;
 pub mod rate_limits;
+
+pub(crate) mod pagination;

--- a/crates/adapters/polymarket/src/http/pagination.rs
+++ b/crates/adapters/polymarket/src/http/pagination.rs
@@ -13,107 +13,828 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::{collections::HashSet, fmt::Debug, hash::Hash};
+use std::{collections::HashSet, future::Future};
+
+use aws_lc_rs::digest::{self, Context};
 
 pub(crate) const PAGINATION_PAGE_LIMIT: usize = 100;
 pub(crate) const PAGINATION_ROW_LIMIT: usize = 100_000;
+pub(crate) const PAGINATION_CURSOR_LIMIT: usize = 8 * 1024;
 
-#[derive(Eq, Hash, PartialEq)]
-pub(crate) struct CursorKey(String);
+#[derive(Debug)]
+pub(crate) enum FetchOutcome<T, W, S> {
+    Page { rows: Vec<T>, wire: W },
+    Stop(S),
+}
 
-impl CursorKey {
-    pub(crate) fn new(value: String) -> Self {
-        Self(value)
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum Completion<S> {
+    WireComplete,
+    Stopped(S),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Completed<O, S> {
+    pub(crate) output: O,
+    pub(crate) completion: Completion<S>,
+}
+
+pub(crate) enum PageObservation<P, C, S> {
+    Terminal,
+    Continue { next: P, commit: C },
+    Stop(S),
+}
+
+pub(crate) type ObservationResult<P, C, S> = Result<PageObservation<P, C, S>, PaginationError>;
+
+pub(crate) trait PageProtocol<T> {
+    type Position: Clone;
+    type Wire;
+    type Stop;
+    type Commit;
+
+    fn initial_position(&self) -> Self::Position;
+
+    fn observe(
+        &mut self,
+        position: &Self::Position,
+        page_index: usize,
+        rows: &[T],
+        wire: Self::Wire,
+    ) -> ObservationResult<Self::Position, Self::Commit, Self::Stop>;
+
+    fn commit_continue(&mut self, commit: Self::Commit);
+}
+
+pub(crate) trait PageReducer<T, E> {
+    type Output;
+    type Stop;
+
+    fn consume(&mut self, rows: Vec<T>) -> Result<Option<Self::Stop>, E>;
+
+    fn finish(self, completion: &Completion<Self::Stop>) -> Result<Self::Output, E>;
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct PageFingerprint([u8; 32]);
+
+pub(crate) fn encode_length_prefixed(output: &mut Vec<u8>, value: &[u8]) {
+    let length = u64::try_from(value.len()).expect("fingerprint field length exceeds u64");
+    output.extend_from_slice(&length.to_be_bytes());
+    output.extend_from_slice(value);
+}
+
+pub(crate) fn fingerprint_multiset(version: u8, mut descriptors: Vec<Vec<u8>>) -> PageFingerprint {
+    descriptors.sort_unstable();
+    let mut context = Context::new(&digest::SHA256);
+    context.update(&[version]);
+    let row_count = u64::try_from(descriptors.len()).expect("fingerprint row count exceeds u64");
+    context.update(&row_count.to_be_bytes());
+    for descriptor in descriptors {
+        encode_length_prefixed_digest(&mut context, &descriptor);
+    }
+    let digest = context.finish();
+    let mut fingerprint = [0; 32];
+    fingerprint.copy_from_slice(digest.as_ref());
+    PageFingerprint(fingerprint)
+}
+
+fn encode_length_prefixed_digest(context: &mut Context, value: &[u8]) {
+    let length = u64::try_from(value.len()).expect("fingerprint row length exceeds u64");
+    context.update(&length.to_be_bytes());
+    context.update(value);
+}
+
+pub(crate) struct OffsetProtocol<T, S> {
+    endpoint: &'static str,
+    page_size: usize,
+    fingerprint: fn(&[T]) -> PageFingerprint,
+    local_ceiling: Option<(u32, S)>,
+    seen: HashSet<PageFingerprint>,
+}
+
+impl<T, S> OffsetProtocol<T, S> {
+    pub(crate) fn new(
+        endpoint: &'static str,
+        page_size: usize,
+        fingerprint: fn(&[T]) -> PageFingerprint,
+        local_ceiling: Option<(u32, S)>,
+    ) -> Self {
+        Self {
+            endpoint,
+            page_size,
+            fingerprint,
+            local_ceiling,
+            seen: HashSet::new(),
+        }
     }
 }
 
-impl Debug for CursorKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "cursor {:?}", self.0)
+impl<T, S> PageProtocol<T> for OffsetProtocol<T, S>
+where
+    S: Clone,
+{
+    type Commit = PageFingerprint;
+    type Position = u32;
+    type Stop = S;
+    type Wire = ();
+
+    fn initial_position(&self) -> Self::Position {
+        0
+    }
+
+    fn observe(
+        &mut self,
+        position: &Self::Position,
+        page_index: usize,
+        rows: &[T],
+        (): Self::Wire,
+    ) -> Result<PageObservation<Self::Position, Self::Commit, Self::Stop>, PaginationError> {
+        if rows.len() < self.page_size {
+            return Ok(PageObservation::Terminal);
+        }
+
+        let fingerprint = (self.fingerprint)(rows);
+        if self.seen.contains(&fingerprint) {
+            return Err(PaginationError::RepeatedPage {
+                endpoint: self.endpoint,
+                page: page_index,
+                offset: *position,
+            });
+        }
+
+        let count = u32::try_from(rows.len()).map_err(|_| PaginationError::OffsetOverflow {
+            endpoint: self.endpoint,
+        })?;
+        let next = position
+            .checked_add(count)
+            .ok_or(PaginationError::OffsetOverflow {
+                endpoint: self.endpoint,
+            })?;
+
+        if let Some((ceiling, stop)) = &self.local_ceiling
+            && next >= *ceiling
+        {
+            return Ok(PageObservation::Stop(stop.clone()));
+        }
+
+        Ok(PageObservation::Continue {
+            next,
+            commit: fingerprint,
+        })
+    }
+
+    fn commit_continue(&mut self, commit: Self::Commit) {
+        self.seen.insert(commit);
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct BoundedCursor(String);
+
+impl BoundedCursor {
+    fn new(endpoint: &'static str, value: String) -> Result<Self, PaginationError> {
+        if value.len() > PAGINATION_CURSOR_LIMIT {
+            return Err(PaginationError::CursorTooLong { endpoint });
+        }
+        Ok(Self(value))
+    }
+}
+
+impl AsRef<str> for BoundedCursor {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CursorProtocol<S> {
+    endpoint: &'static str,
+    initial: Option<BoundedCursor>,
+    dialect: CursorDialect,
+    seen: HashSet<BoundedCursor>,
+    stop: std::marker::PhantomData<fn() -> S>,
+}
+
+#[derive(Debug)]
+enum CursorDialect {
+    Clob { terminal_cursor: &'static str },
+    Gamma,
+}
+
+impl<S> CursorProtocol<S> {
+    pub(crate) fn clob(
+        endpoint: &'static str,
+        initial: String,
+        terminal_cursor: &'static str,
+    ) -> Result<Self, PaginationError> {
+        let initial = BoundedCursor::new(endpoint, initial)?;
+        let seen = HashSet::from([initial.clone()]);
+        Ok(Self {
+            endpoint,
+            initial: Some(initial),
+            dialect: CursorDialect::Clob { terminal_cursor },
+            seen,
+            stop: std::marker::PhantomData,
+        })
+    }
+
+    pub(crate) fn gamma(endpoint: &'static str) -> Self {
+        Self {
+            endpoint,
+            initial: None,
+            dialect: CursorDialect::Gamma,
+            seen: HashSet::new(),
+            stop: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, S> PageProtocol<T> for CursorProtocol<S> {
+    type Commit = BoundedCursor;
+    type Position = Option<BoundedCursor>;
+    type Stop = S;
+    type Wire = Option<String>;
+
+    fn initial_position(&self) -> Self::Position {
+        self.initial.clone()
+    }
+
+    fn observe(
+        &mut self,
+        position: &Self::Position,
+        _page_index: usize,
+        _rows: &[T],
+        wire: Self::Wire,
+    ) -> Result<PageObservation<Self::Position, Self::Commit, Self::Stop>, PaginationError> {
+        let raw = match (&self.dialect, wire) {
+            (CursorDialect::Gamma, None) => return Ok(PageObservation::Terminal),
+            (CursorDialect::Clob { .. }, None) => {
+                return Err(PaginationError::MissingCursor {
+                    endpoint: self.endpoint,
+                });
+            }
+            (_, Some(raw)) => raw,
+        };
+
+        match &self.dialect {
+            CursorDialect::Clob { terminal_cursor }
+                if raw.is_empty() || raw == *terminal_cursor =>
+            {
+                return Ok(PageObservation::Terminal);
+            }
+            CursorDialect::Clob { .. } | CursorDialect::Gamma => {}
+        }
+
+        let next = BoundedCursor::new(self.endpoint, raw)?;
+        if matches!(&self.dialect, CursorDialect::Clob { .. }) && position.as_ref() == Some(&next) {
+            return Err(PaginationError::StalledCursor {
+                endpoint: self.endpoint,
+                cursor: next.0,
+            });
+        }
+
+        if self.seen.contains(&next) {
+            return Err(PaginationError::RepeatedCursor {
+                endpoint: self.endpoint,
+                cursor: next.0,
+            });
+        }
+
+        Ok(PageObservation::Continue {
+            next: Some(next.clone()),
+            commit: next,
+        })
+    }
+
+    fn commit_continue(&mut self, commit: Self::Commit) {
+        self.seen.insert(commit);
+    }
+}
+
+pub(crate) struct CollectAll<T, S = std::convert::Infallible> {
+    rows: Vec<T>,
+    stop: std::marker::PhantomData<fn() -> S>,
+}
+
+impl<T, S> CollectAll<T, S> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            rows: Vec::new(),
+            stop: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, E, S> PageReducer<T, E> for CollectAll<T, S> {
+    type Output = Vec<T>;
+    type Stop = S;
+
+    fn consume(&mut self, rows: Vec<T>) -> Result<Option<Self::Stop>, E> {
+        self.rows.extend(rows);
+        Ok(None)
+    }
+
+    fn finish(self, _completion: &Completion<Self::Stop>) -> Result<Self::Output, E> {
+        Ok(self.rows)
+    }
+}
+
+pub(crate) struct WindowedCollect<T, S> {
+    remaining_skip: usize,
+    maximum: Option<usize>,
+    rows: Vec<T>,
+    stop: S,
+}
+
+impl<T, S> WindowedCollect<T, S> {
+    pub(crate) const fn new(remaining_skip: usize, maximum: Option<usize>, stop: S) -> Self {
+        Self {
+            remaining_skip,
+            maximum,
+            rows: Vec::new(),
+            stop,
+        }
+    }
+}
+
+impl<T, E, S> PageReducer<T, E> for WindowedCollect<T, S>
+where
+    S: Clone,
+{
+    type Output = Vec<T>;
+    type Stop = S;
+
+    fn consume(&mut self, rows: Vec<T>) -> Result<Option<Self::Stop>, E> {
+        let skipped = self.remaining_skip.min(rows.len());
+        self.remaining_skip -= skipped;
+        let retained = rows.into_iter().skip(skipped);
+
+        if let Some(maximum) = self.maximum {
+            let remaining = maximum.saturating_sub(self.rows.len());
+            self.rows.extend(retained.take(remaining));
+            if self.rows.len() >= maximum {
+                return Ok(Some(self.stop.clone()));
+            }
+        } else {
+            self.rows.extend(retained);
+        }
+
+        Ok(None)
+    }
+
+    fn finish(self, _completion: &Completion<Self::Stop>) -> Result<Self::Output, E> {
+        Ok(self.rows)
+    }
+}
+
+pub(crate) struct Paginator<P, R> {
+    endpoint: &'static str,
+    protocol: P,
+    reducer: R,
+    pages: usize,
+    fetched_rows: usize,
+}
+
+impl<P, R> Paginator<P, R> {
+    pub(crate) const fn new(endpoint: &'static str, protocol: P, reducer: R) -> Self {
+        Self {
+            endpoint,
+            protocol,
+            reducer,
+            pages: 0,
+            fetched_rows: 0,
+        }
+    }
+
+    pub(crate) async fn run<T, E, F, Fut, M>(
+        mut self,
+        mut fetch: F,
+        mut map_pagination_error: M,
+    ) -> Result<Completed<R::Output, R::Stop>, E>
+    where
+        P: PageProtocol<T, Stop = R::Stop>,
+        R: PageReducer<T, E>,
+        F: FnMut(P::Position) -> Fut,
+        Fut: Future<Output = Result<FetchOutcome<T, P::Wire, R::Stop>, E>>,
+        M: FnMut(PaginationError) -> E,
+    {
+        let mut position = self.protocol.initial_position();
+
+        loop {
+            let (rows, wire) = match fetch(position.clone()).await? {
+                FetchOutcome::Page { rows, wire } => (rows, wire),
+                FetchOutcome::Stop(stop) => {
+                    let completion = Completion::Stopped(stop);
+                    let output = self.reducer.finish(&completion)?;
+                    return Ok(Completed { output, completion });
+                }
+            };
+
+            let prospective_pages = self.pages.checked_add(1).ok_or_else(|| {
+                map_pagination_error(PaginationError::PageLimit {
+                    endpoint: self.endpoint,
+                })
+            })?;
+            let prospective_rows = self
+                .fetched_rows
+                .checked_add(rows.len())
+                .filter(|total| *total <= PAGINATION_ROW_LIMIT)
+                .ok_or_else(|| {
+                    map_pagination_error(PaginationError::RowLimit {
+                        endpoint: self.endpoint,
+                    })
+                })?;
+            let observation = self
+                .protocol
+                .observe(&position, prospective_pages, &rows, wire)
+                .map_err(&mut map_pagination_error)?;
+
+            self.pages = prospective_pages;
+            self.fetched_rows = prospective_rows;
+
+            if let Some(stop) = self.reducer.consume(rows)? {
+                let completion = Completion::Stopped(stop);
+                let output = self.reducer.finish(&completion)?;
+                return Ok(Completed { output, completion });
+            }
+
+            match observation {
+                PageObservation::Terminal => {
+                    let completion = Completion::WireComplete;
+                    let output = self.reducer.finish(&completion)?;
+                    return Ok(Completed { output, completion });
+                }
+                PageObservation::Stop(stop) => {
+                    let completion = Completion::Stopped(stop);
+                    let output = self.reducer.finish(&completion)?;
+                    return Ok(Completed { output, completion });
+                }
+                PageObservation::Continue { next, commit } => {
+                    if self.pages >= PAGINATION_PAGE_LIMIT {
+                        return Err(map_pagination_error(PaginationError::PageLimit {
+                            endpoint: self.endpoint,
+                        }));
+                    }
+
+                    if self.fetched_rows >= PAGINATION_ROW_LIMIT {
+                        return Err(map_pagination_error(PaginationError::RowLimit {
+                            endpoint: self.endpoint,
+                        }));
+                    }
+                    self.protocol.commit_continue(commit);
+                    position = next;
+                }
+            }
+        }
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum PaginationError {
-    #[error("{endpoint} pagination repeated {progress}")]
-    Repeated {
+    #[error("{endpoint} pagination cursor exceeds {PAGINATION_CURSOR_LIMIT} bytes")]
+    CursorTooLong { endpoint: &'static str },
+    #[error("{endpoint} response omitted next_cursor")]
+    MissingCursor { endpoint: &'static str },
+    #[error("{endpoint} pagination cursor did not advance from {cursor:?}")]
+    StalledCursor {
         endpoint: &'static str,
-        progress: String,
+        cursor: String,
     },
+    #[error("{endpoint} pagination repeated cursor {cursor:?}")]
+    RepeatedCursor {
+        endpoint: &'static str,
+        cursor: String,
+    },
+    #[error("{endpoint} pagination repeated a full page at page {page} offset {offset}")]
+    RepeatedPage {
+        endpoint: &'static str,
+        page: usize,
+        offset: u32,
+    },
+    #[error("{endpoint} pagination offset overflowed u32")]
+    OffsetOverflow { endpoint: &'static str },
     #[error("{endpoint} pagination exceeded {PAGINATION_PAGE_LIMIT} pages")]
     PageLimit { endpoint: &'static str },
     #[error("{endpoint} pagination exceeded {PAGINATION_ROW_LIMIT} rows")]
     RowLimit { endpoint: &'static str },
 }
 
-pub(crate) struct PaginationGuard<K> {
-    endpoint: &'static str,
-    pages: usize,
-    rows: usize,
-    seen: HashSet<K>,
-}
-
-impl<K> PaginationGuard<K>
-where
-    K: Debug + Eq + Hash,
-{
-    pub(crate) fn new(endpoint: &'static str) -> Self {
-        Self {
-            endpoint,
-            pages: 0,
-            rows: 0,
-            seen: HashSet::new(),
-        }
-    }
-
-    pub(crate) fn seed(&mut self, key: K) {
-        self.seen.insert(key);
-    }
-
-    pub(crate) fn advance(
-        &mut self,
-        rows: usize,
-        progress: Option<K>,
-    ) -> Result<(), PaginationError> {
-        self.pages += 1;
-        self.rows = match self.rows.checked_add(rows) {
-            Some(total) if total <= PAGINATION_ROW_LIMIT => total,
-            _ => {
-                return Err(PaginationError::RowLimit {
-                    endpoint: self.endpoint,
-                });
-            }
-        };
-
-        match progress {
-            None => Ok(()),
-            Some(key) if self.seen.contains(&key) => Err(PaginationError::Repeated {
-                endpoint: self.endpoint,
-                progress: format!("{key:?}"),
-            }),
-            Some(_) if self.pages >= PAGINATION_PAGE_LIMIT => Err(PaginationError::PageLimit {
-                endpoint: self.endpoint,
-            }),
-            Some(key) => {
-                self.seen.insert(key);
-                Ok(())
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::{
+        convert::Infallible,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
     use rstest::rstest;
 
     use super::*;
 
+    struct LinearProtocol;
+
+    impl PageProtocol<usize> for LinearProtocol {
+        type Commit = ();
+        type Position = usize;
+        type Stop = Infallible;
+        type Wire = bool;
+
+        fn initial_position(&self) -> Self::Position {
+            0
+        }
+
+        fn observe(
+            &mut self,
+            position: &Self::Position,
+            _page_index: usize,
+            _rows: &[usize],
+            terminal: Self::Wire,
+        ) -> Result<PageObservation<Self::Position, Self::Commit, Self::Stop>, PaginationError>
+        {
+            if terminal {
+                Ok(PageObservation::Terminal)
+            } else {
+                Ok(PageObservation::Continue {
+                    next: position + 1,
+                    commit: (),
+                })
+            }
+        }
+
+        fn commit_continue(&mut self, (): Self::Commit) {}
+    }
+
+    struct StopProtocol;
+
+    impl PageProtocol<usize> for StopProtocol {
+        type Commit = ();
+        type Position = usize;
+        type Stop = &'static str;
+        type Wire = ();
+
+        fn initial_position(&self) -> Self::Position {
+            0
+        }
+
+        fn observe(
+            &mut self,
+            _position: &Self::Position,
+            _page_index: usize,
+            _rows: &[usize],
+            (): Self::Wire,
+        ) -> Result<PageObservation<Self::Position, Self::Commit, Self::Stop>, PaginationError>
+        {
+            Ok(PageObservation::Stop("local"))
+        }
+
+        fn commit_continue(&mut self, (): Self::Commit) {}
+    }
+
+    struct TrackingReducer {
+        consume_calls: Arc<AtomicUsize>,
+    }
+
+    impl PageReducer<usize, PaginationError> for TrackingReducer {
+        type Output = ();
+        type Stop = Infallible;
+
+        fn consume(&mut self, _rows: Vec<usize>) -> Result<Option<Self::Stop>, PaginationError> {
+            self.consume_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(None)
+        }
+
+        fn finish(
+            self,
+            _completion: &Completion<Self::Stop>,
+        ) -> Result<Self::Output, PaginationError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_paginator_accepts_terminal_page_100_without_request_101() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let requests_for_fetch = Arc::clone(&requests);
+        let paginator = Paginator::new("test", LinearProtocol, CollectAll::new());
+
+        let completed = paginator
+            .run(
+                move |position| {
+                    requests_for_fetch.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        Ok::<_, PaginationError>(FetchOutcome::Page {
+                            rows: vec![position],
+                            wire: position == PAGINATION_PAGE_LIMIT - 1,
+                        })
+                    }
+                },
+                std::convert::identity,
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(completed.completion, Completion::WireComplete));
+        assert_eq!(completed.output.len(), PAGINATION_PAGE_LIMIT);
+        assert_eq!(requests.load(Ordering::SeqCst), PAGINATION_PAGE_LIMIT);
+    }
+
+    #[tokio::test]
+    async fn test_paginator_rejects_continuation_after_page_100_without_request_101() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let requests_for_fetch = Arc::clone(&requests);
+        let paginator = Paginator::new("test", LinearProtocol, CollectAll::new());
+
+        let error = paginator
+            .run(
+                move |position| {
+                    requests_for_fetch.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        Ok::<_, PaginationError>(FetchOutcome::Page {
+                            rows: vec![position],
+                            wire: false,
+                        })
+                    }
+                },
+                std::convert::identity,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            PaginationError::PageLimit { endpoint: "test" }
+        ));
+        assert_eq!(requests.load(Ordering::SeqCst), PAGINATION_PAGE_LIMIT);
+    }
+
+    #[tokio::test]
+    async fn test_paginator_accepts_exact_row_limit_when_terminal() {
+        let paginator = Paginator::new("test", LinearProtocol, CollectAll::new());
+
+        let completed = paginator
+            .run(
+                |_position| async {
+                    Ok::<_, PaginationError>(FetchOutcome::Page {
+                        rows: vec![0; PAGINATION_ROW_LIMIT],
+                        wire: true,
+                    })
+                },
+                std::convert::identity,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(completed.output.len(), PAGINATION_ROW_LIMIT);
+    }
+
+    #[tokio::test]
+    async fn test_paginator_rejects_continuation_at_exact_row_limit() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let requests_for_fetch = Arc::clone(&requests);
+        let paginator = Paginator::new("test", LinearProtocol, CollectAll::new());
+
+        let error = paginator
+            .run(
+                move |_position| {
+                    requests_for_fetch.fetch_add(1, Ordering::SeqCst);
+                    async {
+                        Ok::<_, PaginationError>(FetchOutcome::Page {
+                            rows: vec![0; PAGINATION_ROW_LIMIT],
+                            wire: false,
+                        })
+                    }
+                },
+                std::convert::identity,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            PaginationError::RowLimit { endpoint: "test" }
+        ));
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_paginator_rejects_oversized_page_before_reducer_mutation() {
+        let consume_calls = Arc::new(AtomicUsize::new(0));
+        let reducer = TrackingReducer {
+            consume_calls: Arc::clone(&consume_calls),
+        };
+        let paginator = Paginator::new("test", LinearProtocol, reducer);
+
+        let error = paginator
+            .run(
+                |_position| async {
+                    Ok::<_, PaginationError>(FetchOutcome::Page {
+                        rows: vec![0; PAGINATION_ROW_LIMIT + 1],
+                        wire: true,
+                    })
+                },
+                std::convert::identity,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            PaginationError::RowLimit { endpoint: "test" }
+        ));
+        assert_eq!(consume_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_paginator_finalizes_remote_stop_without_fetching_again() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let requests_for_fetch = Arc::clone(&requests);
+        let paginator = Paginator::new(
+            "test",
+            StopProtocol,
+            CollectAll::<usize, &'static str>::new(),
+        );
+
+        let completed = paginator
+            .run(
+                move |_position| {
+                    requests_for_fetch.fetch_add(1, Ordering::SeqCst);
+                    async { Ok::<_, PaginationError>(FetchOutcome::Stop("remote")) }
+                },
+                std::convert::identity,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(completed.completion, Completion::Stopped("remote"));
+        assert!(completed.output.is_empty());
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_paginator_finalizes_protocol_stop_after_consuming_page() {
+        let paginator = Paginator::new(
+            "test",
+            StopProtocol,
+            CollectAll::<usize, &'static str>::new(),
+        );
+
+        let completed = paginator
+            .run(
+                |_position| async {
+                    Ok::<_, PaginationError>(FetchOutcome::Page {
+                        rows: vec![7],
+                        wire: (),
+                    })
+                },
+                std::convert::identity,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(completed.completion, Completion::Stopped("local"));
+        assert_eq!(completed.output, vec![7]);
+    }
+
     #[rstest]
-    fn test_pagination_guard_rejects_row_limit() {
-        let mut guard = PaginationGuard::<CursorKey>::new("test");
+    fn test_clob_cursor_protocol_rejects_overlong_initial_cursor() {
+        let cursor = "x".repeat(PAGINATION_CURSOR_LIMIT + 1);
 
-        let error = guard.advance(100_001, None).unwrap_err();
+        let error = CursorProtocol::<Infallible>::clob("test", cursor, "END").unwrap_err();
 
-        assert_eq!(error.to_string(), "test pagination exceeded 100000 rows");
+        assert!(matches!(
+            error,
+            PaginationError::CursorTooLong { endpoint: "test" }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_clob_cursor_protocol_reports_immediate_echo_as_stalled() {
+        let protocol =
+            CursorProtocol::<Infallible>::clob("test", "seed".to_string(), "END").unwrap();
+        let paginator = Paginator::new("test", protocol, CollectAll::new());
+
+        let error = paginator
+            .run(
+                |_position| async {
+                    Ok::<_, PaginationError>(FetchOutcome::Page {
+                        rows: vec![1],
+                        wire: Some("seed".to_string()),
+                    })
+                },
+                std::convert::identity,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            PaginationError::StalledCursor {
+                endpoint: "test",
+                cursor
+            } if cursor == "seed"
+        ));
     }
 }

--- a/crates/adapters/polymarket/src/http/pagination.rs
+++ b/crates/adapters/polymarket/src/http/pagination.rs
@@ -445,6 +445,11 @@ impl<P, R> Paginator<P, R> {
                         endpoint: self.endpoint,
                     })
                 })?;
+            log::debug!(
+                "Fetched {} page {prospective_pages}: {} rows ({prospective_rows} total)",
+                self.endpoint,
+                rows.len(),
+            );
             let observation = self
                 .protocol
                 .observe(&position, prospective_pages, &rows, wire)

--- a/crates/adapters/polymarket/src/http/pagination.rs
+++ b/crates/adapters/polymarket/src/http/pagination.rs
@@ -1,0 +1,119 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::{collections::HashSet, fmt::Debug, hash::Hash};
+
+pub(crate) const PAGINATION_PAGE_LIMIT: usize = 100;
+pub(crate) const PAGINATION_ROW_LIMIT: usize = 100_000;
+
+#[derive(Eq, Hash, PartialEq)]
+pub(crate) struct CursorKey(String);
+
+impl CursorKey {
+    pub(crate) fn new(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl Debug for CursorKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "cursor {:?}", self.0)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PaginationError {
+    #[error("{endpoint} pagination repeated {progress}")]
+    Repeated {
+        endpoint: &'static str,
+        progress: String,
+    },
+    #[error("{endpoint} pagination exceeded {PAGINATION_PAGE_LIMIT} pages")]
+    PageLimit { endpoint: &'static str },
+    #[error("{endpoint} pagination exceeded {PAGINATION_ROW_LIMIT} rows")]
+    RowLimit { endpoint: &'static str },
+}
+
+pub(crate) struct PaginationGuard<K> {
+    endpoint: &'static str,
+    pages: usize,
+    rows: usize,
+    seen: HashSet<K>,
+}
+
+impl<K> PaginationGuard<K>
+where
+    K: Debug + Eq + Hash,
+{
+    pub(crate) fn new(endpoint: &'static str) -> Self {
+        Self {
+            endpoint,
+            pages: 0,
+            rows: 0,
+            seen: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn seed(&mut self, key: K) {
+        self.seen.insert(key);
+    }
+
+    pub(crate) fn advance(
+        &mut self,
+        rows: usize,
+        progress: Option<K>,
+    ) -> Result<(), PaginationError> {
+        self.pages += 1;
+        self.rows = match self.rows.checked_add(rows) {
+            Some(total) if total <= PAGINATION_ROW_LIMIT => total,
+            _ => {
+                return Err(PaginationError::RowLimit {
+                    endpoint: self.endpoint,
+                });
+            }
+        };
+
+        match progress {
+            None => Ok(()),
+            Some(key) if self.seen.contains(&key) => Err(PaginationError::Repeated {
+                endpoint: self.endpoint,
+                progress: format!("{key:?}"),
+            }),
+            Some(_) if self.pages >= PAGINATION_PAGE_LIMIT => Err(PaginationError::PageLimit {
+                endpoint: self.endpoint,
+            }),
+            Some(key) => {
+                self.seen.insert(key);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn test_pagination_guard_rejects_row_limit() {
+        let mut guard = PaginationGuard::<CursorKey>::new("test");
+
+        let error = guard.advance(100_001, None).unwrap_err();
+
+        assert_eq!(error.to_string(), "test pagination exceeded 100000 rows");
+    }
+}

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -96,7 +96,9 @@ struct TestServerState {
     /// Delay before `handle_get_orders` responds. Used by the timeout test.
     get_orders_delay_secs: Arc<AtomicUsize>,
     orders_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
+    orders_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     trades_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
+    trades_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     gamma_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     gamma_markets_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     gamma_markets_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
@@ -115,6 +117,7 @@ struct TestServerState {
     gamma_clob_token_responses: Arc<tokio::sync::Mutex<AHashMap<String, Value>>>,
     single_order_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     data_api_position_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
+    data_api_position_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     data_api_trade_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     data_api_ignore_trade_offset: Arc<AtomicBool>,
     data_api_trade_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
@@ -144,7 +147,9 @@ impl Default for TestServerState {
             rate_limit_response_headers: Arc::new(tokio::sync::Mutex::new(HeaderMap::new())),
             get_orders_delay_secs: Arc::new(AtomicUsize::new(0)),
             orders_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            orders_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             trades_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            trades_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             gamma_response: Arc::new(tokio::sync::Mutex::new(None)),
             gamma_markets_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             gamma_markets_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
@@ -163,6 +168,7 @@ impl Default for TestServerState {
             gamma_clob_token_responses: Arc::new(tokio::sync::Mutex::new(AHashMap::new())),
             single_order_response: Arc::new(tokio::sync::Mutex::new(None)),
             data_api_position_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            data_api_position_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             data_api_trade_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             data_api_ignore_trade_offset: Arc::new(AtomicBool::new(false)),
             data_api_trade_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
@@ -266,7 +272,11 @@ async fn maybe_rate_limit(state: &TestServerState) -> Option<Response> {
     }
 }
 
-async fn handle_get_orders(State(state): State<TestServerState>, headers: HeaderMap) -> Response {
+async fn handle_get_orders(
+    State(state): State<TestServerState>,
+    headers: HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Response {
     if let Some(r) = maybe_rate_limit(&state).await {
         return r;
     }
@@ -275,6 +285,7 @@ async fn handle_get_orders(State(state): State<TestServerState>, headers: Header
         tokio::time::sleep(Duration::from_secs(delay as u64)).await;
     }
     *state.last_headers.lock().await = extract_headers(&headers);
+    state.orders_query_log.lock().await.push(params);
     let mut pages = state.orders_pages.lock().await;
     if let Some(page) = pages.pop_front() {
         return Json(page).into_response();
@@ -282,11 +293,16 @@ async fn handle_get_orders(State(state): State<TestServerState>, headers: Header
     Json(load_json("http_open_orders_page.json")).into_response()
 }
 
-async fn handle_get_trades(State(state): State<TestServerState>, headers: HeaderMap) -> Response {
+async fn handle_get_trades(
+    State(state): State<TestServerState>,
+    headers: HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Response {
     if let Some(r) = maybe_rate_limit(&state).await {
         return r;
     }
     *state.last_headers.lock().await = extract_headers(&headers);
+    state.trades_query_log.lock().await.push(params);
     let mut pages = state.trades_pages.lock().await;
     if let Some(page) = pages.pop_front() {
         return Json(page).into_response();
@@ -670,10 +686,14 @@ async fn handle_data_api_trades(
     Json(json!(page)).into_response()
 }
 
-async fn handle_data_api_positions(State(state): State<TestServerState>) -> Response {
+async fn handle_data_api_positions(
+    State(state): State<TestServerState>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Response {
     if let Some(r) = maybe_rate_limit(&state).await {
         return r;
     }
+    state.data_api_position_query_log.lock().await.push(params);
     let mut pages = state.data_api_position_pages.lock().await;
     Json(pages.pop_front().unwrap_or_else(|| json!([]))).into_response()
 }
@@ -831,6 +851,35 @@ async fn test_get_trades_returns_trades() {
 
     assert_eq!(trades.len(), 1);
     assert_eq!(trades[0].id, "trade-0x001");
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_trades_paginates_with_driver_cursor() {
+    let state = TestServerState::default();
+    let mut first = load_json("http_trades_page.json");
+    first["next_cursor"] = json!("page-2");
+    let mut second = load_json("http_trades_page.json");
+    second["data"][0]["id"] = json!("trade-0x002");
+    second["next_cursor"] = json!("LTE=");
+    state.trades_pages.lock().await.extend([first, second]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let trades = client.get_trades(GetTradesParams::default()).await.unwrap();
+    let queries = state.trades_query_log.lock().await;
+
+    assert_eq!(trades.len(), 2);
+    assert_eq!(queries.len(), 2);
+    assert_eq!(
+        queries[0].get("next_cursor").map(String::as_str),
+        Some("MA==")
+    );
+    assert_eq!(
+        queries[1].get("next_cursor").map(String::as_str),
+        Some("page-2")
+    );
 }
 
 #[rstest]
@@ -1471,6 +1520,16 @@ async fn test_get_orders_auto_paginates_multiple_pages() {
         "0xpage2order000000000000000000000000000000000000000000000000000002"
     );
     assert_eq!(*state.request_count.lock().await, 2);
+    let queries = state.orders_query_log.lock().await;
+    assert_eq!(queries.len(), 2);
+    assert_eq!(
+        queries[0].get("next_cursor").map(String::as_str),
+        Some("MA==")
+    );
+    assert_eq!(
+        queries[1].get("next_cursor").map(String::as_str),
+        Some("cGFnZTI=")
+    );
 }
 
 #[rstest]
@@ -1593,6 +1652,31 @@ async fn test_get_orders_errors_on_cursor_cycle() {
         "decode error: /data/orders pagination repeated cursor \"cursor-a\""
     );
     assert_eq!(*state.request_count.lock().await, 3);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_orders_rejects_recurrence_of_initial_cursor() {
+    let state = TestServerState::default();
+    let mut first = load_json("http_open_orders_page.json");
+    first["next_cursor"] = json!("cursor-a");
+    let mut second = load_json("http_open_orders_page.json");
+    second["next_cursor"] = json!("MA==");
+    state.orders_pages.lock().await.extend([first, second]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let error = client
+        .get_orders(GetOrdersParams::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /data/orders pagination repeated cursor \"MA==\""
+    );
+    assert_eq!(*state.request_count.lock().await, 2);
 }
 
 #[rstest]
@@ -4787,6 +4871,32 @@ fn make_data_api_position(index: usize) -> Value {
 
 #[rstest]
 #[tokio::test]
+async fn test_get_positions_paginates_distinct_pages_with_driver_offset() {
+    let state = TestServerState::default();
+    let first = Value::Array((0..100).map(make_data_api_position).collect());
+    let second = Value::Array((100..200).map(make_data_api_position).collect());
+    let terminal = Value::Array(vec![make_data_api_position(200)]);
+    state
+        .data_api_position_pages
+        .lock()
+        .await
+        .extend([first, second, terminal]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let positions = client.get_positions(TEST_ADDRESS).await.unwrap();
+    let queries = state.data_api_position_query_log.lock().await;
+
+    assert_eq!(positions.len(), 201);
+    assert_eq!(queries.len(), 3);
+    assert_eq!(queries[0].get("offset").map(String::as_str), Some("0"));
+    assert_eq!(queries[1].get("offset").map(String::as_str), Some("100"));
+    assert_eq!(queries[2].get("offset").map(String::as_str), Some("200"));
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_get_positions_errors_on_repeated_full_page() {
     let state = TestServerState::default();
     let page = Value::Array((0..100).map(make_data_api_position).collect());
@@ -4989,7 +5099,7 @@ async fn test_request_trade_ticks_rejects_repeated_full_page() {
 
 #[rstest]
 #[tokio::test]
-async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_condition() {
+async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_title() {
     let state = TestServerState::default();
     let token = "token_restamped";
     let first = (0..500)
@@ -5006,7 +5116,7 @@ async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_cond
         .iter()
         .cloned()
         .map(|mut trade| {
-            trade["conditionId"] = json!("0xrestamped_condition");
+            trade["title"] = json!("Restamped presentation metadata");
             trade
         })
         .collect::<Vec<_>>();
@@ -5038,6 +5148,42 @@ async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_cond
         "/trades pagination repeated a full page at page 2 offset 500"
     );
     assert_eq!(state.data_api_trade_query_log.lock().await.len(), 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_rejects_trade_outside_requested_condition() {
+    let state = TestServerState::default();
+    let token = "token_wrong_condition";
+    let mut trade = make_data_api_trade(token, 0.50, 1_710_000_000, "wrong-condition");
+    trade["conditionId"] = json!("0xother_condition");
+    state
+        .data_api_trade_pages
+        .lock()
+        .await
+        .push_back(json!([trade]));
+
+    let addr = start_mock_server(state).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_wrong_condition.POLYMARKET"),
+            "0xcondition_test",
+            token,
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "Polymarket Data API returned trade for condition 0xother_condition while requesting 0xcondition_test"
+    );
 }
 
 #[rstest]
@@ -5310,6 +5456,35 @@ async fn test_request_trade_ticks_stops_at_data_api_offset_ceiling() {
     assert_eq!(queries.len(), 20);
     assert_eq!(queries[0].get("offset").map(String::as_str), Some("0"));
     assert_eq!(queries[19].get("offset").map(String::as_str), Some("9500"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_preserves_remote_offset_ceiling_partial_result() {
+    let state = TestServerState::default();
+    *state.data_api_error_response.lock().await = Some((
+        StatusCode::TOO_MANY_REQUESTS,
+        json!({"error": "max historical activity offset reached"}),
+    ));
+
+    let addr = start_mock_server(state).await;
+    let client = create_data_api_client(&addr);
+
+    let ticks = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_ceiling.POLYMARKET"),
+            "0xcondition_test",
+            "token_ceiling",
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(ticks.is_empty());
 }
 
 #[rstest]

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -114,6 +114,7 @@ struct TestServerState {
     gamma_search_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     gamma_clob_token_responses: Arc<tokio::sync::Mutex<AHashMap<String, Value>>>,
     single_order_response: Arc<tokio::sync::Mutex<Option<Value>>>,
+    data_api_position_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     data_api_trade_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     data_api_trade_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     data_api_error_response: Arc<tokio::sync::Mutex<Option<(StatusCode, Value)>>>,
@@ -160,6 +161,7 @@ impl Default for TestServerState {
             gamma_search_response: Arc::new(tokio::sync::Mutex::new(None)),
             gamma_clob_token_responses: Arc::new(tokio::sync::Mutex::new(AHashMap::new())),
             single_order_response: Arc::new(tokio::sync::Mutex::new(None)),
+            data_api_position_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             data_api_trade_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             data_api_trade_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             data_api_error_response: Arc::new(tokio::sync::Mutex::new(None)),
@@ -662,6 +664,14 @@ async fn handle_data_api_trades(
     Json(json!(page)).into_response()
 }
 
+async fn handle_data_api_positions(State(state): State<TestServerState>) -> Response {
+    if let Some(r) = maybe_rate_limit(&state).await {
+        return r;
+    }
+    let mut pages = state.data_api_position_pages.lock().await;
+    Json(pages.pop_front().unwrap_or_else(|| json!([]))).into_response()
+}
+
 async fn handle_get_order(State(state): State<TestServerState>) -> Response {
     let resp = state.single_order_response.lock().await;
     match resp.as_ref() {
@@ -709,6 +719,7 @@ fn create_test_router(state: TestServerState) -> Router {
         .route("/events/keyset", get(handle_gamma_events_keyset))
         .route("/tags", get(handle_gamma_tags))
         .route("/public-search", get(handle_public_search))
+        .route("/positions", get(handle_data_api_positions))
         .route("/trades", get(handle_data_api_trades))
         .route("/health", get(handle_health))
         .with_state(state)
@@ -1506,6 +1517,63 @@ async fn test_get_orders_errors_on_repeated_caller_cursor() {
 
 #[rstest]
 #[tokio::test]
+async fn test_get_orders_errors_on_cursor_cycle() {
+    let state = TestServerState::default();
+    let mut page1 = load_json("http_open_orders_page.json");
+    page1["next_cursor"] = json!("cursor-a");
+    let mut page2 = load_json("http_open_orders_page.json");
+    page2["next_cursor"] = json!("cursor-b");
+    let mut page3 = load_json("http_open_orders_page.json");
+    page3["next_cursor"] = json!("cursor-a");
+    state
+        .orders_pages
+        .lock()
+        .await
+        .extend([page1, page2, page3]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let error = client
+        .get_orders(GetOrdersParams::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /data/orders pagination repeated cursor \"cursor-a\""
+    );
+    assert_eq!(*state.request_count.lock().await, 3);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_orders_errors_when_page_limit_exhausted() {
+    let state = TestServerState::default();
+    let pages = (1..=100).map(|page_number| {
+        let mut page = load_json("http_open_orders_page.json");
+        page["next_cursor"] = json!(format!("cursor-{page_number}"));
+        page
+    });
+    state.orders_pages.lock().await.extend(pages);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let error = client
+        .get_orders(GetOrdersParams::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /data/orders pagination exceeded 100 pages"
+    );
+    assert_eq!(*state.request_count.lock().await, 100);
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_get_trades_errors_on_absent_cursor() {
     let state = TestServerState::default();
     let mut page1 = load_json("http_trades_page.json");
@@ -1553,6 +1621,37 @@ async fn test_get_trades_errors_on_repeated_caller_cursor() {
         "decode error: /data/trades pagination cursor did not advance from \"custom_cursor\""
     );
     assert_eq!(*state.request_count.lock().await, 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_trades_errors_on_cursor_cycle() {
+    let state = TestServerState::default();
+    let mut page1 = load_json("http_trades_page.json");
+    page1["next_cursor"] = json!("cursor-a");
+    let mut page2 = load_json("http_trades_page.json");
+    page2["next_cursor"] = json!("cursor-b");
+    let mut page3 = load_json("http_trades_page.json");
+    page3["next_cursor"] = json!("cursor-a");
+    state
+        .trades_pages
+        .lock()
+        .await
+        .extend([page1, page2, page3]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let error = client
+        .get_trades(GetTradesParams::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /data/trades pagination repeated cursor \"cursor-a\""
+    );
+    assert_eq!(*state.request_count.lock().await, 3);
 }
 
 #[rstest]
@@ -3715,6 +3814,40 @@ async fn test_fetch_gamma_markets_rejects_repeated_cursor() {
 
 #[rstest]
 #[tokio::test]
+async fn test_fetch_gamma_markets_errors_when_page_limit_exhausted() {
+    let state = TestServerState::default();
+    let pages = (1..=100).map(|page_number| {
+        let first_token = format!("51{page_number:064}");
+        let second_token = format!("52{page_number:064}");
+        let market = gamma_market_with_slug(
+            &format!("bounded-market-{page_number}"),
+            &format!("0x{page_number:064x}"),
+            [&first_token, &second_token],
+        );
+        json!({
+            "markets": [market],
+            "next_cursor": format!("cursor-{page_number}"),
+        })
+    });
+    state.gamma_markets_pages.lock().await.extend(pages);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_gamma_domain_client(&addr);
+
+    let error = client
+        .request_markets_by_params(GetGammaMarketsParams::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "Gamma market pagination exceeded 100 pages"
+    );
+    assert_eq!(state.gamma_markets_query_log.lock().await.len(), 100);
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_fetch_gamma_events_paginated_uses_next_cursor_and_500_limit() {
     let state = TestServerState::default();
     let market_a = gamma_market_with_slug(
@@ -4486,6 +4619,38 @@ fn make_data_api_trade(asset: &str, price: f64, timestamp: i64, tx_suffix: &str)
         "timestamp": timestamp,
         "transactionHash": format!("0x{tx_suffix:0>66}")
     })
+}
+
+fn make_data_api_position(index: usize) -> Value {
+    json!({
+        "asset": index.to_string(),
+        "conditionId": format!("0xcondition{index:064x}"),
+        "size": 1.0,
+        "avgPrice": 0.5
+    })
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_positions_errors_on_repeated_full_page() {
+    let state = TestServerState::default();
+    let page = Value::Array((0..100).map(make_data_api_position).collect());
+    state
+        .data_api_position_pages
+        .lock()
+        .await
+        .extend([page.clone(), page]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client.get_positions(TEST_ADDRESS).await.unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /positions pagination repeated a full page"
+    );
+    assert_eq!(*state.request_count.lock().await, 2);
 }
 
 #[rstest]

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -21,7 +21,7 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -116,6 +116,7 @@ struct TestServerState {
     single_order_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     data_api_position_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     data_api_trade_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
+    data_api_ignore_trade_offset: Arc<AtomicBool>,
     data_api_trade_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     data_api_error_response: Arc<tokio::sync::Mutex<Option<(StatusCode, Value)>>>,
 }
@@ -163,6 +164,7 @@ impl Default for TestServerState {
             single_order_response: Arc::new(tokio::sync::Mutex::new(None)),
             data_api_position_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             data_api_trade_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            data_api_ignore_trade_offset: Arc::new(AtomicBool::new(false)),
             data_api_trade_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             data_api_error_response: Arc::new(tokio::sync::Mutex::new(None)),
         }
@@ -651,10 +653,14 @@ async fn handle_data_api_trades(
         .cloned()
         .collect();
 
-    let offset: usize = params
-        .get("offset")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
+    let offset: usize = if state.data_api_ignore_trade_offset.load(Ordering::SeqCst) {
+        0
+    } else {
+        params
+            .get("offset")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0)
+    };
     let limit: usize = params
         .get("limit")
         .and_then(|s| s.parse().ok())
@@ -1517,6 +1523,49 @@ async fn test_get_orders_errors_on_repeated_caller_cursor() {
 
 #[rstest]
 #[tokio::test]
+async fn test_get_orders_rejects_overlong_initial_cursor_before_request() {
+    let state = TestServerState::default();
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+    let params = GetOrdersParams {
+        next_cursor: Some("x".repeat(8 * 1024 + 1)),
+        ..Default::default()
+    };
+
+    let error = client.get_orders(params).await.unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /data/orders pagination cursor exceeds 8192 bytes"
+    );
+    assert_eq!(*state.request_count.lock().await, 0);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_orders_rejects_overlong_response_cursor() {
+    let state = TestServerState::default();
+    let mut page = load_json("http_open_orders_page.json");
+    page["next_cursor"] = json!("x".repeat(8 * 1024 + 1));
+    state.orders_pages.lock().await.push_back(page);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let error = client
+        .get_orders(GetOrdersParams::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /data/orders pagination cursor exceeds 8192 bytes"
+    );
+    assert_eq!(*state.request_count.lock().await, 1);
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_get_orders_errors_on_cursor_cycle() {
     let state = TestServerState::default();
     let mut page1 = load_json("http_open_orders_page.json");
@@ -1544,6 +1593,30 @@ async fn test_get_orders_errors_on_cursor_cycle() {
         "decode error: /data/orders pagination repeated cursor \"cursor-a\""
     );
     assert_eq!(*state.request_count.lock().await, 3);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_orders_accepts_terminal_page_100_without_request_101() {
+    let state = TestServerState::default();
+    let pages = (1..=100).map(|page_number| {
+        let mut page = load_json("http_open_orders_page.json");
+        page["next_cursor"] = if page_number == 100 {
+            json!("LTE=")
+        } else {
+            json!(format!("cursor-{page_number}"))
+        };
+        page
+    });
+    state.orders_pages.lock().await.extend(pages);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let orders = client.get_orders(GetOrdersParams::default()).await.unwrap();
+
+    assert_eq!(orders.len(), 200);
+    assert_eq!(*state.request_count.lock().await, 100);
 }
 
 #[rstest]
@@ -3814,6 +3887,51 @@ async fn test_fetch_gamma_markets_rejects_repeated_cursor() {
 
 #[rstest]
 #[tokio::test]
+async fn test_fetch_gamma_markets_rejects_repeated_cursor_before_cap() {
+    let state = TestServerState::default();
+    let skipped = gamma_market_with_slug(
+        "skipped-market",
+        "0xcondition_skipped_market",
+        ["97400000000000000001", "97400000000000000002"],
+    );
+    let retained = gamma_market_with_slug(
+        "retained-market",
+        "0xcondition_retained_market",
+        ["97500000000000000001", "97500000000000000002"],
+    );
+    {
+        let mut pages = state.gamma_markets_pages.lock().await;
+        pages.push_back(json!({
+            "markets": [skipped],
+            "next_cursor": "stuck",
+        }));
+        pages.push_back(json!({
+            "markets": [retained],
+            "next_cursor": "stuck",
+        }));
+    }
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_gamma_domain_client(&addr);
+
+    let error = client
+        .request_markets_by_params(GetGammaMarketsParams {
+            limit: Some(1),
+            offset: Some(1),
+            max_markets: Some(1),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "Gamma market pagination repeated cursor \"stuck\""
+    );
+    assert_eq!(state.gamma_markets_query_log.lock().await.len(), 2);
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_fetch_gamma_markets_errors_when_page_limit_exhausted() {
     let state = TestServerState::default();
     let pages = (1..=100).map(|page_number| {
@@ -3843,6 +3961,43 @@ async fn test_fetch_gamma_markets_errors_when_page_limit_exhausted() {
         error.to_string(),
         "Gamma market pagination exceeded 100 pages"
     );
+    assert_eq!(state.gamma_markets_query_log.lock().await.len(), 100);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_fetch_gamma_markets_cap_wins_on_page_100() {
+    let state = TestServerState::default();
+    let pages = (1..=100).map(|page_number| {
+        let first_token = format!("61{page_number:064}");
+        let second_token = format!("62{page_number:064}");
+        let market = gamma_market_with_slug(
+            &format!("capped-market-{page_number}"),
+            &format!("0xc{page_number:063x}"),
+            [&first_token, &second_token],
+        );
+        json!({
+            "markets": [market],
+            "next_cursor": format!("cursor-{page_number}"),
+        })
+    });
+    state.gamma_markets_pages.lock().await.extend(pages);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_gamma_domain_client(&addr);
+
+    let markets = client
+        .request_markets_by_params(GetGammaMarketsParams {
+            limit: Some(1),
+            offset: Some(99),
+            max_markets: Some(1),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(markets.len(), 1);
+    assert_eq!(markets[0].market_slug.as_deref(), Some("capped-market-100"));
     assert_eq!(state.gamma_markets_query_log.lock().await.len(), 100);
 }
 
@@ -4648,9 +4803,64 @@ async fn test_get_positions_errors_on_repeated_full_page() {
 
     assert_eq!(
         error.to_string(),
-        "decode error: /positions pagination repeated a full page"
+        "decode error: /positions pagination repeated a full page at page 2 offset 100"
     );
     assert_eq!(*state.request_count.lock().await, 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_positions_rejects_repeated_identities_with_changed_values() {
+    let state = TestServerState::default();
+    let first = Value::Array((0..100).map(make_data_api_position).collect());
+    let second = Value::Array(
+        (0..100)
+            .map(|index| {
+                json!({
+                    "avgPrice": 0.75,
+                    "size": 2.0,
+                    "conditionId": format!("0xcondition{index:064x}"),
+                    "asset": index.to_string(),
+                })
+            })
+            .collect(),
+    );
+    state
+        .data_api_position_pages
+        .lock()
+        .await
+        .extend([first, second]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client.get_positions(TEST_ADDRESS).await.unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /positions pagination repeated a full page at page 2 offset 100"
+    );
+    assert_eq!(*state.request_count.lock().await, 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_positions_rejects_oversized_page() {
+    let state = TestServerState::default();
+    let position = make_data_api_position(0);
+    let page = Value::Array(std::iter::repeat_n(position, 100_001).collect());
+    state.data_api_position_pages.lock().await.push_back(page);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client.get_positions(TEST_ADDRESS).await.unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /positions pagination exceeded 100000 rows"
+    );
+    assert_eq!(*state.request_count.lock().await, 1);
 }
 
 #[rstest]
@@ -4725,6 +4935,109 @@ async fn test_request_trade_ticks_paginates_multiple_pages() {
     for i in 1..ticks.len() {
         assert!(ticks[i - 1].ts_event <= ticks[i].ts_event);
     }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_rejects_repeated_full_page() {
+    let state = TestServerState::default();
+    state
+        .data_api_ignore_trade_offset
+        .store(true, Ordering::SeqCst);
+    let token = "token_repeated";
+    let trades = (0..500)
+        .map(|index| {
+            make_data_api_trade(
+                token,
+                0.50,
+                1_710_000_000 + index as i64,
+                &format!("repeated{index}"),
+            )
+        })
+        .collect();
+    state
+        .data_api_trade_pages
+        .lock()
+        .await
+        .push_back(Value::Array(trades));
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_repeated.POLYMARKET"),
+            "0xcondition_test",
+            token,
+            2,
+            2,
+            Some(nautilus_core::UnixNanos::from(
+                1_710_000_000_000_000_000_u64,
+            )),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "/trades pagination repeated a full page at page 2 offset 500"
+    );
+    assert_eq!(state.data_api_trade_query_log.lock().await.len(), 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_condition() {
+    let state = TestServerState::default();
+    let token = "token_restamped";
+    let first = (0..500)
+        .map(|index| {
+            make_data_api_trade(
+                token,
+                0.50,
+                1_710_000_000 + index as i64,
+                &format!("restamped{index}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let second = first
+        .iter()
+        .cloned()
+        .map(|mut trade| {
+            trade["conditionId"] = json!("0xrestamped_condition");
+            trade
+        })
+        .collect::<Vec<_>>();
+    state
+        .data_api_trade_pages
+        .lock()
+        .await
+        .extend([Value::Array(first), Value::Array(second)]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_restamped.POLYMARKET"),
+            "0xcondition_test",
+            token,
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "/trades pagination repeated a full page at page 2 offset 500"
+    );
+    assert_eq!(state.data_api_trade_query_log.lock().await.len(), 2);
 }
 
 #[rstest]
@@ -5006,7 +5319,7 @@ async fn test_request_trade_ticks_stops_at_data_api_offset_ceiling() {
 async fn test_request_trade_ticks_rejects_start_at_offset_ceiling(#[case] limit: Option<u32>) {
     let state = TestServerState::default();
     let token = "token_ceiling";
-    let trades = (0..10_000)
+    let mut trades = (0..10_000)
         .map(|index| {
             make_data_api_trade(
                 token,
@@ -5016,6 +5329,7 @@ async fn test_request_trade_ticks_rejects_start_at_offset_ceiling(#[case] limit:
             )
         })
         .collect::<Vec<_>>();
+    trades[0]["price"] = json!(100_000_000_000_000.0);
     state
         .data_api_trade_pages
         .lock()
@@ -5045,7 +5359,8 @@ async fn test_request_trade_ticks_rejects_start_at_offset_ceiling(#[case] limit:
     assert!(
         error
             .to_string()
-            .contains("cannot guarantee complete start-anchored results")
+            .contains("cannot guarantee complete start-anchored results"),
+        "unexpected error: {error:#}"
     );
     assert_eq!(queries.len(), 20);
 }


### PR DESCRIPTION
# Pull Request

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Replace six endpoint-owned Polymarket pagination loops with one operation-level paginator that owns
request sequencing, progress validation, bounded accumulation, and completion. This prevents
repeated or malformed venue pagination from returning an apparently valid prefix while preserving
the existing CLOB, Gamma, positions, and historical trade-tick completion behavior.

## Related issues/PRs

None.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

None.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation or PyO3 surface changed.

## Testing

**New or changed logic must be covered by tests.** Select all that apply:

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Validated with `make format`, `make pre-commit`, and `cargo test -p nautilus-polymarket`.
