### PR TITLE
Report a strategy left running after backtest end

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -30,8 +30,8 @@ use nautilus_common::{
     actor::{DataActor, DataActorNative},
     cache::Cache,
     clock::{Clock, TestClock},
-    component::Component,
-    enums::LogColor,
+    component::{Component, component_state},
+    enums::{ComponentState, LogColor},
     log_info,
     logging::{
         logging_clock_set_realtime_mode, logging_clock_set_static_mode,
@@ -54,7 +54,7 @@ use nautilus_model::{
     accounts::{Account, AccountAny},
     data::{Data, HasTsInit},
     enums::{AccountType, AggregationSource, BookType},
-    identifiers::{AccountId, ClientId, InstrumentId, TraderId, Venue},
+    identifiers::{AccountId, ClientId, InstrumentId, StrategyId, TraderId, Venue},
     instruments::{Instrument, InstrumentAny},
     position::Position,
     types::Price,
@@ -971,6 +971,12 @@ impl BacktestEngine {
 
         self.settle_venues(ts_now);
 
+        for strategy_id in self.running_strategy_ids() {
+            log::error!(
+                "Strategy {strategy_id} is still RUNNING after the backtest end sequence; its stop did not complete",
+            );
+        }
+
         let save_result = self.kernel.save_trader_state();
         self.kernel.portfolio.borrow_mut().finalize_equity_curve();
 
@@ -987,6 +993,28 @@ impl BacktestEngine {
 
         self.log_post_run();
         save_result
+    }
+
+    /// Returns registered strategies whose state resolves to `Running` after the end sequence.
+    ///
+    /// Known causes include a stop deferred for a managed market exit that never completed,
+    /// and an earlier component stop failure making `Trader::stop_components` return before
+    /// reaching the strategy - so callers must report the state observed rather than
+    /// attribute a cause.
+    fn running_strategy_ids(&self) -> Vec<StrategyId> {
+        self.kernel
+            .trader
+            .borrow()
+            .strategy_ids()
+            .into_iter()
+            .filter(|strategy_id| match component_state(&strategy_id.inner()) {
+                Ok(state) => matches!(state, ComponentState::Running),
+                Err(e) => {
+                    log::warn!("Cannot resolve stop state for strategy {strategy_id}: {e}");
+                    false
+                }
+            })
+            .collect()
     }
 
     /// Reset the backtest engine.
@@ -2182,7 +2210,10 @@ mod tests {
         instruments::{
             CryptoPerpetual, Instrument, InstrumentAny, stubs::crypto_perpetual_ethusdt,
         },
-        orders::{Order, OrderAny, OrderTestBuilder, stubs::TestOrderEventStubs},
+        orders::{
+            Order, OrderAny, OrderTestBuilder,
+            stubs::{OrderFilledTestBuilder, TestOrderEventStubs},
+        },
         types::{Money, Price, Quantity},
     };
     use nautilus_system::{KernelEventStore, RegisteredComponents};
@@ -2302,6 +2333,47 @@ mod tests {
             .borrow_mut()
             .initialize_account();
         engine
+    }
+
+    fn create_engine_with_strategy(manage_stop: bool) -> (BacktestEngine, StrategyId) {
+        let mut engine = create_engine();
+        let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        let strategy_id = StrategyId::from(if manage_stop {
+            "MANAGED-STOP-001"
+        } else {
+            "IMMEDIATE-STOP-001"
+        });
+        engine.add_instrument(&instrument).unwrap();
+        engine
+            .add_strategy(TestStrategy::new(StrategyConfig {
+                strategy_id: Some(strategy_id),
+                manage_stop,
+                ..Default::default()
+            }))
+            .unwrap();
+
+        if manage_stop {
+            let order = OrderTestBuilder::new(OrderType::Market)
+                .trader_id(engine.trader_id())
+                .strategy_id(strategy_id)
+                .instrument_id(instrument.id())
+                .side(OrderSide::Buy)
+                .quantity(Quantity::from("1.000"))
+                .build();
+            let fill = OrderFilledTestBuilder::new(&order, &instrument).build();
+            let OrderEventAny::Filled(fill) = fill else {
+                unreachable!();
+            };
+            let position = Position::new(&instrument, fill);
+            engine
+                .kernel
+                .cache
+                .borrow_mut()
+                .add_position_without_order(&position, OmsType::Netting)
+                .unwrap();
+        }
+
+        (engine, strategy_id)
     }
 
     fn send_execution_command(command: TradingCommand) {
@@ -2868,6 +2940,53 @@ mod tests {
         assert!(engine.kernel.is_event_store_replay_configured());
         assert!(engine.kernel.is_event_store_replay());
         assert!(!engine.kernel.trader.borrow().is_running());
+    }
+
+    #[rstest]
+    fn test_end_reports_strategy_stranded_by_managed_stop() {
+        let (mut engine, strategy_id) = create_engine_with_strategy(true);
+
+        let result = engine.run(
+            Some(UnixNanos::from(0)),
+            Some(UnixNanos::from(1)),
+            None,
+            false,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(
+            component_state(&strategy_id.inner()).unwrap(),
+            ComponentState::Running
+        );
+        assert_eq!(engine.running_strategy_ids(), vec![strategy_id]);
+    }
+
+    #[rstest]
+    fn test_end_reports_no_cleanly_stopped_strategies() {
+        let mut empty_engine = create_engine();
+        let empty_result = empty_engine.run(
+            Some(UnixNanos::from(0)),
+            Some(UnixNanos::from(1)),
+            None,
+            false,
+        );
+        assert!(empty_result.is_ok());
+        assert!(empty_engine.running_strategy_ids().is_empty());
+
+        let (mut engine, strategy_id) = create_engine_with_strategy(false);
+        let result = engine.run(
+            Some(UnixNanos::from(0)),
+            Some(UnixNanos::from(1)),
+            None,
+            false,
+        );
+
+        assert!(result.is_ok());
+        assert_ne!(
+            component_state(&strategy_id.inner()).unwrap(),
+            ComponentState::Running
+        );
+        assert!(engine.running_strategy_ids().is_empty());
     }
 
     #[rstest]

--- a/docs/concepts/strategies.md
+++ b/docs/concepts/strategies.md
@@ -699,6 +699,14 @@ config = StrategyConfig(manage_stop=True)
 With this option, calling `stop()` will first perform a market exit, then stop the strategy
 once flat.
 
+:::note
+In a backtest, a managed stop requested at the end of the run cannot complete. `market_exit()`
+schedules its first completion check `market_exit_interval_ms` after the current time, which falls
+beyond the requested end, and the engine has already performed its final timer flush by then. No
+callback runs to observe that the exit is done, so the strategy ends the run still `RUNNING` and is
+reported at `ERROR` even when it is already flat.
+:::
+
 Configuration options in `StrategyConfig`:
 
 - `manage_stop` (default: `False`): if `True`, `stop()` performs a market exit before stopping.


### PR DESCRIPTION
# Report a strategy left running after backtest end

`BacktestEngine::end` can return with a managed-stop strategy still `RUNNING`, and nothing reports it.

## The mechanism

`end_with_result` performs its only timer flush, then calls `stop_trader()`. That reaches `Trader::stop_components`, which invokes each strategy's stop wrapper before `Component::stop`. With `manage_stop` enabled the strategy is still `Running` at that point, so `Strategy::stop` sets `pending_stop`, calls `market_exit()`, and returns `false` - meaning stop is deferred until the exit completes - and `Component::stop` is never called. `market_exit` passes its own `Running` guard and schedules the recurring retry timer.

Nothing after that fires timer callbacks. The command drain and `settle_venues` do not, and the flush already ran. So the exit is never evaluated once, and the run ends with the strategy `Running`, `pending_stop`, `is_exiting`. This happens with no open orders or positions, because completion is only discovered by the first timer callback.

## Why this only reports it

A second flush at the same boundary fires nothing: `market_exit` schedules at terminal clock plus interval, which is past `flush_ts` by construction. Extending the horizon would fire every other component timer in the added window - bars, GTD alerts, actor and strategy periodics - and reverse the graceful-stop cap at `last_ns` that exists to suppress exactly that. Moving `stop_trader()` before the flush is also unsafe, since actors and execution algorithms cancel their timers during stop, which is what the flush comment says it must precede.

So the change is one observation: after the stop sequence, any registered strategy whose state resolves to `Running` is reported at ERROR. The message states the observed state and no cause, because a strategy can also be left `Running` when an earlier component stop failure makes `Trader::stop_components` return before reaching it - it propagates with `?`, and the kernel logs and swallows the result. Attributing the managed exit would be wrong on that path.

Control flow is unchanged: `end_with_result` returns exactly what it returned before in every case.

## Scope

Completing an exit initiated at `end_ns` would mean allowing managed exits simulated time beyond the requested end - a bounded phase between requesting exits and stopping components, which needs a lifecycle seam that does not exist today. That is a separate decision and is not part of this change.

The `manage_stop` section of the strategy guide now records the boundary: the first completion check falls past the requested end, so the strategy can end the run `RUNNING` and be reported at `ERROR` while already flat.

## Testing

`test_end_reports_strategy_stranded_by_managed_stop` runs a `manage_stop` strategy holding a position to completion, asserts the run returns `Ok`, and asserts the strategy is still `Running` afterwards - the stranding as an executable fact rather than a code trace. There is no differential claim here: this changes no behaviour, so that assertion holds against the unmodified code as well, which is the point of it.

`test_end_reports_no_cleanly_stopped_strategies` covers both negative cases - a `manage_stop` disabled strategy stops normally and is not reported, and an engine with no strategies reports nothing.
