### PR TITLE
Fail closed on Polymarket positions offset ceiling

### DIFF
--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -270,6 +270,7 @@ impl PolymarketDataApiHttpClient {
     /// until a partial page is returned. Fails if the venue's maximum supported offset is
     /// exhausted before the response is complete.
     pub async fn get_positions(&self, user_address: &str) -> Result<Vec<DataApiPosition>> {
+        // Polymarket defines the `/positions` maximum offset as 10,000 inclusive
         const MAX_OFFSET: u32 = 10_000;
         const PAGE_SIZE: usize = 100;
 

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -267,8 +267,10 @@ impl PolymarketDataApiHttpClient {
     /// Fetches all positions for a user from the Data API.
     ///
     /// Paginates through `GET /positions?user={address}&sizeThreshold=0`
-    /// until a partial page is returned.
+    /// until a partial page is returned. Fails if the venue's maximum supported offset is
+    /// exhausted before the response is complete.
     pub async fn get_positions(&self, user_address: &str) -> Result<Vec<DataApiPosition>> {
+        const MAX_OFFSET: u32 = 10_000;
         const PAGE_SIZE: usize = 100;
 
         let protocol = OffsetProtocol::<DataApiPosition, Infallible>::new(
@@ -281,6 +283,12 @@ impl PolymarketDataApiHttpClient {
         let completed = paginator
             .run(
                 |offset| async move {
+                    if offset > MAX_OFFSET {
+                        return Err(Error::decode(format!(
+                            "/positions pagination exhausted the maximum supported offset {MAX_OFFSET}"
+                        )));
+                    }
+
                     let params = vec![
                         ("user".to_string(), user_address.to_string()),
                         ("limit".to_string(), PAGE_SIZE.to_string()),

--- a/crates/adapters/polymarket/tests/http.rs
+++ b/crates/adapters/polymarket/tests/http.rs
@@ -4671,6 +4671,67 @@ async fn test_get_positions_paginates_distinct_pages_with_offset() {
 
 #[rstest]
 #[tokio::test]
+async fn test_get_positions_fails_closed_at_offset_ceiling() {
+    let state = TestServerState::default();
+    let pages = (0..=100).map(|page| {
+        let start = page * 100;
+        Value::Array((start..start + 100).map(make_data_api_position).collect())
+    });
+    state.data_api_position_pages.lock().await.extend(pages);
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let error = client.get_positions(TEST_ADDRESS).await.unwrap_err();
+    let queries = state.data_api_position_query_log.lock().await;
+
+    assert_eq!(
+        error.to_string(),
+        "decode error: /positions pagination exhausted the maximum supported offset 10000",
+    );
+    assert_eq!(queries.len(), 101);
+    assert_eq!(
+        queries
+            .last()
+            .and_then(|query| query.get("offset"))
+            .map(String::as_str),
+        Some("10000"),
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_get_positions_accepts_partial_page_at_offset_ceiling() {
+    let state = TestServerState::default();
+    let full_pages = (0..100).map(|page| {
+        let start = page * 100;
+        Value::Array((start..start + 100).map(make_data_api_position).collect())
+    });
+    state
+        .data_api_position_pages
+        .lock()
+        .await
+        .extend(full_pages.chain([Value::Array(vec![make_data_api_position(10_000)])]));
+
+    let addr = start_mock_server(state.clone()).await;
+    let client = create_data_api_client(&addr);
+
+    let positions = client.get_positions(TEST_ADDRESS).await.unwrap();
+    let queries = state.data_api_position_query_log.lock().await;
+
+    assert_eq!(positions.len(), 10_001);
+    assert_eq!(queries.len(), 101);
+    assert_eq!(
+        queries
+            .last()
+            .and_then(|query| query.get("offset"))
+            .map(String::as_str),
+        Some("10000"),
+    );
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_get_positions_rejects_repeated_identities_with_changed_values() {
     let state = TestServerState::default();
     let first = Value::Array((0..100).map(make_data_api_position).collect());


### PR DESCRIPTION
# Pull Request

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Fail closed when `/positions` pagination exhausts Polymarket's maximum supported offset. A partial
page at offset 10,000 remains valid, while a full page causes an explicit error before any request
past the venue limit and prevents an incomplete positions prefix from escaping into reconciliation.

## Related issues/PRs

Closes #4810

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Validated with the focused and full Polymarket HTTP tests, crate-wide nextest, Clippy, formatting,
and pre-commit checks. The final review-only source comment was checked with `git diff --check`;
Cargo was not rerun for that comment-only commit due to a local resource constraint.
