### PR TITLE
Fix field order in indicator string representations

### DIFF
--- a/crates/indicators/src/python/volatility/rvi.rs
+++ b/crates/indicators/src/python/volatility/rvi.rs
@@ -34,8 +34,8 @@ impl RelativeVolatilityIndex {
 
     fn __repr__(&self) -> String {
         format!(
-            "RelativeVolatilityIndex({},{},{},{})",
-            self.period, self.ma_type, self.scalar, self.ma_type,
+            "RelativeVolatilityIndex({},{},{})",
+            self.period, self.scalar, self.ma_type,
         )
     }
 

--- a/crates/indicators/src/volatility/fuzzy.rs
+++ b/crates/indicators/src/volatility/fuzzy.rs
@@ -151,7 +151,7 @@ impl Display for FuzzyCandle {
         write!(
             f,
             "{}({},{},{},{})",
-            self.direction, self.size, self.body_size, self.lower_wick_size, self.upper_wick_size
+            self.direction, self.size, self.body_size, self.upper_wick_size, self.lower_wick_size
         )
     }
 }
@@ -518,6 +518,22 @@ mod tests {
         stubs::{fuzzy_candlesticks_1, fuzzy_candlesticks_3, fuzzy_candlesticks_10},
         volatility::fuzzy::FuzzyCandlesticks,
     };
+
+    #[rstest]
+    fn test_fuzzy_candle_display_orders_wicks_upper_then_lower() {
+        // Regression: `Display` emitted the wick sizes in the opposite order to the
+        // struct definition, the constructor and `__repr__`, so an upper-heavy candle
+        // rendered as a lower-heavy one.
+        let candle = FuzzyCandle::new(
+            CandleDirection::Bull,
+            CandleSize::Medium,
+            CandleBodySize::Small,
+            CandleWickSize::Large,
+            CandleWickSize::None,
+        );
+
+        assert_eq!(format!("{candle}"), "BULL(MEDIUM,SMALL,LARGE,NONE)");
+    }
 
     #[rstest]
     fn test_psl_initialized(fuzzy_candlesticks_10: FuzzyCandlesticks) {


### PR DESCRIPTION
Two indicator string representations disagree with the field order of the type
they describe. No calculation changes; both misreport values that people read
while debugging.

**`FuzzyCandle`'s `Display`** emits the wick sizes as `(lower, upper)`, while the
struct definition, `FuzzyCandle::new` and the Python `__repr__` all order them
`(upper, lower)`. The representation carries no field labels, so position is the
only cue: a candle with a large upper wick and no lower wick currently renders as
its mirror image. This `Display` had no test — only `FuzzyCandlesticks`' own was
covered.

**`RelativeVolatilityIndex.__repr__`** formats four fields for a three-parameter
constructor, printing `ma_type` twice and placing the first copy where `scalar`
belongs:

```
__repr__  RelativeVolatilityIndex(10,SIMPLE,10,SIMPLE)
Display   RelativeVolatilityIndex(10,10,SIMPLE)
```

`#[pyo3(signature = (period, scalar=None, ma_type=None))]` gives the intended
shape, and the neighbouring `AverageTrueRange` binding follows it — one field per
constructor parameter, in order.

## Changes

- `FuzzyCandle`'s `Display` emits `upper_wick_size` before `lower_wick_size`,
  with a regression test.
- `RelativeVolatilityIndex.__repr__` emits `(period, scalar, ma_type)`.

## Validation

- `cargo test -p nautilus-indicators` — 552 passed, 0 failed
- `cargo clippy -p nautilus-indicators --all-targets -- -D warnings` — clean
- `cargo +nightly fmt -p nautilus-indicators -- --check` — clean
- `cargo check -p nautilus-indicators --features python` — clean. The `__repr__`
  change only compiles under that feature, so the default test run does not
  cover it.
- The repository's Rust convention hooks, including `check_pyo3_conventions` and
  `check_testing_conventions`

`RelativeVolatilityIndex` has no Python test module, as is the case for most
indicators, so I left adding one out of scope rather than widening the patch.
Happy to add one if you'd prefer.

## Noted, not changed

Ten other `__repr__` implementations diverge from their Rust `Display` by adding
or omitting fields: `bb`, `bias`, `kp`, `macd`, `roc`, `spread_analyzer`,
`stochastics`, `vhf`, `vidya`, `vr`. Each is internally consistent and readable,
unlike the two above, so I left them alone. `IchimokuCloud` sidesteps the problem
by delegating its `__repr__` to `Display`; if you'd like that applied across the
bindings I can do it separately.
