### PR TITLE
Reject a fill whose instrument does not match its position

### DIFF
--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -2684,6 +2684,10 @@ impl ExecutionEngine {
                 let mut fill = fill.clone();
                 fill.position_id = Some(position_id);
 
+                if !self.validate_fill_for_position(position_id, &fill) {
+                    return;
+                }
+
                 let validation = if apply_position {
                     self.validate_fill_for_order(&order_before_fill, &fill)
                 } else {
@@ -2846,6 +2850,11 @@ impl ExecutionEngine {
         let oms_type = self.determine_oms_type(&fill);
         let position_id = self.determine_leg_fill_position_id(&fill, oms_type);
         fill.position_id = Some(position_id);
+
+        if !self.validate_fill_for_position(position_id, &fill) {
+            return;
+        }
+
         let duplicate_position_fill = self.position_contains_trade_id(position_id, fill.trade_id);
 
         let event = OrderEventAny::Filled(fill.clone());
@@ -3100,6 +3109,35 @@ impl ExecutionEngine {
         }
 
         position_id
+    }
+
+    /// Returns whether `fill` may be applied to the position assigned to `position_id`.
+    ///
+    /// Only `instrument_id` is compared. A position's instrument never changes, and a fill
+    /// for another instrument would be priced with this position's precision, multiplier,
+    /// currencies, and PnL rules.
+    ///
+    /// `account_id` and `strategy_id` are deliberately NOT compared, because each has a
+    /// legitimate mismatch path. Netting position IDs are `{instrument_id}-{strategy_id}`,
+    /// so two accounts trading one instrument under one strategy share a position ID.
+    /// External order claims can be handed to a successor strategy while the predecessor's
+    /// positions stay cached, so a later venue fill can carry the new strategy against them.
+    fn validate_fill_for_position(&self, position_id: PositionId, fill: &OrderFilled) -> bool {
+        let Some(position) = self.cache.borrow().position_owned(&position_id) else {
+            return true;
+        };
+
+        if position.instrument_id != fill.instrument_id {
+            log::error!(
+                "Cannot apply fill {} to position {position_id}: instrument_id mismatch, expected={}, received={}",
+                fill.trade_id,
+                position.instrument_id,
+                fill.instrument_id
+            );
+            return false;
+        }
+
+        true
     }
 
     fn determine_hedging_position_id(

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -2673,8 +2673,11 @@ impl ExecutionEngine {
                     return;
                 };
                 let configured_oms_type = self.determine_oms_type(fill);
-                let position_id =
-                    self.determine_position_id(fill, configured_oms_type, Some(&order_before_fill));
+                let Some(position_id) =
+                    self.determine_position_id(fill, configured_oms_type, Some(&order_before_fill))
+                else {
+                    return;
+                };
                 let oms_type = self
                     .cache
                     .borrow()
@@ -2683,10 +2686,6 @@ impl ExecutionEngine {
 
                 let mut fill = fill.clone();
                 fill.position_id = Some(position_id);
-
-                if !self.validate_fill_for_position(position_id, &fill) {
-                    return;
-                }
 
                 let validation = if apply_position {
                     self.validate_fill_for_order(&order_before_fill, &fill)
@@ -3026,7 +3025,7 @@ impl ExecutionEngine {
         fill: &OrderFilled,
         oms_type: OmsType,
         order: Option<&OrderAny>,
-    ) -> PositionId {
+    ) -> Option<PositionId> {
         let cache = self.cache.borrow();
         let cached_position_id = cache.position_id(&fill.client_order_id()).copied();
         drop(cache);
@@ -3054,7 +3053,11 @@ impl ExecutionEngine {
                 log::debug!("Assigned {position_id} to {}", fill.client_order_id());
             }
 
-            return position_id;
+            if !self.validate_fill_for_position(position_id, fill) {
+                return None;
+            }
+
+            return Some(position_id);
         }
 
         let position_id = match oms_type {
@@ -3062,6 +3065,10 @@ impl ExecutionEngine {
             OmsType::Netting => self.determine_netting_position_id(fill),
             _ => self.determine_netting_position_id(fill),
         };
+
+        if !self.validate_fill_for_position(position_id, fill) {
+            return None;
+        }
 
         let order = if let Some(o) = order {
             o.clone()
@@ -3089,7 +3096,7 @@ impl ExecutionEngine {
                     "Primary exec spawn order {exec_spawn_id} not found, \
                      skipping position ID propagation"
                 );
-                return position_id;
+                return Some(position_id);
             };
             let primary_already_indexed = cache.position_id(&primary.client_order_id()).is_some();
             drop(cache);
@@ -3108,7 +3115,7 @@ impl ExecutionEngine {
             }
         }
 
-        position_id
+        Some(position_id)
     }
 
     /// Returns whether `fill` may be applied to the position assigned to `position_id`.
@@ -3123,7 +3130,8 @@ impl ExecutionEngine {
     /// External order claims can be handed to a successor strategy while the predecessor's
     /// positions stay cached, so a later venue fill can carry the new strategy against them.
     fn validate_fill_for_position(&self, position_id: PositionId, fill: &OrderFilled) -> bool {
-        let Some(position) = self.cache.borrow().position_owned(&position_id) else {
+        let cache = self.cache.borrow();
+        let Some(position) = cache.position_ref(&position_id) else {
             return true;
         };
 

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -8056,6 +8056,151 @@ fn test_exec_algorithm_position_id_propagates_to_primary_order(
 }
 
 #[rstest]
+fn test_exec_algorithm_rejected_foreign_fill_does_not_route_spawn(
+    mut execution_engine: ExecutionEngine,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = gbpusd_sim();
+    let mut foreign_position = stub_position_long(audusd_sim());
+    foreign_position.id = PositionId::from("P-FOREIGN-INSTRUMENT");
+
+    let stub_client = StubExecutionClient::new(
+        ClientId::from("STUB"),
+        AccountId::test_default(),
+        Venue::test_default(),
+        OmsType::Hedging,
+        None,
+    );
+    execution_engine
+        .register_client(Box::new(stub_client))
+        .unwrap();
+
+    {
+        let mut cache = execution_engine.cache().borrow_mut();
+        cache.add_instrument(instrument.clone().into()).unwrap();
+        cache.add_instrument(audusd_sim().into()).unwrap();
+        cache.add_account(CashAccount::default().into()).unwrap();
+        cache
+            .add_position(&foreign_position, OmsType::Hedging)
+            .unwrap();
+    }
+
+    let exec_algo_id = ExecAlgorithmId::new("TWAP");
+    let primary_client_order_id = ClientOrderId::from("O-PRIMARY-FOREIGN");
+    let child_client_order_id = ClientOrderId::from("O-CHILD-FOREIGN");
+    let primary_order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(primary_client_order_id)
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(200_000))
+        .exec_algorithm_id(exec_algo_id)
+        .exec_spawn_id(primary_client_order_id)
+        .build();
+    let child_order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(child_client_order_id)
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .exec_algorithm_id(exec_algo_id)
+        .exec_spawn_id(primary_client_order_id)
+        .build();
+
+    {
+        let mut cache = execution_engine.cache().borrow_mut();
+        cache
+            .add_order(primary_order, None, Some(ClientId::from("STUB")), true)
+            .unwrap();
+        cache
+            .add_order(
+                child_order.clone(),
+                None,
+                Some(ClientId::from("STUB")),
+                true,
+            )
+            .unwrap();
+    }
+
+    execution_engine.process(&TestOrderEventStubs::submitted(
+        &child_order,
+        AccountId::test_default(),
+    ));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &child_order,
+        AccountId::test_default(),
+        VenueOrderId::from("V-FOREIGN-001"),
+    ));
+
+    let cached_child = cached_order_or(&execution_engine, &child_order);
+    let foreign_fill = TestOrderEventStubs::filled(
+        &cached_child,
+        &instrument.clone().into(),
+        Some(TradeId::new("E-19700101-000000-001-001-8")),
+        Some(foreign_position.id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(AccountId::test_default()),
+    );
+    execution_engine.process(&foreign_fill);
+
+    {
+        let cache = execution_engine.cache().borrow();
+        let primary = cache.order(&primary_client_order_id).unwrap();
+        assert_eq!(primary.position_id(), None);
+        assert_eq!(cache.position_id(&primary_client_order_id), None);
+        assert_eq!(
+            cache.order(&child_client_order_id).unwrap().status(),
+            OrderStatus::Accepted
+        );
+        let foreign = cache.position(&foreign_position.id).unwrap();
+        assert!(
+            !foreign
+                .trade_ids
+                .contains(&TradeId::new("E-19700101-000000-001-001-8"))
+        );
+    }
+
+    let valid_fill = TestOrderEventStubs::filled(
+        &cached_child,
+        &instrument.clone().into(),
+        Some(TradeId::new("E-19700101-000000-001-001-2")),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(AccountId::test_default()),
+    );
+    execution_engine.process(&valid_fill);
+
+    let cache = execution_engine.cache().borrow();
+    let primary = cache.order(&primary_client_order_id).unwrap();
+    let position_id = primary
+        .position_id()
+        .expect("valid fill should route the execution spawn");
+    assert_eq!(
+        cache.position_id(&primary_client_order_id),
+        Some(&position_id)
+    );
+    assert_eq!(
+        cache.order(&child_client_order_id).unwrap().status(),
+        OrderStatus::Filled
+    );
+    assert_eq!(
+        cache.position(&position_id).unwrap().instrument_id,
+        instrument.id
+    );
+}
+
+#[rstest]
 fn test_exec_algorithm_does_not_overwrite_primary_cached_position_id(
     mut execution_engine: ExecutionEngine,
 ) {

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -1590,6 +1590,231 @@ fn test_order_filled_with_unrecognized_strategy_id(mut execution_engine: Executi
 }
 
 #[rstest]
+fn test_fill_with_foreign_instrument_is_rejected(mut execution_engine: ExecutionEngine) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let instrument_id = InstrumentId::from("GBP/USD.SIM");
+    let account_id = AccountId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let (position, order) = prepare_order_targeting_cached_position(
+        &mut execution_engine,
+        instrument_id,
+        account_id,
+        strategy_id,
+        OrderSide::Buy,
+        Quantity::from(1),
+    );
+    let position_events = Rc::new(RefCell::new(Vec::new()));
+    let position_handler = TypedHandler::from({
+        let position_events = position_events.clone();
+        move |event: &PositionEvent| position_events.borrow_mut().push(event.clone())
+    });
+    let order_events = Rc::new(RefCell::new(Vec::new()));
+    let order_handler = TypedHandler::from({
+        let order_events = order_events.clone();
+        move |event: &OrderEventAny| order_events.borrow_mut().push(event.clone())
+    });
+    let position_topic = switchboard::get_event_position_topic(position.strategy_id);
+    let order_topic = switchboard::get_event_order_topic(order.strategy_id());
+    msgbus::subscribe_position_events(position_topic.into(), position_handler.clone(), None);
+    msgbus::subscribe_order_events(order_topic.into(), order_handler.clone(), None);
+
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &execution_engine
+            .cache()
+            .borrow()
+            .instrument(&instrument_id)
+            .unwrap()
+            .clone(),
+        Some(TradeId::new("T-FOREIGN")),
+        Some(position.id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(account_id),
+    );
+    execution_engine.process(&fill);
+    msgbus::unsubscribe_position_events(position_topic.into(), &position_handler);
+    msgbus::unsubscribe_order_events(order_topic.into(), &order_handler);
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
+    let cached_position = cache.position(&position.id).unwrap();
+    assert!(order_events.borrow().is_empty());
+    assert!(position_events.borrow().is_empty());
+    assert_eq!(cached_order.status(), OrderStatus::Accepted);
+    assert_eq!(cached_order.filled_qty(), Quantity::zero(0));
+    assert_eq!(cached_position.quantity, position.quantity);
+    assert_eq!(cached_position.trade_ids, position.trade_ids);
+}
+
+#[rstest]
+fn test_fill_with_matching_position_identity_is_unchanged(mut execution_engine: ExecutionEngine) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let instrument_id = audusd_sim().id;
+    let account_id = AccountId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let (position, order) = prepare_order_targeting_cached_position(
+        &mut execution_engine,
+        instrument_id,
+        account_id,
+        strategy_id,
+        OrderSide::Buy,
+        Quantity::from(1),
+    );
+    let position_events = Rc::new(RefCell::new(Vec::new()));
+    let position_handler = TypedHandler::from({
+        let position_events = position_events.clone();
+        move |event: &PositionEvent| position_events.borrow_mut().push(event.clone())
+    });
+    let order_events = Rc::new(RefCell::new(Vec::new()));
+    let order_handler = TypedHandler::from({
+        let order_events = order_events.clone();
+        move |event: &OrderEventAny| order_events.borrow_mut().push(event.clone())
+    });
+    let position_topic = switchboard::get_event_position_topic(position.strategy_id);
+    let order_topic = switchboard::get_event_order_topic(order.strategy_id());
+    msgbus::subscribe_position_events(position_topic.into(), position_handler.clone(), None);
+    msgbus::subscribe_order_events(order_topic.into(), order_handler.clone(), None);
+
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &execution_engine
+            .cache()
+            .borrow()
+            .instrument(&instrument_id)
+            .unwrap()
+            .clone(),
+        Some(TradeId::new("T-MATCHING")),
+        Some(position.id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(account_id),
+    );
+    execution_engine.process(&fill);
+    msgbus::unsubscribe_position_events(position_topic.into(), &position_handler);
+    msgbus::unsubscribe_order_events(order_topic.into(), &order_handler);
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
+    let cached_position = cache.position(&position.id).unwrap();
+    assert_eq!(cached_order.status(), OrderStatus::Filled);
+    assert_eq!(cached_order.filled_qty(), Quantity::from(1));
+    assert_eq!(cached_position.quantity, Quantity::from(2));
+    assert_eq!(order_events.borrow().len(), 1);
+    assert!(matches!(order_events.borrow()[0], OrderEventAny::Filled(_)));
+    assert_eq!(position_events.borrow().len(), 1);
+    assert!(matches!(
+        position_events.borrow()[0],
+        PositionEvent::PositionChanged(_)
+    ));
+}
+
+/// A fill whose `account_id` or `strategy_id` differs from the target position must still be
+/// applied. Netting position IDs are `{instrument_id}-{strategy_id}`, so two accounts trading
+/// one instrument under one strategy share a position ID; and external order claims can be
+/// handed to a successor strategy while the predecessor's positions stay cached. Rejecting on
+/// either field would drop venue-confirmed fills.
+#[rstest]
+#[case::foreign_account(AccountId::from("FOREIGN-ACCOUNT"), StrategyId::test_default())]
+#[case::foreign_strategy(AccountId::test_default(), StrategyId::from("FOREIGN-STRATEGY"))]
+fn test_fill_with_foreign_account_or_strategy_is_still_applied(
+    mut execution_engine: ExecutionEngine,
+    #[case] account_id: AccountId,
+    #[case] strategy_id: StrategyId,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let instrument_id = InstrumentId::from("AUD/USD.SIM");
+    let (position, order) = prepare_order_targeting_cached_position(
+        &mut execution_engine,
+        instrument_id,
+        account_id,
+        strategy_id,
+        OrderSide::Buy,
+        Quantity::from(1),
+    );
+
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &execution_engine
+            .cache()
+            .borrow()
+            .instrument(&instrument_id)
+            .unwrap()
+            .clone(),
+        Some(TradeId::new("T-FOREIGN-OK")),
+        Some(position.id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(account_id),
+    );
+    execution_engine.process(&fill);
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
+    let cached_position = cache.position(&position.id).unwrap();
+    assert_eq!(cached_order.status(), OrderStatus::Filled);
+    assert_eq!(cached_order.filled_qty(), Quantity::from(1));
+    assert_eq!(cached_position.quantity, Quantity::from(2));
+}
+
+#[rstest]
+fn test_oversized_foreign_fill_does_not_flip_position(mut execution_engine: ExecutionEngine) {
+    let instrument_id = gbpusd_sim().id;
+    let (position, order) = prepare_order_targeting_cached_position(
+        &mut execution_engine,
+        instrument_id,
+        AccountId::test_default(),
+        StrategyId::test_default(),
+        OrderSide::Sell,
+        Quantity::from(2),
+    );
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &execution_engine
+            .cache()
+            .borrow()
+            .instrument(&instrument_id)
+            .unwrap()
+            .clone(),
+        Some(TradeId::new("T-FOREIGN-FLIP")),
+        Some(position.id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(AccountId::test_default()),
+    );
+    execution_engine.process(&fill);
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
+    let cached_position = cache.position(&position.id).unwrap();
+    assert_eq!(cached_order.status(), OrderStatus::Accepted);
+    assert_eq!(cached_position.side, position.side);
+    assert_eq!(cached_position.quantity, position.quantity);
+    assert_eq!(cached_position.trade_ids, position.trade_ids);
+    assert!(
+        cache
+            .position_snapshots(Some(&position.id), None)
+            .is_empty()
+    );
+    assert_eq!(cache.positions(None, None, None, None, None).len(), 1);
+}
+
+#[rstest]
 fn test_process_filled_order_publishes_fill_order_position_topics_in_order(
     mut execution_engine: ExecutionEngine,
 ) {
@@ -2562,6 +2787,40 @@ fn test_hedging_leg_fill_without_order_reuses_position_for_same_synthetic_leg(
     assert!(cache.check_integrity());
 }
 
+/// An orderless leg fill reaches `handle_position_update` without passing through the
+/// order-associated path, so it needs the same instrument guard: in HEDGING the supplied
+/// `position_id` is accepted when no same-instrument correlation is found, which would
+/// otherwise apply a fill for one instrument to a cached position for another.
+#[rstest]
+fn test_leg_fill_without_order_with_foreign_instrument_is_rejected(
+    mut execution_engine: ExecutionEngine,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+
+    let (_instrument, fill, _) = prepare_leg_fill_without_order(&execution_engine);
+    execution_engine.register_oms_type(fill.strategy_id, OmsType::Hedging);
+
+    let foreign_position = stub_position_long(audusd_sim());
+    {
+        let mut cache = execution_engine.cache().borrow_mut();
+        cache.add_instrument(audusd_sim().into()).unwrap();
+        cache
+            .add_position(&foreign_position, OmsType::Hedging)
+            .unwrap();
+    }
+
+    let mut foreign_fill = fill;
+    foreign_fill.position_id = Some(foreign_position.id);
+    execution_engine.process(&OrderEventAny::Filled(foreign_fill));
+
+    let cache = execution_engine.cache().borrow();
+    let cached = cache.position(&foreign_position.id).unwrap();
+    assert_eq!(cached.instrument_id, foreign_position.instrument_id);
+    assert_eq!(cached.quantity, foreign_position.quantity);
+    assert_eq!(cached.trade_ids, foreign_position.trade_ids);
+    assert_eq!(cache.positions_total_count(None, None, None, None, None), 1);
+}
+
 #[rstest]
 fn test_hedging_leg_fill_without_order_reuses_open_position_after_flip(
     mut execution_engine: ExecutionEngine,
@@ -3275,6 +3534,53 @@ fn prepare_accepted_order_with_account(
 
     let order = cached_order_or(execution_engine, &order);
     (instrument, order)
+}
+
+fn prepare_order_targeting_cached_position(
+    execution_engine: &mut ExecutionEngine,
+    instrument_id: InstrumentId,
+    account_id: AccountId,
+    strategy_id: StrategyId,
+    side: OrderSide,
+    quantity: Quantity,
+) -> (Position, OrderAny) {
+    let position = stub_position_long(audusd_sim());
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(position.trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(ClientOrderId::from("O-TARGET-CACHED-POSITION"))
+        .side(side)
+        .quantity(quantity)
+        .build();
+
+    {
+        let mut cache = execution_engine.cache().borrow_mut();
+        cache.add_instrument(audusd_sim().into()).unwrap();
+        cache.add_instrument(gbpusd_sim().into()).unwrap();
+        cache
+            .add_account(cash_account_for(account_id).into())
+            .unwrap();
+        cache.add_position(&position, OmsType::Netting).unwrap();
+        cache
+            .add_order(
+                order.clone(),
+                Some(position.id),
+                Some(ClientId::from("STUB")),
+                true,
+            )
+            .unwrap();
+    }
+
+    execution_engine.process(&TestOrderEventStubs::submitted(&order, account_id));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &order,
+        account_id,
+        VenueOrderId::from("V-TARGET-CACHED-POSITION"),
+    ));
+
+    let order = cached_order_or(execution_engine, &order);
+    (position, order)
 }
 
 fn prepare_submitted_limit_order_with_account(

--- a/docs/concepts/execution.md
+++ b/docs/concepts/execution.md
@@ -229,6 +229,9 @@ as a separate venue position.
 | `NETTING`    | `HEDGING` | One virtual position across the venue positions.                    |
 | `HEDGING`    | `NETTING` | Multiple virtual positions against the venue's single net position. |
 
+If a fill resolves to a cached position for a different instrument, the `ExecutionEngine` logs an
+error and drops the fill. The order remains non-terminal so a subsequent valid fill can be applied.
+
 ### OMS configuration
 
 When a strategy omits `oms_type` or uses `UNSPECIFIED`, the `ExecutionEngine` follows the venue's


### PR DESCRIPTION
# Reject a fill whose instrument does not match its position

`Position::new` validates that the opening fill belongs to the instrument, but every later fill reaches `Position::apply` with no identity check at all.

## The routing

`determine_position_id` prefers the position ID cached against the fill's `client_order_id` over the one the fill carries, warning on a mismatch. `handle_position_update` then fetches the position by that ID alone, and `update_position` calls `position.apply(fill)`. `OrderAny::apply` guards `client_order_id` and `strategy_id`, but nothing on this path compares the instrument, so a fill for one instrument applied to a position for another is priced with that position's precision, multiplier, currencies, and PnL rules, and its quantity and realized PnL move accordingly.

The engine now rejects the fill where it can still do nothing: after the effective position ID is assigned and before the cached order is updated, the fill is forwarded to the portfolio, the update/flip/reopen branch is chosen, or any event is published. `handle_leg_fill_without_order` carries the same guard, since an orderless leg fill reaches `handle_position_update` without passing through the order-associated path, and in `HEDGING` the supplied position ID is accepted when no same-instrument correlation is found.

Only `instrument_id` is compared. A position's instrument never changes, so there is no legitimate mismatch. `account_id` and `strategy_id` both have one and are deliberately excluded: netting position IDs are `{instrument_id}-{strategy_id}`, so two accounts trading one instrument under one strategy share a position ID; and external order claims can be handed to a successor strategy while the predecessor's positions stay cached, so a later venue fill legitimately carries the new strategy against them. Rejecting on either would drop venue-confirmed fills. Both exclusions are recorded on the function and pinned by tests.

The fill is dropped rather than rerouted - an unroutable fill has no correct destination, but nothing then records it against any position. Direct `Position::apply` callers also stay unguarded: event-store replay, Redis and Postgres reconstruction, and the Python wrapper. Closing those means giving `Position::apply` an observable outcome so callers stop building events after a rejection, which changes every Rust caller and the pyo3 binding, so it is not attempted here.

If you would rather have that shape, or would rather this were rejected earlier or later on the path, I am happy to redo it.

## Testing

`test_fill_with_foreign_instrument_is_rejected` asserts the order stays `Accepted` at zero filled quantity, the position keeps its quantity and trade IDs, and no order or position event is published. `test_leg_fill_without_order_with_foreign_instrument_is_rejected` covers the orderless path: an XCME futures leg fill carrying a cached AUD/USD position ID leaves that position untouched and creates no second position. Both fail against the unfixed code - the second with the FX position's quantity moved from 1 to 2 by the futures fill.

`test_fill_with_foreign_account_or_strategy_is_still_applied` pins the two exclusions from the other side, asserting a foreign account and a foreign strategy are both applied; restoring either comparison fails it. `test_fill_with_matching_position_identity_is_unchanged` and `test_oversized_foreign_fill_does_not_flip_position` cover the unchanged success path and the flip branch.
