### PR TITLE
Fix convert_stream_to_data silently skipping FeatherWriter custom data (#4607)

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -3947,13 +3947,29 @@ impl ParquetDataCatalog {
             return Ok(());
         }
 
-        // Convert data class name to filename (e.g., "quotes" -> "quotes")
-        // The data_cls should already be in the correct format (snake_case)
-        let data_name = to_snake_case(data_cls);
+        // Preserve the `custom/` marker that `is_supported_stream_data_type`
+        // checks: `custom/RustTestHashMapCustomData` must not become
+        // `custom_rust_test_hash_map_custom_data`, or the custom branch in
+        // `convert_feather_batches_to_parquet` is never reached and custom
+        // streams silently convert nothing.
+        let data_name = if let Some(type_name) = data_cls.strip_prefix("custom/") {
+            format!("custom/{type_name}")
+        } else {
+            to_snake_case(data_cls)
+        };
+
+        // `FeatherWriter` physically writes custom data beneath
+        // `data/custom/{TypeName}/...` (see `get_writer_path_custom`), while
+        // the logical name keeps the `custom/` marker, so the discovery prefix
+        // is the physical layout rather than `custom/{TypeName}`.
+        let search_prefix = data_name
+            .strip_prefix("custom/")
+            .map(|type_name| format!("data/custom/{type_name}"))
+            .unwrap_or_else(|| data_name.clone());
 
         // List all feather files for this data class
         let feather_files =
-            self.list_feather_files(subdirectory, instance_id, &data_name, identifiers)?;
+            self.list_feather_files(subdirectory, instance_id, &search_prefix, identifiers)?;
 
         if feather_files.is_empty() {
             return Ok(());

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -4694,6 +4694,97 @@ fn test_convert_stream_to_data_writes_flat_stream_file() {
     assert_eq!(payload.value(1), "b");
 }
 
+/// Regression for #4607: `convert_stream_to_data` silently converts nothing
+/// for custom data written by `FeatherWriter`.
+///
+/// Two coordinated causes: `to_snake_case` turned `custom/RustTestHashMapCustomData`
+/// into `custom_rust_test_hash_map_custom_data` (destroying the `custom/` marker
+/// that `is_supported_stream_data_type` checks), and file discovery searched
+/// `{data_name}/...` while `FeatherWriter` physically writes beneath
+/// `data/custom/{TypeName}/...`. Conversion returned `Ok(())` with zero files,
+/// and a subsequent custom-data query returned zero records.
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_convert_stream_to_data_converts_custom_data_written_by_feather_writer() {
+    use std::{cell::RefCell, rc::Rc};
+
+    use nautilus_common::clock::{Clock, TestClock};
+    use nautilus_persistence::backend::feather::{FeatherWriter, RotationConfig};
+    use object_store::ObjectStore;
+
+    ensure_test_custom_data_registered();
+
+    let temp_dir = TempDir::new().unwrap();
+    let instance_id = "test_instance_custom_4607";
+    let subdirectory = "live";
+
+    let mut catalog = ParquetDataCatalog::new(temp_dir.path(), None, None, None, None);
+    let local_fs = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(local_fs);
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+
+    // Root the FeatherWriter at the catalog-relative logical path
+    // `{subdirectory}/{instance_id}`: the catalog's own `base_path` is empty
+    // (see `create_local_store`), so it discovers streams under the relative
+    // path `live/{instance_id}/`, and that is where the writer must put files.
+    let writer_root = format!("{subdirectory}/{instance_id}");
+
+    let mut writer = FeatherWriter::new(
+        writer_root,
+        store,
+        clock,
+        RotationConfig::NoRotation,
+        None,
+        None,
+        None,
+    );
+
+    // Write three records for each of two identifiers (six total) through the
+    // same `FeatherWriter` path a live data engine uses.
+    for (ident, base_ts) in [("ident_a", 1000u64), ("ident_b", 2000u64)] {
+        let data_type = DataType::new("RustTestHashMapCustomData", None, Some(ident.to_string()));
+        for i in 0..3 {
+            let item = RustTestHashMapCustomData {
+                name: format!("{ident}_{i}"),
+                prices: HashMap::from([("AUD/USD.SIM".to_string(), Price::from("1.23456"))]),
+                ts_event: UnixNanos::from(base_ts + i),
+                ts_init: UnixNanos::from(base_ts + i),
+            };
+            let data = Data::Custom(CustomData::new(Arc::new(item), data_type.clone()));
+            writer.write_data(data).await.unwrap();
+        }
+    }
+    writer.close().await.unwrap();
+
+    catalog
+        .convert_stream_to_data(
+            instance_id,
+            "custom/RustTestHashMapCustomData",
+            Some(subdirectory),
+            None,
+            false,
+        )
+        .unwrap();
+
+    let loaded = catalog
+        .query_custom_data_dynamic(
+            "RustTestHashMapCustomData",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(
+        loaded.len(),
+        6,
+        "all FeatherWriter custom records must convert to queryable parquet"
+    );
+}
+
 #[rstest]
 fn test_convert_stream_to_data_keeps_flat_stream_file_with_identifiers() {
     use std::sync::Arc;


### PR DESCRIPTION
Fixes the silent no-op where `convert_stream_to_data` converts nothing for custom data written by `FeatherWriter` (issue #4607).

## Problem

Two coordinated causes left the custom-data conversion branch unreachable, so conversion returned `Ok(())` while a subsequent `query_custom_data_dynamic` returned zero records:

1. **The `custom/` marker was destroyed.** `to_snake_case("custom/RustTestHashMapCustomData")` produced `custom_rust_test_hash_map_custom_data`, so `is_supported_stream_data_type` — which checks `starts_with("custom/")` — rejected it, and `convert_feather_batches_to_parquet` never reached its `strip_prefix("custom/")` branch.

2. **File discovery searched the wrong prefix.** `list_feather_files` looked beneath `{data_name}/`, but `FeatherWriter::get_writer_path_custom` physically writes beneath `data/custom/{TypeName}/...`.

The failure is silent by design — `convert_stream_to_data` deliberately treats an empty file list as a successful no-op — so no error surfaced.

## What

In `convert_stream_to_data` (`crates/persistence/src/backend/catalog.rs`):

- **Preserve the marker**: a `custom/`-prefixed `data_cls` keeps the `custom/{TypeName}` form instead of passing through `to_snake_case`.
- **Map to the physical layout**: custom data is discovered beneath `data/custom/{TypeName}/...`, matching the FeatherWriter's actual output.

The conversion side (`convert_feather_batches_to_parquet`, `identifier_from_batch_or_path`, `make_path_custom_data`) already handled the `custom/` layout correctly — it was simply never reached.

## Tests

New `test_convert_stream_to_data_converts_custom_data_written_by_feather_writer`: writes six `RustTestHashMapCustomData` records (three per identifier) through a real `FeatherWriter`, converts the stream, and asserts all six are queryable via `query_custom_data_dynamic`. This is the exact repro flow from the issue.

Note on the CLA: happy to sign the [Contributor License Agreement](CLA.md) via CLA Assistant on first PR.
