### PR TITLE
Harden Polymarket pagination progress

### DIFF
--- a/crates/adapters/polymarket/src/http/clob.rs
+++ b/crates/adapters/polymarket/src/http/clob.rs
@@ -15,7 +15,10 @@
 
 //! Provides the HTTP client for the Polymarket CLOB REST API.
 
-use std::{collections::HashMap, result::Result as StdResult, str::from_utf8, sync::Arc};
+use std::{
+    collections::HashMap, convert::Infallible, result::Result as StdResult, str::from_utf8,
+    sync::Arc,
+};
 
 use nautilus_core::{
     consts::NAUTILUS_USER_AGENT,
@@ -45,6 +48,7 @@ use crate::{
             ClobBookResponse, ClobMarketResponse, FeeRateResponse, PolymarketOpenOrder,
             PolymarketOrder, PolymarketTradeReport, TickSizeResponse,
         },
+        pagination::{CollectAll, Completion, CursorProtocol, FetchOutcome, Paginator},
         query::{
             BalanceAllowance, BatchCancelResponse, CancelMarketOrdersParams, CancelResponse,
             ClobVersionResponse, GetBalanceAllowanceParams, GetOrdersParams, GetTradesParams,
@@ -450,26 +454,36 @@ impl PolymarketClobHttpClient {
     }
 
     /// Fetches all open orders matching the given parameters (auto-paginated).
-    pub async fn get_orders(
-        &self,
-        mut params: GetOrdersParams,
-    ) -> Result<Vec<PolymarketOpenOrder>> {
-        let mut all = Vec::new();
+    pub async fn get_orders(&self, params: GetOrdersParams) -> Result<Vec<PolymarketOpenOrder>> {
+        let initial_cursor = params
+            .next_cursor
+            .clone()
+            .unwrap_or_else(|| CURSOR_START.to_string());
+        let protocol = CursorProtocol::<Infallible>::clob(PATH_ORDERS, initial_cursor, CURSOR_END);
+        let paginator = Paginator::new(PATH_ORDERS, protocol, CollectAll::new());
+        let completed = paginator
+            .run(
+                |position| {
+                    let mut request = params.clone();
+                    request.next_cursor =
+                        position.as_ref().map(|cursor| cursor.as_ref().to_string());
+                    async move {
+                        let page: PaginatedResponse<PolymarketOpenOrder> =
+                            self.send_get(PATH_ORDERS, Some(&request), true).await?;
+                        Ok(FetchOutcome::Page {
+                            rows: page.data,
+                            wire: page.next_cursor,
+                        })
+                    }
+                },
+                |e| Error::decode(e.to_string()),
+            )
+            .await?;
 
-        loop {
-            let cursor = params
-                .next_cursor
-                .get_or_insert_with(|| CURSOR_START.to_string())
-                .clone();
-            let page: PaginatedResponse<PolymarketOpenOrder> =
-                self.send_get(PATH_ORDERS, Some(&params), true).await?;
-            all.extend(page.data);
-            let Some(next_cursor) = cursor_next(PATH_ORDERS, &cursor, page.next_cursor)? else {
-                break;
-            };
-            params.next_cursor = Some(next_cursor);
+        match completed.completion {
+            Completion::WireComplete => Ok(completed.output),
+            Completion::Stopped(never) => match never {},
         }
-        Ok(all)
     }
 
     /// Fetches a single order by ID, returning `None` for empty/null responses.
@@ -489,26 +503,36 @@ impl PolymarketClobHttpClient {
     }
 
     /// Fetches all trades matching the given parameters (auto-paginated).
-    pub async fn get_trades(
-        &self,
-        mut params: GetTradesParams,
-    ) -> Result<Vec<PolymarketTradeReport>> {
-        let mut all = Vec::new();
+    pub async fn get_trades(&self, params: GetTradesParams) -> Result<Vec<PolymarketTradeReport>> {
+        let initial_cursor = params
+            .next_cursor
+            .clone()
+            .unwrap_or_else(|| CURSOR_START.to_string());
+        let protocol = CursorProtocol::<Infallible>::clob(PATH_TRADES, initial_cursor, CURSOR_END);
+        let paginator = Paginator::new(PATH_TRADES, protocol, CollectAll::new());
+        let completed = paginator
+            .run(
+                |position| {
+                    let mut request = params.clone();
+                    request.next_cursor =
+                        position.as_ref().map(|cursor| cursor.as_ref().to_string());
+                    async move {
+                        let page: PaginatedResponse<PolymarketTradeReport> =
+                            self.send_get(PATH_TRADES, Some(&request), true).await?;
+                        Ok(FetchOutcome::Page {
+                            rows: page.data,
+                            wire: page.next_cursor,
+                        })
+                    }
+                },
+                |e| Error::decode(e.to_string()),
+            )
+            .await?;
 
-        loop {
-            let cursor = params
-                .next_cursor
-                .get_or_insert_with(|| CURSOR_START.to_string())
-                .clone();
-            let page: PaginatedResponse<PolymarketTradeReport> =
-                self.send_get(PATH_TRADES, Some(&params), true).await?;
-            all.extend(page.data);
-            let Some(next_cursor) = cursor_next(PATH_TRADES, &cursor, page.next_cursor)? else {
-                break;
-            };
-            params.next_cursor = Some(next_cursor);
+        match completed.completion {
+            Completion::WireComplete => Ok(completed.output),
+            Completion::Stopped(never) => match never {},
         }
-        Ok(all)
     }
 
     /// Fetches strict V2 balance and allowance evidence for the given parameters.
@@ -767,24 +791,6 @@ impl PolymarketClobPublicClient {
         );
 
         Ok(book)
-    }
-}
-
-fn cursor_next(
-    endpoint: &'static str,
-    cursor: &str,
-    next_cursor: Option<String>,
-) -> Result<Option<String>> {
-    let next_cursor = next_cursor
-        .ok_or_else(|| Error::decode(format!("{endpoint} response omitted next_cursor")))?;
-    if next_cursor.is_empty() || next_cursor == CURSOR_END {
-        Ok(None)
-    } else if next_cursor == cursor {
-        Err(Error::decode(format!(
-            "{endpoint} pagination cursor did not advance from {cursor:?}"
-        )))
-    } else {
-        Ok(Some(next_cursor))
     }
 }
 

--- a/crates/adapters/polymarket/src/http/clob.rs
+++ b/crates/adapters/polymarket/src/http/clob.rs
@@ -481,7 +481,7 @@ impl PolymarketClobHttpClient {
             .await?;
 
         match completed.completion {
-            Completion::WireComplete => Ok(completed.output),
+            Completion::WireExhausted => Ok(completed.output),
             Completion::Stopped(never) => match never {},
         }
     }
@@ -530,7 +530,7 @@ impl PolymarketClobHttpClient {
             .await?;
 
         match completed.completion {
-            Completion::WireComplete => Ok(completed.output),
+            Completion::WireExhausted => Ok(completed.output),
             Completion::Stopped(never) => match never {},
         }
     }

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -114,10 +114,11 @@ fn validate_trade_page_scope(
     rows: Vec<DataApiTrade>,
     expected_condition_id: &str,
 ) -> anyhow::Result<Vec<DataApiTrade>> {
-    match rows
-        .iter()
-        .find(|trade| trade.condition_id != expected_condition_id)
-    {
+    match rows.iter().find(|trade| {
+        !trade
+            .condition_id
+            .eq_ignore_ascii_case(expected_condition_id)
+    }) {
         Some(trade) => anyhow::bail!(
             "Polymarket Data API returned trade for condition {} while requesting {expected_condition_id}",
             trade.condition_id
@@ -318,7 +319,7 @@ impl PolymarketDataApiHttpClient {
             .await?;
 
         match completed.completion {
-            Completion::WireComplete => Ok(completed.output),
+            Completion::WireExhausted => Ok(completed.output),
             Completion::Stopped(never) => match never {},
         }
     }
@@ -466,7 +467,7 @@ impl PolymarketDataApiHttpClient {
             .await?;
 
         match completed.completion {
-            Completion::WireComplete | Completion::Stopped(TradeTickStop::CallerCapped) => {
+            Completion::WireExhausted | Completion::Stopped(TradeTickStop::CallerCapped) => {
                 Ok(completed.output)
             }
             Completion::Stopped(TradeTickStop::VenueOffsetCeiling(OffsetCeilingSource::Local)) => {

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -15,7 +15,7 @@
 
 //! Provides the HTTP client for the Polymarket Data API.
 
-use std::{collections::HashMap, result::Result as StdResult};
+use std::{collections::HashMap, convert::Infallible, result::Result as StdResult};
 
 use anyhow::Context;
 use nautilus_core::{UnixNanos, consts::NAUTILUS_USER_AGENT};
@@ -36,6 +36,10 @@ use crate::{
     http::{
         error::{Error, Result},
         models::{DataApiPosition, DataApiTrade},
+        pagination::{
+            CollectAll, Completion, FetchOutcome, OffsetProtocol, PageFingerprint, PageReducer,
+            Paginator, encode_length_prefixed, fingerprint_multiset,
+        },
     },
 };
 
@@ -72,6 +76,144 @@ pub(crate) fn build_polymarket_trade_id(transaction_hash: &str, asset: &str, seq
 }
 
 const POLYMARKET_DATA_API_URL: &str = "https://data-api.polymarket.com";
+
+fn position_page_fingerprint(rows: &[DataApiPosition]) -> PageFingerprint {
+    let descriptors = rows
+        .iter()
+        .map(|position| {
+            let mut descriptor = Vec::new();
+            encode_length_prefixed(&mut descriptor, position.condition_id.as_bytes());
+            encode_length_prefixed(&mut descriptor, position.asset.as_bytes());
+            descriptor
+        })
+        .collect();
+    fingerprint_multiset(1, descriptors)
+}
+
+fn trade_page_fingerprint(rows: &[DataApiTrade]) -> PageFingerprint {
+    let descriptors = rows
+        .iter()
+        .map(|trade| {
+            let mut descriptor = Vec::new();
+            encode_length_prefixed(&mut descriptor, trade.transaction_hash.as_bytes());
+            encode_length_prefixed(&mut descriptor, trade.asset.as_bytes());
+            descriptor.push(match trade.side {
+                PolymarketOrderSide::Buy => 0,
+                PolymarketOrderSide::Sell => 1,
+            });
+            encode_decimal(&mut descriptor, trade.price);
+            encode_decimal(&mut descriptor, trade.size);
+            descriptor.extend_from_slice(&trade.timestamp.to_be_bytes());
+            descriptor
+        })
+        .collect();
+    fingerprint_multiset(2, descriptors)
+}
+
+fn validate_trade_page_scope(
+    rows: Vec<DataApiTrade>,
+    expected_condition_id: &str,
+) -> anyhow::Result<Vec<DataApiTrade>> {
+    match rows
+        .iter()
+        .find(|trade| trade.condition_id != expected_condition_id)
+    {
+        Some(trade) => anyhow::bail!(
+            "Polymarket Data API returned trade for condition {} while requesting {expected_condition_id}",
+            trade.condition_id
+        ),
+        None => Ok(rows),
+    }
+}
+
+fn encode_decimal(output: &mut Vec<u8>, value: Decimal) {
+    let normalized = value.normalize();
+    output.extend_from_slice(&normalized.mantissa().to_be_bytes());
+    output.extend_from_slice(&normalized.scale().to_be_bytes());
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TradeTickStop {
+    CallerCapped,
+    VenueOffsetCeiling(OffsetCeilingSource),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum OffsetCeilingSource {
+    Local,
+    Remote(String),
+}
+
+struct TradeTickReducer {
+    rows: Vec<DataApiTrade>,
+    instrument_id: InstrumentId,
+    condition_id: String,
+    token_id: String,
+    price_precision: u8,
+    size_precision: u8,
+    start: Option<UnixNanos>,
+    end: Option<UnixNanos>,
+    limit: Option<usize>,
+}
+
+impl PageReducer<DataApiTrade, anyhow::Error> for TradeTickReducer {
+    type Output = Vec<TradeTick>;
+    type Stop = TradeTickStop;
+
+    fn consume(&mut self, rows: Vec<DataApiTrade>) -> anyhow::Result<Option<Self::Stop>> {
+        self.rows.extend(rows);
+        let capped = self.start.is_none()
+            && self.limit.is_some_and(|target| {
+                count_matching_trades_within_end(&self.rows, &self.token_id, self.end) >= target
+            });
+        Ok(capped.then_some(TradeTickStop::CallerCapped))
+    }
+
+    fn finish(self, completion: &Completion<Self::Stop>) -> anyhow::Result<Self::Output> {
+        if self.start.is_some()
+            && matches!(
+                completion,
+                Completion::Stopped(TradeTickStop::VenueOffsetCeiling(_))
+            )
+        {
+            anyhow::bail!(
+                "Polymarket public trades API reached the historical offset ceiling for condition {}; cannot guarantee complete start-anchored results, narrow the time window",
+                self.condition_id
+            );
+        }
+
+        let start_secs = self
+            .start
+            .map(|value| (value.as_u64() / 1_000_000_000) as i64);
+        let end_secs = self
+            .end
+            .map(|value| (value.as_u64() / 1_000_000_000) as i64);
+        let mut trades = parse_trade_ticks(
+            self.rows,
+            self.instrument_id,
+            &self.token_id,
+            self.price_precision,
+            self.size_precision,
+        )?;
+        trades.retain(|trade| {
+            let event_secs = trade.ts_event.as_u64() / 1_000_000_000;
+            start_secs.is_none_or(|start| event_secs >= start as u64)
+                && end_secs.is_none_or(|end| event_secs <= end as u64)
+        });
+
+        if let Some(target) = self.limit
+            && trades.len() > target
+        {
+            if self.start.is_some() {
+                trades.truncate(target);
+            } else {
+                trades.drain(..trades.len() - target);
+            }
+        }
+
+        Ok(trades)
+    }
+}
 
 /// Provides an unauthenticated HTTP client for the Polymarket Data API.
 ///
@@ -126,47 +268,59 @@ impl PolymarketDataApiHttpClient {
     /// Paginates through `GET /positions?user={address}&sizeThreshold=0`
     /// until a partial page is returned.
     pub async fn get_positions(&self, user_address: &str) -> Result<Vec<DataApiPosition>> {
-        const PAGE_SIZE: u32 = 100;
+        const PAGE_SIZE: usize = 100;
 
-        let mut all_positions: Vec<DataApiPosition> = Vec::new();
-        let mut offset: u32 = 0;
+        let protocol = OffsetProtocol::<DataApiPosition, Infallible>::new(
+            "/positions",
+            PAGE_SIZE,
+            position_page_fingerprint,
+            None,
+        );
+        let paginator = Paginator::new("/positions", protocol, CollectAll::new());
+        let completed = paginator
+            .run(
+                |offset| async move {
+                    let params = vec![
+                        ("user".to_string(), user_address.to_string()),
+                        ("limit".to_string(), PAGE_SIZE.to_string()),
+                        ("offset".to_string(), offset.to_string()),
+                        ("sizeThreshold".to_string(), "0".to_string()),
+                        ("sortBy".to_string(), "TOKENS".to_string()),
+                        ("sortDirection".to_string(), "DESC".to_string()),
+                    ];
+                    let url = format!("{}/positions", self.base_url);
+                    let response = self
+                        .client
+                        .request_with_params(
+                            Method::GET,
+                            url,
+                            Some(&params),
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .await
+                        .map_err(Error::from_http_client)?;
 
-        loop {
-            let params = vec![
-                ("user".to_string(), user_address.to_string()),
-                ("limit".to_string(), PAGE_SIZE.to_string()),
-                ("offset".to_string(), offset.to_string()),
-                ("sizeThreshold".to_string(), "0".to_string()),
-                ("sortBy".to_string(), "TOKENS".to_string()),
-                ("sortDirection".to_string(), "DESC".to_string()),
-            ];
+                    if response.status.is_success() {
+                        let rows = serde_json::from_slice(&response.body).map_err(Error::Serde)?;
+                        Ok(FetchOutcome::Page { rows, wire: () })
+                    } else {
+                        Err(Error::from_status_code(
+                            response.status.as_u16(),
+                            &response.body,
+                        ))
+                    }
+                },
+                |e| Error::decode(e.to_string()),
+            )
+            .await?;
 
-            let url = format!("{}/positions", self.base_url);
-            let response = self
-                .client
-                .request_with_params(Method::GET, url, Some(&params), None, None, None, None)
-                .await
-                .map_err(Error::from_http_client)?;
-
-            if response.status.is_success() {
-                let page: Vec<DataApiPosition> =
-                    serde_json::from_slice(&response.body).map_err(Error::Serde)?;
-                let count = page.len() as u32;
-                all_positions.extend(page);
-
-                if count < PAGE_SIZE {
-                    break;
-                }
-                offset += count;
-            } else {
-                return Err(Error::from_status_code(
-                    response.status.as_u16(),
-                    &response.body,
-                ));
-            }
+        match completed.completion {
+            Completion::WireComplete => Ok(completed.output),
+            Completion::Stopped(never) => match never {},
         }
-
-        Ok(all_positions)
     }
 
     /// Fetches trades from the Data API for the given condition ID.
@@ -261,92 +415,93 @@ impl PolymarketDataApiHttpClient {
 
         let start_secs = start.map(|value| (value.as_u64() / 1_000_000_000) as i64);
         let end_secs = end.map(|value| (value.as_u64() / 1_000_000_000) as i64);
-        let page_size = PAGE_SIZE;
-        let mut all_trades: Vec<DataApiTrade> = Vec::new();
-        let mut offset: u32 = 0;
-        let mut offset_ceiling_reached = false;
-
-        loop {
-            let page = match self
-                .get_trades_in_window(
-                    condition_id,
-                    Some(page_size),
-                    Some(offset),
-                    start_secs,
-                    end_secs,
-                )
-                .await
-            {
-                Ok(page) => page,
-                Err(e) => {
-                    if format!("{e}").contains("max historical activity offset") {
-                        // Public API caps pagination depth; warn and return partial
-                        log::warn!(
-                            "Polymarket public trades API hit its historical offset \
-                             ceiling for condition {condition_id}; returning partial \
-                            results: {e}",
-                        );
-                        offset_ceiling_reached = true;
-                        break;
+        let protocol = OffsetProtocol::new(
+            "/trades",
+            PAGE_SIZE as usize,
+            trade_page_fingerprint,
+            Some((
+                MAX_OFFSET,
+                TradeTickStop::VenueOffsetCeiling(OffsetCeilingSource::Local),
+            )),
+        );
+        let reducer = TradeTickReducer {
+            rows: Vec::new(),
+            instrument_id,
+            condition_id: condition_id.to_string(),
+            token_id: token_id.to_string(),
+            price_precision,
+            size_precision,
+            start,
+            end,
+            limit: limit.map(|value| value as usize),
+        };
+        let paginator = Paginator::new("/trades", protocol, reducer);
+        let completed = paginator
+            .run(
+                |offset| async move {
+                    match self
+                        .get_trades_in_window(
+                            condition_id,
+                            Some(PAGE_SIZE),
+                            Some(offset),
+                            start_secs,
+                            end_secs,
+                        )
+                        .await
+                    {
+                        Ok(rows) => Ok(FetchOutcome::Page {
+                            rows: validate_trade_page_scope(rows, condition_id)?,
+                            wire: (),
+                        }),
+                        Err(e) if is_historical_offset_ceiling(&e) => {
+                            Ok(FetchOutcome::Stop(TradeTickStop::VenueOffsetCeiling(
+                                OffsetCeilingSource::Remote(e.to_string()),
+                            )))
+                        }
+                        Err(e) => Err(anyhow::Error::new(e)),
                     }
-                    anyhow::bail!(e);
-                }
-            };
+                },
+                anyhow::Error::new,
+            )
+            .await?;
 
-            let count = page.len() as u32;
-            all_trades.extend(page);
-
-            if count < page_size {
-                break;
+        match completed.completion {
+            Completion::WireComplete | Completion::Stopped(TradeTickStop::CallerCapped) => {
+                Ok(completed.output)
             }
-
-            if start.is_none()
-                && limit.is_some_and(|target| {
-                    count_matching_trades_within_end(&all_trades, token_id, end) >= target as usize
-                })
-            {
-                break;
-            }
-            offset += count;
-            if offset >= MAX_OFFSET {
+            Completion::Stopped(TradeTickStop::VenueOffsetCeiling(OffsetCeilingSource::Local)) => {
                 log::warn!(
                     "Polymarket public trades API reached the historical offset ceiling for condition {condition_id}; returning partial results"
                 );
-                offset_ceiling_reached = true;
-                break;
+                Ok(completed.output)
+            }
+            Completion::Stopped(TradeTickStop::VenueOffsetCeiling(
+                OffsetCeilingSource::Remote(error),
+            )) => {
+                log::warn!(
+                    "Polymarket public trades API hit its historical offset ceiling for condition {condition_id}; returning partial results: {error}"
+                );
+                Ok(completed.output)
             }
         }
+    }
+}
 
-        if offset_ceiling_reached && start.is_some() {
-            anyhow::bail!(
-                "Polymarket public trades API reached the historical offset ceiling for condition {condition_id}; cannot guarantee complete start-anchored results, narrow the time window"
-            );
+fn is_historical_offset_ceiling(error: &Error) -> bool {
+    match error {
+        Error::Http { message, .. } | Error::RateLimit { message, .. } => {
+            message.contains("max historical activity offset")
         }
-
-        let mut trades = parse_trade_ticks(
-            all_trades,
-            instrument_id,
-            token_id,
-            price_precision,
-            size_precision,
-        )?;
-        trades.retain(|trade| {
-            let event_secs = trade.ts_event.as_u64() / 1_000_000_000;
-            start_secs.is_none_or(|start| event_secs >= start as u64)
-                && end_secs.is_none_or(|end| event_secs <= end as u64)
-        });
-
-        if let Some(target) = limit.map(|value| value as usize)
-            && trades.len() > target
-        {
-            if start.is_some() {
-                trades.truncate(target);
-            } else {
-                trades.drain(..trades.len() - target);
-            }
-        }
-
-        Ok(trades)
+        Error::Transport(_)
+        | Error::Serde(_)
+        | Error::Auth(_)
+        | Error::BadRequest(_)
+        | Error::BurstExceeded { .. }
+        | Error::Exchange(_)
+        | Error::Timeout
+        | Error::Decode(_)
+        | Error::UrlParse(_)
+        | Error::Io(_) => false,
     }
 }
 

--- a/crates/adapters/polymarket/src/http/gamma.rs
+++ b/crates/adapters/polymarket/src/http/gamma.rs
@@ -537,7 +537,7 @@ impl PolymarketGammaHttpClient {
             .await?;
 
         match completed.completion {
-            Completion::WireComplete | Completion::Stopped(GammaStop::CallerCapped) => {
+            Completion::WireExhausted | Completion::Stopped(GammaStop::CallerCapped) => {
                 Ok(completed.output)
             }
         }
@@ -896,7 +896,7 @@ impl PolymarketGammaHttpClient {
             .await?;
 
         match completed.completion {
-            Completion::WireComplete | Completion::Stopped(GammaStop::CallerCapped) => {
+            Completion::WireExhausted | Completion::Stopped(GammaStop::CallerCapped) => {
                 Ok(completed.output)
             }
         }

--- a/crates/adapters/polymarket/src/http/gamma.rs
+++ b/crates/adapters/polymarket/src/http/gamma.rs
@@ -27,7 +27,6 @@
 
 use std::{collections::HashMap, result::Result as StdResult, sync::Arc};
 
-use ahash::AHashSet;
 use nautilus_core::{
     UnixNanos,
     consts::NAUTILUS_USER_AGENT,
@@ -48,6 +47,7 @@ use crate::{
     http::{
         error::{Error, Result},
         models::{GammaEvent, GammaMarket, GammaTag, SearchResponse},
+        pagination::{Completion, CursorProtocol, FetchOutcome, Paginator, WindowedCollect},
         parse::{create_instrument_from_def, parse_gamma_market},
         query::{GetGammaEventsParams, GetGammaMarketsParams, GetSearchParams},
         rate_limits::POLYMARKET_GAMMA_REST_QUOTA,
@@ -56,6 +56,11 @@ use crate::{
 
 const GAMMA_MARKETS_KEYSET_PAGE_LIMIT: u32 = 100;
 const GAMMA_EVENTS_KEYSET_PAGE_LIMIT: u32 = 500;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GammaStop {
+    CallerCapped,
+}
 
 /// Provides a raw HTTP client for the Polymarket Gamma API.
 ///
@@ -500,54 +505,42 @@ impl PolymarketGammaHttpClient {
             .limit
             .unwrap_or(GAMMA_MARKETS_KEYSET_PAGE_LIMIT)
             .min(GAMMA_MARKETS_KEYSET_PAGE_LIMIT);
-        let max_markets = base_params.max_markets;
-        let mut all_markets = Vec::new();
-        let mut remaining_offset = base_params.offset.unwrap_or(0);
-        let mut after_cursor = None;
-        let mut seen_cursors = AHashSet::new();
-        let mut page_num = 0u32;
+        let protocol = CursorProtocol::<GammaStop>::gamma("Gamma market");
+        let reducer = WindowedCollect::new(
+            base_params.offset.unwrap_or(0) as usize,
+            base_params.max_markets.map(|value| value as usize),
+            GammaStop::CallerCapped,
+        );
+        let paginator = Paginator::new("Gamma market", protocol, reducer);
+        let completed = paginator
+            .run(
+                |position| {
+                    let after_cursor = position.map(|cursor| cursor.as_ref().to_string());
+                    let params = GetGammaMarketsParams {
+                        limit: Some(page_size),
+                        offset: None,
+                        ..base_params.clone()
+                    };
+                    async move {
+                        let response = self
+                            .inner
+                            .get_gamma_markets_keyset(params, after_cursor.as_deref())
+                            .await?;
+                        Ok::<_, anyhow::Error>(FetchOutcome::Page {
+                            rows: response.markets,
+                            wire: response.next_cursor,
+                        })
+                    }
+                },
+                anyhow::Error::new,
+            )
+            .await?;
 
-        loop {
-            let params = GetGammaMarketsParams {
-                limit: Some(page_size),
-                offset: None,
-                ..base_params.clone()
-            };
-
-            let response = self
-                .inner
-                .get_gamma_markets_keyset(params, after_cursor.as_deref())
-                .await?;
-            let page_len = response.markets.len() as u32;
-            let skipped = remaining_offset.min(page_len) as usize;
-            remaining_offset -= skipped as u32;
-            page_num += 1;
-            all_markets.extend(response.markets.into_iter().skip(skipped));
-
-            log::debug!(
-                "Fetched markets page {page_num}: {page_len} markets (total: {})",
-                all_markets.len(),
-            );
-
-            if let Some(cap) = max_markets
-                && all_markets.len() as u32 >= cap
-            {
-                all_markets.truncate(cap as usize);
-                break;
+        match completed.completion {
+            Completion::WireComplete | Completion::Stopped(GammaStop::CallerCapped) => {
+                Ok(completed.output)
             }
-
-            let Some(next_cursor) = response.next_cursor else {
-                break;
-            };
-
-            anyhow::ensure!(
-                seen_cursors.insert(next_cursor.clone()),
-                "Gamma market pagination repeated cursor {next_cursor:?}",
-            );
-            after_cursor = Some(next_cursor);
         }
-
-        Ok(all_markets)
     }
 
     /// Fetches all active markets from the Gamma API, paginating automatically.
@@ -871,55 +864,42 @@ impl PolymarketGammaHttpClient {
             .limit
             .unwrap_or(GAMMA_EVENTS_KEYSET_PAGE_LIMIT)
             .min(GAMMA_EVENTS_KEYSET_PAGE_LIMIT);
-        let max_events = base_params.max_events;
-        let mut all_events = Vec::new();
-        let mut remaining_offset = base_params.offset.unwrap_or(0);
-        let mut after_cursor = None;
-        let mut seen_cursors = AHashSet::new();
-        let mut page_num = 0u32;
+        let protocol = CursorProtocol::<GammaStop>::gamma("Gamma event");
+        let reducer = WindowedCollect::new(
+            base_params.offset.unwrap_or(0) as usize,
+            base_params.max_events.map(|value| value as usize),
+            GammaStop::CallerCapped,
+        );
+        let paginator = Paginator::new("Gamma event", protocol, reducer);
+        let completed = paginator
+            .run(
+                |position| {
+                    let after_cursor = position.map(|cursor| cursor.as_ref().to_string());
+                    let params = GetGammaEventsParams {
+                        limit: Some(page_size),
+                        offset: None,
+                        ..base_params.clone()
+                    };
+                    async move {
+                        let response = self
+                            .inner
+                            .get_gamma_events_keyset(params, after_cursor.as_deref())
+                            .await?;
+                        Ok::<_, anyhow::Error>(FetchOutcome::Page {
+                            rows: response.events,
+                            wire: response.next_cursor,
+                        })
+                    }
+                },
+                anyhow::Error::new,
+            )
+            .await?;
 
-        loop {
-            let params = GetGammaEventsParams {
-                limit: Some(page_size),
-                offset: None,
-                ..base_params.clone()
-            };
-
-            let response = self
-                .inner
-                .get_gamma_events_keyset(params, after_cursor.as_deref())
-                .await?;
-            let page_len = response.events.len() as u32;
-            let skipped = remaining_offset.min(page_len) as usize;
-            remaining_offset -= skipped as u32;
-            page_num += 1;
-            let market_count: usize = response.events.iter().map(|e| e.markets.len()).sum();
-            all_events.extend(response.events.into_iter().skip(skipped));
-
-            log::debug!(
-                "Fetched events page {page_num}: {page_len} events, {market_count} markets (total events: {})",
-                all_events.len(),
-            );
-
-            if let Some(cap) = max_events
-                && all_events.len() as u32 >= cap
-            {
-                all_events.truncate(cap as usize);
-                break;
+        match completed.completion {
+            Completion::WireComplete | Completion::Stopped(GammaStop::CallerCapped) => {
+                Ok(completed.output)
             }
-
-            let Some(next_cursor) = response.next_cursor else {
-                break;
-            };
-
-            anyhow::ensure!(
-                seen_cursors.insert(next_cursor.clone()),
-                "Gamma event pagination repeated cursor {next_cursor:?}",
-            );
-            after_cursor = Some(next_cursor);
         }
-
-        Ok(all_events)
     }
 
     /// Fetches instruments from events matching full query params (paginated).

--- a/crates/adapters/polymarket/src/http/mod.rs
+++ b/crates/adapters/polymarket/src/http/mod.rs
@@ -24,3 +24,5 @@ pub mod models;
 pub mod parse;
 pub mod query;
 pub mod rate_limits;
+
+pub(crate) mod pagination;

--- a/crates/adapters/polymarket/src/http/pagination.rs
+++ b/crates/adapters/polymarket/src/http/pagination.rs
@@ -25,7 +25,7 @@ pub(crate) enum FetchOutcome<T, W, S> {
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum Completion<S> {
-    WireComplete,
+    WireExhausted,
     Stopped(S),
 }
 
@@ -436,7 +436,7 @@ impl<P, R> Paginator<P, R> {
 
             match observation {
                 PageObservation::Terminal => {
-                    let completion = Completion::WireComplete;
+                    let completion = Completion::WireExhausted;
                     let output = self.reducer.finish(&completion)?;
                     return Ok(Completed { output, completion });
                 }

--- a/crates/adapters/polymarket/src/http/pagination.rs
+++ b/crates/adapters/polymarket/src/http/pagination.rs
@@ -1,0 +1,481 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::{collections::HashSet, future::Future};
+
+use aws_lc_rs::digest::{self, Context};
+
+#[derive(Debug)]
+pub(crate) enum FetchOutcome<T, W, S> {
+    Page { rows: Vec<T>, wire: W },
+    Stop(S),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum Completion<S> {
+    WireComplete,
+    Stopped(S),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct Completed<O, S> {
+    pub(crate) output: O,
+    pub(crate) completion: Completion<S>,
+}
+
+pub(crate) enum PageObservation<P, C, S> {
+    Terminal,
+    Continue { next: P, commit: C },
+    Stop(S),
+}
+
+pub(crate) type ObservationResult<P, C, S> = Result<PageObservation<P, C, S>, PaginationError>;
+
+pub(crate) trait PageProtocol<T> {
+    type Position: Clone;
+    type Wire;
+    type Stop;
+    type Commit;
+
+    fn initial_position(&self) -> Self::Position;
+
+    fn observe(
+        &mut self,
+        position: &Self::Position,
+        page_index: usize,
+        rows: &[T],
+        wire: Self::Wire,
+    ) -> ObservationResult<Self::Position, Self::Commit, Self::Stop>;
+
+    fn commit_continue(&mut self, commit: Self::Commit);
+}
+
+pub(crate) trait PageReducer<T, E> {
+    type Output;
+    type Stop;
+
+    fn consume(&mut self, rows: Vec<T>) -> Result<Option<Self::Stop>, E>;
+
+    fn finish(self, completion: &Completion<Self::Stop>) -> Result<Self::Output, E>;
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct PageFingerprint([u8; 32]);
+
+pub(crate) fn encode_length_prefixed(output: &mut Vec<u8>, value: &[u8]) {
+    let length = u64::try_from(value.len()).expect("fingerprint field length exceeds u64");
+    output.extend_from_slice(&length.to_be_bytes());
+    output.extend_from_slice(value);
+}
+
+pub(crate) fn fingerprint_multiset(version: u8, mut descriptors: Vec<Vec<u8>>) -> PageFingerprint {
+    descriptors.sort_unstable();
+    let mut context = Context::new(&digest::SHA256);
+    context.update(&[version]);
+
+    for descriptor in descriptors {
+        encode_length_prefixed_digest(&mut context, &descriptor);
+    }
+    let digest = context.finish();
+    let mut fingerprint = [0; 32];
+    fingerprint.copy_from_slice(digest.as_ref());
+    PageFingerprint(fingerprint)
+}
+
+fn encode_length_prefixed_digest(context: &mut Context, value: &[u8]) {
+    let length = u64::try_from(value.len()).expect("fingerprint row length exceeds u64");
+    context.update(&length.to_be_bytes());
+    context.update(value);
+}
+
+pub(crate) struct OffsetProtocol<T, S> {
+    endpoint: &'static str,
+    page_size: usize,
+    fingerprint: fn(&[T]) -> PageFingerprint,
+    local_ceiling: Option<(u32, S)>,
+    seen: HashSet<PageFingerprint>,
+}
+
+impl<T, S> OffsetProtocol<T, S> {
+    pub(crate) fn new(
+        endpoint: &'static str,
+        page_size: usize,
+        fingerprint: fn(&[T]) -> PageFingerprint,
+        local_ceiling: Option<(u32, S)>,
+    ) -> Self {
+        Self {
+            endpoint,
+            page_size,
+            fingerprint,
+            local_ceiling,
+            seen: HashSet::new(),
+        }
+    }
+}
+
+impl<T, S> PageProtocol<T> for OffsetProtocol<T, S>
+where
+    S: Clone,
+{
+    type Commit = PageFingerprint;
+    type Position = u32;
+    type Stop = S;
+    type Wire = ();
+
+    fn initial_position(&self) -> Self::Position {
+        0
+    }
+
+    fn observe(
+        &mut self,
+        position: &Self::Position,
+        page_index: usize,
+        rows: &[T],
+        (): Self::Wire,
+    ) -> ObservationResult<Self::Position, Self::Commit, Self::Stop> {
+        if rows.len() < self.page_size {
+            return Ok(PageObservation::Terminal);
+        }
+
+        let fingerprint = (self.fingerprint)(rows);
+        if self.seen.contains(&fingerprint) {
+            return Err(PaginationError::RepeatedPage {
+                endpoint: self.endpoint,
+                page: page_index,
+                offset: *position,
+            });
+        }
+
+        let count = u32::try_from(rows.len()).map_err(|_| PaginationError::OffsetOverflow {
+            endpoint: self.endpoint,
+        })?;
+        let next = position
+            .checked_add(count)
+            .ok_or(PaginationError::OffsetOverflow {
+                endpoint: self.endpoint,
+            })?;
+
+        if let Some((ceiling, stop)) = &self.local_ceiling
+            && next >= *ceiling
+        {
+            return Ok(PageObservation::Stop(stop.clone()));
+        }
+
+        Ok(PageObservation::Continue {
+            next,
+            commit: fingerprint,
+        })
+    }
+
+    fn commit_continue(&mut self, commit: Self::Commit) {
+        self.seen.insert(commit);
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct Cursor(String);
+
+impl AsRef<str> for Cursor {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CursorProtocol<S> {
+    endpoint: &'static str,
+    initial: Option<Cursor>,
+    dialect: CursorDialect,
+    seen: HashSet<Cursor>,
+    stop: std::marker::PhantomData<fn() -> S>,
+}
+
+#[derive(Debug)]
+enum CursorDialect {
+    Clob { terminal_cursor: &'static str },
+    Gamma,
+}
+
+impl<S> CursorProtocol<S> {
+    pub(crate) fn clob(
+        endpoint: &'static str,
+        initial: String,
+        terminal_cursor: &'static str,
+    ) -> Self {
+        let initial = Cursor(initial);
+        let seen = HashSet::from([initial.clone()]);
+        Self {
+            endpoint,
+            initial: Some(initial),
+            dialect: CursorDialect::Clob { terminal_cursor },
+            seen,
+            stop: std::marker::PhantomData,
+        }
+    }
+
+    pub(crate) fn gamma(endpoint: &'static str) -> Self {
+        Self {
+            endpoint,
+            initial: None,
+            dialect: CursorDialect::Gamma,
+            seen: HashSet::new(),
+            stop: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, S> PageProtocol<T> for CursorProtocol<S> {
+    type Commit = Cursor;
+    type Position = Option<Cursor>;
+    type Stop = S;
+    type Wire = Option<String>;
+
+    fn initial_position(&self) -> Self::Position {
+        self.initial.clone()
+    }
+
+    fn observe(
+        &mut self,
+        position: &Self::Position,
+        _page_index: usize,
+        _rows: &[T],
+        wire: Self::Wire,
+    ) -> ObservationResult<Self::Position, Self::Commit, Self::Stop> {
+        let raw = match (&self.dialect, wire) {
+            (CursorDialect::Gamma, None) => return Ok(PageObservation::Terminal),
+            (CursorDialect::Clob { .. }, None) => {
+                return Err(PaginationError::MissingCursor {
+                    endpoint: self.endpoint,
+                });
+            }
+            (_, Some(raw)) => raw,
+        };
+
+        match &self.dialect {
+            CursorDialect::Clob { terminal_cursor }
+                if raw.is_empty() || raw == *terminal_cursor =>
+            {
+                return Ok(PageObservation::Terminal);
+            }
+            CursorDialect::Clob { .. } | CursorDialect::Gamma => {}
+        }
+
+        let next = Cursor(raw);
+        if matches!(&self.dialect, CursorDialect::Clob { .. }) && position.as_ref() == Some(&next) {
+            return Err(PaginationError::StalledCursor {
+                endpoint: self.endpoint,
+                cursor: next.0,
+            });
+        }
+
+        if self.seen.contains(&next) {
+            return Err(PaginationError::RepeatedCursor {
+                endpoint: self.endpoint,
+                cursor: next.0,
+            });
+        }
+
+        Ok(PageObservation::Continue {
+            next: Some(next.clone()),
+            commit: next,
+        })
+    }
+
+    fn commit_continue(&mut self, commit: Self::Commit) {
+        self.seen.insert(commit);
+    }
+}
+
+pub(crate) struct CollectAll<T, S = std::convert::Infallible> {
+    rows: Vec<T>,
+    stop: std::marker::PhantomData<fn() -> S>,
+}
+
+impl<T, S> CollectAll<T, S> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            rows: Vec::new(),
+            stop: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, E, S> PageReducer<T, E> for CollectAll<T, S> {
+    type Output = Vec<T>;
+    type Stop = S;
+
+    fn consume(&mut self, rows: Vec<T>) -> Result<Option<Self::Stop>, E> {
+        self.rows.extend(rows);
+        Ok(None)
+    }
+
+    fn finish(self, _completion: &Completion<Self::Stop>) -> Result<Self::Output, E> {
+        Ok(self.rows)
+    }
+}
+
+pub(crate) struct WindowedCollect<T, S> {
+    remaining_skip: usize,
+    maximum: Option<usize>,
+    rows: Vec<T>,
+    stop: S,
+}
+
+impl<T, S> WindowedCollect<T, S> {
+    pub(crate) const fn new(remaining_skip: usize, maximum: Option<usize>, stop: S) -> Self {
+        Self {
+            remaining_skip,
+            maximum,
+            rows: Vec::new(),
+            stop,
+        }
+    }
+}
+
+impl<T, E, S> PageReducer<T, E> for WindowedCollect<T, S>
+where
+    S: Clone,
+{
+    type Output = Vec<T>;
+    type Stop = S;
+
+    fn consume(&mut self, rows: Vec<T>) -> Result<Option<Self::Stop>, E> {
+        let skipped = self.remaining_skip.min(rows.len());
+        self.remaining_skip -= skipped;
+        let retained = rows.into_iter().skip(skipped);
+
+        if let Some(maximum) = self.maximum {
+            let remaining = maximum.saturating_sub(self.rows.len());
+            self.rows.extend(retained.take(remaining));
+            if self.rows.len() >= maximum {
+                return Ok(Some(self.stop.clone()));
+            }
+        } else {
+            self.rows.extend(retained);
+        }
+
+        Ok(None)
+    }
+
+    fn finish(self, _completion: &Completion<Self::Stop>) -> Result<Self::Output, E> {
+        Ok(self.rows)
+    }
+}
+
+pub(crate) struct Paginator<P, R> {
+    endpoint: &'static str,
+    protocol: P,
+    reducer: R,
+    pages: usize,
+}
+
+impl<P, R> Paginator<P, R> {
+    pub(crate) const fn new(endpoint: &'static str, protocol: P, reducer: R) -> Self {
+        Self {
+            endpoint,
+            protocol,
+            reducer,
+            pages: 0,
+        }
+    }
+
+    pub(crate) async fn run<T, E, F, Fut, M>(
+        mut self,
+        mut fetch: F,
+        mut map_pagination_error: M,
+    ) -> Result<Completed<R::Output, R::Stop>, E>
+    where
+        P: PageProtocol<T, Stop = R::Stop>,
+        R: PageReducer<T, E>,
+        F: FnMut(P::Position) -> Fut,
+        Fut: Future<Output = Result<FetchOutcome<T, P::Wire, R::Stop>, E>>,
+        M: FnMut(PaginationError) -> E,
+    {
+        let mut position = self.protocol.initial_position();
+
+        loop {
+            let (rows, wire) = match fetch(position.clone()).await? {
+                FetchOutcome::Page { rows, wire } => (rows, wire),
+                FetchOutcome::Stop(stop) => {
+                    let completion = Completion::Stopped(stop);
+                    let output = self.reducer.finish(&completion)?;
+                    return Ok(Completed { output, completion });
+                }
+            };
+
+            let page = self.pages.checked_add(1).ok_or_else(|| {
+                map_pagination_error(PaginationError::PageCounterOverflow {
+                    endpoint: self.endpoint,
+                })
+            })?;
+            let observation = self
+                .protocol
+                .observe(&position, page, &rows, wire)
+                .map_err(&mut map_pagination_error)?;
+
+            log::debug!("Fetched {} page {page}: {} rows", self.endpoint, rows.len(),);
+            self.pages = page;
+
+            if let Some(stop) = self.reducer.consume(rows)? {
+                let completion = Completion::Stopped(stop);
+                let output = self.reducer.finish(&completion)?;
+                return Ok(Completed { output, completion });
+            }
+
+            match observation {
+                PageObservation::Terminal => {
+                    let completion = Completion::WireComplete;
+                    let output = self.reducer.finish(&completion)?;
+                    return Ok(Completed { output, completion });
+                }
+                PageObservation::Stop(stop) => {
+                    let completion = Completion::Stopped(stop);
+                    let output = self.reducer.finish(&completion)?;
+                    return Ok(Completed { output, completion });
+                }
+                PageObservation::Continue { next, commit } => {
+                    self.protocol.commit_continue(commit);
+                    position = next;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PaginationError {
+    #[error("{endpoint} response omitted next_cursor")]
+    MissingCursor { endpoint: &'static str },
+    #[error("{endpoint} pagination cursor did not advance from {cursor:?}")]
+    StalledCursor {
+        endpoint: &'static str,
+        cursor: String,
+    },
+    #[error("{endpoint} pagination repeated cursor {cursor:?}")]
+    RepeatedCursor {
+        endpoint: &'static str,
+        cursor: String,
+    },
+    #[error("{endpoint} pagination repeated a full page at page {page} offset {offset}")]
+    RepeatedPage {
+        endpoint: &'static str,
+        page: usize,
+        offset: u32,
+    },
+    #[error("{endpoint} pagination offset overflowed u32")]
+    OffsetOverflow { endpoint: &'static str },
+    #[error("{endpoint} pagination page counter overflowed usize")]
+    PageCounterOverflow { endpoint: &'static str },
+}

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -119,6 +119,7 @@ struct TestServerState {
     data_api_position_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     data_api_position_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     data_api_trade_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
+    data_api_trade_raw_responses: Arc<tokio::sync::Mutex<VecDeque<String>>>,
     data_api_trade_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     data_api_error_response: Arc<tokio::sync::Mutex<Option<(StatusCode, Value)>>>,
 }
@@ -169,6 +170,7 @@ impl Default for TestServerState {
             data_api_position_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             data_api_position_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             data_api_trade_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            data_api_trade_raw_responses: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             data_api_trade_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             data_api_error_response: Arc::new(tokio::sync::Mutex::new(None)),
         }
@@ -646,6 +648,9 @@ async fn handle_data_api_trades(
         .lock()
         .await
         .push(params.clone());
+    if let Some(body) = state.data_api_trade_raw_responses.lock().await.pop_front() {
+        return ([("content-type", "application/json")], body).into_response();
+    }
     let all_trades = state.data_api_trade_pages.lock().await;
     let start = params
         .get("start")
@@ -4825,6 +4830,96 @@ async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_meta
         "/trades pagination repeated a full page at page 2 offset 500"
     );
     assert_eq!(state.data_api_trade_query_log.lock().await.len(), 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_rejects_repeated_economics_with_rescaled_decimals() {
+    let state = TestServerState::default();
+    let token = "token_rescaled";
+    let page = (0..500)
+        .map(|index| {
+            make_data_api_trade(
+                token,
+                0.50,
+                1_710_000_000 + index as i64,
+                &format!("rescaled{index}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let first = serde_json::to_string(&page).unwrap();
+    let second = first
+        .replace("\"price\":0.5", "\"price\":0.5000")
+        .replace("\"size\":10.0", "\"size\":10.0000");
+    assert_ne!(first, second);
+    state
+        .data_api_trade_raw_responses
+        .lock()
+        .await
+        .extend([first, second, "[]".to_string()]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_rescaled.POLYMARKET"),
+            "0xcondition_test",
+            token,
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "/trades pagination repeated a full page at page 2 offset 500"
+    );
+    assert_eq!(state.data_api_trade_query_log.lock().await.len(), 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_preserves_page_multiplicity_in_progress() {
+    let state = TestServerState::default();
+    let token = "token_multiplicity";
+    let first_trade = make_data_api_trade(token, 0.50, 1_710_000_000, "multiplicity-a");
+    let second_trade = make_data_api_trade(token, 0.60, 1_710_000_001, "multiplicity-b");
+    let first = std::iter::repeat_n(first_trade.clone(), 250)
+        .chain(std::iter::repeat_n(second_trade.clone(), 250))
+        .collect::<Vec<_>>();
+    let second = std::iter::repeat_n(first_trade, 249)
+        .chain(std::iter::repeat_n(second_trade, 251))
+        .collect::<Vec<_>>();
+    state
+        .data_api_trade_pages
+        .lock()
+        .await
+        .extend([Value::Array(first), Value::Array(second)]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let ticks = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_multiplicity.POLYMARKET"),
+            "0xcondition_test",
+            token,
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(ticks.len(), 1_000);
+    assert_eq!(state.data_api_trade_query_log.lock().await.len(), 3);
 }
 
 #[rstest]

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -96,7 +96,9 @@ struct TestServerState {
     /// Delay before `handle_get_orders` responds. Used by the timeout test.
     get_orders_delay_secs: Arc<AtomicUsize>,
     orders_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
+    orders_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     trades_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
+    trades_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     gamma_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     gamma_markets_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     gamma_markets_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
@@ -114,6 +116,8 @@ struct TestServerState {
     gamma_search_response: Arc<tokio::sync::Mutex<Option<Value>>>,
     gamma_clob_token_responses: Arc<tokio::sync::Mutex<AHashMap<String, Value>>>,
     single_order_response: Arc<tokio::sync::Mutex<Option<Value>>>,
+    data_api_position_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
+    data_api_position_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     data_api_trade_pages: Arc<tokio::sync::Mutex<VecDeque<Value>>>,
     data_api_trade_query_log: Arc<tokio::sync::Mutex<Vec<HashMap<String, String>>>>,
     data_api_error_response: Arc<tokio::sync::Mutex<Option<(StatusCode, Value)>>>,
@@ -142,7 +146,9 @@ impl Default for TestServerState {
             rate_limit_response_headers: Arc::new(tokio::sync::Mutex::new(HeaderMap::new())),
             get_orders_delay_secs: Arc::new(AtomicUsize::new(0)),
             orders_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            orders_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             trades_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            trades_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             gamma_response: Arc::new(tokio::sync::Mutex::new(None)),
             gamma_markets_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             gamma_markets_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
@@ -160,6 +166,8 @@ impl Default for TestServerState {
             gamma_search_response: Arc::new(tokio::sync::Mutex::new(None)),
             gamma_clob_token_responses: Arc::new(tokio::sync::Mutex::new(AHashMap::new())),
             single_order_response: Arc::new(tokio::sync::Mutex::new(None)),
+            data_api_position_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            data_api_position_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             data_api_trade_pages: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             data_api_trade_query_log: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             data_api_error_response: Arc::new(tokio::sync::Mutex::new(None)),
@@ -262,7 +270,11 @@ async fn maybe_rate_limit(state: &TestServerState) -> Option<Response> {
     }
 }
 
-async fn handle_get_orders(State(state): State<TestServerState>, headers: HeaderMap) -> Response {
+async fn handle_get_orders(
+    State(state): State<TestServerState>,
+    headers: HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Response {
     if let Some(r) = maybe_rate_limit(&state).await {
         return r;
     }
@@ -271,6 +283,7 @@ async fn handle_get_orders(State(state): State<TestServerState>, headers: Header
         tokio::time::sleep(Duration::from_secs(delay as u64)).await;
     }
     *state.last_headers.lock().await = extract_headers(&headers);
+    state.orders_query_log.lock().await.push(params);
     let mut pages = state.orders_pages.lock().await;
     if let Some(page) = pages.pop_front() {
         return Json(page).into_response();
@@ -278,11 +291,16 @@ async fn handle_get_orders(State(state): State<TestServerState>, headers: Header
     Json(load_json("http_open_orders_page.json")).into_response()
 }
 
-async fn handle_get_trades(State(state): State<TestServerState>, headers: HeaderMap) -> Response {
+async fn handle_get_trades(
+    State(state): State<TestServerState>,
+    headers: HeaderMap,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Response {
     if let Some(r) = maybe_rate_limit(&state).await {
         return r;
     }
     *state.last_headers.lock().await = extract_headers(&headers);
+    state.trades_query_log.lock().await.push(params);
     let mut pages = state.trades_pages.lock().await;
     if let Some(page) = pages.pop_front() {
         return Json(page).into_response();
@@ -662,6 +680,18 @@ async fn handle_data_api_trades(
     Json(json!(page)).into_response()
 }
 
+async fn handle_data_api_positions(
+    State(state): State<TestServerState>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Response {
+    if let Some(r) = maybe_rate_limit(&state).await {
+        return r;
+    }
+    state.data_api_position_query_log.lock().await.push(params);
+    let mut pages = state.data_api_position_pages.lock().await;
+    Json(pages.pop_front().unwrap_or_else(|| json!([]))).into_response()
+}
+
 async fn handle_get_order(State(state): State<TestServerState>) -> Response {
     let resp = state.single_order_response.lock().await;
     match resp.as_ref() {
@@ -709,6 +739,7 @@ fn create_test_router(state: TestServerState) -> Router {
         .route("/events/keyset", get(handle_gamma_events_keyset))
         .route("/tags", get(handle_gamma_tags))
         .route("/public-search", get(handle_public_search))
+        .route("/positions", get(handle_data_api_positions))
         .route("/trades", get(handle_data_api_trades))
         .route("/health", get(handle_health))
         .with_state(state)
@@ -814,6 +845,35 @@ async fn test_get_trades_returns_trades() {
 
     assert_eq!(trades.len(), 1);
     assert_eq!(trades[0].id, "trade-0x001");
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_trades_paginates_with_returned_cursor() {
+    let state = TestServerState::default();
+    let mut first = load_json("http_trades_page.json");
+    first["next_cursor"] = json!("page-2");
+    let mut second = load_json("http_trades_page.json");
+    second["data"][0]["id"] = json!("trade-0x002");
+    second["next_cursor"] = json!("LTE=");
+    state.trades_pages.lock().await.extend([first, second]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let trades = client.get_trades(GetTradesParams::default()).await.unwrap();
+    let queries = state.trades_query_log.lock().await;
+
+    assert_eq!(trades.len(), 2);
+    assert_eq!(queries.len(), 2);
+    assert_eq!(
+        queries[0].get("next_cursor").map(String::as_str),
+        Some("MA==")
+    );
+    assert_eq!(
+        queries[1].get("next_cursor").map(String::as_str),
+        Some("page-2")
+    );
 }
 
 #[rstest]
@@ -1454,6 +1514,16 @@ async fn test_get_orders_auto_paginates_multiple_pages() {
         "0xpage2order000000000000000000000000000000000000000000000000000002"
     );
     assert_eq!(*state.request_count.lock().await, 2);
+    let queries = state.orders_query_log.lock().await;
+    assert_eq!(queries.len(), 2);
+    assert_eq!(
+        queries[0].get("next_cursor").map(String::as_str),
+        Some("MA==")
+    );
+    assert_eq!(
+        queries[1].get("next_cursor").map(String::as_str),
+        Some("cGFnZTI=")
+    );
 }
 
 #[rstest]
@@ -1502,6 +1572,31 @@ async fn test_get_orders_errors_on_repeated_caller_cursor() {
         "decode error: /data/orders pagination cursor did not advance from \"custom_cursor\""
     );
     assert_eq!(*state.request_count.lock().await, 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_orders_rejects_recurrence_of_initial_cursor() {
+    let state = TestServerState::default();
+    let mut first = load_json("http_open_orders_page.json");
+    first["next_cursor"] = json!("cursor-a");
+    let mut second = load_json("http_open_orders_page.json");
+    second["next_cursor"] = json!("MA==");
+    state.orders_pages.lock().await.extend([first, second]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_clob_client(&addr);
+
+    let error = client
+        .get_orders(GetOrdersParams::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /data/orders pagination repeated cursor \"MA==\""
+    );
+    assert_eq!(*state.request_count.lock().await, 2);
 }
 
 #[rstest]
@@ -3715,6 +3810,51 @@ async fn test_fetch_gamma_markets_rejects_repeated_cursor() {
 
 #[rstest]
 #[tokio::test]
+async fn test_fetch_gamma_markets_validates_progress_before_cap() {
+    let state = TestServerState::default();
+    let skipped = gamma_market_with_slug(
+        "skipped-market",
+        "0xcondition_skipped_market",
+        ["97400000000000000001", "97400000000000000002"],
+    );
+    let retained = gamma_market_with_slug(
+        "retained-market",
+        "0xcondition_retained_market",
+        ["97500000000000000001", "97500000000000000002"],
+    );
+    {
+        let mut pages = state.gamma_markets_pages.lock().await;
+        pages.push_back(json!({
+            "markets": [skipped],
+            "next_cursor": "stuck",
+        }));
+        pages.push_back(json!({
+            "markets": [retained],
+            "next_cursor": "stuck",
+        }));
+    }
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_gamma_domain_client(&addr);
+
+    let error = client
+        .request_markets_by_params(GetGammaMarketsParams {
+            limit: Some(1),
+            offset: Some(1),
+            max_markets: Some(1),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "Gamma market pagination repeated cursor \"stuck\""
+    );
+    assert_eq!(state.gamma_markets_query_log.lock().await.len(), 2);
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_fetch_gamma_events_paginated_uses_next_cursor_and_500_limit() {
     let state = TestServerState::default();
     let market_a = gamma_market_with_slug(
@@ -4488,6 +4628,76 @@ fn make_data_api_trade(asset: &str, price: f64, timestamp: i64, tx_suffix: &str)
     })
 }
 
+fn make_data_api_position(index: usize) -> Value {
+    json!({
+        "asset": index.to_string(),
+        "conditionId": format!("0xcondition{index:064x}"),
+        "size": 1.0,
+        "avgPrice": 0.5
+    })
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_positions_paginates_distinct_pages_with_offset() {
+    let state = TestServerState::default();
+    let first = Value::Array((0..100).map(make_data_api_position).collect());
+    let second = Value::Array((100..200).map(make_data_api_position).collect());
+    let terminal = Value::Array(vec![make_data_api_position(200)]);
+    state
+        .data_api_position_pages
+        .lock()
+        .await
+        .extend([first, second, terminal]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let positions = client.get_positions(TEST_ADDRESS).await.unwrap();
+    let queries = state.data_api_position_query_log.lock().await;
+
+    assert_eq!(positions.len(), 201);
+    assert_eq!(queries.len(), 3);
+    assert_eq!(queries[0].get("offset").map(String::as_str), Some("0"));
+    assert_eq!(queries[1].get("offset").map(String::as_str), Some("100"));
+    assert_eq!(queries[2].get("offset").map(String::as_str), Some("200"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_positions_rejects_repeated_identities_with_changed_values() {
+    let state = TestServerState::default();
+    let first = Value::Array((0..100).map(make_data_api_position).collect());
+    let second = Value::Array(
+        (0..100)
+            .map(|index| {
+                json!({
+                    "avgPrice": 0.75,
+                    "size": 2.0,
+                    "conditionId": format!("0xcondition{index:064x}"),
+                    "asset": index.to_string(),
+                })
+            })
+            .collect(),
+    );
+    state
+        .data_api_position_pages
+        .lock()
+        .await
+        .extend([first, second]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client.get_positions(TEST_ADDRESS).await.unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /positions pagination repeated a full page at page 2 offset 100"
+    );
+    assert_eq!(*state.request_count.lock().await, 2);
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_data_api_http_error_preserves_status_and_clean_reason() {
@@ -4560,6 +4770,96 @@ async fn test_request_trade_ticks_paginates_multiple_pages() {
     for i in 1..ticks.len() {
         assert!(ticks[i - 1].ts_event <= ticks[i].ts_event);
     }
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_title() {
+    let state = TestServerState::default();
+    let token = "token_restamped";
+    let first = (0..500)
+        .map(|index| {
+            make_data_api_trade(
+                token,
+                0.50,
+                1_710_000_000 + index as i64,
+                &format!("restamped{index}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let second = first
+        .iter()
+        .rev()
+        .cloned()
+        .map(|mut trade| {
+            trade["title"] = json!("Restamped presentation metadata");
+            trade
+        })
+        .collect::<Vec<_>>();
+    state
+        .data_api_trade_pages
+        .lock()
+        .await
+        .extend([Value::Array(first), Value::Array(second)]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_restamped.POLYMARKET"),
+            "0xcondition_test",
+            token,
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "/trades pagination repeated a full page at page 2 offset 500"
+    );
+    assert_eq!(state.data_api_trade_query_log.lock().await.len(), 2);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_rejects_trade_outside_requested_condition() {
+    let state = TestServerState::default();
+    let token = "token_wrong_condition";
+    let mut trade = make_data_api_trade(token, 0.50, 1_710_000_000, "wrong-condition");
+    trade["conditionId"] = json!("0xother_condition");
+    state
+        .data_api_trade_pages
+        .lock()
+        .await
+        .push_back(json!([trade]));
+
+    let addr = start_mock_server(state).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_wrong_condition.POLYMARKET"),
+            "0xcondition_test",
+            token,
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "Polymarket Data API returned trade for condition 0xother_condition while requesting 0xcondition_test"
+    );
 }
 
 #[rstest]
@@ -4832,6 +5132,34 @@ async fn test_request_trade_ticks_stops_at_data_api_offset_ceiling() {
     assert_eq!(queries.len(), 20);
     assert_eq!(queries[0].get("offset").map(String::as_str), Some("0"));
     assert_eq!(queries[19].get("offset").map(String::as_str), Some("9500"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_preserves_remote_offset_ceiling_partial_result() {
+    let state = TestServerState::default();
+    *state.data_api_error_response.lock().await = Some((
+        StatusCode::TOO_MANY_REQUESTS,
+        json!({"error": "max historical activity offset reached"}),
+    ));
+    let addr = start_mock_server(state).await;
+    let client = create_data_api_client(&addr);
+
+    let ticks = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_remote_ceiling.POLYMARKET"),
+            "0xcondition_test",
+            "token_remote_ceiling",
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(ticks.is_empty());
 }
 
 #[rstest]

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -4774,7 +4774,7 @@ async fn test_request_trade_ticks_paginates_multiple_pages() {
 
 #[rstest]
 #[tokio::test]
-async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_title() {
+async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_metadata() {
     let state = TestServerState::default();
     let token = "token_restamped";
     let first = (0..500)
@@ -4793,6 +4793,7 @@ async fn test_request_trade_ticks_rejects_repeated_economics_with_restamped_titl
         .cloned()
         .map(|mut trade| {
             trade["title"] = json!("Restamped presentation metadata");
+            trade["proxyWallet"] = json!("0x1111111111111111111111111111111111111111");
             trade
         })
         .collect::<Vec<_>>();
@@ -4860,6 +4861,93 @@ async fn test_request_trade_ticks_rejects_trade_outside_requested_condition() {
         error.to_string(),
         "Polymarket Data API returned trade for condition 0xother_condition while requesting 0xcondition_test"
     );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_request_trade_ticks_accepts_equivalent_condition_id_hex_case() {
+    let state = TestServerState::default();
+    let token = "token_condition_case";
+    let condition_id = format!("0x{}", "ab".repeat(32));
+    let mut trade = make_data_api_trade(token, 0.50, 1_710_000_000, "condition-case");
+    trade["conditionId"] = json!(condition_id.to_ascii_uppercase());
+    state
+        .data_api_trade_pages
+        .lock()
+        .await
+        .push_back(json!([trade]));
+
+    let addr = start_mock_server(state).await;
+    let client = create_data_api_client(&addr);
+    let instrument_id = InstrumentId::from(format!("{condition_id}-{token}.POLYMARKET"));
+
+    let ticks = client
+        .request_trade_ticks(instrument_id, &condition_id, token, 2, 2, None, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(ticks.len(), 1);
+}
+
+#[rstest]
+#[case::transaction_hash("transactionHash", 1_000)]
+#[case::asset("asset", 999)]
+#[case::side("side", 1_000)]
+#[case::price("price", 1_000)]
+#[case::size("size", 1_000)]
+#[case::timestamp("timestamp", 1_000)]
+#[tokio::test]
+async fn test_request_trade_ticks_accepts_page_with_changed_economic_field(
+    #[case] field: &str,
+    #[case] expected_ticks: usize,
+) {
+    let state = TestServerState::default();
+    let token = "token_changed_economics";
+    let first = (0..500)
+        .map(|index| {
+            make_data_api_trade(
+                token,
+                0.50,
+                1_710_000_000 + index as i64,
+                &format!("economics{index}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut second = first.clone();
+    match field {
+        "transactionHash" => second[0][field] = json!(format!("0x{:064x}", 1)),
+        "asset" => second[0][field] = json!("other_token"),
+        "side" => second[0][field] = json!("SELL"),
+        "price" => second[0][field] = json!(0.75),
+        "size" => second[0][field] = json!(11.0),
+        "timestamp" => second[0][field] = json!(1_720_000_000),
+        _ => unreachable!(),
+    }
+    state
+        .data_api_trade_pages
+        .lock()
+        .await
+        .extend([Value::Array(first), Value::Array(second)]);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let ticks = client
+        .request_trade_ticks(
+            InstrumentId::from("0xcondition_test-token_changed_economics.POLYMARKET"),
+            "0xcondition_test",
+            token,
+            2,
+            2,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(ticks.len(), expected_ticks);
+    assert_eq!(state.data_api_trade_query_log.lock().await.len(), 3);
 }
 
 #[rstest]

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -648,6 +648,7 @@ async fn handle_data_api_trades(
         .lock()
         .await
         .push(params.clone());
+
     if let Some(body) = state.data_api_trade_raw_responses.lock().await.pop_front() {
         return ([("content-type", "application/json")], body).into_response();
     }


### PR DESCRIPTION
## Summary

- Replace six endpoint-owned Polymarket HTTP pagination loops with one crate-private operation driver that owns request position and validates progress before accumulation.
- Reject CLOB cursor stalls and cycles, plus repeated full Data API pages using canonical semantic fingerprints.
- Preserve Gamma offset/cap behavior and Data API trade limit/offset-ceiling behavior while validating the actual cursors and offsets sent on the wire.

## Problem

Pagination policy was duplicated across CLOB, Gamma, and Data API operations. That made progress validation, cursor/offset ownership, accumulation ordering, and endpoint-specific stopping behavior easy to drift independently.

## Design

- `Paginator::run` owns fetch sequencing and makes pagination failures discard private reducer state rather than return an accumulated prefix.
- Cursor protocols validate missing, stalled, repeated, and cyclic cursors.
- Offset protocols detect identical full pages using order-independent, multiplicity-preserving fingerprints with canonical decimal encoding.
- Data API trade rows are checked against the requested condition before admission.
- Reducers retain Gamma windowing and trade-tick whole-operation sorting, filtering, ID assignment, limits, and venue-ceiling behavior.
- `WireExhausted` records only observed wire termination; it is not a source-completeness proof.

## Scope and non-goals

This is pagination progress and custody hardening only. It does not claim a stable venue snapshot, solve mutable-offset overlap or source completeness, add persistence or reconciliation authority, impose a new arbitrary global pagination bound, or expand the public API.

## Verification coverage

- CLOB missing/stalled/cyclic cursors and recurrence of the initial cursor.
- Data API cursor/offset transmission, repeated semantic pages, condition scope, decimal-scale canonicalization, and multiplicity preservation.
- Gamma offsets, caps, terminal behavior, and progress-error precedence.
- Data API trade sorting, filtering, IDs, result limits, and local/remote offset-ceiling behavior.
- Adapter integration tests, formatting, Clippy with warnings denied, and repository pre-commit checks were exercised during fork review.
