### PR TITLE
Validate execution manager lookback minutes at construction

### DIFF
--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -27,6 +27,7 @@ use nautilus_common::{
     cache::Cache,
     clients::{DEFAULT_POSITION_RECONCILIATION_TOLERANCE, ExecutionClient},
     clock::Clock,
+    config::{ConfigError, ConfigErrorCollector, ConfigResult},
     enums::{LogColor, LogLevel},
     live::dst,
     log_info,
@@ -44,7 +45,7 @@ use nautilus_common::{
 };
 use nautilus_core::{
     UUID4, UnixNanos,
-    datetime::{mins_to_nanos, mins_to_secs},
+    datetime::{checked_mins_to_nanos, checked_mins_to_secs, mins_to_nanos, mins_to_secs},
 };
 use nautilus_execution::{
     engine::ExecutionEngine,
@@ -358,6 +359,38 @@ impl Default for ExecutionManagerConfig {
 }
 
 impl ExecutionManagerConfig {
+    /// Validates the execution manager configuration, collecting every field violation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] (a [`ConfigError::Multiple`] when more than one field is
+    /// invalid) if any field fails validation.
+    pub fn validate(&self) -> ConfigResult<()> {
+        let mut errors = ConfigErrorCollector::with_capacity(2);
+
+        if let Some(mins) = self.lookback_mins {
+            errors.check(
+                checked_mins_to_secs(mins).is_some(),
+                ConfigError::range(
+                    "ExecutionManagerConfig.lookback_mins",
+                    format!("{mins} minutes (must fit in `u64` seconds)"),
+                ),
+            );
+        }
+
+        if let Some(mins) = self.open_check_lookback_mins {
+            errors.check(
+                checked_mins_to_nanos(mins).is_some(),
+                ConfigError::range(
+                    "ExecutionManagerConfig.open_check_lookback_mins",
+                    format!("{mins} minutes (must fit in `u64` nanoseconds)"),
+                ),
+            );
+        }
+
+        errors.into_result()
+    }
+
     /// Sets the trader ID on the configuration.
     #[must_use]
     pub fn with_trader_id(mut self, trader_id: TraderId) -> Self {
@@ -448,12 +481,18 @@ impl Debug for ExecutionManager {
 
 impl ExecutionManager {
     /// Creates a new [`ExecutionManager`] instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if `config` fails validation.
     pub fn new(
         clock: Rc<RefCell<dyn Clock>>,
         cache: Rc<RefCell<Cache>>,
         config: ExecutionManagerConfig,
-    ) -> Self {
-        Self {
+    ) -> ConfigResult<Self> {
+        config.validate()?;
+
+        Ok(Self {
             clock,
             cache,
             config,
@@ -471,7 +510,7 @@ impl ExecutionManager {
             missing_order_coverage_warnings: IndexSet::new(),
             unresolved_order_coverage: IndexSet::new(),
             targeted_order_queries: IndexSet::new(),
-        }
+        })
     }
 
     pub(crate) fn set_position_reconciliation_tolerance(
@@ -4745,6 +4784,82 @@ mod tests {
 
     use super::*;
 
+    #[rstest]
+    fn test_new_validates_open_check_lookback_mins_boundaries() {
+        let create_manager = |mins| {
+            ExecutionManager::new(
+                Rc::new(RefCell::new(TestClock::new())),
+                Rc::new(RefCell::new(Cache::default())),
+                ExecutionManagerConfig {
+                    open_check_lookback_mins: Some(mins),
+                    ..Default::default()
+                },
+            )
+        };
+
+        assert!(create_manager(307_445_734).is_ok());
+        assert!(matches!(
+            create_manager(307_445_735),
+            Err(ConfigError::Range { field, .. })
+                if field == "ExecutionManagerConfig.open_check_lookback_mins"
+        ));
+    }
+
+    #[rstest]
+    fn test_new_validates_reconciliation_lookback_mins_boundaries() {
+        let create_manager = |mins| {
+            ExecutionManager::new(
+                Rc::new(RefCell::new(TestClock::new())),
+                Rc::new(RefCell::new(Cache::default())),
+                ExecutionManagerConfig {
+                    lookback_mins: Some(mins),
+                    ..Default::default()
+                },
+            )
+        };
+
+        assert!(create_manager(307_445_734_561_825_860).is_ok());
+        assert!(matches!(
+            create_manager(307_445_734_561_825_861),
+            Err(ConfigError::Range { field, .. })
+                if field == "ExecutionManagerConfig.lookback_mins"
+        ));
+    }
+
+    #[rstest]
+    fn test_new_reports_every_invalid_lookback_field() {
+        let error = ExecutionManager::new(
+            Rc::new(RefCell::new(TestClock::new())),
+            Rc::new(RefCell::new(Cache::default())),
+            ExecutionManagerConfig {
+                lookback_mins: Some(307_445_734_561_825_861),
+                open_check_lookback_mins: Some(307_445_735),
+                ..Default::default()
+            },
+        )
+        .expect_err("both lookback fields are out of range");
+
+        let ConfigError::Multiple { errors } = error else {
+            panic!("expected a `Multiple` error, was {error:?}");
+        };
+
+        let fields = errors
+            .iter()
+            .map(|e| match e {
+                ConfigError::Range { field, .. } => field.as_str(),
+                other => panic!("expected a `Range` error, was {other:?}"),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            fields,
+            [
+                "ExecutionManagerConfig.lookback_mins",
+                "ExecutionManagerConfig.open_check_lookback_mins",
+            ]
+        );
+    }
+
     #[derive(Clone)]
     enum CommissionOutcome {
         Value(Money),
@@ -4904,7 +5019,8 @@ mod tests {
         )
         .with_avg_px(dec!(100.0));
         let manager =
-            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default());
+            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default())
+                .expect("valid config");
 
         (manager, cache, order, report, instrument)
     }
@@ -5088,7 +5204,8 @@ mod tests {
             .borrow_mut()
             .add_instrument(instrument.clone())
             .expect("instrument is cacheable");
-        let manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default());
+        let manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default())
+            .expect("valid config");
         let (report, fill) = external_report_with_partial_fill(&instrument);
         let expected = Money::new(2.5, Currency::USDT());
         let client = CommissionStubClient::new(CommissionOutcome::Value(expected));
@@ -5119,7 +5236,8 @@ mod tests {
             .add_instrument(instrument.clone())
             .expect("instrument is cacheable");
         let manager =
-            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default());
+            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default())
+                .expect("valid config");
         let (report, fill) = external_report_with_partial_fill(&instrument);
         let client = CommissionStubClient::new(CommissionOutcome::Failure);
         let mut fill_queue = ReconciliationFillQueue::default();
@@ -5180,7 +5298,8 @@ mod tests {
             .add_instrument(instrument.clone())
             .expect("instrument is cacheable");
         let manager =
-            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default());
+            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default())
+                .expect("valid config");
         let (report, _) = external_report_with_partial_fill(&instrument);
         let failing_client = CommissionStubClient::new(CommissionOutcome::Failure);
 
@@ -5237,7 +5356,8 @@ mod tests {
             .borrow_mut()
             .add_instrument(instrument.clone())
             .expect("instrument is cacheable");
-        let manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default());
+        let manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default())
+            .expect("valid config");
         let (report, fill) = external_report_with_partial_fill(&instrument);
         let client = CommissionStubClient::new(CommissionOutcome::NoOverride);
         let mut fill_queue = ReconciliationFillQueue::default();
@@ -5470,7 +5590,8 @@ mod tests {
     fn test_clear_recon_tracking_removes_targeted_query() {
         let clock = Rc::new(RefCell::new(TestClock::new()));
         let cache = Rc::new(RefCell::new(Cache::default()));
-        let mut manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default());
+        let mut manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default())
+            .expect("valid config");
         let client_order_id = ClientOrderId::from("O-TARGETED-CLEAR");
         manager.targeted_order_queries.insert(client_order_id);
 
@@ -5491,7 +5612,8 @@ mod tests {
                 filtered_client_order_ids: IndexSet::from([client_order_id]),
                 ..Default::default()
             },
-        );
+        )
+        .expect("valid config");
 
         manager.register_inflight(client_order_id);
 
@@ -5516,7 +5638,8 @@ mod tests {
                 inflight_threshold_ms: 100,
                 ..Default::default()
             },
-        );
+        )
+        .expect("valid config");
         manager.register_inflight(client_order_id);
         manager
             .config
@@ -5555,7 +5678,8 @@ mod tests {
         let client_order_id = ClientOrderId::from("O-STATUS-MATRIX");
         let clock = Rc::new(RefCell::new(TestClock::new()));
         let cache = Rc::new(RefCell::new(Cache::default()));
-        let mut manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default());
+        let mut manager = ExecutionManager::new(clock, cache, ExecutionManagerConfig::default())
+            .expect("valid config");
         manager.register_inflight(client_order_id);
         manager.order_query_recency.mark(client_order_id);
         manager
@@ -5672,7 +5796,8 @@ mod tests {
                 open_check_missing_retries: 1,
                 ..Default::default()
             },
-        );
+        )
+        .expect("valid config");
         manager.record_local_activity(client_order_id);
         assert!(
             manager
@@ -5732,7 +5857,8 @@ mod tests {
                 open_check_threshold_ns: 100_000_000,
                 ..Default::default()
             },
-        );
+        )
+        .expect("valid config");
         manager.record_local_activity(old_id);
         dst::time::sleep(Duration::from_millis(101)).await;
         manager.record_local_activity(fresh_id);
@@ -5758,7 +5884,8 @@ mod tests {
                 reconciliation_instrument_ids: IndexSet::from([crypto_perpetual_ethusdt().id()]),
                 ..Default::default()
             },
-        );
+        )
+        .expect("valid config");
         let included_id = ClientOrderId::from("O-REPORT-001");
         let excluded_id = ClientOrderId::from("O-REPORT-002");
         let included_instrument_id = crypto_perpetual_ethusdt().id();
@@ -5820,7 +5947,8 @@ mod tests {
                 reconciliation_instrument_ids: IndexSet::from([crypto_perpetual_ethusdt().id()]),
                 ..Default::default()
             },
-        );
+        )
+        .expect("valid config");
         let included_instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         let excluded_instrument = InstrumentAny::CryptoPerpetual(xbtusd_bitmex());
 
@@ -5884,7 +6012,8 @@ mod tests {
                 position_check_threshold_ns: 5_000_000_000,
                 ..Default::default()
             },
-        );
+        )
+        .expect("valid config");
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         let instrument_id = instrument.id();
         let position = insert_open_position(
@@ -5958,7 +6087,8 @@ mod tests {
                 position_check_threshold_ns: 0,
                 ..Default::default()
             },
-        );
+        )
+        .expect("valid config");
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         let instrument_id = instrument.id();
         let position = insert_open_position(
@@ -6011,7 +6141,8 @@ mod tests {
         let clock = Rc::new(RefCell::new(TestClock::new()));
         let cache = Rc::new(RefCell::new(Cache::default()));
         let mut manager =
-            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default());
+            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default())
+                .expect("valid config");
         let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
         let client_order_id = ClientOrderId::from("O-MASS-VOID-001");
         let venue_order_id = VenueOrderId::from("V-MASS-VOID-001");

--- a/crates/live/src/node/builder.rs
+++ b/crates/live/src/node/builder.rs
@@ -705,7 +705,7 @@ impl LiveNodeBuilder {
             kernel.clock.clone(),
             kernel.cache.clone(),
             exec_manager_config,
-        );
+        )?;
 
         for client in &exec_clients {
             exec_manager.set_position_reconciliation_tolerance(

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -262,7 +262,7 @@ impl LiveNode {
             kernel.clock.clone(),
             kernel.cache.clone(),
             exec_manager_config,
-        );
+        )?;
 
         let node = Self {
             kernel,

--- a/crates/live/tests/manager.rs
+++ b/crates/live/tests/manager.rs
@@ -133,7 +133,8 @@ impl TestContext {
         let account = AccountAny::Margin(MarginAccount::new(account_state, true));
         cache.borrow_mut().add_account(account).unwrap();
 
-        let manager = ExecutionManager::new(clock.clone(), cache.clone(), config);
+        let manager =
+            ExecutionManager::new(clock.clone(), cache.clone(), config).expect("valid config");
         let mut engine = ExecutionEngine::new(clock.clone(), cache.clone(), None);
         engine
             .register_client(Box::new(MockExecutionClient::new(Vec::new())))
@@ -1592,7 +1593,8 @@ async fn test_external_order_filled_uses_real_fills() {
         ctx.clock.clone(),
         ctx.cache.clone(),
         ExecutionManagerConfig::default(),
-    );
+    )
+    .expect("valid config");
     let replay = ctx
         .manager
         .reconcile_execution_mass_status(mass_status, ctx.exec_engine.clone())


### PR DESCRIPTION
A follow-up to the purge-timer conversion work in #4784 and #4804, taking up the suggestion on that thread to validate these fields at construction rather than at the conversion site.

## Unvalidated lookback minutes reach a panicking conversion

`ExecutionManagerConfig` carries no validation of any kind - its only inherent method is `with_trader_id` - and `ExecutionManager::new` stores the config verbatim. Two of its public `Option<u64>` fields then reach conversions that panic on overflow: `open_check_lookback_mins` reaches `mins_to_nanos` in the open-order report check, which panics above 307,445,734 minutes, and `lookback_mins` reaches `Duration::from_mins`, which panics above 307,445,734,561,825,860.

The supported node route is unaffected: `LiveExecEngineConfig::validate` already rejects an unrepresentable value with `checked_mins_to_nanos`, and the conversion into `ExecutionManagerConfig` widens `Option<u32>` to `Option<u64>`. What remains exposed is direct construction of `ExecutionManagerConfig`, which is public with public fields.

`ExecutionManagerConfig::validate` now collects every offending field through `ConfigErrorCollector`, and `ExecutionManager::new` enforces it by returning `ConfigResult<Self>`. Unlike `ExecutionEngineConfig` and `RiskEngineConfig`, which validate inside a derived-builder `build()`, `ExecutionManagerConfig` has no builder and is commonly constructed directly, so the constructor is the only boundary covering every construction path. This does change a public constructor signature; both call sites, in `LiveNode::new` and `LiveNodeBuilder`, already return `anyhow::Result` and propagate with `?`.

`position_check_lookback_mins` is deliberately not validated: it has no read site, so there is no target representation whose bound could honestly be imposed. Its eventual consumer should introduce the constraint.

## Testing

`test_new_validates_open_check_lookback_mins_boundaries` and `test_new_validates_reconciliation_lookback_mins_boundaries` pin the maximum valid value and the first invalid value for each field, asserting the typed `ConfigError::Range` and its field name. `test_new_reports_every_invalid_lookback_field` sets both fields out of range and asserts a `ConfigError::Multiple` carrying both field names in declaration order.

Each test was checked against a mutation that removes the property it claims. Discarding the validation result in the constructor, which leaves the code compiling, fails both boundary tests by assertion. Making the second field check conditional on no earlier error, recreating fail-fast, fails only the aggregation test, with `Range` in place of `Multiple`.
