### PR TITLE
Preserve execution client source for Bybit reports

### DIFF
--- a/crates/adapters/bybit/src/config.rs
+++ b/crates/adapters/bybit/src/config.rs
@@ -230,6 +230,9 @@ pub struct BybitExecutionClientConfig {
     /// coverage as unavailable.
     #[builder(default)]
     pub use_spot_position_reports: bool,
+    /// Whether to route this client's execution events through the source-bound ingress.
+    #[builder(default)]
+    pub use_sourced_execution_events: bool,
     /// Whether to automatically repay SPOT margin borrows after BUY orders tracked by
     /// this client and reported on the standard `execution` channel (not `execution.fast`)
     /// fully fill.
@@ -262,6 +265,7 @@ nautilus_core::impl_pyo3_config_getters!(BybitExecutionClientConfig {
     recv_window_ms: u64,
     account_id: Option<AccountId>,
     use_spot_position_reports: bool,
+    use_sourced_execution_events: bool,
     auto_repay_spot_borrows: bool,
     margin_mode: Option<BybitMarginMode>,
     transport_backend: TransportBackend,
@@ -436,6 +440,7 @@ mod tests {
         assert_eq!(config.product_types, vec![BybitProductType::Linear]);
         assert_eq!(config.http_timeout_secs, 60);
         assert_eq!(config.heartbeat_interval_secs, 20);
+        assert!(!config.use_sourced_execution_events);
     }
 
     #[rstest]
@@ -525,6 +530,18 @@ http_timeout_secs = 45
             expected.heartbeat_interval_secs,
         );
         assert_eq!(config.recv_window_ms, expected.recv_window_ms);
+        assert_eq!(
+            config.use_sourced_execution_events,
+            expected.use_sourced_execution_events,
+        );
         assert_eq!(config.transport_backend, expected.transport_backend);
+    }
+
+    #[rstest]
+    fn test_exec_config_toml_enables_sourced_execution_events() {
+        let config: BybitExecutionClientConfig =
+            toml::from_str("use_sourced_execution_events = true").unwrap();
+
+        assert!(config.use_sourced_execution_events);
     }
 }

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -874,9 +874,14 @@ impl ExecutionClient for BybitExecutionClient {
                     account_state.balances.len()
                 );
             }
-            self.emitter
-                .try_send_bootstrap_account_state(account_state)
-                .context("failed to emit Bybit bootstrap account state")?;
+
+            if self.use_sourced_execution_events {
+                self.emitter
+                    .try_send_bootstrap_account_state(account_state)
+                    .context("failed to emit Bybit bootstrap account state")?;
+            } else {
+                self.emitter.send_account_state(account_state);
+            }
 
             self.await_account_registered(30.0).await?;
 

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -28,11 +28,15 @@ use futures_util::{StreamExt, pin_mut};
 use nautilus_common::{
     clients::ExecutionClient,
     live::runner::get_exec_event_sender,
-    messages::execution::{
-        BatchCancelOrders, CancelAllOrders, CancelOrder, GenerateFillReports,
-        GenerateFillReportsBuilder, GenerateOrderStatusReport, GenerateOrderStatusReports,
-        GenerateOrderStatusReportsBuilder, GeneratePositionStatusReports, ModifyOrder,
-        QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList,
+    messages::{
+        ExecutionEvent,
+        execution::{
+            BatchCancelOrders, CancelAllOrders, CancelOrder, GenerateFillReports,
+            GenerateFillReportsBuilder, GenerateOrderStatusReport, GenerateOrderStatusReports,
+            GenerateOrderStatusReportsBuilder, GeneratePositionStatusReports,
+            GeneratePositionStatusReportsBuilder, ModifyOrder, QueryAccount, QueryOrder,
+            SubmitOrder, SubmitOrderList,
+        },
     },
 };
 use nautilus_core::{
@@ -43,6 +47,7 @@ use nautilus_core::{
 use nautilus_live::{
     ExecutionClientCore, ExecutionEventEmitter, SocketControl,
     execution::failure::CommandFailure,
+    runner::{SourcedExecutionEventSink, get_sourced_exec_event_sink},
     task::{TaskGroup, TaskGroupGuard},
 };
 use nautilus_model::{
@@ -99,6 +104,7 @@ pub struct BybitExecutionClient {
     core: ExecutionClientCore,
     clock: &'static AtomicTime,
     config: BybitExecutionClientConfig,
+    use_sourced_execution_events: bool,
     emitter: ExecutionEventEmitter,
     http_client: BybitHttpClient,
     ws_private: BybitWebSocketClient,
@@ -176,6 +182,7 @@ impl BybitExecutionClient {
         }
         ws_trade.set_recv_window_ms(config.recv_window_ms);
 
+        let use_sourced_execution_events = config.use_sourced_execution_events;
         let clock = get_atomic_clock_realtime();
         let emitter = ExecutionEventEmitter::new(
             clock,
@@ -192,6 +199,7 @@ impl BybitExecutionClient {
             core,
             clock,
             config,
+            use_sourced_execution_events,
             emitter,
             http_client,
             ws_private,
@@ -366,6 +374,23 @@ impl BybitExecutionClient {
         }
 
         Ok(reports)
+    }
+
+    fn bind_execution_event_target(&mut self) {
+        self.bind_execution_event_target_with(get_exec_event_sender, get_sourced_exec_event_sink);
+    }
+
+    fn bind_execution_event_target_with(
+        &mut self,
+        legacy_sender: impl FnOnce() -> tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
+        sourced_sink: impl FnOnce(ClientId) -> SourcedExecutionEventSink,
+    ) {
+        if self.use_sourced_execution_events {
+            self.emitter
+                .set_sourced_sink(sourced_sink(self.core.client_id));
+        } else {
+            self.emitter.set_sender(legacy_sender());
+        }
     }
 
     fn resolve_position_idx(
@@ -947,8 +972,7 @@ impl ExecutionClient for BybitExecutionClient {
             return Ok(());
         }
 
-        let sender = get_exec_event_sender();
-        self.emitter.set_sender(sender);
+        self.bind_execution_event_target();
         self.core.set_started();
 
         let http_client = self.http_client.clone();
@@ -2249,7 +2273,11 @@ impl BybitExecutionClient {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc, time::Duration};
+    use std::{
+        cell::{Cell, RefCell},
+        rc::Rc,
+        time::Duration,
+    };
 
     use nautilus_common::{
         cache::Cache,
@@ -2260,7 +2288,7 @@ mod tests {
         },
     };
     use nautilus_core::{Params, UUID4};
-    use nautilus_live::ExecutionClientCore;
+    use nautilus_live::{ExecutionClientCore, runner::AsyncRunner};
     use nautilus_model::{
         enums::{AccountType, OrderSide, OrderStatus},
         events::OrderEventAny,
@@ -2276,7 +2304,9 @@ mod tests {
         enums::BybitMarketUnit,
     };
 
-    fn test_execution_client() -> (BybitExecutionClient, Rc<RefCell<Cache>>) {
+    fn test_execution_client_with_sourced_events(
+        use_sourced_execution_events: bool,
+    ) -> (BybitExecutionClient, Rc<RefCell<Cache>>) {
         let cache = Rc::new(RefCell::new(Cache::default()));
         let core = ExecutionClientCore::new(
             TraderId::from("TESTER-001"),
@@ -2291,10 +2321,44 @@ mod tests {
         let config = BybitExecutionClientConfig {
             api_key: Some("test_key".to_string()),
             api_secret: Some("test_secret".to_string()),
+            use_sourced_execution_events,
             ..Default::default()
         };
 
         (BybitExecutionClient::new(core, config).unwrap(), cache)
+    }
+
+    fn test_execution_client() -> (BybitExecutionClient, Rc<RefCell<Cache>>) {
+        test_execution_client_with_sourced_events(false)
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn test_sourced_execution_event_setting_is_frozen_at_construction(#[case] enabled: bool) {
+        let (mut client, _cache) = test_execution_client_with_sourced_events(enabled);
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let legacy_calls = Cell::new(0);
+        let sourced_calls = Cell::new(0);
+
+        assert_eq!(client.use_sourced_execution_events, enabled);
+        client.config.use_sourced_execution_events = !enabled;
+        assert_eq!(client.use_sourced_execution_events, enabled);
+        client.bind_execution_event_target_with(
+            || {
+                legacy_calls.set(legacy_calls.get() + 1);
+                get_exec_event_sender()
+            },
+            |client_id| {
+                sourced_calls.set(sourced_calls.get() + 1);
+                assert_eq!(client_id, *BYBIT_CLIENT_ID);
+                get_sourced_exec_event_sink(client_id)
+            },
+        );
+
+        assert_eq!(legacy_calls.get(), (!enabled) as usize);
+        assert_eq!(sourced_calls.get(), enabled as usize);
     }
 
     async fn wait_for_spawned_tasks(client: &BybitExecutionClient) {

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -28,15 +28,12 @@ use futures_util::{StreamExt, pin_mut};
 use nautilus_common::{
     clients::ExecutionClient,
     live::runner::get_exec_event_sender,
-    messages::{
-        ExecutionEvent,
-        execution::{
-            BatchCancelOrders, CancelAllOrders, CancelOrder, GenerateFillReports,
-            GenerateFillReportsBuilder, GenerateOrderStatusReport, GenerateOrderStatusReports,
-            GenerateOrderStatusReportsBuilder, GeneratePositionStatusReports,
-            GeneratePositionStatusReportsBuilder, ModifyOrder, QueryAccount, QueryOrder,
-            SubmitOrder, SubmitOrderList,
-        },
+    messages::execution::{
+        BatchCancelOrders, CancelAllOrders, CancelOrder, GenerateFillReports,
+        GenerateFillReportsBuilder, GenerateOrderStatusReport, GenerateOrderStatusReports,
+        GenerateOrderStatusReportsBuilder, GeneratePositionStatusReports,
+        GeneratePositionStatusReportsBuilder, ModifyOrder, QueryAccount, QueryOrder, SubmitOrder,
+        SubmitOrderList,
     },
 };
 use nautilus_core::{
@@ -47,7 +44,7 @@ use nautilus_core::{
 use nautilus_live::{
     ExecutionClientCore, ExecutionEventEmitter, SocketControl,
     execution::failure::CommandFailure,
-    runner::{SourcedExecutionEventSink, get_sourced_exec_event_sink},
+    runner::get_sourced_exec_event_sink,
     task::{TaskGroup, TaskGroupGuard},
 };
 use nautilus_model::{
@@ -377,19 +374,11 @@ impl BybitExecutionClient {
     }
 
     fn bind_execution_event_target(&mut self) {
-        self.bind_execution_event_target_with(get_exec_event_sender, get_sourced_exec_event_sink);
-    }
-
-    fn bind_execution_event_target_with(
-        &mut self,
-        legacy_sender: impl FnOnce() -> tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
-        sourced_sink: impl FnOnce(ClientId) -> SourcedExecutionEventSink,
-    ) {
         if self.use_sourced_execution_events {
             self.emitter
-                .set_sourced_sink(sourced_sink(self.core.client_id));
+                .set_sourced_sink(get_sourced_exec_event_sink(self.core.client_id));
         } else {
-            self.emitter.set_sender(legacy_sender());
+            self.emitter.set_sender(get_exec_event_sender());
         }
     }
 
@@ -2286,12 +2275,13 @@ mod tests {
             ExecutionEvent,
             execution::{CancelOrder, ModifyOrder, SubmitOrder, SubmitOrderList},
         },
+        msgbus::{self, MessagingSwitchboard, TypedHandler},
     };
-    use nautilus_core::{Params, UUID4};
+    use nautilus_core::{Params, UUID4, UnixNanos};
     use nautilus_live::{ExecutionClientCore, runner::AsyncRunner};
     use nautilus_model::{
         enums::{AccountType, OrderSide, OrderStatus},
-        events::OrderEventAny,
+        events::{AccountState, OrderEventAny},
         identifiers::{ClientOrderId, OrderListId, PositionId, StrategyId, TraderId, VenueOrderId},
         orders::{OrderList, builder::OrderTestBuilder},
         types::Quantity,
@@ -2335,30 +2325,51 @@ mod tests {
     #[rstest]
     #[case(false)]
     #[case(true)]
-    fn test_sourced_execution_event_setting_is_frozen_at_construction(#[case] enabled: bool) {
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_sourced_execution_event_setting_is_frozen_at_construction(#[case] enabled: bool) {
+        msgbus::get_message_bus().borrow_mut().dispose();
+        let received = Rc::new(Cell::new(0));
+        let handler_received = received.clone();
+        msgbus::register_account_state_endpoint(
+            MessagingSwitchboard::portfolio_update_account(),
+            TypedHandler::from(move |_: &AccountState| {
+                handler_received.set(handler_received.get() + 1);
+            }),
+        );
+
         let (mut client, _cache) = test_execution_client_with_sourced_events(enabled);
         let runner = AsyncRunner::new();
         runner.bind_senders();
-        let legacy_calls = Cell::new(0);
-        let sourced_calls = Cell::new(0);
 
         assert_eq!(client.use_sourced_execution_events, enabled);
         client.config.use_sourced_execution_events = !enabled;
         assert_eq!(client.use_sourced_execution_events, enabled);
-        client.bind_execution_event_target_with(
-            || {
-                legacy_calls.set(legacy_calls.get() + 1);
-                get_exec_event_sender()
-            },
-            |client_id| {
-                sourced_calls.set(sourced_calls.get() + 1);
-                assert_eq!(client_id, *BYBIT_CLIENT_ID);
-                get_sourced_exec_event_sink(client_id)
-            },
+        client.bind_execution_event_target();
+        client.emitter.send_account_state(AccountState::new(
+            AccountId::from("BYBIT-001"),
+            AccountType::Margin,
+            vec![],
+            vec![],
+            true,
+            UUID4::new(),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            None,
+        ));
+
+        let mut channels = runner.take_channels();
+        assert_eq!(channels.exec_evt_rx.len(), (!enabled) as usize);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                AsyncRunner::handle_next_exec_event(&mut channels.exec_evt_rx),
+            )
+            .await
+            .expect("execution event should be available on the configured lane")
         );
 
-        assert_eq!(legacy_calls.get(), (!enabled) as usize);
-        assert_eq!(sourced_calls.get(), enabled as usize);
+        assert_eq!(received.get(), 1);
+        msgbus::get_message_bus().borrow_mut().dispose();
     }
 
     async fn wait_for_spawned_tasks(client: &BybitExecutionClient) {

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -31,9 +31,8 @@ use nautilus_common::{
     messages::execution::{
         BatchCancelOrders, CancelAllOrders, CancelOrder, GenerateFillReports,
         GenerateFillReportsBuilder, GenerateOrderStatusReport, GenerateOrderStatusReports,
-        GenerateOrderStatusReportsBuilder, GeneratePositionStatusReports,
-        GeneratePositionStatusReportsBuilder, ModifyOrder, QueryAccount, QueryOrder, SubmitOrder,
-        SubmitOrderList,
+        GenerateOrderStatusReportsBuilder, GeneratePositionStatusReports, ModifyOrder,
+        QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList,
     },
 };
 use nautilus_core::{

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -875,7 +875,9 @@ impl ExecutionClient for BybitExecutionClient {
                     account_state.balances.len()
                 );
             }
-            self.emitter.send_account_state(account_state);
+            self.emitter
+                .try_send_bootstrap_account_state(account_state)
+                .context("failed to emit Bybit bootstrap account state")?;
 
             self.await_account_registered(30.0).await?;
 

--- a/crates/adapters/bybit/src/python/config.rs
+++ b/crates/adapters/bybit/src/python/config.rs
@@ -132,10 +132,10 @@ impl BybitExecutionClientConfig {
         recv_window_ms = None,
         account_id = None,
         use_spot_position_reports = None,
-        use_sourced_execution_events = None,
         auto_repay_spot_borrows = None,
         margin_mode = None,
         transport_backend = None,
+        use_sourced_execution_events = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -156,10 +156,10 @@ impl BybitExecutionClientConfig {
         recv_window_ms: Option<u64>,
         account_id: Option<AccountId>,
         use_spot_position_reports: Option<bool>,
-        use_sourced_execution_events: Option<bool>,
         auto_repay_spot_borrows: Option<bool>,
         margin_mode: Option<BybitMarginMode>,
         transport_backend: Option<TransportBackend>,
+        use_sourced_execution_events: Option<bool>,
     ) -> Self {
         let defaults = Self::default();
         Self {

--- a/crates/adapters/bybit/src/python/config.rs
+++ b/crates/adapters/bybit/src/python/config.rs
@@ -132,6 +132,7 @@ impl BybitExecutionClientConfig {
         recv_window_ms = None,
         account_id = None,
         use_spot_position_reports = None,
+        use_sourced_execution_events = None,
         auto_repay_spot_borrows = None,
         margin_mode = None,
         transport_backend = None,
@@ -155,6 +156,7 @@ impl BybitExecutionClientConfig {
         recv_window_ms: Option<u64>,
         account_id: Option<AccountId>,
         use_spot_position_reports: Option<bool>,
+        use_sourced_execution_events: Option<bool>,
         auto_repay_spot_borrows: Option<bool>,
         margin_mode: Option<BybitMarginMode>,
         transport_backend: Option<TransportBackend>,
@@ -181,6 +183,8 @@ impl BybitExecutionClientConfig {
             account_id,
             use_spot_position_reports: use_spot_position_reports
                 .unwrap_or(defaults.use_spot_position_reports),
+            use_sourced_execution_events: use_sourced_execution_events
+                .unwrap_or(defaults.use_sourced_execution_events),
             auto_repay_spot_borrows: auto_repay_spot_borrows
                 .unwrap_or(defaults.auto_repay_spot_borrows),
             futures_leverages: None,

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -804,7 +804,6 @@ async fn test_exec_client_scoped_spot_position_reports_follow_config(
     config.use_spot_position_reports = use_spot_position_reports;
     let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
-    client.start().unwrap();
     client.connect().await.unwrap();
 
     let reports = client
@@ -837,7 +836,6 @@ async fn test_exec_client_mixed_unscoped_position_reports_omit_spot() {
     config.use_spot_position_reports = true;
     let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
-    client.start().unwrap();
     client.connect().await.unwrap();
 
     // Measure against a post-connect baseline, since connect issues requests of its own.
@@ -955,7 +953,6 @@ async fn test_exec_client_mass_status_omits_spot_and_preserves_derivative_positi
     config.use_spot_position_reports = true;
     let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
-    client.start().unwrap();
     client.connect().await.unwrap();
     state.wallet_balance_requests.store(0, Ordering::Relaxed);
 
@@ -1101,7 +1098,6 @@ async fn test_exec_client_connect_disconnect() {
     let (mut client, _rx, cache) = registry.scope(|| create_test_execution_client(addr));
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.start().unwrap();
     client.connect().await.unwrap();
 
     wait_until_async(
@@ -1206,6 +1202,41 @@ async fn test_exec_client_failed_startup_rolls_back_private_stream() {
 
 #[rstest]
 #[tokio::test]
+async fn test_exec_client_sourced_bootstrap_failure_rolls_back_session() {
+    let (addr, state) = start_test_server().await.unwrap();
+    let registry = SocketReconnectRegistry::default();
+    let mut config = create_test_exec_config(addr);
+    config.use_sourced_execution_events = true;
+    let (mut client, _rx, cache) =
+        registry.scope(|| create_test_execution_client_with_config(config));
+    add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
+
+    let error = client.connect().await.unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("failed to emit Bybit bootstrap account state"),
+        "unexpected startup error: {error:#}",
+    );
+    wait_until_async(
+        || async { *state.ws_connection_count.lock().await == 0 },
+        Duration::from_secs(2),
+    )
+    .await;
+    assert_eq!(state.private_ws_connections.load(Ordering::Relaxed), 1);
+    assert!(!client.is_connected());
+    assert!(
+        ["bybit-user-streams", "bybit-trading"]
+            .into_iter()
+            .all(|endpoint| registry
+                .handle(*BYBIT_CLIENT_ID, Ustr::from(endpoint))
+                .is_none())
+    );
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_exec_client_connect_applies_position_mode_for_derivative_symbols() {
     let (addr, state) = start_test_server().await.unwrap();
     let trader_id = TraderId::from("TESTER-001");
@@ -1243,7 +1274,6 @@ async fn test_exec_client_connect_applies_position_mode_for_derivative_symbols()
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
 
-    client.start().unwrap();
     client.connect().await.unwrap();
 
     wait_until_async(
@@ -1311,7 +1341,6 @@ async fn test_exec_client_connect_applies_leverage_and_margin_mode() {
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
 
-    client.start().unwrap();
     client.connect().await.unwrap();
 
     wait_until_async(
@@ -1397,7 +1426,6 @@ async fn test_exec_client_demo_mode_skips_trade_ws() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
 
     // Wait for subscriptions to confirm connection phase is complete
@@ -1430,8 +1458,8 @@ async fn test_exec_client_query_order() {
     let (mut client, mut rx, cache) = create_test_execution_client(addr);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(|| async { client.is_connected() }, Duration::from_secs(10)).await;
 
@@ -1576,8 +1604,8 @@ async fn test_query_account_does_not_block_within_runtime() {
     let (mut client, mut rx, cache) = create_test_execution_client(addr);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(|| async { client.is_connected() }, Duration::from_secs(10)).await;
 
@@ -1668,8 +1696,8 @@ async fn test_exec_client_submit_order_list_demo() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -1792,8 +1820,8 @@ async fn test_exec_client_demo_cancel_post_lookup_failure_does_not_reject() {
     let (mut client, mut rx, cache) = create_test_demo_execution_client(addr);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -1829,8 +1857,8 @@ async fn test_exec_client_demo_modify_whole_http_failure_does_not_reject() {
     let (mut client, mut rx, cache) = create_test_demo_execution_client(addr);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -1892,8 +1920,8 @@ async fn test_exec_client_demo_submit_post_lookup_failure_does_not_reject() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2019,8 +2047,8 @@ async fn test_exec_client_demo_submit_tp_trigger_price_emits_order_denied() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2133,8 +2161,8 @@ async fn test_exec_client_demo_submit_confirmed_rejection_emits_order_rejected()
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2285,8 +2313,8 @@ async fn test_exec_client_submit_order_list_denies_all_on_invalid_leg() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2465,8 +2493,8 @@ async fn test_exec_client_submit_order_unsupported_order_type_emits_order_denied
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2583,8 +2611,8 @@ async fn test_exec_client_submit_order_list_denies_incomplete_when_leg_missing()
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2726,8 +2754,8 @@ async fn test_exec_client_submit_order_list_denies_closed_leg() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.start().unwrap();
     client.connect().await.unwrap();
+    client.start().unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -804,6 +804,7 @@ async fn test_exec_client_scoped_spot_position_reports_follow_config(
     config.use_spot_position_reports = use_spot_position_reports;
     let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
+    client.start().unwrap();
     client.connect().await.unwrap();
 
     let reports = client
@@ -836,6 +837,7 @@ async fn test_exec_client_mixed_unscoped_position_reports_omit_spot() {
     config.use_spot_position_reports = true;
     let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
+    client.start().unwrap();
     client.connect().await.unwrap();
 
     // Measure against a post-connect baseline, since connect issues requests of its own.
@@ -953,6 +955,7 @@ async fn test_exec_client_mass_status_omits_spot_and_preserves_derivative_positi
     config.use_spot_position_reports = true;
     let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
+    client.start().unwrap();
     client.connect().await.unwrap();
     state.wallet_balance_requests.store(0, Ordering::Relaxed);
 
@@ -1098,6 +1101,7 @@ async fn test_exec_client_connect_disconnect() {
     let (mut client, _rx, cache) = registry.scope(|| create_test_execution_client(addr));
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
+    client.start().unwrap();
     client.connect().await.unwrap();
 
     wait_until_async(
@@ -1239,6 +1243,7 @@ async fn test_exec_client_connect_applies_position_mode_for_derivative_symbols()
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
 
+    client.start().unwrap();
     client.connect().await.unwrap();
 
     wait_until_async(
@@ -1306,6 +1311,7 @@ async fn test_exec_client_connect_applies_leverage_and_margin_mode() {
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
 
+    client.start().unwrap();
     client.connect().await.unwrap();
 
     wait_until_async(
@@ -1391,6 +1397,7 @@ async fn test_exec_client_demo_mode_skips_trade_ws() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
+    client.start().unwrap();
     client.connect().await.unwrap();
 
     // Wait for subscriptions to confirm connection phase is complete
@@ -1423,8 +1430,8 @@ async fn test_exec_client_query_order() {
     let (mut client, mut rx, cache) = create_test_execution_client(addr);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(|| async { client.is_connected() }, Duration::from_secs(10)).await;
 
@@ -1569,8 +1576,8 @@ async fn test_query_account_does_not_block_within_runtime() {
     let (mut client, mut rx, cache) = create_test_execution_client(addr);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(|| async { client.is_connected() }, Duration::from_secs(10)).await;
 
@@ -1661,8 +1668,8 @@ async fn test_exec_client_submit_order_list_demo() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -1785,8 +1792,8 @@ async fn test_exec_client_demo_cancel_post_lookup_failure_does_not_reject() {
     let (mut client, mut rx, cache) = create_test_demo_execution_client(addr);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -1822,8 +1829,8 @@ async fn test_exec_client_demo_modify_whole_http_failure_does_not_reject() {
     let (mut client, mut rx, cache) = create_test_demo_execution_client(addr);
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
 
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -1885,8 +1892,8 @@ async fn test_exec_client_demo_submit_post_lookup_failure_does_not_reject() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2012,8 +2019,8 @@ async fn test_exec_client_demo_submit_tp_trigger_price_emits_order_denied() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2126,8 +2133,8 @@ async fn test_exec_client_demo_submit_confirmed_rejection_emits_order_rejected()
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2278,8 +2285,8 @@ async fn test_exec_client_submit_order_list_denies_all_on_invalid_leg() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2458,8 +2465,8 @@ async fn test_exec_client_submit_order_unsupported_order_type_emits_order_denied
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2576,8 +2583,8 @@ async fn test_exec_client_submit_order_list_denies_incomplete_when_leg_missing()
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },
@@ -2719,8 +2726,8 @@ async fn test_exec_client_submit_order_list_denies_closed_leg() {
     set_exec_event_sender(tx);
 
     let mut client = BybitExecutionClient::new(core, config).unwrap();
-    client.connect().await.unwrap();
     client.start().unwrap();
+    client.connect().await.unwrap();
 
     wait_until_async(
         || async { state.subscriptions.lock().await.len() >= 4 },

--- a/crates/adapters/bybit/tests/python.rs
+++ b/crates/adapters/bybit/tests/python.rs
@@ -20,7 +20,7 @@ use std::{cell::RefCell, rc::Rc};
 use nautilus_bybit::{
     common::{
         consts::BYBIT,
-        enums::{BybitEnvironment, BybitProductType},
+        enums::{BybitEnvironment, BybitMarginMode, BybitProductType},
     },
     config::{BybitDataClientConfig, BybitExecutionClientConfig},
     factories::{BybitDataClientFactory, BybitExecutionClientFactory},
@@ -33,10 +33,11 @@ use nautilus_common::{
     messages::{DataEvent, ExecutionEvent},
 };
 use nautilus_model::identifiers::{AccountId, ClientId, TraderId};
+use nautilus_network::websocket::TransportBackend;
 use nautilus_system::get_global_pyo3_registry;
 use pyo3::{
-    Py, Python,
-    types::{PyAnyMethods, PyDict, PyDictMethods, PyModule},
+    IntoPyObjectExt, Py, Python,
+    types::{PyAny, PyAnyMethods, PyDict, PyDictMethods, PyModule, PyTuple},
 };
 use rstest::rstest;
 
@@ -54,6 +55,7 @@ fn test_bybit_python_factories_extract_from_registry() {
         assert_data_factory_extracts_from_python_object(py);
         assert_exec_factory_extracts_from_python_object(py);
         assert_exec_config_sourced_event_opt_in(py);
+        assert_exec_config_preserves_legacy_positional_bindings(py);
     });
 }
 
@@ -193,4 +195,50 @@ fn assert_exec_config_sourced_event_opt_in(py: Python<'_>) {
         .extract::<bool>()
         .expect("sourced event getter should return bool");
     assert!(enabled);
+}
+
+fn assert_exec_config_preserves_legacy_positional_bindings(py: Python<'_>) {
+    let config_type = py.get_type::<BybitExecutionClientConfig>();
+    let args = PyTuple::new(
+        py,
+        [
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py.None(),
+            py_object(py, true),
+            py_object(py, BybitMarginMode::PortfolioMargin),
+            py_object(py, TransportBackend::Tungstenite),
+        ],
+    )
+    .expect("legacy execution config args should build");
+    let config = config_type
+        .call1(args)
+        .expect("legacy BybitExecutionClientConfig should construct from Python")
+        .extract::<BybitExecutionClientConfig>()
+        .expect("legacy execution config should extract");
+
+    assert!(config.auto_repay_spot_borrows);
+    assert_eq!(config.margin_mode, Some(BybitMarginMode::PortfolioMargin));
+    assert_eq!(config.transport_backend, TransportBackend::Tungstenite);
+    assert!(!config.use_sourced_execution_events);
+}
+
+fn py_object<'py>(py: Python<'py>, value: impl IntoPyObjectExt<'py>) -> Py<PyAny> {
+    value
+        .into_py_any(py)
+        .expect("value should convert to a Python object")
 }

--- a/crates/adapters/bybit/tests/python.rs
+++ b/crates/adapters/bybit/tests/python.rs
@@ -34,7 +34,10 @@ use nautilus_common::{
 };
 use nautilus_model::identifiers::{AccountId, ClientId, TraderId};
 use nautilus_system::get_global_pyo3_registry;
-use pyo3::{Py, Python, types::PyModule};
+use pyo3::{
+    Py, Python,
+    types::{PyAnyMethods, PyDict, PyDictMethods, PyModule},
+};
 use rstest::rstest;
 
 const SMOKE_API_KEY: &str = "test_key";
@@ -50,6 +53,7 @@ fn test_bybit_python_factories_extract_from_registry() {
         register_bybit_python_module(py);
         assert_data_factory_extracts_from_python_object(py);
         assert_exec_factory_extracts_from_python_object(py);
+        assert_exec_config_sourced_event_opt_in(py);
     });
 }
 
@@ -162,4 +166,31 @@ fn assert_exec_factory_extracts_from_python_object(py: Python<'_>) {
     assert_eq!(bybit_config.product_types, [BybitProductType::Linear]);
     assert_eq!(client.client_id(), ClientId::from("BYBIT-EXEC-EXTRACTED"));
     assert_eq!(client.account_id(), account_id);
+}
+
+fn assert_exec_config_sourced_event_opt_in(py: Python<'_>) {
+    let config_type = py.get_type::<BybitExecutionClientConfig>();
+    let default_config = config_type
+        .call0()
+        .expect("default config should construct");
+    let default_enabled = default_config
+        .getattr("use_sourced_execution_events")
+        .expect("sourced event getter should exist")
+        .extract::<bool>()
+        .expect("sourced event getter should return bool");
+    assert!(!default_enabled);
+
+    let kwargs = PyDict::new(py);
+    kwargs
+        .set_item("use_sourced_execution_events", true)
+        .expect("sourced event opt-in should be accepted");
+    let enabled_config = config_type
+        .call((), Some(&kwargs))
+        .expect("opted-in config should construct");
+    let enabled = enabled_config
+        .getattr("use_sourced_execution_events")
+        .expect("sourced event getter should exist")
+        .extract::<bool>()
+        .expect("sourced event getter should return bool");
+    assert!(enabled);
 }

--- a/crates/common/src/messages/execution/mod.rs
+++ b/crates/common/src/messages/execution/mod.rs
@@ -54,6 +54,23 @@ pub enum ExecutionReport {
     MassStatus(Box<ExecutionMassStatus>),
 }
 
+/// An execution report stamped with the client that emitted it.
+#[derive(Clone, Debug)]
+pub struct SourcedExecutionReport {
+    /// The execution client that emitted the report.
+    pub client_id: ClientId,
+    /// The report emitted by the execution client.
+    pub report: ExecutionReport,
+}
+
+impl SourcedExecutionReport {
+    /// Creates a new [`SourcedExecutionReport`] instance.
+    #[must_use]
+    pub const fn new(client_id: ClientId, report: ExecutionReport) -> Self {
+        Self { client_id, report }
+    }
+}
+
 #[expect(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Eq, PartialEq, Display)]
 pub enum TradingCommand {

--- a/crates/common/src/msgbus/api.rs
+++ b/crates/common/src/msgbus/api.rs
@@ -68,7 +68,7 @@ use super::{
 };
 use crate::messages::{
     data::{DataCommand, DataResponse},
-    execution::{ExecutionReport, TradingCommand},
+    execution::{ExecutionReport, SourcedExecutionReport, TradingCommand},
 };
 
 /// Registers a handler for an endpoint using runtime type dispatch (Any).
@@ -189,6 +189,17 @@ pub fn register_execution_report_endpoint(
     get_message_bus()
         .borrow_mut()
         .endpoints_exec_reports
+        .register(endpoint, handler);
+}
+
+/// Registers a sourced execution report handler at an endpoint (ownership-based).
+pub fn register_sourced_execution_report_endpoint(
+    endpoint: MStr<Endpoint>,
+    handler: TypedIntoHandler<SourcedExecutionReport>,
+) {
+    get_message_bus()
+        .borrow_mut()
+        .endpoints_sourced_exec_reports
         .register(endpoint, handler);
 }
 
@@ -1478,6 +1489,16 @@ pub fn send_execution_report(endpoint: MStr<Endpoint>, report: ExecutionReport) 
         report,
         |bus| bus.endpoints_exec_reports.get(endpoint),
         "send_execution_report",
+    );
+}
+
+/// Sends a sourced execution report to an endpoint handler, transferring ownership.
+pub fn send_sourced_execution_report(endpoint: MStr<Endpoint>, report: SourcedExecutionReport) {
+    send_endpoint_owned(
+        endpoint,
+        report,
+        |bus| bus.endpoints_sourced_exec_reports.get(endpoint),
+        "send_sourced_execution_report",
     );
 }
 

--- a/crates/common/src/msgbus/core.rs
+++ b/crates/common/src/msgbus/core.rs
@@ -127,7 +127,7 @@ use crate::{
     enums::SerializationEncoding,
     messages::{
         data::{DataCommand, DataResponse},
-        execution::{ExecutionReport, TradingCommand},
+        execution::{ExecutionReport, SourcedExecutionReport, TradingCommand},
     },
 };
 
@@ -278,6 +278,7 @@ pub struct MessageBus {
     pub(crate) endpoints_data_commands: IntoEndpointMap<DataCommand>,
     pub(crate) endpoints_data_responses: IntoEndpointMap<DataResponse>,
     pub(crate) endpoints_exec_reports: IntoEndpointMap<ExecutionReport>,
+    pub(crate) endpoints_sourced_exec_reports: IntoEndpointMap<SourcedExecutionReport>,
     pub(crate) endpoints_order_events: IntoEndpointMap<OrderEventAny>,
     pub(crate) endpoints_data: IntoEndpointMap<Data>,
     routers_typed: AHashMap<TypeId, Box<dyn Any>>,
@@ -373,6 +374,7 @@ impl MessageBus {
             endpoints_data_commands: IntoEndpointMap::new(),
             endpoints_data_responses: IntoEndpointMap::new(),
             endpoints_exec_reports: IntoEndpointMap::new(),
+            endpoints_sourced_exec_reports: IntoEndpointMap::new(),
             endpoints_order_events: IntoEndpointMap::new(),
             endpoints_data: IntoEndpointMap::new(),
             routers_typed: AHashMap::new(),
@@ -554,6 +556,7 @@ impl MessageBus {
         self.endpoints_data_commands.clear();
         self.endpoints_data_responses.clear();
         self.endpoints_exec_reports.clear();
+        self.endpoints_sourced_exec_reports.clear();
         self.endpoints_order_events.clear();
         self.endpoints_data.clear();
 

--- a/crates/common/src/msgbus/switchboard.rs
+++ b/crates/common/src/msgbus/switchboard.rs
@@ -52,6 +52,7 @@ static EXEC_QUEUE_COMMAND_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static EXEC_EXECUTE_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static EXEC_PROCESS_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static EXEC_RECONCILE_REPORT_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
+static EXEC_RECONCILE_SOURCED_REPORT_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static RISK_EXECUTE_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static RISK_QUEUE_EXECUTE_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
 static RISK_PROCESS_ENDPOINT: OnceLock<MStr<Endpoint>> = OnceLock::new();
@@ -192,6 +193,13 @@ macro_rules! define_switchboard {
             #[must_use]
             pub fn exec_engine_reconcile_execution_report() -> MStr<Endpoint> {
                 *EXEC_RECONCILE_REPORT_ENDPOINT.get_or_init(|| "ExecEngine.reconcile_execution_report".into())
+            }
+
+            #[inline]
+            #[must_use]
+            pub fn exec_engine_reconcile_sourced_execution_report() -> MStr<Endpoint> {
+                *EXEC_RECONCILE_SOURCED_REPORT_ENDPOINT
+                    .get_or_init(|| "ExecEngine.reconcile_sourced_execution_report".into())
             }
 
             /// Direct dispatch endpoint for `RiskEngine` commands.

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -1191,10 +1191,10 @@ impl ExecutionEngine {
             );
         }
 
-        let direct_order = direct_client_order_id
-            .and_then(|client_order_id| cache.order(&client_order_id).map(|order| order.clone()));
-        let indexed_order = indexed_client_order_id
-            .and_then(|client_order_id| cache.order(&client_order_id).map(|order| order.clone()));
+        let direct_order =
+            direct_client_order_id.and_then(|client_order_id| cache.order_ref(&client_order_id));
+        let indexed_order =
+            indexed_client_order_id.and_then(|client_order_id| cache.order_ref(&client_order_id));
 
         if let Some(indexed_client_order_id) = indexed_client_order_id {
             anyhow::ensure!(

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -48,7 +48,8 @@ use nautilus_common::{
         ExecutionReport,
         execution::{
             BatchCancelOrders, BatchModifyOrders, CancelAllOrders, CancelOrder, ModifyOrder,
-            QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList, TradingCommand,
+            QueryAccount, QueryOrder, SourcedExecutionReport, SubmitOrder, SubmitOrderList,
+            TradingCommand,
         },
     },
     msgbus::{
@@ -208,12 +209,23 @@ impl ExecutionEngine {
             }),
         );
 
-        let weak3 = weak;
+        let weak3 = weak.clone();
         msgbus::register_execution_report_endpoint(
             MessagingSwitchboard::exec_engine_reconcile_execution_report(),
             TypedIntoHandler::from(move |report: ExecutionReport| {
                 if let Some(rc) = weak3.upgrade() {
                     rc.borrow_mut().reconcile_execution_report(&report);
+                }
+            }),
+        );
+
+        msgbus::register_sourced_execution_report_endpoint(
+            MessagingSwitchboard::exec_engine_reconcile_sourced_execution_report(),
+            TypedIntoHandler::from(move |report: SourcedExecutionReport| {
+                if let Some(rc) = weak.upgrade()
+                    && let Err(e) = Self::reconcile_sourced_execution_report(&rc, &report)
+                {
+                    log::error!("Cannot reconcile sourced execution report: {e:#}");
                 }
             }),
         );
@@ -1045,6 +1057,205 @@ impl ExecutionEngine {
         self.cache.borrow_mut().flush_db();
     }
 
+    /// Validates a sourced runtime execution report without mutating engine state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the report is not an order or fill report, its source client is not
+    /// registered, its account or venue falls outside the source client's scope, or its order
+    /// identity conflicts with cached state.
+    pub fn preflight_sourced_execution_report(
+        &self,
+        sourced: &SourcedExecutionReport,
+    ) -> anyhow::Result<()> {
+        let client = self.clients.get(&sourced.client_id).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Execution report source {} is not registered",
+                sourced.client_id
+            )
+        })?;
+
+        match &sourced.report {
+            ExecutionReport::Order(report) => {
+                self.preflight_sourced_order_reference(
+                    client,
+                    report.account_id,
+                    report.instrument_id,
+                    report.client_order_id,
+                    report.venue_order_id,
+                )?;
+            }
+            ExecutionReport::Fill(report) => {
+                self.preflight_sourced_order_reference(
+                    client,
+                    report.account_id,
+                    report.instrument_id,
+                    report.client_order_id,
+                    report.venue_order_id,
+                )?;
+            }
+            report => {
+                anyhow::bail!("Sourced runtime reconciliation does not support {report} reports")
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reconciles a sourced runtime order or fill report through both validation fences.
+    ///
+    /// The raw reconciliation topic retains its existing bare report payload. No engine borrow is
+    /// held while publishing, so subscribers may update state before the second validation fence.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error without applying the report if either validation fence fails.
+    pub fn reconcile_sourced_execution_report(
+        engine: &Rc<RefCell<Self>>,
+        sourced: &SourcedExecutionReport,
+    ) -> anyhow::Result<()> {
+        engine
+            .borrow()
+            .preflight_sourced_execution_report(sourced)?;
+
+        match &sourced.report {
+            ExecutionReport::Order(report) => msgbus::publish_any(
+                MessagingSwitchboard::reconciliation_raw_order_status_report_topic(),
+                report.as_ref(),
+            ),
+            ExecutionReport::Fill(report) => msgbus::publish_any(
+                MessagingSwitchboard::reconciliation_raw_fill_report_topic(),
+                report.as_ref(),
+            ),
+            _ => unreachable!("sourced report variant was validated before publication"),
+        }
+
+        engine
+            .borrow()
+            .preflight_sourced_execution_report(sourced)?;
+
+        let mut engine = engine.borrow_mut();
+
+        match &sourced.report {
+            ExecutionReport::Order(report) => {
+                engine.report_count += 1;
+                engine.apply_order_status_report(report, Some(sourced.client_id));
+            }
+            ExecutionReport::Fill(report) => {
+                engine.report_count += 1;
+                engine.apply_fill_report(report, Some(sourced.client_id));
+            }
+            _ => unreachable!("sourced report variant was validated before application"),
+        }
+
+        Ok(())
+    }
+
+    fn preflight_sourced_report_scope(
+        client: &ExecutionClientAdapter,
+        account_id: AccountId,
+        instrument_id: InstrumentId,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            account_id == client.account_id,
+            "Execution report account {account_id} did not match source account {}",
+            client.account_id,
+        );
+        anyhow::ensure!(
+            client.handles_order_venue(instrument_id.venue),
+            "Execution client {} does not handle report venue {}",
+            client.client_id,
+            instrument_id.venue,
+        );
+        Ok(())
+    }
+
+    fn preflight_sourced_order_reference(
+        &self,
+        client: &ExecutionClientAdapter,
+        account_id: AccountId,
+        instrument_id: InstrumentId,
+        direct_client_order_id: Option<ClientOrderId>,
+        venue_order_id: VenueOrderId,
+    ) -> anyhow::Result<()> {
+        Self::preflight_sourced_report_scope(client, account_id, instrument_id)?;
+
+        let cache = self.cache.borrow();
+        let indexed_client_order_id = cache.client_order_id(&venue_order_id).copied();
+
+        if let (Some(direct), Some(indexed)) = (direct_client_order_id, indexed_client_order_id) {
+            anyhow::ensure!(
+                direct == indexed,
+                "Execution report client order ID {direct} conflicts with venue order ID \
+                 {venue_order_id} mapped to {indexed}",
+            );
+        }
+
+        let direct_order = direct_client_order_id
+            .and_then(|client_order_id| cache.order(&client_order_id).map(|order| order.clone()));
+        let indexed_order = indexed_client_order_id
+            .and_then(|client_order_id| cache.order(&client_order_id).map(|order| order.clone()));
+
+        if let Some(indexed_client_order_id) = indexed_client_order_id {
+            anyhow::ensure!(
+                indexed_order.is_some(),
+                "Venue order ID {venue_order_id} mapped to missing order \
+                 {indexed_client_order_id}",
+            );
+        }
+
+        if let (Some(direct), Some(indexed)) = (&direct_order, &indexed_order) {
+            anyhow::ensure!(
+                direct.client_order_id() == indexed.client_order_id(),
+                "Execution report IDs resolved to different cached orders",
+            );
+        }
+
+        let order = direct_order.or(indexed_order);
+        if let Some(order) = order {
+            let client_order_id = order.client_order_id();
+            let cached_source = cache.client_id(&client_order_id).copied();
+            anyhow::ensure!(
+                cached_source == Some(client.client_id),
+                "Cached order {client_order_id} origin {cached_source:?} did not match report \
+                 source {}",
+                client.client_id,
+            );
+            anyhow::ensure!(
+                order.instrument_id() == instrument_id,
+                "Cached order {client_order_id} instrument {} did not match report instrument \
+                 {instrument_id}",
+                order.instrument_id(),
+            );
+
+            if let Some(cached_account_id) = order.account_id() {
+                anyhow::ensure!(
+                    cached_account_id == account_id,
+                    "Cached order {client_order_id} account {cached_account_id} did not match \
+                     report account {account_id}",
+                );
+            }
+
+            if let Some(cached_venue_order_id) = order.venue_order_id() {
+                anyhow::ensure!(
+                    cached_venue_order_id == venue_order_id
+                        || indexed_client_order_id == Some(client_order_id),
+                    "Cached order {client_order_id} venue order ID {cached_venue_order_id} did \
+                     not match report venue order ID {venue_order_id}, which is not a known alias",
+                );
+            }
+        } else if direct_client_order_id.is_none() && indexed_client_order_id.is_none() {
+            let derived_client_order_id = ClientOrderId::from(venue_order_id.as_str());
+            anyhow::ensure!(
+                !cache.order_exists(&derived_client_order_id),
+                "Derived client order ID {derived_client_order_id} already exists without venue \
+                 order ID {venue_order_id} mapping",
+            );
+        }
+
+        Ok(())
+    }
+
     /// Reconciles an execution report.
     pub fn reconcile_execution_report(&mut self, report: &ExecutionReport) {
         if !matches!(report, ExecutionReport::MassStatus(_)) {
@@ -1085,6 +1296,14 @@ impl ExecutionEngine {
             report,
         );
 
+        self.apply_order_status_report(report, None);
+    }
+
+    fn apply_order_status_report(
+        &mut self,
+        report: &OrderStatusReport,
+        source_client_id: Option<ClientId>,
+    ) {
         let cache = self.cache.borrow();
 
         let order = report
@@ -1109,7 +1328,7 @@ impl ExecutionEngine {
                 self.handle_event(event);
             }
         } else {
-            self.create_external_order(report, instrument.as_ref());
+            self.create_external_order(report, instrument.as_ref(), source_client_id);
         }
     }
 
@@ -1117,6 +1336,7 @@ impl ExecutionEngine {
         &mut self,
         report: &OrderStatusReport,
         instrument: Option<&InstrumentAny>,
+        source_client_id: Option<ClientId>,
     ) {
         let Some(instrument) = instrument else {
             log::warn!(
@@ -1127,7 +1347,9 @@ impl ExecutionEngine {
             return;
         };
 
-        let Some(order) = self.materialize_external_order_from_status(report) else {
+        let Some(order) =
+            self.materialize_external_order_from_status_with_source(report, source_client_id)
+        else {
             return;
         };
 
@@ -1150,6 +1372,14 @@ impl ExecutionEngine {
     fn materialize_external_order_from_status(
         &mut self,
         report: &OrderStatusReport,
+    ) -> Option<OrderAny> {
+        self.materialize_external_order_from_status_with_source(report, None)
+    }
+
+    fn materialize_external_order_from_status_with_source(
+        &mut self,
+        report: &OrderStatusReport,
+        source_client_id: Option<ClientId>,
     ) -> Option<OrderAny> {
         let strategy_id = self.resolve_external_strategy(&report.instrument_id);
         if self.should_filter_unclaimed_external_order(strategy_id) {
@@ -1180,13 +1410,18 @@ impl ExecutionEngine {
             return None;
         }
 
-        self.materialize_external_order_from_status_with_strategy(report, strategy_id)
+        self.materialize_external_order_from_status_with_strategy(
+            report,
+            strategy_id,
+            source_client_id,
+        )
     }
 
     fn materialize_external_order_from_status_with_strategy(
         &self,
         report: &OrderStatusReport,
         strategy_id: StrategyId,
+        source_client_id: Option<ClientId>,
     ) -> Option<OrderAny> {
         let client_order_id = report
             .client_order_id
@@ -1247,6 +1482,10 @@ impl ExecutionEngine {
             }
         };
 
+        let cache_source_client_id = source_client_id.or_else(|| {
+            self.source_client_id_for_account(report.account_id, &report.instrument_id)
+        });
+
         self.materialize_external_order(
             initialized,
             client_order_id,
@@ -1255,7 +1494,8 @@ impl ExecutionEngine {
             strategy_id,
             ts_now,
             Some(report.order_status),
-            self.source_client_id_for_account(report.account_id, &report.instrument_id),
+            cache_source_client_id,
+            source_client_id,
         )
     }
 
@@ -1266,7 +1506,11 @@ impl ExecutionEngine {
     ///
     /// This handles venue-initiated fills (most commonly Hyperliquid liquidations)
     /// where the venue does not surface a user-level order on its order channel.
-    fn materialize_external_order_from_fill(&mut self, report: &FillReport) -> Option<OrderAny> {
+    fn materialize_external_order_from_fill(
+        &mut self,
+        report: &FillReport,
+        source_client_id: Option<ClientId>,
+    ) -> Option<OrderAny> {
         let strategy_id = self.resolve_external_strategy(&report.instrument_id);
         if self.should_filter_unclaimed_external_order(strategy_id) {
             self.filtered_unclaimed_external_order_count += 1;
@@ -1338,6 +1582,10 @@ impl ExecutionEngine {
             None, // tags
         );
 
+        let cache_source_client_id = source_client_id.or_else(|| {
+            self.source_client_id_for_account(report.account_id, &report.instrument_id)
+        });
+
         self.materialize_external_order(
             initialized,
             client_order_id,
@@ -1346,7 +1594,8 @@ impl ExecutionEngine {
             strategy_id,
             ts_now,
             None,
-            self.source_client_id_for_account(report.account_id, &report.instrument_id),
+            cache_source_client_id,
+            source_client_id,
         )
     }
 
@@ -1377,7 +1626,9 @@ impl ExecutionEngine {
         ts_now: UnixNanos,
         order_status: Option<OrderStatus>,
         source_client_id: Option<ClientId>,
+        exact_source_client_id: Option<ClientId>,
     ) -> Option<OrderAny> {
+        let initialized_event_id = initialized.event_id;
         let initialized = OrderEventAny::Initialized(initialized);
         let order = match OrderAny::from_events(vec![initialized.clone()]) {
             Ok(order) => order,
@@ -1387,17 +1638,56 @@ impl ExecutionEngine {
             }
         };
 
+        let exact_source_client = if let Some(source_client_id) = exact_source_client_id {
+            let Some(client) = self.clients.get(&source_client_id) else {
+                log::error!(
+                    "Cannot register external order {client_order_id}: source client \
+                     {source_client_id} is no longer registered"
+                );
+                return None;
+            };
+            Some(client)
+        } else {
+            None
+        };
+
         {
             let mut cache = self.cache.borrow_mut();
+            let order_existed_before = cache.order_exists(&client_order_id);
             if let Err(e) = cache.add_venue_order_id(&client_order_id, &venue_order_id, false) {
                 log::warn!("Failed to claim venue order ID for external order: {e}");
                 return None;
             }
 
             if let Err(e) = cache.add_order(order.clone(), None, source_client_id, false) {
-                log::error!("Failed to add external order to cache: {e}");
-                return None;
+                let committed_to_memory = exact_source_client.is_some()
+                    && source_client_id == exact_source_client_id
+                    && !order_existed_before
+                    && cache
+                        .order(&client_order_id)
+                        .is_some_and(|cached| cached.init_event().event_id == initialized_event_id)
+                    && cache.client_id(&client_order_id).copied() == exact_source_client_id
+                    && cache.client_order_id(&venue_order_id) == Some(&client_order_id);
+
+                if committed_to_memory {
+                    log::error!(
+                        "Failed to persist external order after committing it to memory: {e}"
+                    );
+                } else {
+                    log::error!("Failed to add external order to cache: {e}");
+                    return None;
+                }
             }
+        }
+
+        if let Some(client) = exact_source_client {
+            client.register_external_order(
+                client_order_id,
+                venue_order_id,
+                instrument_id,
+                strategy_id,
+                ts_now,
+            );
         }
 
         self.publish_order_event(&initialized);
@@ -1411,13 +1701,15 @@ impl ExecutionEngine {
             ),
         }
 
-        self.register_external_order(
-            client_order_id,
-            venue_order_id,
-            instrument_id,
-            strategy_id,
-            ts_now,
-        );
+        if exact_source_client.is_none() {
+            self.register_external_order(
+                client_order_id,
+                venue_order_id,
+                instrument_id,
+                strategy_id,
+                ts_now,
+            );
+        }
 
         Some(order)
     }
@@ -1457,6 +1749,10 @@ impl ExecutionEngine {
             report,
         );
 
+        self.apply_fill_report(report, None);
+    }
+
+    fn apply_fill_report(&mut self, report: &FillReport, source_client_id: Option<ClientId>) {
         let cache = self.cache.borrow();
 
         let order = report
@@ -1484,7 +1780,9 @@ impl ExecutionEngine {
         let order = match order {
             Some(order) => order,
             None => {
-                let Some(order) = self.materialize_external_order_from_fill(report) else {
+                let Some(order) =
+                    self.materialize_external_order_from_fill(report, source_client_id)
+                else {
                     return;
                 };
                 let ts_now = self.clock.borrow().timestamp_ns();
@@ -4573,6 +4871,7 @@ mod tests {
             instrument.id(),
             order.strategy_id(),
             UnixNanos::default(),
+            None,
             None,
             None,
         );

--- a/crates/execution/tests/exec_engine.rs
+++ b/crates/execution/tests/exec_engine.rs
@@ -20,7 +20,7 @@
 mod cache_database;
 
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::HashSet,
     future::Future,
     pin::pin,
@@ -39,11 +39,12 @@ use nautilus_common::{
         ExecutionReport,
         execution::{
             BatchModifyOrders, CancelAllOrders, CancelOrder, ModifyOrder, QueryAccount,
-            SubmitOrder, SubmitOrderList, TradingCommand,
+            SourcedExecutionReport, SubmitOrder, SubmitOrderList, TradingCommand,
         },
     },
     msgbus::{
-        self, MessageBus, MessagingSwitchboard, TypedHandler, TypedIntoHandler,
+        self, MessageBus, MessagingSwitchboard, ShareableMessageHandler, TypedHandler,
+        TypedIntoHandler,
         stubs::{
             TypedIntoMessageSavingHandler, get_any_saving_handler,
             get_typed_into_message_saving_handler,
@@ -13137,6 +13138,691 @@ fn create_order_status_report(
         None,
     )
     .with_price(Price::from("1.00000"))
+}
+
+fn register_sourced_report_client(
+    execution_engine: &mut ExecutionEngine,
+    client_id: ClientId,
+    account_id: AccountId,
+    venue: Venue,
+    handles_all_order_venues: bool,
+) -> StubExecutionClient {
+    let client = StubExecutionClient::new(client_id, account_id, venue, OmsType::Netting, None);
+    let client = if handles_all_order_venues {
+        client.with_handles_all_order_venues()
+    } else {
+        client
+    };
+    let handle = client.clone();
+    execution_engine.register_client(Box::new(client)).unwrap();
+    handle
+}
+
+fn add_accepted_sourced_order(
+    execution_engine: &mut ExecutionEngine,
+    instrument_id: InstrumentId,
+    client_order_id: ClientOrderId,
+    venue_order_id: VenueOrderId,
+    source_client_id: ClientId,
+) -> OrderAny {
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .price(Price::from("1.00000"))
+        .build();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, Some(source_client_id), true)
+        .unwrap();
+    execution_engine.process(&TestOrderEventStubs::submitted(
+        &order,
+        AccountId::test_default(),
+    ));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &order,
+        AccountId::test_default(),
+        venue_order_id,
+    ));
+    execution_engine
+        .cache()
+        .borrow()
+        .order(&client_order_id)
+        .unwrap()
+        .clone()
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SourcedPilotReportKind {
+    Order,
+    Fill,
+}
+
+fn create_sourced_pilot_report(
+    report_kind: SourcedPilotReportKind,
+    account_id: AccountId,
+    instrument_id: InstrumentId,
+    client_order_id: ClientOrderId,
+    venue_order_id: VenueOrderId,
+) -> ExecutionReport {
+    match report_kind {
+        SourcedPilotReportKind::Order => {
+            let mut report = create_order_status_report(
+                Some(client_order_id),
+                venue_order_id,
+                instrument_id,
+                OrderStatus::Canceled,
+                Quantity::from(100_000),
+                Quantity::from(0),
+            );
+            report.account_id = account_id;
+            ExecutionReport::Order(Box::new(report))
+        }
+        SourcedPilotReportKind::Fill => {
+            let mut report = create_fill_report(
+                instrument_id,
+                Some(client_order_id),
+                venue_order_id,
+                TradeId::from("T-SOURCED-PREFLIGHT"),
+                Quantity::from(100_000),
+                Price::from("1.00000"),
+            );
+            report.account_id = account_id;
+            ExecutionReport::Fill(Box::new(report))
+        }
+    }
+}
+
+fn subscribe_sourced_raw_report_counter(
+    report_kind: SourcedPilotReportKind,
+) -> (
+    msgbus::MStr<msgbus::Pattern>,
+    ShareableMessageHandler,
+    Rc<Cell<usize>>,
+) {
+    let raw_count = Rc::new(Cell::new(0));
+    let raw_count_for_handler = Rc::clone(&raw_count);
+    let (raw_topic, raw_handler) = match report_kind {
+        SourcedPilotReportKind::Order => (
+            MessagingSwitchboard::reconciliation_raw_order_status_report_topic(),
+            ShareableMessageHandler::from_typed(move |_report: &OrderStatusReport| {
+                raw_count_for_handler.set(raw_count_for_handler.get() + 1);
+            }),
+        ),
+        SourcedPilotReportKind::Fill => (
+            MessagingSwitchboard::reconciliation_raw_fill_report_topic(),
+            ShareableMessageHandler::from_typed(move |_report: &FillReport| {
+                raw_count_for_handler.set(raw_count_for_handler.get() + 1);
+            }),
+        ),
+    };
+    let raw_pattern: msgbus::MStr<msgbus::Pattern> = raw_topic.into();
+    msgbus::subscribe_any(raw_pattern, raw_handler.clone(), None);
+
+    (raw_pattern, raw_handler, raw_count)
+}
+
+#[rstest]
+#[case::order(SourcedPilotReportKind::Order)]
+#[case::fill(SourcedPilotReportKind::Fill)]
+fn test_reconcile_sourced_report_registers_unknown_order_with_exact_source(
+    execution_engine: ExecutionEngine,
+    #[case] report_kind: SourcedPilotReportKind,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut execution_engine = execution_engine;
+    let instrument = audusd_sim();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let venue_client = register_sourced_report_client(
+        &mut execution_engine,
+        ClientId::from("VENUE-A"),
+        AccountId::test_default(),
+        instrument.id().venue,
+        false,
+    );
+    let source_client_id = ClientId::from("SOURCE-B");
+    let source_client = register_sourced_report_client(
+        &mut execution_engine,
+        source_client_id,
+        AccountId::test_default(),
+        Venue::from("BROKER-B"),
+        true,
+    );
+    let venue_registrations = venue_client.registered_external_order_ids();
+    let source_registrations = source_client.registered_external_order_ids();
+    let client_order_id = ClientOrderId::from("O-SOURCED-EXACT");
+    let venue_order_id = VenueOrderId::from("V-SOURCED-EXACT");
+    let report = match report_kind {
+        SourcedPilotReportKind::Order => {
+            ExecutionReport::Order(Box::new(create_order_status_report(
+                Some(client_order_id),
+                venue_order_id,
+                instrument.id(),
+                OrderStatus::Accepted,
+                Quantity::from(100_000),
+                Quantity::from(0),
+            )))
+        }
+        SourcedPilotReportKind::Fill => ExecutionReport::Fill(Box::new(create_fill_report(
+            instrument.id(),
+            Some(client_order_id),
+            venue_order_id,
+            TradeId::from("T-SOURCED-EXACT"),
+            Quantity::from(100_000),
+            Price::from("1.00000"),
+        ))),
+    };
+    let sourced = SourcedExecutionReport::new(source_client_id, report);
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+
+    ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced).unwrap();
+
+    assert!(venue_registrations.borrow().is_empty());
+    assert_eq!(source_registrations.borrow().as_slice(), &[client_order_id]);
+    let execution_engine = execution_engine.borrow();
+    assert_eq!(execution_engine.report_count(), 1);
+    let cache = execution_engine.cache().borrow();
+    assert!(cache.order_exists(&client_order_id));
+    assert_eq!(cache.client_id(&client_order_id), Some(&source_client_id));
+}
+
+#[rstest]
+#[case::order(SourcedPilotReportKind::Order, OrderStatus::Accepted)]
+#[case::fill(SourcedPilotReportKind::Fill, OrderStatus::Filled)]
+fn test_reconcile_sourced_report_completes_exact_source_after_database_add_failure(
+    execution_engine: ExecutionEngine,
+    #[case] report_kind: SourcedPilotReportKind,
+    #[case] expected_status: OrderStatus,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut execution_engine = execution_engine;
+    let instrument = audusd_sim();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let venue_client = register_sourced_report_client(
+        &mut execution_engine,
+        ClientId::from("VENUE-A"),
+        AccountId::test_default(),
+        instrument.id().venue,
+        false,
+    );
+    let source_client_id = ClientId::from("SOURCE-B");
+    let source_client = register_sourced_report_client(
+        &mut execution_engine,
+        source_client_id,
+        AccountId::test_default(),
+        Venue::from("BROKER-B"),
+        true,
+    );
+    let venue_registrations = venue_client.registered_external_order_ids();
+    let source_registrations = source_client.registered_external_order_ids();
+    let (database, control) = FailNthAddOrderDatabase::create();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .set_database(Box::new(database));
+    control.set_fail_add_order_on(Some(1));
+
+    let client_order_id = ClientOrderId::from("O-SOURCED-DB-FAIL");
+    let venue_order_id = VenueOrderId::from("V-SOURCED-DB-FAIL");
+    let report = match report_kind {
+        SourcedPilotReportKind::Order => {
+            ExecutionReport::Order(Box::new(create_order_status_report(
+                Some(client_order_id),
+                venue_order_id,
+                instrument.id(),
+                OrderStatus::Accepted,
+                Quantity::from(100_000),
+                Quantity::from(0),
+            )))
+        }
+        SourcedPilotReportKind::Fill => ExecutionReport::Fill(Box::new(create_fill_report(
+            instrument.id(),
+            Some(client_order_id),
+            venue_order_id,
+            TradeId::from("T-SOURCED-DB-FAIL"),
+            Quantity::from(100_000),
+            Price::from("1.00000"),
+        ))),
+    };
+    let sourced = SourcedExecutionReport::new(source_client_id, report);
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+
+    ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced).unwrap();
+
+    assert_eq!(control.add_order_calls(), 1);
+    assert!(venue_registrations.borrow().is_empty());
+    assert_eq!(source_registrations.borrow().as_slice(), &[client_order_id]);
+    let execution_engine = execution_engine.borrow();
+    assert_eq!(execution_engine.report_count(), 1);
+    let cache = execution_engine.cache().borrow();
+    let cached = cache.order(&client_order_id).unwrap();
+    assert_eq!(cached.status(), expected_status);
+    assert_eq!(cache.client_id(&client_order_id), Some(&source_client_id));
+}
+
+#[rstest]
+fn test_reconcile_sourced_order_report_publishes_bare_raw_payload(
+    execution_engine: ExecutionEngine,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut execution_engine = execution_engine;
+    let instrument = audusd_sim();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+    let source_client_id = ClientId::from("SOURCE");
+    register_sourced_report_client(
+        &mut execution_engine,
+        source_client_id,
+        AccountId::test_default(),
+        instrument.id().venue,
+        false,
+    );
+    let report = create_order_status_report(
+        Some(ClientOrderId::from("O-RAW-SOURCED")),
+        VenueOrderId::from("V-RAW-SOURCED"),
+        instrument.id(),
+        OrderStatus::Accepted,
+        Quantity::from(100_000),
+        Quantity::from(0),
+    );
+    let sourced = SourcedExecutionReport::new(
+        source_client_id,
+        ExecutionReport::Order(Box::new(report.clone())),
+    );
+    let raw_topic = MessagingSwitchboard::reconciliation_raw_order_status_report_topic();
+    let raw_pattern: msgbus::MStr<msgbus::Pattern> = raw_topic.into();
+    let (raw_handler, raw_saver) = get_any_saving_handler::<OrderStatusReport>(None);
+    msgbus::subscribe_any(raw_pattern, raw_handler.clone(), None);
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+
+    ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced).unwrap();
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+    assert_eq!(raw_saver.get_messages(), vec![report]);
+}
+
+#[rstest]
+fn test_reconcile_sourced_fill_report_publishes_bare_raw_payload(
+    execution_engine: ExecutionEngine,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut execution_engine = execution_engine;
+    let instrument = audusd_sim();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+    let source_client_id = ClientId::from("SOURCE");
+    register_sourced_report_client(
+        &mut execution_engine,
+        source_client_id,
+        AccountId::test_default(),
+        instrument.id().venue,
+        false,
+    );
+    let report = create_fill_report(
+        instrument.id(),
+        Some(ClientOrderId::from("O-RAW-SOURCED-FILL")),
+        VenueOrderId::from("V-RAW-SOURCED-FILL"),
+        TradeId::from("T-RAW-SOURCED-FILL"),
+        Quantity::from(100_000),
+        Price::from("1.00000"),
+    );
+    let sourced = SourcedExecutionReport::new(
+        source_client_id,
+        ExecutionReport::Fill(Box::new(report.clone())),
+    );
+    let raw_topic = MessagingSwitchboard::reconciliation_raw_fill_report_topic();
+    let raw_pattern: msgbus::MStr<msgbus::Pattern> = raw_topic.into();
+    let (raw_handler, raw_saver) = get_any_saving_handler::<FillReport>(None);
+    msgbus::subscribe_any(raw_pattern, raw_handler.clone(), None);
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+
+    ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced).unwrap();
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+    assert_eq!(raw_saver.get_messages(), vec![report]);
+}
+
+#[rstest]
+#[case::order(SourcedPilotReportKind::Order)]
+#[case::fill(SourcedPilotReportKind::Fill)]
+fn test_reconcile_sourced_report_rejects_unregistered_source_before_raw_publish(
+    execution_engine: ExecutionEngine,
+    #[case] report_kind: SourcedPilotReportKind,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let instrument = audusd_sim();
+    let client_order_id = ClientOrderId::from("O-SOURCED-UNREGISTERED");
+    let report = create_sourced_pilot_report(
+        report_kind,
+        AccountId::test_default(),
+        instrument.id(),
+        client_order_id,
+        VenueOrderId::from("V-SOURCED-UNREGISTERED"),
+    );
+    let sourced = SourcedExecutionReport::new(ClientId::from("UNREGISTERED"), report);
+    let (raw_pattern, raw_handler, raw_count) = subscribe_sourced_raw_report_counter(report_kind);
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+
+    let result = ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced);
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+    assert!(result.is_err());
+    assert_eq!(raw_count.get(), 0);
+    let execution_engine = execution_engine.borrow();
+    assert_eq!(execution_engine.report_count(), 0);
+    assert_eq!(execution_engine.event_count(), 0);
+    assert!(
+        !execution_engine
+            .cache()
+            .borrow()
+            .order_exists(&client_order_id)
+    );
+}
+
+#[rstest]
+#[case::order_wrong_account(SourcedPilotReportKind::Order, true, false)]
+#[case::order_unhandled_venue(SourcedPilotReportKind::Order, false, true)]
+#[case::fill_wrong_account(SourcedPilotReportKind::Fill, true, false)]
+#[case::fill_unhandled_venue(SourcedPilotReportKind::Fill, false, true)]
+fn test_reconcile_sourced_report_rejects_scope_before_raw_publish(
+    execution_engine: ExecutionEngine,
+    #[case] report_kind: SourcedPilotReportKind,
+    #[case] wrong_account: bool,
+    #[case] unhandled_venue: bool,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut execution_engine = execution_engine;
+    let source_client_id = ClientId::from("SOURCE");
+    register_sourced_report_client(
+        &mut execution_engine,
+        source_client_id,
+        AccountId::test_default(),
+        Venue::from("SIM"),
+        false,
+    );
+    let client_order_id = ClientOrderId::from("O-SOURCED-SCOPE");
+    let instrument_id = if unhandled_venue {
+        InstrumentId::from("AUDUSD.OTHER")
+    } else {
+        InstrumentId::from("AUDUSD.SIM")
+    };
+    let report = create_sourced_pilot_report(
+        report_kind,
+        if wrong_account {
+            AccountId::from("WRONG-ACCOUNT")
+        } else {
+            AccountId::test_default()
+        },
+        instrument_id,
+        client_order_id,
+        VenueOrderId::from("V-SOURCED-SCOPE"),
+    );
+    let sourced = SourcedExecutionReport::new(source_client_id, report);
+    let (raw_pattern, raw_handler, raw_count) = subscribe_sourced_raw_report_counter(report_kind);
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+
+    let result = ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced);
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+    assert!(result.is_err());
+    assert_eq!(raw_count.get(), 0);
+    let execution_engine = execution_engine.borrow();
+    assert_eq!(execution_engine.report_count(), 0);
+    assert_eq!(execution_engine.event_count(), 0);
+    assert!(
+        !execution_engine
+            .cache()
+            .borrow()
+            .order_exists(&client_order_id)
+    );
+}
+
+#[rstest]
+#[case::order(SourcedPilotReportKind::Order)]
+#[case::fill(SourcedPilotReportKind::Fill)]
+fn test_reconcile_sourced_report_rejects_cached_origin_before_raw_publish(
+    execution_engine: ExecutionEngine,
+    #[case] report_kind: SourcedPilotReportKind,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut execution_engine = execution_engine;
+    let instrument = audusd_sim();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+    let source_client_id = ClientId::from("SOURCE");
+    register_sourced_report_client(
+        &mut execution_engine,
+        source_client_id,
+        AccountId::test_default(),
+        instrument.id().venue,
+        false,
+    );
+    let client_order_id = ClientOrderId::from("O-SOURCED-ORIGIN");
+    let venue_order_id = VenueOrderId::from("V-SOURCED-ORIGIN");
+    let order = add_accepted_sourced_order(
+        &mut execution_engine,
+        instrument.id(),
+        client_order_id,
+        venue_order_id,
+        ClientId::from("OTHER"),
+    );
+    let report = create_sourced_pilot_report(
+        report_kind,
+        AccountId::test_default(),
+        instrument.id(),
+        client_order_id,
+        venue_order_id,
+    );
+    let sourced = SourcedExecutionReport::new(source_client_id, report);
+    let (raw_pattern, raw_handler, raw_count) = subscribe_sourced_raw_report_counter(report_kind);
+    let event_count = execution_engine.event_count();
+    let order_event_count = order.event_count();
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+
+    let result = ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced);
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+    assert!(result.is_err());
+    assert_eq!(raw_count.get(), 0);
+    let execution_engine = execution_engine.borrow();
+    assert_eq!(execution_engine.report_count(), 0);
+    assert_eq!(execution_engine.event_count(), event_count);
+    let cache = execution_engine.cache().borrow();
+    let cached = cache.order(&client_order_id).unwrap();
+    assert_eq!(cached.status(), OrderStatus::Accepted);
+    assert_eq!(cached.event_count(), order_event_count);
+    assert_eq!(
+        cache.client_id(&client_order_id),
+        Some(&ClientId::from("OTHER"))
+    );
+}
+
+#[rstest]
+#[case::order(SourcedPilotReportKind::Order)]
+#[case::fill(SourcedPilotReportKind::Fill)]
+fn test_reconcile_sourced_report_rejects_conflicting_order_ids_before_raw_publish(
+    execution_engine: ExecutionEngine,
+    #[case] report_kind: SourcedPilotReportKind,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut execution_engine = execution_engine;
+    let instrument = audusd_sim();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+    let source_client_id = ClientId::from("SOURCE");
+    let source_client = register_sourced_report_client(
+        &mut execution_engine,
+        source_client_id,
+        AccountId::test_default(),
+        instrument.id().venue,
+        false,
+    );
+    let source_registrations = source_client.registered_external_order_ids();
+    let client_order_id_a = ClientOrderId::from("O-SOURCED-DUAL-A");
+    let client_order_id_b = ClientOrderId::from("O-SOURCED-DUAL-B");
+    let venue_order_id_a = VenueOrderId::from("V-SOURCED-DUAL-A");
+    let venue_order_id_b = VenueOrderId::from("V-SOURCED-DUAL-B");
+    let order_a = add_accepted_sourced_order(
+        &mut execution_engine,
+        instrument.id(),
+        client_order_id_a,
+        venue_order_id_a,
+        source_client_id,
+    );
+    let order_b = add_accepted_sourced_order(
+        &mut execution_engine,
+        instrument.id(),
+        client_order_id_b,
+        venue_order_id_b,
+        source_client_id,
+    );
+    let report = create_sourced_pilot_report(
+        report_kind,
+        AccountId::test_default(),
+        instrument.id(),
+        client_order_id_a,
+        venue_order_id_b,
+    );
+    let sourced = SourcedExecutionReport::new(source_client_id, report);
+    let (raw_pattern, raw_handler, raw_count) = subscribe_sourced_raw_report_counter(report_kind);
+    let event_count = execution_engine.event_count();
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+
+    let result = ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced);
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+    assert!(result.is_err());
+    assert_eq!(raw_count.get(), 0);
+    assert!(source_registrations.borrow().is_empty());
+    let execution_engine = execution_engine.borrow();
+    assert_eq!(execution_engine.report_count(), 0);
+    assert_eq!(execution_engine.event_count(), event_count);
+    let cache = execution_engine.cache().borrow();
+    let cached_a = cache.order(&client_order_id_a).unwrap();
+    let cached_b = cache.order(&client_order_id_b).unwrap();
+    assert_eq!(cached_a.status(), OrderStatus::Accepted);
+    assert_eq!(cached_b.status(), OrderStatus::Accepted);
+    assert_eq!(cached_a.event_count(), order_a.event_count());
+    assert_eq!(cached_b.event_count(), order_b.event_count());
+}
+
+#[rstest]
+#[case::order(SourcedPilotReportKind::Order)]
+#[case::fill(SourcedPilotReportKind::Fill)]
+fn test_reconcile_sourced_report_rechecks_source_after_raw_publish(
+    execution_engine: ExecutionEngine,
+    #[case] report_kind: SourcedPilotReportKind,
+) {
+    *msgbus::get_message_bus().borrow_mut() = MessageBus::default();
+    let mut execution_engine = execution_engine;
+    let instrument = audusd_sim();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+    let source_client_id = ClientId::from("SOURCE");
+    register_sourced_report_client(
+        &mut execution_engine,
+        source_client_id,
+        AccountId::test_default(),
+        instrument.id().venue,
+        false,
+    );
+    let client_order_id = ClientOrderId::from("O-SOURCED-SECOND-FENCE");
+    let venue_order_id = VenueOrderId::from("V-SOURCED-SECOND-FENCE");
+    let order = add_accepted_sourced_order(
+        &mut execution_engine,
+        instrument.id(),
+        client_order_id,
+        venue_order_id,
+        source_client_id,
+    );
+    let report = create_sourced_pilot_report(
+        report_kind,
+        AccountId::test_default(),
+        instrument.id(),
+        client_order_id,
+        venue_order_id,
+    );
+    let sourced = SourcedExecutionReport::new(source_client_id, report);
+    let execution_engine = Rc::new(RefCell::new(execution_engine));
+    let raw_count = Rc::new(Cell::new(0));
+    let raw_count_for_handler = raw_count.clone();
+    let engine_for_handler = execution_engine.clone();
+    let raw_handler = match report_kind {
+        SourcedPilotReportKind::Order => {
+            ShareableMessageHandler::from_typed(move |_report: &OrderStatusReport| {
+                raw_count_for_handler.set(raw_count_for_handler.get() + 1);
+                engine_for_handler
+                    .borrow_mut()
+                    .deregister_client(source_client_id)
+                    .unwrap();
+            })
+        }
+        SourcedPilotReportKind::Fill => {
+            ShareableMessageHandler::from_typed(move |_report: &FillReport| {
+                raw_count_for_handler.set(raw_count_for_handler.get() + 1);
+                engine_for_handler
+                    .borrow_mut()
+                    .deregister_client(source_client_id)
+                    .unwrap();
+            })
+        }
+    };
+    let raw_topic = match report_kind {
+        SourcedPilotReportKind::Order => {
+            MessagingSwitchboard::reconciliation_raw_order_status_report_topic()
+        }
+        SourcedPilotReportKind::Fill => {
+            MessagingSwitchboard::reconciliation_raw_fill_report_topic()
+        }
+    };
+    let raw_pattern: msgbus::MStr<msgbus::Pattern> = raw_topic.into();
+    msgbus::subscribe_any(raw_pattern, raw_handler.clone(), None);
+    let event_count = execution_engine.borrow().event_count();
+
+    let result = ExecutionEngine::reconcile_sourced_execution_report(&execution_engine, &sourced);
+
+    msgbus::unsubscribe_any(raw_pattern, &raw_handler);
+    assert!(result.is_err());
+    assert_eq!(raw_count.get(), 1);
+    let execution_engine = execution_engine.borrow();
+    assert!(execution_engine.get_client(&source_client_id).is_none());
+    assert_eq!(execution_engine.report_count(), 0);
+    assert_eq!(execution_engine.event_count(), event_count);
+    let cached = execution_engine
+        .cache()
+        .borrow()
+        .order(&client_order_id)
+        .unwrap()
+        .clone();
+    assert_eq!(cached.status(), OrderStatus::Accepted);
+    assert_eq!(cached.event_count(), order.event_count());
 }
 
 #[rstest]

--- a/crates/execution/tests/matching_engine/cache_database.rs
+++ b/crates/execution/tests/matching_engine/cache_database.rs
@@ -61,6 +61,11 @@ impl FailNthAddOrderDatabaseControl {
         state.add_order_calls = 0;
     }
 
+    #[allow(dead_code, reason = "used by the execution engine test target")]
+    pub(super) fn add_order_calls(&self) -> usize {
+        self.state.lock().unwrap().add_order_calls
+    }
+
     #[allow(
         dead_code,
         reason = "used by the exec_engine test target sharing this module"

--- a/crates/live/src/execution/emitter.rs
+++ b/crates/live/src/execution/emitter.rs
@@ -70,6 +70,18 @@ impl ExecutionEventTarget {
             Self::Sourced(sink) => sink.send(event),
         }
     }
+
+    fn send_bootstrap_account(
+        &self,
+        state: AccountState,
+    ) -> Result<(), Box<tokio::sync::mpsc::error::SendError<ExecutionEvent>>> {
+        match self {
+            Self::Legacy(sender) => sender
+                .send(ExecutionEvent::Account(state))
+                .map_err(Box::new),
+            Self::Sourced(sink) => sink.send_bootstrap_account(state),
+        }
+    }
 }
 
 /// Event emitter for live trading - combines event generation with async dispatch.
@@ -516,6 +528,25 @@ impl ExecutionEventEmitter {
             .map_err(|e| anyhow::anyhow!("Failed to send account state: {e}"))
     }
 
+    /// Emits the source-bound account barrier required while an execution client connects.
+    ///
+    /// Legacy targets receive an ordinary account event. Sourced targets retain the account's
+    /// bootstrap purpose until the live node applies the barrier.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the sender is uninitialized or its receiver is closed.
+    #[doc(hidden)]
+    pub fn try_send_bootstrap_account_state(&self, state: AccountState) -> anyhow::Result<()> {
+        let target = self.target.load();
+        let target = target.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("Cannot send bootstrap account state: sender not initialized")
+        })?;
+        target
+            .send_bootstrap_account(state)
+            .map_err(|e| anyhow::anyhow!("Failed to send bootstrap account state: {e}"))
+    }
+
     /// Emits an execution report.
     pub fn send_execution_report(&self, report: ExecutionReport) {
         if let Err(e) = self.try_send_execution_report(report) {
@@ -561,8 +592,8 @@ impl ExecutionEventEmitter {
 
 #[cfg(test)]
 mod tests {
-    use nautilus_core::time::get_atomic_clock_static;
     use nautilus_common::live::runner::get_exec_event_sender;
+    use nautilus_core::time::get_atomic_clock_static;
     use nautilus_model::{
         enums::PositionSide, events::order::spec::OrderSubmittedSpec, identifiers::ClientId,
     };
@@ -603,6 +634,20 @@ mod tests {
         )
     }
 
+    fn test_account_state(event_id: UUID4) -> AccountState {
+        AccountState::new(
+            AccountId::from("BYBIT-001"),
+            AccountType::Margin,
+            vec![],
+            vec![],
+            true,
+            event_id,
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            None,
+        )
+    }
+
     #[rstest]
     fn test_clone_before_set_sender_observes_sender() {
         let mut emitter = test_emitter();
@@ -638,9 +683,10 @@ mod tests {
         else {
             panic!("expected sourced execution event");
         };
-        assert_eq!(sourced.client_id, source_client_id);
+        let (client_id, event) = sourced.into_parts();
+        assert_eq!(client_id, source_client_id);
         assert!(matches!(
-            sourced.event,
+            event,
             ExecutionEvent::Report(ExecutionReport::Position(_))
         ));
     }
@@ -663,9 +709,10 @@ mod tests {
         else {
             panic!("expected sourced execution event");
         };
-        assert_eq!(sourced.client_id, source_client_id);
+        let (client_id, event) = sourced.into_parts();
+        assert_eq!(client_id, source_client_id);
         assert!(matches!(
-            sourced.event,
+            event,
             ExecutionEvent::Report(ExecutionReport::Position(_))
         ));
     }
@@ -735,6 +782,68 @@ mod tests {
         let result = emitter.try_send_order_event(OrderEventAny::Submitted(
             OrderSubmittedSpec::builder().build(),
         ));
+
+        assert!(result.is_err());
+        assert!(channels.exec_evt_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_sourced_bootstrap_account_retains_its_purpose() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let source_client_id = ClientId::from("BYBIT");
+        let event_id = UUID4::new();
+        let mut emitter = test_emitter();
+        emitter.set_sender(get_exec_event_sender());
+        emitter.set_sourced_sink(get_sourced_exec_event_sink(source_client_id));
+
+        emitter
+            .try_send_bootstrap_account_state(test_account_state(event_id))
+            .unwrap();
+
+        let (mut channels, mut sourced_rx) = runner.take_channels_with_sourced();
+        assert!(channels.exec_evt_rx.try_recv().is_err());
+        let Some(ExecutionEventIngress::Sourced(
+            crate::runner::SourcedExecutionEvent::BootstrapAccount { client_id, state },
+        )) = sourced_rx.try_recv(&mut channels.exec_evt_rx)
+        else {
+            panic!("expected sourced bootstrap account event");
+        };
+        assert_eq!(client_id, source_client_id);
+        assert_eq!(state.event_id, event_id);
+    }
+
+    #[rstest]
+    fn test_legacy_bootstrap_account_is_an_ordinary_account_event() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let event_id = UUID4::new();
+        let mut emitter = test_emitter();
+        emitter.set_sender(get_exec_event_sender());
+
+        emitter
+            .try_send_bootstrap_account_state(test_account_state(event_id))
+            .unwrap();
+
+        let (mut channels, mut sourced_rx) = runner.take_channels_with_sourced();
+        let ExecutionEvent::Account(state) = channels.exec_evt_rx.try_recv().unwrap() else {
+            panic!("expected ordinary account event");
+        };
+        assert_eq!(state.event_id, event_id);
+        assert!(sourced_rx.try_recv(&mut channels.exec_evt_rx).is_none());
+    }
+
+    #[rstest]
+    fn test_closed_sourced_target_rejects_bootstrap_without_legacy_fallback() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let mut emitter = test_emitter();
+        emitter.set_sender(get_exec_event_sender());
+        emitter.set_sourced_sink(get_sourced_exec_event_sink(ClientId::from("BYBIT")));
+        let (mut channels, sourced_rx) = runner.take_channels_with_sourced();
+        drop(sourced_rx);
+
+        let result = emitter.try_send_bootstrap_account_state(test_account_state(UUID4::new()));
 
         assert!(result.is_err());
         assert!(channels.exec_evt_rx.try_recv().is_err());

--- a/crates/live/src/execution/emitter.rs
+++ b/crates/live/src/execution/emitter.rs
@@ -26,7 +26,7 @@
 //! |-- core: ExecutionClientCore    (identity + connection state)
 //! `-- emitter: ExecutionEventEmitter   (event generation + async dispatch)
 //!     |-- factory: OrderEventFactory
-//!     `-- sender: ArcSwapOption<Sender>   (set in start())
+//!     `-- target: ArcSwapOption<Legacy | Sourced>   (set in start())
 //! ```
 
 use std::sync::Arc;
@@ -52,25 +52,47 @@ use nautilus_model::{
     types::{AccountBalance, Currency, MarginBalance, Money, Price, Quantity},
 };
 
+use crate::runner::SourcedExecutionEventSink;
+
+#[derive(Debug, Clone)]
+enum ExecutionEventTarget {
+    Legacy(tokio::sync::mpsc::UnboundedSender<ExecutionEvent>),
+    Sourced(SourcedExecutionEventSink),
+}
+
+impl ExecutionEventTarget {
+    fn send(
+        &self,
+        event: ExecutionEvent,
+    ) -> Result<(), Box<tokio::sync::mpsc::error::SendError<ExecutionEvent>>> {
+        match self {
+            Self::Legacy(sender) => sender.send(event).map_err(Box::new),
+            Self::Sourced(sink) => sink.send(event),
+        }
+    }
+}
+
 /// Event emitter for live trading - combines event generation with async dispatch.
 ///
 /// This struct wraps an [`OrderEventFactory`] for event construction and an unbounded
-/// channel sender for async dispatch. It provides `emit_*` convenience methods that
+/// dispatch target. It provides `emit_*` convenience methods that
 /// generate and send events in a single call.
 ///
-/// The sender is set during the adapter's `start()` phase via [`set_sender`](Self::set_sender).
-/// Clones share the sender slot and observe later sender installations and replacements.
+/// The dispatch target is set during the adapter's `start()` phase via
+/// [`set_sender`](Self::set_sender) or [`set_sourced_sink`](Self::set_sourced_sink).
+/// Clones share the target slot and observe later target installations and replacements.
 #[derive(Debug, Clone)]
 pub struct ExecutionEventEmitter {
     clock: &'static AtomicTime,
     factory: OrderEventFactory,
-    sender: Arc<ArcSwapOption<tokio::sync::mpsc::UnboundedSender<ExecutionEvent>>>,
+    target: Arc<ArcSwapOption<ExecutionEventTarget>>,
 }
 
 impl ExecutionEventEmitter {
     /// Creates a new [`ExecutionEventEmitter`] with no sender.
     ///
-    /// Call [`set_sender`](Self::set_sender) in the adapter's `start()` method.
+    /// Call [`set_sender`](Self::set_sender) or [`set_sourced_sink`](Self::set_sourced_sink) in the
+    /// adapter's `start()` method.
     #[must_use]
     pub fn new(
         clock: &'static AtomicTime,
@@ -82,7 +104,7 @@ impl ExecutionEventEmitter {
         Self {
             clock,
             factory: OrderEventFactory::new(trader_id, account_id, account_type, base_currency),
-            sender: Arc::new(ArcSwapOption::empty()),
+            target: Arc::new(ArcSwapOption::empty()),
         }
     }
 
@@ -94,13 +116,20 @@ impl ExecutionEventEmitter {
     ///
     /// Call in the adapter's `start()` method.
     pub fn set_sender(&mut self, sender: tokio::sync::mpsc::UnboundedSender<ExecutionEvent>) {
-        self.sender.store(Some(Arc::new(sender)));
+        self.target
+            .store(Some(Arc::new(ExecutionEventTarget::Legacy(sender))));
+    }
+
+    /// Sets a source-bound sink. Call in an opted-in adapter's `start()`.
+    pub fn set_sourced_sink(&mut self, sink: SourcedExecutionEventSink) {
+        self.target
+            .store(Some(Arc::new(ExecutionEventTarget::Sourced(sink))));
     }
 
     /// Returns true if the sender is initialized for this emitter and its clones.
     #[must_use]
     pub fn is_initialized(&self) -> bool {
-        self.sender.load().is_some()
+        self.target.load().is_some()
     }
 
     /// Returns the trader ID.
@@ -425,20 +454,20 @@ impl ExecutionEventEmitter {
     ///
     /// Returns an error if the sender is uninitialized or its receiver is closed.
     pub fn try_send_order_event(&self, event: OrderEventAny) -> anyhow::Result<()> {
-        let sender = self.sender.load();
-        let sender = sender
+        let target = self.target.load();
+        let target = target
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Cannot send order event: sender not initialized"))?;
-        sender
+        target
             .send(ExecutionEvent::Order(event))
             .map_err(|e| anyhow::anyhow!("Failed to send order event: {e}"))
     }
 
     /// Emits a batch of order submitted events as a single channel message.
     pub fn send_order_submitted_batch(&self, batch: OrderSubmittedBatch) {
-        let sender = self.sender.load();
-        if let Some(sender) = sender.as_ref() {
-            if let Err(e) = sender.send(ExecutionEvent::OrderSubmittedBatch(batch)) {
+        let target = self.target.load();
+        if let Some(target) = target.as_ref() {
+            if let Err(e) = target.send(ExecutionEvent::OrderSubmittedBatch(batch)) {
                 log::warn!("Failed to send order submitted batch: {e}");
             }
         } else {
@@ -448,9 +477,9 @@ impl ExecutionEventEmitter {
 
     /// Emits a batch of order accepted events as a single channel message.
     pub fn send_order_accepted_batch(&self, batch: OrderAcceptedBatch) {
-        let sender = self.sender.load();
-        if let Some(sender) = sender.as_ref() {
-            if let Err(e) = sender.send(ExecutionEvent::OrderAcceptedBatch(batch)) {
+        let target = self.target.load();
+        if let Some(target) = target.as_ref() {
+            if let Err(e) = target.send(ExecutionEvent::OrderAcceptedBatch(batch)) {
                 log::warn!("Failed to send order accepted batch: {e}");
             }
         } else {
@@ -460,9 +489,9 @@ impl ExecutionEventEmitter {
 
     /// Emits a batch of order canceled events as a single channel message.
     pub fn send_order_canceled_batch(&self, batch: OrderCanceledBatch) {
-        let sender = self.sender.load();
-        if let Some(sender) = sender.as_ref() {
-            if let Err(e) = sender.send(ExecutionEvent::OrderCanceledBatch(batch)) {
+        let target = self.target.load();
+        if let Some(target) = target.as_ref() {
+            if let Err(e) = target.send(ExecutionEvent::OrderCanceledBatch(batch)) {
                 log::warn!("Failed to send order canceled batch: {e}");
             }
         } else {
@@ -478,11 +507,11 @@ impl ExecutionEventEmitter {
     }
 
     fn try_send_account_state(&self, state: AccountState) -> anyhow::Result<()> {
-        let sender = self.sender.load();
-        let sender = sender
+        let target = self.target.load();
+        let target = target
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Cannot send account state: sender not initialized"))?;
-        sender
+        target
             .send(ExecutionEvent::Account(state))
             .map_err(|e| anyhow::anyhow!("Failed to send account state: {e}"))
     }
@@ -500,11 +529,11 @@ impl ExecutionEventEmitter {
     ///
     /// Returns an error if the sender is not initialized or the receiving channel is closed.
     pub fn try_send_execution_report(&self, report: ExecutionReport) -> anyhow::Result<()> {
-        let sender = self.sender.load();
-        let sender = sender.as_ref().ok_or_else(|| {
+        let target = self.target.load();
+        let target = target.as_ref().ok_or_else(|| {
             anyhow::anyhow!("Cannot send execution report: sender not initialized")
         })?;
-        sender
+        target
             .send(ExecutionEvent::Report(report))
             .map_err(|e| anyhow::anyhow!("Failed to send execution report: {e}"))
     }
@@ -533,22 +562,26 @@ impl ExecutionEventEmitter {
 #[cfg(test)]
 mod tests {
     use nautilus_core::time::get_atomic_clock_static;
-    use nautilus_model::events::order::spec::OrderSubmittedSpec;
+    use nautilus_common::live::runner::get_exec_event_sender;
+    use nautilus_model::{
+        enums::PositionSide, events::order::spec::OrderSubmittedSpec, identifiers::ClientId,
+    };
     use rstest::rstest;
 
     use super::*;
+    use crate::runner::{AsyncRunner, ExecutionEventIngress, get_sourced_exec_event_sink};
 
-    fn create_emitter() -> ExecutionEventEmitter {
+    fn test_emitter() -> ExecutionEventEmitter {
         ExecutionEventEmitter::new(
             get_atomic_clock_static(),
-            TraderId::from("TRADER-001"),
-            AccountId::from("SIM-001"),
-            AccountType::Cash,
+            TraderId::from("TESTER-001"),
+            AccountId::from("BYBIT-001"),
+            AccountType::Margin,
             None,
         )
     }
 
-    fn create_order_event() -> OrderEventAny {
+    fn test_order_event() -> OrderEventAny {
         OrderEventAny::Submitted(
             OrderSubmittedSpec::builder()
                 .client_order_id(ClientOrderId::from("O-001"))
@@ -556,16 +589,30 @@ mod tests {
         )
     }
 
+    fn test_position_report() -> PositionStatusReport {
+        PositionStatusReport::new(
+            AccountId::from("BYBIT-001"),
+            InstrumentId::from("BTCUSDT-LINEAR.BYBIT"),
+            PositionSide::Long,
+            Quantity::from(1),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            None,
+            Some(PositionId::from("P-BYBIT-001")),
+            None,
+        )
+    }
+
     #[rstest]
     fn test_clone_before_set_sender_observes_sender() {
-        let mut emitter = create_emitter();
+        let mut emitter = test_emitter();
         let cloned = emitter.clone();
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         emitter.set_sender(tx);
 
         assert!(cloned.is_initialized());
-        cloned.send_order_event(create_order_event());
+        cloned.send_order_event(test_order_event());
         assert!(matches!(
             rx.try_recv(),
             Ok(ExecutionEvent::Order(OrderEventAny::Submitted(_)))
@@ -573,14 +620,65 @@ mod tests {
     }
 
     #[rstest]
+    fn test_clone_before_set_sourced_sink_observes_sink() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let source_client_id = ClientId::from("BYBIT");
+        let mut emitter = test_emitter();
+        let cloned = emitter.clone();
+
+        emitter.set_sourced_sink(get_sourced_exec_event_sink(source_client_id));
+
+        assert!(cloned.is_initialized());
+        cloned.send_position_report(test_position_report());
+        let (mut channels, mut sourced_rx) = runner.take_channels_with_sourced();
+        assert!(channels.exec_evt_rx.try_recv().is_err());
+        let Some(ExecutionEventIngress::Sourced(sourced)) =
+            sourced_rx.try_recv(&mut channels.exec_evt_rx)
+        else {
+            panic!("expected sourced execution event");
+        };
+        assert_eq!(sourced.client_id, source_client_id);
+        assert!(matches!(
+            sourced.event,
+            ExecutionEvent::Report(ExecutionReport::Position(_))
+        ));
+    }
+
+    #[rstest]
+    fn test_sourced_target_replaces_legacy_target() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let source_client_id = ClientId::from("BYBIT");
+        let mut emitter = test_emitter();
+        emitter.set_sender(get_exec_event_sender());
+        emitter.set_sourced_sink(get_sourced_exec_event_sink(source_client_id));
+
+        emitter.send_position_report(test_position_report());
+
+        let (mut channels, mut sourced_rx) = runner.take_channels_with_sourced();
+        assert!(channels.exec_evt_rx.try_recv().is_err());
+        let Some(ExecutionEventIngress::Sourced(sourced)) =
+            sourced_rx.try_recv(&mut channels.exec_evt_rx)
+        else {
+            panic!("expected sourced execution event");
+        };
+        assert_eq!(sourced.client_id, source_client_id);
+        assert!(matches!(
+            sourced.event,
+            ExecutionEvent::Report(ExecutionReport::Position(_))
+        ));
+    }
+
+    #[rstest]
     fn test_set_sender_replaces_existing_sender() {
-        let mut emitter = create_emitter();
+        let mut emitter = test_emitter();
         let (tx_a, mut rx_a) = tokio::sync::mpsc::unbounded_channel();
         let (tx_b, mut rx_b) = tokio::sync::mpsc::unbounded_channel();
 
         emitter.set_sender(tx_a);
         emitter.set_sender(tx_b);
-        emitter.send_order_event(create_order_event());
+        emitter.send_order_event(test_order_event());
 
         assert!(matches!(
             rx_a.try_recv(),
@@ -594,16 +692,68 @@ mod tests {
 
     #[rstest]
     fn test_never_initialized_sender_drops_or_errors() {
-        let emitter = create_emitter();
+        let emitter = test_emitter();
 
-        emitter.send_order_event(create_order_event());
+        emitter.send_order_event(test_order_event());
         let error = emitter
-            .try_send_order_event(create_order_event())
+            .try_send_order_event(test_order_event())
             .unwrap_err();
 
         assert_eq!(
             error.to_string(),
             "Cannot send order event: sender not initialized"
         );
+    }
+
+    #[rstest]
+    fn test_closed_sourced_target_returns_report_error_without_legacy_fallback() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let mut emitter = test_emitter();
+        emitter.set_sender(get_exec_event_sender());
+        emitter.set_sourced_sink(get_sourced_exec_event_sink(ClientId::from("BYBIT")));
+        let (mut channels, sourced_rx) = runner.take_channels_with_sourced();
+        drop(sourced_rx);
+
+        let result = emitter
+            .try_send_execution_report(ExecutionReport::Position(Box::new(test_position_report())));
+
+        assert!(result.is_err());
+        assert!(channels.exec_evt_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_closed_sourced_target_returns_order_error_without_legacy_fallback() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let mut emitter = test_emitter();
+        emitter.set_sender(get_exec_event_sender());
+        emitter.set_sourced_sink(get_sourced_exec_event_sink(ClientId::from("BYBIT")));
+        let (mut channels, sourced_rx) = runner.take_channels_with_sourced();
+        drop(sourced_rx);
+
+        let result = emitter.try_send_order_event(OrderEventAny::Submitted(
+            OrderSubmittedSpec::builder().build(),
+        ));
+
+        assert!(result.is_err());
+        assert!(channels.exec_evt_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_legacy_target_remains_unchanged() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let mut emitter = test_emitter();
+        emitter.set_sender(get_exec_event_sender());
+
+        emitter.send_position_report(test_position_report());
+
+        let (mut channels, mut sourced_rx) = runner.take_channels_with_sourced();
+        assert!(matches!(
+            channels.exec_evt_rx.try_recv().unwrap(),
+            ExecutionEvent::Report(ExecutionReport::Position(_))
+        ));
+        assert!(sourced_rx.try_recv(&mut channels.exec_evt_rx).is_none());
     }
 }

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -3472,8 +3472,9 @@ impl ExecutionManager {
 
     /// Observes an incoming execution report and updates tracking state.
     ///
-    /// This should be called **before** the report is dispatched to the execution
-    /// engine, so that the manager's state is current when periodic checks run.
+    /// Legacy ingress calls this **before** dispatch so the manager's state is current when
+    /// periodic checks run. Source-bound strict ingress calls it only after successful engine
+    /// reconciliation so a rejected report cannot mutate tracking state.
     ///
     /// Updates performed per report variant:
     /// - `Order`: updates reconciliation tracking based on order status

--- a/crates/live/src/node/metrics.rs
+++ b/crates/live/src/node/metrics.rs
@@ -857,10 +857,10 @@ mod tests {
             exec_evt_tx.send(stub_exec_event()).unwrap();
         }
         sourced_exec_evt_tx
-            .send(SourcedExecutionEvent {
-                client_id: ClientId::from("SIM"),
-                event: stub_exec_event(),
-            })
+            .send(SourcedExecutionEvent::runtime(
+                ClientId::from("SIM"),
+                stub_exec_event(),
+            ))
             .unwrap();
 
         for _ in 0..3 {

--- a/crates/live/src/node/metrics.rs
+++ b/crates/live/src/node/metrics.rs
@@ -23,6 +23,10 @@ use nautilus_common::{
     runner::{SystemChannel, TimeEventMessage, TradingCommandMessage},
 };
 
+#[cfg(test)]
+use crate::runner::SourcedExecutionEvent;
+use crate::runner::SourcedExecutionIngress;
+
 /// Primitive metrics for one `LiveNode::run` dispatch channel after startup.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -358,13 +362,14 @@ impl RunnerChannelQueueDepths {
     pub(crate) fn from_receivers(
         time_events: &tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
         exec_events: &tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+        sourced_exec_events: &SourcedExecutionIngress,
         exec_commands: &tokio::sync::mpsc::UnboundedReceiver<TradingCommandMessage>,
         data_events: &tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
         data_commands: &tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
     ) -> Self {
         Self {
             time_events: time_events.len(),
-            exec_events: exec_events.len(),
+            exec_events: exec_events.len().saturating_add(sourced_exec_events.len()),
             exec_commands: exec_commands.len(),
             data_events: data_events.len(),
             data_commands: data_commands.len(),
@@ -438,7 +443,7 @@ mod tests {
     use nautilus_model::{
         enums::AccountType,
         events::account::state::AccountState,
-        identifiers::{AccountId, TraderId, Venue},
+        identifiers::{AccountId, ClientId, TraderId, Venue},
         instruments::{InstrumentAny, stubs::crypto_perpetual_ethusdt},
     };
     use rstest::rstest;
@@ -838,6 +843,9 @@ mod tests {
     fn test_runner_metrics_queue_depths_use_receiver_lengths() {
         let (time_tx, time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
         let (exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        let (sourced_exec_evt_tx, sourced_exec_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SourcedExecutionEvent>();
+        let sourced_exec_ingress = SourcedExecutionIngress::new(sourced_exec_evt_rx);
         let (exec_cmd_tx, exec_cmd_rx) =
             tokio::sync::mpsc::unbounded_channel::<TradingCommandMessage>();
         let (data_evt_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
@@ -848,6 +856,12 @@ mod tests {
         for _ in 0..2 {
             exec_evt_tx.send(stub_exec_event()).unwrap();
         }
+        sourced_exec_evt_tx
+            .send(SourcedExecutionEvent {
+                client_id: ClientId::from("SIM"),
+                event: stub_exec_event(),
+            })
+            .unwrap();
 
         for _ in 0..3 {
             exec_cmd_tx
@@ -870,6 +884,7 @@ mod tests {
             RunnerChannelQueueDepths::from_receivers(
                 &time_rx,
                 &exec_evt_rx,
+                &sourced_exec_ingress,
                 &exec_cmd_rx,
                 &data_evt_rx,
                 &data_cmd_rx,
@@ -879,7 +894,7 @@ mod tests {
         let snapshot = metrics.snapshot();
 
         assert_eq!(snapshot.time_events.queue_depth, 1);
-        assert_eq!(snapshot.exec_events.queue_depth, 2);
+        assert_eq!(snapshot.exec_events.queue_depth, 3);
         assert_eq!(snapshot.exec_commands.queue_depth, 3);
         assert_eq!(snapshot.data_events.queue_depth, 4);
         assert_eq!(snapshot.data_commands.queue_depth, 5);

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -167,14 +167,6 @@ pub use state::{LiveNodeHandle, NodeRunMode, NodeState};
 /// which shows up as lapsed heartbeats and reconnects rather than as backpressure.
 const DISPATCHES_PER_YIELD: usize = 64;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum StrictSourcedReportResult {
-    PreflightRejected,
-    RecentlyProcessed,
-    ReconciliationRejected,
-    Applied,
-}
-
 /// High-level abstraction for a live Nautilus system node.
 ///
 /// Provides a simplified interface for running live systems
@@ -2055,13 +2047,9 @@ impl LiveNode {
     /// Validates and applies a strict sourced report before mutating manager observation state.
     ///
     /// The preflight precedes recent-fill deduplication. The shared engine entry applies both
-    /// validation fences and returns a result, so manager activity and close tracking are updated
-    /// only after the report was accepted by the engine.
-    fn process_strict_sourced_exec_report(
-        &mut self,
-        client_id: ClientId,
-        report: ExecutionReport,
-    ) -> StrictSourcedReportResult {
+    /// validation fences, so manager activity and close tracking are updated only after the report
+    /// was accepted by the engine.
+    fn process_strict_sourced_exec_report(&mut self, client_id: ClientId, report: ExecutionReport) {
         let sourced = SourcedExecutionReport::new(client_id, report);
 
         if let Err(e) = self
@@ -2071,7 +2059,7 @@ impl LiveNode {
             .preflight_sourced_execution_report(&sourced)
         {
             log::error!("Cannot dispatch sourced execution report: {e:#}");
-            return StrictSourcedReportResult::PreflightRejected;
+            return;
         }
 
         if let ExecutionReport::Fill(fill_report) = &sourced.report
@@ -2085,22 +2073,20 @@ impl LiveNode {
                 "Skipping recently processed sourced fill report: {}",
                 fill_report.trade_id,
             );
-            return StrictSourcedReportResult::RecentlyProcessed;
+            return;
         }
 
         if let Err(e) =
             ExecutionEngine::reconcile_sourced_execution_report(&self.kernel.exec_engine, &sourced)
         {
             log::error!("Cannot reconcile sourced execution report: {e:#}");
-            return StrictSourcedReportResult::ReconciliationRejected;
+            return;
         }
 
         self.exec_manager.observe_execution_report(&sourced.report);
         if let Some(client_order_id) = Self::closed_order_report_client_order_id(&sourced.report) {
             self.clear_closed_recon_tracking(&[client_order_id]);
         }
-
-        StrictSourcedReportResult::Applied
     }
 
     fn clear_closed_recon_tracking(&mut self, close_ids: &[ClientOrderId]) {
@@ -3889,6 +3875,7 @@ async fn drive_with_event_buffering<F: std::future::Future>(
                         if sourced_account_handling == SourcedAccountHandling::Dispatch
                             && matches!(&event.event, ExecutionEvent::Account(_)) =>
                     {
+                        pending.drain_sourced_exec_events();
                         AsyncRunner::handle_sourced_exec_event(event);
                     }
                     ingress => pending.buffer_execution_ingress(ingress),
@@ -3996,12 +3983,16 @@ impl PendingEvents {
             AsyncRunner::handle_exec_event(ExecutionEvent::Order(evt));
         }
 
-        for evt in self.sourced_exec_evts.drain(..) {
-            AsyncRunner::handle_sourced_exec_event(evt);
-        }
+        self.drain_sourced_exec_events();
 
         for cmd in self.exec_cmds.drain(..) {
             AsyncRunner::handle_trading_command(cmd);
+        }
+    }
+
+    fn drain_sourced_exec_events(&mut self) {
+        for evt in self.sourced_exec_evts.drain(..) {
+            AsyncRunner::handle_sourced_exec_event(evt);
         }
     }
 
@@ -4816,10 +4807,20 @@ mod tests {
             .unwrap()
             .event_count();
 
-        let rejected = node.process_strict_sourced_exec_report(
-            ClientId::from("UNREGISTERED-SOURCE"),
-            ExecutionReport::Fill(Box::new((*report).clone())),
-        );
+        node.process_sourced_exec_event(SourcedExecutionEvent {
+            client_id: ClientId::from("UNREGISTERED-SOURCE"),
+            event: ExecutionEvent::Report(ExecutionReport::Fill(Box::new((*report).clone()))),
+        });
+
+        {
+            let engine = node.kernel.exec_engine.borrow();
+            assert_eq!(engine.report_count(), report_count);
+            assert_eq!(engine.event_count(), event_count);
+            let cache = engine.cache().borrow();
+            let cached = cache.order(&fill.client_order_id).unwrap();
+            assert_eq!(cached.status(), OrderStatus::Accepted);
+            assert_eq!(cached.event_count(), cached_event_count);
+        }
 
         let source_client_id = ClientId::from("TEST-RECENT-FILL");
         let source_client = StubExecutionClient::new(
@@ -4836,11 +4837,11 @@ mod tests {
             .register_client(Box::new(source_client))
             .unwrap();
 
-        let deduplicated = node
-            .process_strict_sourced_exec_report(source_client_id, ExecutionReport::Fill(report));
+        node.process_sourced_exec_event(SourcedExecutionEvent {
+            client_id: source_client_id,
+            event: ExecutionEvent::Report(ExecutionReport::Fill(report)),
+        });
 
-        assert_eq!(rejected, StrictSourcedReportResult::PreflightRejected);
-        assert_eq!(deduplicated, StrictSourcedReportResult::RecentlyProcessed);
         assert!(source_registrations.borrow().is_empty());
         let engine = node.kernel.exec_engine.borrow();
         assert_eq!(engine.report_count(), report_count);
@@ -8500,15 +8501,15 @@ mod tests {
 
     #[rstest]
     #[tokio::test(start_paused = true)]
-    async fn test_sourced_account_registers_while_execution_client_connects() {
+    async fn test_sourced_bootstrap_account_preserves_lane_fifo_while_execution_client_connects() {
         msgbus::get_message_bus().borrow_mut().dispose();
         let account_id = AccountId::from("SOURCE-CONNECT-001");
         let cache = Rc::new(RefCell::new(Cache::default()));
-        let received = Rc::new(Cell::new(0));
+        let dispatch_order = Rc::new(RefCell::new(Vec::new()));
         let (account_registered_tx, account_registered_rx) = tokio::sync::oneshot::channel();
         let account_registered_tx = Rc::new(RefCell::new(Some(account_registered_tx)));
         let handler_cache = cache.clone();
-        let handler_received = received.clone();
+        let account_dispatch_order = dispatch_order.clone();
         let handler_account_registered_tx = account_registered_tx.clone();
         msgbus::register_account_state_endpoint(
             MessagingSwitchboard::portfolio_update_account(),
@@ -8517,12 +8518,24 @@ mod tests {
                     .borrow_mut()
                     .add_account(AccountAny::Margin(MarginAccount::new(state.clone(), true)))
                     .unwrap();
-                handler_received.set(handler_received.get() + 1);
+                account_dispatch_order.borrow_mut().push("account");
 
                 if let Some(tx) = handler_account_registered_tx.borrow_mut().take() {
                     tx.send(())
                         .expect("execution client connect should await account registration");
                 }
+            }),
+        );
+        let report_dispatch_order = dispatch_order.clone();
+        msgbus::register_sourced_execution_report_endpoint(
+            MessagingSwitchboard::exec_engine_reconcile_sourced_execution_report(),
+            TypedIntoHandler::from(move |report: SourcedExecutionReport| {
+                let kind = match report.report {
+                    ExecutionReport::Order(_) => "order",
+                    ExecutionReport::Fill(_) => "fill",
+                    _ => panic!("unexpected non-strict sourced execution report"),
+                };
+                report_dispatch_order.borrow_mut().push(kind);
             }),
         );
 
@@ -8544,7 +8557,6 @@ mod tests {
         let connect_account_id = account_id;
         let connect = async move {
             sink.send(stub_order_report_event()).unwrap();
-            sink.send(stub_exec_event()).unwrap();
             sink.send(ExecutionEvent::Account(AccountState::new(
                 connect_account_id,
                 AccountType::Margin,
@@ -8561,6 +8573,7 @@ mod tests {
             account_registered_rx
                 .await
                 .expect("account registration handler should remain available");
+            sink.send(stub_exec_event()).unwrap();
         };
         let mut pending = PendingEvents::default();
 
@@ -8583,17 +8596,25 @@ mod tests {
         .await
         .expect("sourced account should be registered during execution client connect");
 
+        flush_all_pending(
+            &mut pending,
+            &mut time_evt_rx,
+            &mut system_evt_rx,
+            &mut system_cmd_rx,
+            &mut exec_evt_rx,
+            &mut sourced_exec,
+            &mut exec_cmd_rx,
+            &mut data_evt_rx,
+            &mut data_cmd_rx,
+        );
+
         assert!(cache.borrow().account(&account_id).is_some());
-        assert_eq!(received.get(), 1);
-        assert_eq!(pending.sourced_exec_evts.len(), 2);
-        assert!(matches!(
-            &pending.sourced_exec_evts[0].event,
-            ExecutionEvent::Report(ExecutionReport::Order(_))
-        ));
-        assert!(matches!(
-            &pending.sourced_exec_evts[1].event,
-            ExecutionEvent::Report(ExecutionReport::Fill(_))
-        ));
+        assert_eq!(
+            dispatch_order.borrow().as_slice(),
+            &["order", "account", "fill"]
+        );
+        assert!(pending.is_empty());
+        msgbus::get_message_bus().borrow_mut().dispose();
     }
 
     #[rstest]

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -1076,6 +1076,7 @@ impl LiveNode {
         // This ensures the cache is populated before execution clients connect.
         let data_connect_result = drive_with_event_buffering(
             self.connect_data_phase(connection_deadline),
+            SourcedAccountHandling::Buffer,
             &mut pending,
             &mut time_evt_rx,
             &mut system_evt_rx,
@@ -1131,6 +1132,7 @@ impl LiveNode {
         // Startup phase 2: Connect execution clients (instruments now in cache)
         let engine_connection_result = drive_with_event_buffering(
             self.connect_exec_phase(connection_deadline),
+            SourcedAccountHandling::Dispatch,
             &mut pending,
             &mut time_evt_rx,
             &mut system_evt_rx,
@@ -3834,17 +3836,25 @@ fn flush_all_pending(
     pending.drain();
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SourcedAccountHandling {
+    Buffer,
+    Dispatch,
+}
+
 /// Drives a future to completion while buffering channel events.
 ///
-/// Time events are handled immediately. Legacy account events are forwarded directly.
-/// All sourced execution events are buffered FIFO within their lane; every other execution event
-/// is buffered in its existing legacy pending category.
+/// Time events are handled immediately. Legacy account events are forwarded directly. Sourced
+/// account events can also be forwarded while execution clients connect; all other sourced events
+/// are buffered FIFO within their lane. Every other execution event is buffered in its existing
+/// legacy pending category.
 #[expect(
     clippy::too_many_arguments,
     reason = "startup buffering owns one future plus the pending state and all runner receivers"
 )]
 async fn drive_with_event_buffering<F: std::future::Future>(
     future: F,
+    sourced_account_handling: SourcedAccountHandling,
     pending: &mut PendingEvents,
     time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
     system_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemEvent>,
@@ -3874,7 +3884,15 @@ async fn drive_with_event_buffering<F: std::future::Future>(
                 pending.system_commands.push(command);
             }
             Some(ingress) = sourced_exec.recv(exec_evt_rx) => {
-                pending.buffer_execution_ingress(ingress);
+                match ingress {
+                    ExecutionEventIngress::Sourced(event)
+                        if sourced_account_handling == SourcedAccountHandling::Dispatch
+                            && matches!(&event.event, ExecutionEvent::Account(_)) =>
+                    {
+                        AsyncRunner::handle_sourced_exec_event(event);
+                    }
+                    ingress => pending.buffer_execution_ingress(ingress),
+                }
             }
             Some(cmd) = exec_cmd_rx.recv() => {
                 pending.exec_cmds.push(cmd);
@@ -8362,6 +8380,27 @@ mod tests {
         ))))
     }
 
+    fn stub_order_report_event() -> ExecutionEvent {
+        use nautilus_model::identifiers::ClientOrderId;
+
+        ExecutionEvent::Report(ExecutionReport::Order(Box::new(OrderStatusReport::new(
+            AccountId::from("TEST-001"),
+            InstrumentId::from("TEST.VENUE"),
+            Some(ClientOrderId::from("O-001")),
+            VenueOrderId::from("V-001"),
+            OrderSide::Buy,
+            OrderType::Limit,
+            TimeInForce::Gtc,
+            OrderStatus::Accepted,
+            Quantity::from("1.0"),
+            Quantity::from("0.0"),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            UnixNanos::from(3),
+            None,
+        ))))
+    }
+
     #[rstest]
     fn test_flush_all_pending_drains_buffered_channels() {
         let (time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
@@ -8457,6 +8496,104 @@ mod tests {
             UnixNanos::default(),
             None,
         ))
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn test_sourced_account_registers_while_execution_client_connects() {
+        msgbus::get_message_bus().borrow_mut().dispose();
+        let account_id = AccountId::from("SOURCE-CONNECT-001");
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let received = Rc::new(Cell::new(0));
+        let (account_registered_tx, account_registered_rx) = tokio::sync::oneshot::channel();
+        let account_registered_tx = Rc::new(RefCell::new(Some(account_registered_tx)));
+        let handler_cache = cache.clone();
+        let handler_received = received.clone();
+        let handler_account_registered_tx = account_registered_tx.clone();
+        msgbus::register_account_state_endpoint(
+            MessagingSwitchboard::portfolio_update_account(),
+            TypedHandler::from(move |state: &AccountState| {
+                handler_cache
+                    .borrow_mut()
+                    .add_account(AccountAny::Margin(MarginAccount::new(state.clone(), true)))
+                    .unwrap();
+                handler_received.set(handler_received.get() + 1);
+
+                if let Some(tx) = handler_account_registered_tx.borrow_mut().take() {
+                    tx.send(())
+                        .expect("execution client connect should await account registration");
+                }
+            }),
+        );
+
+        assert!(cache.borrow().account(&account_id).is_none());
+
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let (channels, mut sourced_exec) = runner.take_channels_with_sourced();
+        let AsyncRunnerChannels {
+            mut time_evt_rx,
+            mut system_evt_rx,
+            mut system_cmd_rx,
+            mut exec_evt_rx,
+            mut exec_cmd_rx,
+            mut data_evt_rx,
+            mut data_cmd_rx,
+        } = channels;
+        let sink = crate::runner::get_sourced_exec_event_sink(ClientId::from("SOURCE-CONNECT"));
+        let connect_account_id = account_id;
+        let connect = async move {
+            sink.send(stub_order_report_event()).unwrap();
+            sink.send(stub_exec_event()).unwrap();
+            sink.send(ExecutionEvent::Account(AccountState::new(
+                connect_account_id,
+                AccountType::Margin,
+                vec![],
+                vec![],
+                true,
+                UUID4::new(),
+                UnixNanos::from(1),
+                UnixNanos::from(2),
+                None,
+            )))
+            .unwrap();
+
+            account_registered_rx
+                .await
+                .expect("account registration handler should remain available");
+        };
+        let mut pending = PendingEvents::default();
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            drive_with_event_buffering(
+                connect,
+                SourcedAccountHandling::Dispatch,
+                &mut pending,
+                &mut time_evt_rx,
+                &mut system_evt_rx,
+                &mut system_cmd_rx,
+                &mut exec_evt_rx,
+                &mut sourced_exec,
+                &mut exec_cmd_rx,
+                &mut data_evt_rx,
+                &mut data_cmd_rx,
+            ),
+        )
+        .await
+        .expect("sourced account should be registered during execution client connect");
+
+        assert!(cache.borrow().account(&account_id).is_some());
+        assert_eq!(received.get(), 1);
+        assert_eq!(pending.sourced_exec_evts.len(), 2);
+        assert!(matches!(
+            &pending.sourced_exec_evts[0].event,
+            ExecutionEvent::Report(ExecutionReport::Order(_))
+        ));
+        assert!(matches!(
+            &pending.sourced_exec_evts[1].event,
+            ExecutionEvent::Report(ExecutionReport::Fill(_))
+        ));
     }
 
     #[rstest]

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -109,7 +109,7 @@ use nautilus_execution::engine::ExecutionEngine;
 #[cfg(test)]
 use nautilus_model::reports::OrderStatusReport;
 use nautilus_model::{
-    events::OrderEventAny,
+    events::{AccountState, OrderEventAny},
     identifiers::{ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId},
     orders::Order,
     reports::{FillReport, PositionStatusReport},
@@ -3876,9 +3876,10 @@ async fn drive_with_event_buffering<F: std::future::Future>(
             Some(ingress) = sourced_exec.recv(exec_evt_rx) => {
                 match ingress {
                     ExecutionEventIngress::Sourced(
-                        SourcedExecutionEvent::BootstrapAccount { state, .. },
+                        SourcedExecutionEvent::BootstrapAccount { client_id, state },
                     ) if sourced_bootstrap_handling == SourcedBootstrapHandling::Dispatch =>
                     {
+                        pending.discard_stale_runtime_account_states(client_id, &state);
                         AsyncRunner::handle_exec_event(ExecutionEvent::Account(state));
                     }
                     ingress => pending.buffer_execution_ingress(ingress),
@@ -3910,6 +3911,26 @@ struct PendingEvents {
 }
 
 impl PendingEvents {
+    fn discard_stale_runtime_account_states(
+        &mut self,
+        client_id: ClientId,
+        bootstrap: &AccountState,
+    ) {
+        self.sourced_exec_evts.retain(|event| {
+            let SourcedExecutionEvent::Runtime {
+                client_id: event_client_id,
+                event: ExecutionEvent::Account(state),
+            } = event
+            else {
+                return true;
+            };
+
+            *event_client_id != client_id
+                || state.account_id != bootstrap.account_id
+                || state.ts_event >= bootstrap.ts_event
+        });
+    }
+
     fn is_empty(&self) -> bool {
         self.system_events.is_empty()
             && self.system_commands.is_empty()
@@ -8632,9 +8653,9 @@ mod tests {
                     self.state.order_report.clone(),
                 ))))?;
             self.sink
-                .send_bootstrap_account(self.state.bootstrap_account.clone())?;
-            self.sink
                 .send(ExecutionEvent::Account(self.state.runtime_account.clone()))?;
+            self.sink
+                .send_bootstrap_account(self.state.bootstrap_account.clone())?;
             self.sink
                 .send(ExecutionEvent::Report(ExecutionReport::Position(Box::new(
                     self.state.position_report.clone(),
@@ -8694,13 +8715,17 @@ mod tests {
         let steady_account = AccountState::new(
             account_id,
             AccountType::Margin,
-            vec![],
+            vec![AccountBalance::new(
+                Money::from("300 USDT"),
+                Money::from("0 USDT"),
+                Money::from("300 USDT"),
+            )],
             vec![],
             true,
             steady_event_id,
             UnixNanos::from(12),
             UnixNanos::from(13),
-            None,
+            Some(Currency::USDT()),
         );
         let state = BootstrapConnectState {
             connected: Rc::new(Cell::new(false)),
@@ -8711,24 +8736,32 @@ mod tests {
             bootstrap_account: AccountState::new(
                 account_id,
                 AccountType::Margin,
-                vec![],
+                vec![AccountBalance::new(
+                    Money::from("200 USDT"),
+                    Money::from("0 USDT"),
+                    Money::from("200 USDT"),
+                )],
                 vec![],
                 true,
                 bootstrap_event_id,
-                UnixNanos::from(1),
-                UnixNanos::from(2),
-                None,
+                UnixNanos::from(3),
+                UnixNanos::from(4),
+                Some(Currency::USDT()),
             ),
             runtime_account: AccountState::new(
                 account_id,
                 AccountType::Margin,
-                vec![],
+                vec![AccountBalance::new(
+                    Money::from("100 USDT"),
+                    Money::from("0 USDT"),
+                    Money::from("100 USDT"),
+                )],
                 vec![],
                 true,
                 runtime_event_id,
-                UnixNanos::from(3),
-                UnixNanos::from(4),
-                None,
+                UnixNanos::from(1),
+                UnixNanos::from(2),
+                Some(Currency::USDT()),
             ),
             order_report: OrderStatusReport::new(
                 account_id,
@@ -8950,17 +8983,19 @@ mod tests {
             |event| node.process_sourced_exec_event(event),
         );
 
-        let account_event_ids = node
-            .kernel
-            .cache
-            .borrow()
-            .account(&account_id)
-            .unwrap()
-            .events()
-            .into_iter()
-            .map(|event| event.event_id)
-            .collect::<Vec<_>>();
-        assert_eq!(account_event_ids, [bootstrap_event_id, runtime_event_id]);
+        let (account_event_ids, account_total) = {
+            let cache = node.kernel.cache.borrow();
+            let account = cache.account(&account_id).unwrap();
+            let event_ids = account
+                .events()
+                .into_iter()
+                .map(|event| event.event_id)
+                .collect::<Vec<_>>();
+            let total = account.balances()[&Currency::USDT()].total;
+            (event_ids, total)
+        };
+        assert_eq!(account_event_ids, [bootstrap_event_id]);
+        assert_eq!(account_total, Money::from("200 USDT"));
         assert!(e3_enqueued.get());
         assert_eq!(
             state.observations.borrow().as_slice(),
@@ -8972,12 +9007,12 @@ mod tests {
                 },
                 BootstrapReportObservation {
                     kind: BootstrapReportKind::Position,
-                    account_event_id: runtime_event_id,
+                    account_event_id: bootstrap_event_id,
                     order_status: OrderStatus::Accepted,
                 },
                 BootstrapReportObservation {
                     kind: BootstrapReportKind::Fill,
-                    account_event_id: runtime_event_id,
+                    account_event_id: bootstrap_event_id,
                     order_status: OrderStatus::Accepted,
                 },
             ]
@@ -9013,20 +9048,19 @@ mod tests {
             panic!("steady-state sourced event should remain behind the startup prefix");
         };
         node.process_sourced_exec_event(steady_event);
-        let account_event_ids = node
-            .kernel
-            .cache
-            .borrow()
-            .account(&account_id)
-            .unwrap()
-            .events()
-            .into_iter()
-            .map(|event| event.event_id)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            account_event_ids,
-            [bootstrap_event_id, runtime_event_id, steady_event_id]
-        );
+        let (account_event_ids, account_total) = {
+            let cache = node.kernel.cache.borrow();
+            let account = cache.account(&account_id).unwrap();
+            let event_ids = account
+                .events()
+                .into_iter()
+                .map(|event| event.event_id)
+                .collect::<Vec<_>>();
+            let total = account.balances()[&Currency::USDT()].total;
+            (event_ids, total)
+        };
+        assert_eq!(account_event_ids, [bootstrap_event_id, steady_event_id]);
+        assert_eq!(account_total, Money::from("300 USDT"));
         assert_eq!(sourced_exec.len(), 0);
         assert!(exec_evt_rx.try_recv().is_err());
         msgbus::get_message_bus().borrow_mut().dispose();
@@ -9257,6 +9291,64 @@ mod tests {
         );
         assert!(pending.exec_reports.is_empty());
         assert!(pending.order_evts.is_empty());
+    }
+
+    #[rstest]
+    fn test_pending_discards_only_stale_runtime_account_state_for_bootstrap() {
+        let source_id = ClientId::from("SOURCE-PENDING");
+        let other_source_id = ClientId::from("OTHER-SOURCE");
+        let account_id = AccountId::from("SOURCE-PENDING-001");
+        let other_account_id = AccountId::from("SOURCE-PENDING-002");
+        let account_state = |account_id, ts_event| {
+            AccountState::new(
+                account_id,
+                AccountType::Margin,
+                vec![],
+                vec![],
+                true,
+                UUID4::new(),
+                UnixNanos::from(ts_event),
+                UnixNanos::from(ts_event),
+                None,
+            )
+        };
+        let bootstrap = account_state(account_id, 10);
+        let mut pending = PendingEvents::default();
+
+        for (client_id, state) in [
+            (source_id, account_state(account_id, 9)),
+            (other_source_id, account_state(account_id, 8)),
+            (source_id, account_state(other_account_id, 7)),
+            (source_id, account_state(account_id, 10)),
+            (source_id, account_state(account_id, 11)),
+        ] {
+            pending.buffer_execution_ingress(ExecutionEventIngress::Sourced(
+                SourcedExecutionEvent::runtime(client_id, ExecutionEvent::Account(state)),
+            ));
+        }
+
+        pending.discard_stale_runtime_account_states(source_id, &bootstrap);
+
+        let retained = pending
+            .sourced_exec_evts
+            .iter()
+            .map(|event| match event {
+                SourcedExecutionEvent::Runtime {
+                    client_id,
+                    event: ExecutionEvent::Account(state),
+                } => (*client_id, state.account_id, state.ts_event),
+                _ => panic!("Expected sourced account event"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            retained,
+            [
+                (other_source_id, account_id, UnixNanos::from(8)),
+                (source_id, other_account_id, UnixNanos::from(7)),
+                (source_id, account_id, UnixNanos::from(10)),
+                (source_id, account_id, UnixNanos::from(11)),
+            ]
+        );
     }
 
     #[rstest]

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -1036,7 +1036,7 @@ impl LiveNode {
                 let result = self
                     .abort_startup("External message bus ingress failed to start")
                     .await;
-                Self::drain_channels(
+                self.drain_channels(
                     &mut time_evt_rx,
                     &mut system_evt_rx,
                     &mut system_cmd_rx,
@@ -1068,7 +1068,7 @@ impl LiveNode {
         // This ensures the cache is populated before execution clients connect.
         let data_connect_result = drive_with_event_buffering(
             self.connect_data_phase(connection_deadline),
-            SourcedAccountHandling::Buffer,
+            SourcedBootstrapHandling::Buffer,
             &mut pending,
             &mut time_evt_rx,
             &mut system_evt_rx,
@@ -1092,11 +1092,12 @@ impl LiveNode {
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
+                |event| self.process_sourced_exec_event(event),
             );
             let result = self
                 .abort_startup_with_error("Data client connection timed out", e)
                 .await;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1124,7 +1125,7 @@ impl LiveNode {
         // Startup phase 2: Connect execution clients (instruments now in cache)
         let engine_connection_result = drive_with_event_buffering(
             self.connect_exec_phase(connection_deadline),
-            SourcedAccountHandling::Dispatch,
+            SourcedBootstrapHandling::Dispatch,
             &mut pending,
             &mut time_evt_rx,
             &mut system_evt_rx,
@@ -1148,6 +1149,7 @@ impl LiveNode {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            |event| self.process_sourced_exec_event(event),
         );
         startup_system_events.extend(pending.take_system_events());
         startup_system_commands.extend(pending.take_system_commands());
@@ -1162,7 +1164,7 @@ impl LiveNode {
                 let result = self
                     .abort_startup_with_error("Execution client connection timed out", e)
                     .await;
-                Self::drain_channels(
+                self.drain_channels(
                     &mut time_evt_rx,
                     &mut system_evt_rx,
                     &mut system_cmd_rx,
@@ -1184,7 +1186,7 @@ impl LiveNode {
                     anyhow::anyhow!("readiness timeout while waiting for engine connections"),
                 )
                 .await;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1203,7 +1205,7 @@ impl LiveNode {
             .or_else(|| self.startup_abort_reason())
         {
             self.abort_startup(reason).await?;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1222,7 +1224,7 @@ impl LiveNode {
         // Run reconciliation now that instruments are in cache and start trader
         if let Err(e) = self.perform_startup_reconciliation().await {
             let result = self.abort_startup("Startup reconciliation failed").await;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1245,7 +1247,7 @@ impl LiveNode {
 
         if let Some(reason) = self.startup_abort_reason() {
             let result = self.abort_startup(reason).await;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1261,7 +1263,7 @@ impl LiveNode {
 
         if let Err(e) = self.kernel.start_trader() {
             let result = self.abort_after_trader_start_failure(e).await;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1277,7 +1279,7 @@ impl LiveNode {
         #[cfg(feature = "plugin")]
         if let Err(e) = self.plugins.start_controllers() {
             let result = self.abort_after_trader_start_failure(e).await;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1852,7 +1854,7 @@ impl LiveNode {
         let stop_result = self.finalize_stop().await;
 
         // Handle events that arrived during finalize_stop
-        Self::drain_channels(
+        self.drain_channels(
             &mut time_evt_rx,
             &mut system_evt_rx,
             &mut system_cmd_rx,
@@ -2016,7 +2018,7 @@ impl LiveNode {
     }
 
     fn process_sourced_exec_event(&mut self, event: SourcedExecutionEvent) {
-        let SourcedExecutionEvent { client_id, event } = event;
+        let (client_id, event) = event.into_parts();
         let event = match event {
             ExecutionEvent::Report(
                 report @ (ExecutionReport::Order(_) | ExecutionReport::Fill(_)),
@@ -2035,7 +2037,7 @@ impl LiveNode {
             ExecutionEvent::Order(OrderEventAny::Filled(fill)) => Some(fill.clone()),
             _ => None,
         };
-        AsyncRunner::handle_sourced_exec_event(SourcedExecutionEvent { client_id, event });
+        AsyncRunner::handle_sourced_exec_event(SourcedExecutionEvent::runtime(client_id, event));
 
         if let Some(fill) = &recent_fill_candidate {
             self.exec_manager.commit_recent_fill_if_applied(fill);
@@ -2276,7 +2278,7 @@ impl LiveNode {
         let finalize_result = self.finalize_stop().await;
 
         if let Some(receivers) = receivers {
-            Self::drain_channels(
+            self.drain_channels(
                 receivers.time_evt,
                 receivers.system_evt,
                 receivers.system_cmd,
@@ -2452,6 +2454,7 @@ impl LiveNode {
         reason = "all runner receivers are drained together"
     )]
     fn drain_channels(
+        &mut self,
         time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
         system_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemEvent>,
         system_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemCommand>,
@@ -2490,7 +2493,7 @@ impl LiveNode {
             match ingress {
                 ExecutionEventIngress::Legacy(event) => AsyncRunner::handle_exec_event(event),
                 ExecutionEventIngress::Sourced(event) => {
-                    AsyncRunner::handle_sourced_exec_event(event);
+                    self.process_sourced_exec_event(event);
                 }
             }
             drained += 1;
@@ -3789,6 +3792,7 @@ fn flush_all_pending(
     exec_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TradingCommandMessage>,
     data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
     data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
+    process_sourced_exec_event: impl FnMut(SourcedExecutionEvent),
 ) {
     // Flush channel receivers into pending
     while let Ok(handler) = time_evt_rx.try_recv() {
@@ -3819,28 +3823,28 @@ fn flush_all_pending(
         pending.exec_cmds.push(cmd);
     }
 
-    pending.drain();
+    pending.drain(process_sourced_exec_event);
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SourcedAccountHandling {
+enum SourcedBootstrapHandling {
     Buffer,
     Dispatch,
 }
 
 /// Drives a future to completion while buffering channel events.
 ///
-/// Time events are handled immediately. Legacy account events are forwarded directly. Sourced
-/// account events can also be forwarded while execution clients connect; all other sourced events
-/// are buffered FIFO within their lane. Every other execution event is buffered in its existing
-/// legacy pending category.
+/// Time events are handled immediately. Legacy account events retain their existing direct path.
+/// Only an explicit sourced bootstrap account can be applied while execution clients connect;
+/// every runtime sourced event, including later account updates, is buffered FIFO within its lane.
+/// Every other execution event is buffered in its existing legacy pending category.
 #[expect(
     clippy::too_many_arguments,
     reason = "startup buffering owns one future plus the pending state and all runner receivers"
 )]
 async fn drive_with_event_buffering<F: std::future::Future>(
     future: F,
-    sourced_account_handling: SourcedAccountHandling,
+    sourced_bootstrap_handling: SourcedBootstrapHandling,
     pending: &mut PendingEvents,
     time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
     system_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemEvent>,
@@ -3871,12 +3875,11 @@ async fn drive_with_event_buffering<F: std::future::Future>(
             }
             Some(ingress) = sourced_exec.recv(exec_evt_rx) => {
                 match ingress {
-                    ExecutionEventIngress::Sourced(event)
-                        if sourced_account_handling == SourcedAccountHandling::Dispatch
-                            && matches!(&event.event, ExecutionEvent::Account(_)) =>
+                    ExecutionEventIngress::Sourced(
+                        SourcedExecutionEvent::BootstrapAccount { state, .. },
+                    ) if sourced_bootstrap_handling == SourcedBootstrapHandling::Dispatch =>
                     {
-                        pending.drain_sourced_exec_events();
-                        AsyncRunner::handle_sourced_exec_event(event);
+                        AsyncRunner::handle_exec_event(ExecutionEvent::Account(state));
                     }
                     ingress => pending.buffer_execution_ingress(ingress),
                 }
@@ -3945,7 +3948,7 @@ impl PendingEvents {
     }
 
     /// Drains all remaining pending events.
-    fn drain(&mut self) {
+    fn drain(&mut self, mut process_sourced_exec_event: impl FnMut(SourcedExecutionEvent)) {
         let total = self.data_evts.len()
             + self.data_cmds.len()
             + self.exec_reports.len()
@@ -3983,16 +3986,12 @@ impl PendingEvents {
             AsyncRunner::handle_exec_event(ExecutionEvent::Order(evt));
         }
 
-        self.drain_sourced_exec_events();
+        for event in self.sourced_exec_evts.drain(..) {
+            process_sourced_exec_event(event);
+        }
 
         for cmd in self.exec_cmds.drain(..) {
             AsyncRunner::handle_trading_command(cmd);
-        }
-    }
-
-    fn drain_sourced_exec_events(&mut self) {
-        for evt in self.sourced_exec_evts.drain(..) {
-            AsyncRunner::handle_sourced_exec_event(evt);
         }
     }
 
@@ -4061,6 +4060,7 @@ mod tests {
         },
     };
 
+    use async_trait::async_trait;
     use bytes::Bytes;
     use indexmap::IndexMap;
     use log::{Level, LevelFilter, Log, Metadata, Record};
@@ -4071,9 +4071,11 @@ mod tests {
     };
     use nautilus_common::{
         actor::{DataActor, DataActorCore, data_actor::DataActorConfig},
-        cache::Cache,
+        cache::{Cache, CacheView},
+        clients::ExecutionClient,
         clock::{Clock, TestClock},
         enums::SerializationEncoding,
+        factories::{ClientConfig, ExecutionClientFactory},
         live::runner::{get_data_event_sender, get_exec_event_sender, get_system_event_sender},
         messages::{
             execution::{QueryAccount, SubmitOrder, TradingCommand},
@@ -4128,7 +4130,11 @@ mod tests {
     use ustr::Ustr;
 
     use super::*;
-    use crate::{execution::manager::ReportClientCoverage, socket::SocketControl};
+    use crate::{
+        execution::manager::ReportClientCoverage,
+        runner::{SourcedExecutionEventSink, get_sourced_exec_event_sink},
+        socket::SocketControl,
+    };
 
     struct ExternalIngressLogCapture {
         messages: Mutex<Vec<String>>,
@@ -4748,13 +4754,13 @@ mod tests {
             )))
         };
 
-        node.process_sourced_exec_event(SourcedExecutionEvent {
-            client_id: ClientId::from("UNREGISTERED-SOURCE"),
-            event: ExecutionEvent::Report(report(
+        node.process_sourced_exec_event(SourcedExecutionEvent::runtime(
+            ClientId::from("UNREGISTERED-SOURCE"),
+            ExecutionEvent::Report(report(
                 invalid_order_id,
                 VenueOrderId::from("V-SOURCED-INVALID"),
             )),
-        });
+        ));
         assert!(
             node.kernel
                 .cache
@@ -4765,13 +4771,13 @@ mod tests {
         assert!(venue_registrations.borrow().is_empty());
         assert!(source_registrations.borrow().is_empty());
 
-        node.process_sourced_exec_event(SourcedExecutionEvent {
-            client_id: source_client_id,
-            event: ExecutionEvent::Report(report(
+        node.process_sourced_exec_event(SourcedExecutionEvent::runtime(
+            source_client_id,
+            ExecutionEvent::Report(report(
                 valid_order_id,
                 VenueOrderId::from("V-SOURCED-VALID"),
             )),
-        });
+        ));
 
         assert_eq!(
             node.kernel.cache.borrow().client_id(&valid_order_id),
@@ -4807,10 +4813,10 @@ mod tests {
             .unwrap()
             .event_count();
 
-        node.process_sourced_exec_event(SourcedExecutionEvent {
-            client_id: ClientId::from("UNREGISTERED-SOURCE"),
-            event: ExecutionEvent::Report(ExecutionReport::Fill(Box::new((*report).clone()))),
-        });
+        node.process_sourced_exec_event(SourcedExecutionEvent::runtime(
+            ClientId::from("UNREGISTERED-SOURCE"),
+            ExecutionEvent::Report(ExecutionReport::Fill(Box::new((*report).clone()))),
+        ));
 
         {
             let engine = node.kernel.exec_engine.borrow();
@@ -4837,10 +4843,10 @@ mod tests {
             .register_client(Box::new(source_client))
             .unwrap();
 
-        node.process_sourced_exec_event(SourcedExecutionEvent {
-            client_id: source_client_id,
-            event: ExecutionEvent::Report(ExecutionReport::Fill(report)),
-        });
+        node.process_sourced_exec_event(SourcedExecutionEvent::runtime(
+            source_client_id,
+            ExecutionEvent::Report(ExecutionReport::Fill(report)),
+        ));
 
         assert!(source_registrations.borrow().is_empty());
         let engine = node.kernel.exec_engine.borrow();
@@ -8381,27 +8387,6 @@ mod tests {
         ))))
     }
 
-    fn stub_order_report_event() -> ExecutionEvent {
-        use nautilus_model::identifiers::ClientOrderId;
-
-        ExecutionEvent::Report(ExecutionReport::Order(Box::new(OrderStatusReport::new(
-            AccountId::from("TEST-001"),
-            InstrumentId::from("TEST.VENUE"),
-            Some(ClientOrderId::from("O-001")),
-            VenueOrderId::from("V-001"),
-            OrderSide::Buy,
-            OrderType::Limit,
-            TimeInForce::Gtc,
-            OrderStatus::Accepted,
-            Quantity::from("1.0"),
-            Quantity::from("0.0"),
-            UnixNanos::from(1),
-            UnixNanos::from(2),
-            UnixNanos::from(3),
-            None,
-        ))))
-    }
-
     #[rstest]
     fn test_flush_all_pending_drains_buffered_channels() {
         let (time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
@@ -8452,6 +8437,7 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            drop,
         );
 
         let system_events = pending.take_system_events();
@@ -8499,51 +8485,422 @@ mod tests {
         ))
     }
 
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum BootstrapReportKind {
+        Order,
+        Position,
+        Fill,
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct BootstrapReportObservation {
+        kind: BootstrapReportKind,
+        account_event_id: UUID4,
+        order_status: OrderStatus,
+    }
+
+    fn bootstrap_report_observation(
+        cache: &Rc<RefCell<Cache>>,
+        kind: BootstrapReportKind,
+        account_id: AccountId,
+        client_order_id: ClientOrderId,
+    ) -> BootstrapReportObservation {
+        let cache = cache.borrow();
+        let account_event_id = cache
+            .account(&account_id)
+            .and_then(|account| account.last_event())
+            .expect("bootstrap account should be registered before reports are flushed")
+            .event_id;
+        let order_status = cache
+            .order(&client_order_id)
+            .expect("submitted order should remain cached while reports are flushed")
+            .status();
+        BootstrapReportObservation {
+            kind,
+            account_event_id,
+            order_status,
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct BootstrapConnectState {
+        connected: Rc<Cell<bool>>,
+        client_id: ClientId,
+        account_id: AccountId,
+        instrument_id: InstrumentId,
+        client_order_id: ClientOrderId,
+        bootstrap_account: AccountState,
+        runtime_account: AccountState,
+        order_report: OrderStatusReport,
+        position_report: PositionStatusReport,
+        fill_report: FillReport,
+        observations: Rc<RefCell<Vec<BootstrapReportObservation>>>,
+    }
+
+    #[derive(Debug)]
+    struct BootstrapConnectClientConfig;
+
+    impl ClientConfig for BootstrapConnectClientConfig {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[derive(Debug)]
+    struct BootstrapConnectClientFactory {
+        state: BootstrapConnectState,
+    }
+
+    impl ExecutionClientFactory for BootstrapConnectClientFactory {
+        fn create(
+            &self,
+            _trader_id: TraderId,
+            _name: &str,
+            _config: &dyn ClientConfig,
+            cache: CacheView,
+        ) -> anyhow::Result<Box<dyn ExecutionClient>> {
+            Ok(Box::new(BootstrapConnectExecutionClient {
+                state: self.state.clone(),
+                cache,
+                sink: get_sourced_exec_event_sink(self.state.client_id),
+            }))
+        }
+
+        fn name(&self) -> &'static str {
+            "bootstrap-connect"
+        }
+
+        fn config_type(&self) -> &'static str {
+            stringify!(BootstrapConnectClientConfig)
+        }
+    }
+
+    struct BootstrapConnectExecutionClient {
+        state: BootstrapConnectState,
+        cache: CacheView,
+        sink: SourcedExecutionEventSink,
+    }
+
+    #[async_trait(?Send)]
+    impl ExecutionClient for BootstrapConnectExecutionClient {
+        fn is_connected(&self) -> bool {
+            self.state.connected.get()
+        }
+
+        fn client_id(&self) -> ClientId {
+            self.state.client_id
+        }
+
+        fn account_id(&self) -> AccountId {
+            self.state.account_id
+        }
+
+        fn venue(&self) -> Venue {
+            self.state.instrument_id.venue
+        }
+
+        fn oms_type(&self) -> OmsType {
+            OmsType::Netting
+        }
+
+        fn get_account(&self) -> Option<AccountAny> {
+            None
+        }
+
+        fn generate_account_state(
+            &self,
+            _balances: Vec<AccountBalance>,
+            _margins: Vec<MarginBalance>,
+            _reported: bool,
+            _ts_event: UnixNanos,
+            _info: Option<Params>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn start(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn connect(&mut self) -> anyhow::Result<()> {
+            self.sink
+                .send(ExecutionEvent::Report(ExecutionReport::Order(Box::new(
+                    self.state.order_report.clone(),
+                ))))?;
+            self.sink
+                .send_bootstrap_account(self.state.bootstrap_account.clone())?;
+            self.sink
+                .send(ExecutionEvent::Account(self.state.runtime_account.clone()))?;
+            self.sink
+                .send(ExecutionEvent::Report(ExecutionReport::Position(Box::new(
+                    self.state.position_report.clone(),
+                ))))?;
+            self.sink
+                .send(ExecutionEvent::Report(ExecutionReport::Fill(Box::new(
+                    self.state.fill_report.clone(),
+                ))))?;
+
+            while self.cache.borrow().account(&self.account_id()).is_none() {
+                dst::time::sleep(Duration::from_millis(1)).await;
+            }
+
+            let cache = self.cache.borrow();
+            let account_event_ids = cache
+                .account(&self.account_id())
+                .expect("bootstrap account should be registered during connect")
+                .events()
+                .into_iter()
+                .map(|event| event.event_id)
+                .collect::<Vec<_>>();
+            anyhow::ensure!(
+                account_event_ids == [self.state.bootstrap_account.event_id],
+                "only the explicit bootstrap account may be applied during connect"
+            );
+            anyhow::ensure!(
+                cache
+                    .order(&self.state.client_order_id)
+                    .is_some_and(|order| order.status() == OrderStatus::Submitted),
+                "runtime reports must remain buffered while the execution engine is borrowed"
+            );
+            drop(cache);
+            anyhow::ensure!(
+                self.state.observations.borrow().is_empty(),
+                "raw runtime reports must not publish during execution-client connect"
+            );
+
+            self.state.connected.set(true);
+            Ok(())
+        }
+    }
+
     #[rstest]
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_sourced_bootstrap_account_preserves_lane_fifo_while_execution_client_connects() {
         msgbus::get_message_bus().borrow_mut().dispose();
-        let account_id = AccountId::from("SOURCE-CONNECT-001");
-        let cache = Rc::new(RefCell::new(Cache::default()));
-        let dispatch_order = Rc::new(RefCell::new(Vec::new()));
-        let (account_registered_tx, account_registered_rx) = tokio::sync::oneshot::channel();
-        let account_registered_tx = Rc::new(RefCell::new(Some(account_registered_tx)));
-        let handler_cache = cache.clone();
-        let account_dispatch_order = dispatch_order.clone();
-        let handler_account_registered_tx = account_registered_tx.clone();
-        msgbus::register_account_state_endpoint(
-            MessagingSwitchboard::portfolio_update_account(),
-            TypedHandler::from(move |state: &AccountState| {
-                handler_cache
-                    .borrow_mut()
-                    .add_account(AccountAny::Margin(MarginAccount::new(state.clone(), true)))
-                    .unwrap();
-                account_dispatch_order.borrow_mut().push("account");
+        let client_id = ClientId::from("SOURCE-CONNECT");
+        let account_id = AccountId::from("TEST-001");
+        let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        let instrument_id = instrument.id();
+        let client_order_id = ClientOrderId::from("O-BOOTSTRAP-CONNECT");
+        let venue_order_id = VenueOrderId::from("V-BOOTSTRAP-CONNECT");
+        let bootstrap_event_id = UUID4::new();
+        let runtime_event_id = UUID4::new();
+        let steady_event_id = UUID4::new();
+        let quantity = Quantity::from("10.0");
+        let steady_account = AccountState::new(
+            account_id,
+            AccountType::Margin,
+            vec![],
+            vec![],
+            true,
+            steady_event_id,
+            UnixNanos::from(12),
+            UnixNanos::from(13),
+            None,
+        );
+        let state = BootstrapConnectState {
+            connected: Rc::new(Cell::new(false)),
+            client_id,
+            account_id,
+            instrument_id,
+            client_order_id,
+            bootstrap_account: AccountState::new(
+                account_id,
+                AccountType::Margin,
+                vec![],
+                vec![],
+                true,
+                bootstrap_event_id,
+                UnixNanos::from(1),
+                UnixNanos::from(2),
+                None,
+            ),
+            runtime_account: AccountState::new(
+                account_id,
+                AccountType::Margin,
+                vec![],
+                vec![],
+                true,
+                runtime_event_id,
+                UnixNanos::from(3),
+                UnixNanos::from(4),
+                None,
+            ),
+            order_report: OrderStatusReport::new(
+                account_id,
+                instrument_id,
+                Some(client_order_id),
+                venue_order_id,
+                OrderSide::Buy.into(),
+                OrderType::Limit,
+                TimeInForce::Gtc,
+                OrderStatus::Accepted,
+                quantity,
+                Quantity::from("0.0"),
+                UnixNanos::from(5),
+                UnixNanos::from(6),
+                UnixNanos::from(7),
+                None,
+            ),
+            position_report: PositionStatusReport::new(
+                account_id,
+                instrument_id,
+                PositionSide::Long,
+                quantity,
+                UnixNanos::from(8),
+                UnixNanos::from(9),
+                None,
+                None,
+                None,
+            ),
+            fill_report: FillReport::new(
+                account_id,
+                instrument_id,
+                venue_order_id,
+                TradeId::from("T-BOOTSTRAP-CONNECT"),
+                OrderSide::Buy,
+                quantity,
+                Price::from("100.0"),
+                Money::from("0.01 USDT"),
+                LiquiditySide::Taker,
+                Some(client_order_id),
+                None,
+                UnixNanos::from(10),
+                UnixNanos::from(11),
+                None,
+            ),
+            observations: Rc::new(RefCell::new(Vec::new())),
+        };
+        let config = LiveNodeConfig {
+            trader_id: TraderId::from("TESTER-001"),
+            exec_engine: crate::config::LiveExecutionEngineConfig {
+                reconciliation: true,
+                inflight_check_threshold_ms: 100,
+                inflight_check_retries: 2,
+                ..Default::default()
+            },
+            timeout_connection: Duration::from_secs(1),
+            ..Default::default()
+        };
+        let mut node = LiveNodeBuilder::from_config(config)
+            .unwrap()
+            .with_name("BootstrapConnectNode")
+            .add_exec_client(
+                Some("bootstrap-connect".to_string()),
+                Box::new(BootstrapConnectClientFactory {
+                    state: state.clone(),
+                }),
+                Box::new(BootstrapConnectClientConfig),
+            )
+            .unwrap()
+            .build()
+            .unwrap();
 
-                if let Some(tx) = handler_account_registered_tx.borrow_mut().take() {
-                    tx.send(())
-                        .expect("execution client connect should await account registration");
+        let order = OrderTestBuilder::new(OrderType::Limit)
+            .trader_id(node.trader_id())
+            .strategy_id(StrategyId::from("S-BOOTSTRAP-CONNECT"))
+            .client_order_id(client_order_id)
+            .instrument_id(instrument_id)
+            .side(OrderSide::Buy)
+            .quantity(quantity)
+            .price(Price::from("100.0"))
+            .build();
+        let submitted = TestOrderEventStubs::submitted(&order, account_id);
+        {
+            let mut cache = node.kernel.cache.borrow_mut();
+            cache.add_instrument(instrument).unwrap();
+            cache
+                .add_order(order, None, Some(client_id), false)
+                .unwrap();
+            cache.update_order(&submitted).unwrap();
+            assert!(cache.account(&account_id).is_none());
+        }
+
+        node.exec_manager.register_inflight(client_order_id);
+        advance_clock(Duration::from_millis(101)).await;
+        let inflight = node.exec_manager.check_inflight_orders();
+        assert_eq!(inflight.queries.len(), 1);
+        assert_eq!(
+            node.exec_manager.recon_check_retry_count(&client_order_id),
+            1
+        );
+
+        let runner = node.runner.take().expect("runner should be available");
+        runner.bind_senders();
+        let steady_sink = get_sourced_exec_event_sink(client_id);
+        let (channels, mut sourced_exec) = runner.take_channels_with_sourced();
+        let cache = node.kernel.cache.clone();
+        let observations = state.observations.clone();
+        let e3_enqueued = Rc::new(Cell::new(false));
+        msgbus::subscribe_any(
+            MessagingSwitchboard::reconciliation_raw_order_status_report_topic().into(),
+            ShareableMessageHandler::from_typed({
+                let cache = cache.clone();
+                let observations = observations.clone();
+                let e3_enqueued = e3_enqueued.clone();
+                move |_: &OrderStatusReport| {
+                    if !e3_enqueued.replace(true) {
+                        steady_sink
+                            .send(ExecutionEvent::Account(steady_account.clone()))
+                            .expect("steady-state account should enter the sourced lane");
+                    }
+                    observations.borrow_mut().push(bootstrap_report_observation(
+                        &cache,
+                        BootstrapReportKind::Order,
+                        account_id,
+                        client_order_id,
+                    ));
                 }
             }),
+            None,
         );
-        let report_dispatch_order = dispatch_order.clone();
-        msgbus::register_sourced_execution_report_endpoint(
-            MessagingSwitchboard::exec_engine_reconcile_sourced_execution_report(),
-            TypedIntoHandler::from(move |report: SourcedExecutionReport| {
-                let kind = match report.report {
-                    ExecutionReport::Order(_) => "order",
-                    ExecutionReport::Fill(_) => "fill",
-                    _ => panic!("unexpected non-strict sourced execution report"),
-                };
-                report_dispatch_order.borrow_mut().push(kind);
+        msgbus::subscribe_any(
+            MessagingSwitchboard::reconciliation_raw_position_status_report_topic().into(),
+            ShareableMessageHandler::from_typed({
+                let cache = cache.clone();
+                let observations = observations.clone();
+                move |_: &PositionStatusReport| {
+                    observations.borrow_mut().push(bootstrap_report_observation(
+                        &cache,
+                        BootstrapReportKind::Position,
+                        account_id,
+                        client_order_id,
+                    ));
+                }
             }),
+            None,
+        );
+        msgbus::subscribe_any(
+            MessagingSwitchboard::reconciliation_raw_fill_report_topic().into(),
+            ShareableMessageHandler::from_typed({
+                let cache = cache.clone();
+                let observations = observations.clone();
+                move |_: &FillReport| {
+                    observations.borrow_mut().push(bootstrap_report_observation(
+                        &cache,
+                        BootstrapReportKind::Fill,
+                        account_id,
+                        client_order_id,
+                    ));
+                }
+            }),
+            None,
         );
 
-        assert!(cache.borrow().account(&account_id).is_none());
+        let report_count = node.kernel.exec_engine.borrow().report_count();
+        let engine_event_count = node.kernel.exec_engine.borrow().event_count();
+        let order_event_count = node
+            .kernel
+            .cache
+            .borrow()
+            .order(&client_order_id)
+            .unwrap()
+            .event_count();
 
-        let runner = AsyncRunner::new();
-        runner.bind_senders();
-        let (channels, mut sourced_exec) = runner.take_channels_with_sourced();
         let AsyncRunnerChannels {
             mut time_evt_rx,
             mut system_evt_rx,
@@ -8553,35 +8910,14 @@ mod tests {
             mut data_evt_rx,
             mut data_cmd_rx,
         } = channels;
-        let sink = crate::runner::get_sourced_exec_event_sink(ClientId::from("SOURCE-CONNECT"));
-        let connect_account_id = account_id;
-        let connect = async move {
-            sink.send(stub_order_report_event()).unwrap();
-            sink.send(ExecutionEvent::Account(AccountState::new(
-                connect_account_id,
-                AccountType::Margin,
-                vec![],
-                vec![],
-                true,
-                UUID4::new(),
-                UnixNanos::from(1),
-                UnixNanos::from(2),
-                None,
-            )))
-            .unwrap();
-
-            account_registered_rx
-                .await
-                .expect("account registration handler should remain available");
-            sink.send(stub_exec_event()).unwrap();
-        };
         let mut pending = PendingEvents::default();
+        let deadline = dst::time::Instant::now() + Duration::from_secs(1);
 
-        tokio::time::timeout(
-            Duration::from_secs(1),
+        let status = tokio::time::timeout(
+            Duration::from_secs(2),
             drive_with_event_buffering(
-                connect,
-                SourcedAccountHandling::Dispatch,
+                node.connect_exec_phase(deadline),
+                SourcedBootstrapHandling::Dispatch,
                 &mut pending,
                 &mut time_evt_rx,
                 &mut system_evt_rx,
@@ -8594,7 +8930,12 @@ mod tests {
             ),
         )
         .await
-        .expect("sourced account should be registered during execution client connect");
+        .expect("execution client connect should finish before the outer guard")
+        .expect("execution client connect should succeed");
+
+        assert_eq!(status, EngineConnectionStatus::Connected);
+        assert!(state.connected.get());
+        assert!(!e3_enqueued.get());
 
         flush_all_pending(
             &mut pending,
@@ -8606,14 +8947,88 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            |event| node.process_sourced_exec_event(event),
         );
 
-        assert!(cache.borrow().account(&account_id).is_some());
+        let account_event_ids = node
+            .kernel
+            .cache
+            .borrow()
+            .account(&account_id)
+            .unwrap()
+            .events()
+            .into_iter()
+            .map(|event| event.event_id)
+            .collect::<Vec<_>>();
+        assert_eq!(account_event_ids, [bootstrap_event_id, runtime_event_id]);
+        assert!(e3_enqueued.get());
         assert_eq!(
-            dispatch_order.borrow().as_slice(),
-            &["order", "account", "fill"]
+            state.observations.borrow().as_slice(),
+            &[
+                BootstrapReportObservation {
+                    kind: BootstrapReportKind::Order,
+                    account_event_id: bootstrap_event_id,
+                    order_status: OrderStatus::Submitted,
+                },
+                BootstrapReportObservation {
+                    kind: BootstrapReportKind::Position,
+                    account_event_id: runtime_event_id,
+                    order_status: OrderStatus::Accepted,
+                },
+                BootstrapReportObservation {
+                    kind: BootstrapReportKind::Fill,
+                    account_event_id: runtime_event_id,
+                    order_status: OrderStatus::Accepted,
+                },
+            ]
+        );
+        assert_eq!(sourced_exec.len(), 1);
+        {
+            let engine = node.kernel.exec_engine.borrow();
+            assert_eq!(engine.report_count(), report_count + 3);
+            assert_eq!(engine.event_count(), engine_event_count + 2);
+            let cache = engine.cache().borrow();
+            let order = cache.order(&client_order_id).unwrap();
+            assert_eq!(order.status(), OrderStatus::Filled);
+            assert_eq!(order.event_count(), order_event_count + 2);
+            let order_events = order.events();
+            assert!(matches!(
+                order_events[order_events.len() - 2],
+                OrderEventAny::Accepted(_)
+            ));
+            assert!(matches!(
+                order_events[order_events.len() - 1],
+                OrderEventAny::Filled(_)
+            ));
+        }
+        assert_eq!(
+            node.exec_manager.recon_check_retry_count(&client_order_id),
+            0
         );
         assert!(pending.is_empty());
+
+        let Some(ExecutionEventIngress::Sourced(steady_event)) =
+            sourced_exec.try_recv(&mut exec_evt_rx)
+        else {
+            panic!("steady-state sourced event should remain behind the startup prefix");
+        };
+        node.process_sourced_exec_event(steady_event);
+        let account_event_ids = node
+            .kernel
+            .cache
+            .borrow()
+            .account(&account_id)
+            .unwrap()
+            .events()
+            .into_iter()
+            .map(|event| event.event_id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            account_event_ids,
+            [bootstrap_event_id, runtime_event_id, steady_event_id]
+        );
+        assert_eq!(sourced_exec.len(), 0);
+        assert!(exec_evt_rx.try_recv().is_err());
         msgbus::get_message_bus().borrow_mut().dispose();
     }
 
@@ -8649,6 +9064,7 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            drop,
         );
 
         // Both order and report events are drained by pending.drain()
@@ -8688,6 +9104,7 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            drop,
         );
 
         // Account events are forwarded immediately, never buffered in pending
@@ -8698,53 +9115,61 @@ mod tests {
     }
 
     #[rstest]
-    fn test_shutdown_drain_processes_sourced_lane_fifo() {
+    fn test_shutdown_drain_processes_sourced_events_through_live_node() {
         msgbus::get_message_bus().borrow_mut().dispose();
-        let received = Rc::new(RefCell::new(Vec::new()));
-        let received_handler = received.clone();
-        msgbus::register_account_state_endpoint(
-            MessagingSwitchboard::portfolio_update_account(),
-            TypedHandler::from(move |account: &AccountState| {
-                received_handler.borrow_mut().push(account.account_id);
-            }),
-        );
+        let (mut node, mut fill_event, _) = recent_fill_test_fixture("ShutdownSourcedDrainNode");
+        let OrderEventAny::Filled(fill) = &mut fill_event else {
+            unreachable!();
+        };
+        fill.last_qty = Quantity::from("10.0");
+        fill.commission = Some(Money::from("2.00 USDT"));
+        let fill = fill.clone();
+        let account = AccountAny::Margin(MarginAccount::new(
+            AccountState::new(
+                fill.account_id,
+                AccountType::Margin,
+                vec![AccountBalance::new(
+                    Money::from("1000000 USDT"),
+                    Money::from("0 USDT"),
+                    Money::from("1000000 USDT"),
+                )],
+                Vec::new(),
+                true,
+                UUID4::new(),
+                UnixNanos::default(),
+                UnixNanos::default(),
+                Some(Currency::USDT()),
+            ),
+            true,
+        ));
+        node.kernel.cache.borrow_mut().add_account(account).unwrap();
+        let engine_event_count = node.kernel.exec_engine.borrow().event_count();
+        let order_event_count = node
+            .kernel
+            .cache
+            .borrow()
+            .order(&fill.client_order_id)
+            .unwrap()
+            .event_count();
+        assert!(!is_recent_fill(&node, &fill));
 
-        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
-        let (_system_evt_tx, mut system_evt_rx) =
-            tokio::sync::mpsc::unbounded_channel::<SystemEvent>();
-        let (_system_cmd_tx, mut system_cmd_rx) =
-            tokio::sync::mpsc::unbounded_channel::<SystemCommand>();
-        let (_exec_evt_tx, mut exec_evt_rx) =
-            tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
-        let (sourced_exec_evt_tx, sourced_exec_evt_rx) =
-            tokio::sync::mpsc::unbounded_channel::<SourcedExecutionEvent>();
-        let mut sourced_exec = SourcedExecutionIngress::new(sourced_exec_evt_rx);
-        let (_exec_cmd_tx, mut exec_cmd_rx) =
-            tokio::sync::mpsc::unbounded_channel::<TradingCommandMessage>();
-        let (_data_evt_tx, mut data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
-        let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
+        let runner = node.runner.take().expect("runner should be available");
+        runner.bind_senders();
+        let sink = get_sourced_exec_event_sink(ClientId::from("SOURCE-DRAIN"));
+        sink.send(ExecutionEvent::Order(fill_event)).unwrap();
+        let (channels, mut sourced_exec) = runner.take_channels_with_sourced();
+        let AsyncRunnerChannels {
+            mut time_evt_rx,
+            mut system_evt_rx,
+            mut system_cmd_rx,
+            mut exec_evt_rx,
+            mut exec_cmd_rx,
+            mut data_evt_rx,
+            mut data_cmd_rx,
+        } = channels;
 
-        for account_id in ["SOURCE-DRAIN-001", "SOURCE-DRAIN-002"] {
-            sourced_exec_evt_tx
-                .send(SourcedExecutionEvent {
-                    client_id: ClientId::from("SOURCE-DRAIN"),
-                    event: ExecutionEvent::Account(AccountState::new(
-                        AccountId::from(account_id),
-                        AccountType::Cash,
-                        vec![],
-                        vec![],
-                        true,
-                        UUID4::new(),
-                        UnixNanos::from(1),
-                        UnixNanos::from(2),
-                        None,
-                    )),
-                })
-                .unwrap();
-        }
-
-        LiveNode::drain_channels(
-            &mut time_rx,
+        node.drain_channels(
+            &mut time_evt_rx,
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
@@ -8755,12 +9180,19 @@ mod tests {
         );
 
         assert_eq!(
-            received.borrow().as_slice(),
-            &[
-                AccountId::from("SOURCE-DRAIN-001"),
-                AccountId::from("SOURCE-DRAIN-002")
-            ]
+            node.kernel.exec_engine.borrow().event_count(),
+            engine_event_count + 1
         );
+        {
+            let cache = node.kernel.cache.borrow();
+            let order = cache.order(&fill.client_order_id).unwrap();
+            assert_eq!(order.status(), OrderStatus::Filled);
+            assert_eq!(order.event_count(), order_event_count + 1);
+        }
+        assert!(is_recent_fill(&node, &fill));
+        assert_eq!(sourced_exec.len(), 0);
+        assert!(exec_evt_rx.try_recv().is_err());
+        msgbus::get_message_bus().borrow_mut().dispose();
     }
 
     #[rstest]
@@ -8794,22 +9226,25 @@ mod tests {
         let mut pending = PendingEvents::default();
         for client_order_id in ["O-SOURCED-001", "O-SOURCED-002"] {
             pending.buffer_execution_ingress(ExecutionEventIngress::Sourced(
-                SourcedExecutionEvent {
-                    client_id: source_id,
-                    event: ExecutionEvent::Order(OrderEventAny::Submitted(
+                SourcedExecutionEvent::runtime(
+                    source_id,
+                    ExecutionEvent::Order(OrderEventAny::Submitted(
                         OrderSubmittedSpec::builder()
                             .client_order_id(ClientOrderId::from(client_order_id))
                             .build(),
                     )),
-                },
+                ),
             ));
         }
 
         let buffered_ids = pending
             .sourced_exec_evts
             .iter()
-            .map(|sourced| match &sourced.event {
-                ExecutionEvent::Order(event) => event.client_order_id(),
+            .map(|sourced| match sourced {
+                SourcedExecutionEvent::Runtime {
+                    event: ExecutionEvent::Order(event),
+                    ..
+                } => event.client_order_id(),
                 _ => panic!("Expected sourced order event"),
             })
             .collect::<Vec<_>>();
@@ -8868,7 +9303,7 @@ mod tests {
                 )),
             ));
 
-            pending.drain();
+            pending.drain(drop);
 
             assert!(pending.is_empty());
             assert_eq!(risk_commands.borrow().len(), 1);
@@ -8971,6 +9406,7 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            drop,
         );
 
         // Batch should be unpacked into individual Submitted events then drained
@@ -9009,6 +9445,7 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            drop,
         );
 
         // Batch should be unpacked into individual Canceled events then drained

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -94,7 +94,7 @@ use nautilus_common::{
         data::DataCommand,
         execution::{
             GenerateFillReports, GenerateOrderStatusReports, GeneratePositionStatusReports,
-            TradingCommand,
+            SourcedExecutionReport, TradingCommand,
         },
         system::{QueueStateChanged, ReconnectSocket, SocketStateChange, SocketStateChanged},
     },
@@ -134,7 +134,10 @@ use crate::{
             request_targeted_order_reports,
         },
     },
-    runner::{AsyncRunner, AsyncRunnerChannels, PendingRunnerEvent},
+    runner::{
+        AsyncRunner, AsyncRunnerChannels, ExecutionEventIngress, PendingRunnerEvent,
+        SourcedExecutionEvent, SourcedExecutionIngress,
+    },
     socket::{SocketReconnectLookup, SocketReconnectRegistry},
 };
 
@@ -163,6 +166,14 @@ pub use state::{LiveNodeHandle, NodeRunMode, NodeState};
 /// `Pending`. Under a host event loop that starves the adapter I/O tasks feeding those channels,
 /// which shows up as lapsed heartbeats and reconnects rather than as backpressure.
 const DISPATCHES_PER_YIELD: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StrictSourcedReportResult {
+    PreflightRejected,
+    RecentlyProcessed,
+    ReconciliationRejected,
+    Applied,
+}
 
 /// High-level abstraction for a live Nautilus system node.
 ///
@@ -576,6 +587,9 @@ impl LiveNode {
             PendingRunnerEvent::SystemEvent(event) => self.process_system_event(event),
             PendingRunnerEvent::SystemCommand(command) => self.process_system_command(command),
             PendingRunnerEvent::ExecEvent(event) => self.process_exec_event(event),
+            PendingRunnerEvent::SourcedExecEvent(event) => {
+                self.process_sourced_exec_event(event);
+            }
             PendingRunnerEvent::ExecCommand(command) => self.process_exec_command(command),
             PendingRunnerEvent::DataEvent(event) => AsyncRunner::handle_data_event(event),
             PendingRunnerEvent::DataCommand(command) => AsyncRunner::handle_data_command(command),
@@ -990,6 +1004,7 @@ impl LiveNode {
         };
         runner.bind_senders();
 
+        let (channels, mut sourced_exec_ingress) = runner.take_channels_with_sourced();
         let AsyncRunnerChannels {
             mut time_evt_rx,
             mut system_evt_rx,
@@ -998,7 +1013,7 @@ impl LiveNode {
             mut exec_cmd_rx,
             mut data_evt_rx,
             mut data_cmd_rx,
-        } = runner.take_channels();
+        } = channels;
 
         log::info!("Event loop starting");
 
@@ -1034,6 +1049,7 @@ impl LiveNode {
                     &mut system_evt_rx,
                     &mut system_cmd_rx,
                     &mut exec_evt_rx,
+                    &mut sourced_exec_ingress,
                     &mut exec_cmd_rx,
                     &mut data_evt_rx,
                     &mut data_cmd_rx,
@@ -1065,6 +1081,7 @@ impl LiveNode {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec_ingress,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
@@ -1078,6 +1095,7 @@ impl LiveNode {
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
                 &mut exec_evt_rx,
+                &mut sourced_exec_ingress,
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
@@ -1090,6 +1108,7 @@ impl LiveNode {
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
                 &mut exec_evt_rx,
+                &mut sourced_exec_ingress,
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
@@ -1117,6 +1136,7 @@ impl LiveNode {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec_ingress,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
@@ -1130,6 +1150,7 @@ impl LiveNode {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec_ingress,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
@@ -1152,6 +1173,7 @@ impl LiveNode {
                     &mut system_evt_rx,
                     &mut system_cmd_rx,
                     &mut exec_evt_rx,
+                    &mut sourced_exec_ingress,
                     &mut exec_cmd_rx,
                     &mut data_evt_rx,
                     &mut data_cmd_rx,
@@ -1173,6 +1195,7 @@ impl LiveNode {
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
                 &mut exec_evt_rx,
+                &mut sourced_exec_ingress,
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
@@ -1191,6 +1214,7 @@ impl LiveNode {
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
                 &mut exec_evt_rx,
+                &mut sourced_exec_ingress,
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
@@ -1209,6 +1233,7 @@ impl LiveNode {
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
                 &mut exec_evt_rx,
+                &mut sourced_exec_ingress,
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
@@ -1231,6 +1256,7 @@ impl LiveNode {
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
                 &mut exec_evt_rx,
+                &mut sourced_exec_ingress,
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
@@ -1246,6 +1272,7 @@ impl LiveNode {
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
                 &mut exec_evt_rx,
+                &mut sourced_exec_ingress,
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
@@ -1261,6 +1288,7 @@ impl LiveNode {
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
                 &mut exec_evt_rx,
+                &mut sourced_exec_ingress,
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
@@ -1280,6 +1308,7 @@ impl LiveNode {
                 data_evt: &mut data_evt_rx,
                 data_cmd: &mut data_cmd_rx,
                 exec_evt: &mut exec_evt_rx,
+                sourced_exec: &mut sourced_exec_ingress,
                 exec_cmd: &mut exec_cmd_rx,
             };
             self.finish_startup_trader(Some(&mut receivers)).await
@@ -1608,6 +1637,7 @@ impl LiveNode {
                         RunnerChannelQueueDepths::from_receivers(
                             &time_evt_rx,
                             &exec_evt_rx,
+                            &sourced_exec_ingress,
                             &exec_cmd_rx,
                             &data_evt_rx,
                             &data_cmd_rx,
@@ -1713,15 +1743,20 @@ impl LiveNode {
                     }
                     self.process_system_command(command);
                 }
-                Some(evt) = exec_evt_rx.recv() => {
+                Some(ingress) = sourced_exec_ingress.recv(&mut exec_evt_rx) => {
                     let dispatch_start = dst::time::Instant::now();
 
                     if is_shutting_down {
-                        log::debug!("Residual exec event: {evt:?}");
+                        log::debug!("Residual exec event: {ingress:?}");
                         residual_events += 1;
                     }
 
-                    self.process_exec_event(evt);
+                    match ingress {
+                        ExecutionEventIngress::Legacy(event) => self.process_exec_event(event),
+                        ExecutionEventIngress::Sourced(event) => {
+                            self.process_sourced_exec_event(event);
+                        }
+                    }
                     record_runner_dispatch(
                         &metrics,
                         SystemChannel::ExecEvents,
@@ -1828,6 +1863,7 @@ impl LiveNode {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec_ingress,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
@@ -1982,8 +2018,91 @@ impl LiveNode {
         };
 
         self.dispatch_exec_event_and_commit_fill(event);
+        self.clear_closed_recon_tracking(&close_ids);
+    }
 
-        for client_order_id in &close_ids {
+    fn process_sourced_exec_event(&mut self, event: SourcedExecutionEvent) {
+        let SourcedExecutionEvent { client_id, event } = event;
+        let event = match event {
+            ExecutionEvent::Report(
+                report @ (ExecutionReport::Order(_) | ExecutionReport::Fill(_)),
+            ) => {
+                self.process_strict_sourced_exec_report(client_id, report);
+                return;
+            }
+            event => event,
+        };
+
+        let Some(close_ids) = self.observe_exec_event_before_dispatch(&event) else {
+            return;
+        };
+
+        let recent_fill_candidate = match &event {
+            ExecutionEvent::Order(OrderEventAny::Filled(fill)) => Some(fill.clone()),
+            _ => None,
+        };
+        AsyncRunner::handle_sourced_exec_event(SourcedExecutionEvent { client_id, event });
+
+        if let Some(fill) = &recent_fill_candidate {
+            self.exec_manager.commit_recent_fill_if_applied(fill);
+        }
+
+        self.clear_closed_recon_tracking(&close_ids);
+    }
+
+    /// Validates and applies a strict sourced report before mutating manager observation state.
+    ///
+    /// The preflight precedes recent-fill deduplication. The shared engine entry applies both
+    /// validation fences and returns a result, so manager activity and close tracking are updated
+    /// only after the report was accepted by the engine.
+    fn process_strict_sourced_exec_report(
+        &mut self,
+        client_id: ClientId,
+        report: ExecutionReport,
+    ) -> StrictSourcedReportResult {
+        let sourced = SourcedExecutionReport::new(client_id, report);
+
+        if let Err(e) = self
+            .kernel
+            .exec_engine
+            .borrow()
+            .preflight_sourced_execution_report(&sourced)
+        {
+            log::error!("Cannot dispatch sourced execution report: {e:#}");
+            return StrictSourcedReportResult::PreflightRejected;
+        }
+
+        if let ExecutionReport::Fill(fill_report) = &sourced.report
+            && self.exec_manager.is_fill_recently_processed(
+                fill_report.account_id,
+                fill_report.instrument_id,
+                fill_report.trade_id,
+            )
+        {
+            log::debug!(
+                "Skipping recently processed sourced fill report: {}",
+                fill_report.trade_id,
+            );
+            return StrictSourcedReportResult::RecentlyProcessed;
+        }
+
+        if let Err(e) =
+            ExecutionEngine::reconcile_sourced_execution_report(&self.kernel.exec_engine, &sourced)
+        {
+            log::error!("Cannot reconcile sourced execution report: {e:#}");
+            return StrictSourcedReportResult::ReconciliationRejected;
+        }
+
+        self.exec_manager.observe_execution_report(&sourced.report);
+        if let Some(client_order_id) = Self::closed_order_report_client_order_id(&sourced.report) {
+            self.clear_closed_recon_tracking(&[client_order_id]);
+        }
+
+        StrictSourcedReportResult::Applied
+    }
+
+    fn clear_closed_recon_tracking(&mut self, close_ids: &[ClientOrderId]) {
+        for client_order_id in close_ids {
             let is_closed = self
                 .kernel
                 .cache()
@@ -2174,6 +2293,7 @@ impl LiveNode {
                 receivers.system_evt,
                 receivers.system_cmd,
                 receivers.exec_evt,
+                receivers.sourced_exec,
                 receivers.exec_cmd,
                 receivers.data_evt,
                 receivers.data_cmd,
@@ -2231,8 +2351,13 @@ impl LiveNode {
                     self.process_system_command(command);
                     processed += 1;
                 }
-                Some(event) = receivers.exec_evt.recv() => {
-                    self.process_exec_event(event);
+                Some(ingress) = receivers.sourced_exec.recv(receivers.exec_evt) => {
+                    match ingress {
+                        ExecutionEventIngress::Legacy(event) => self.process_exec_event(event),
+                        ExecutionEventIngress::Sourced(event) => {
+                            self.process_sourced_exec_event(event);
+                        }
+                    }
                     processed += 1;
                 }
                 Some(command) = receivers.exec_cmd.recv() => {
@@ -2334,11 +2459,16 @@ impl LiveNode {
         }
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "all runner receivers are drained together"
+    )]
     fn drain_channels(
         time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
         system_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemEvent>,
         system_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemCommand>,
         exec_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+        sourced_exec: &mut SourcedExecutionIngress,
         exec_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TradingCommandMessage>,
         data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
         data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
@@ -2368,8 +2498,13 @@ impl LiveNode {
             drained += 1;
         }
 
-        while let Ok(evt) = exec_evt_rx.try_recv() {
-            AsyncRunner::handle_exec_event(evt);
+        while let Some(ingress) = sourced_exec.try_recv(exec_evt_rx) {
+            match ingress {
+                ExecutionEventIngress::Legacy(event) => AsyncRunner::handle_exec_event(event),
+                ExecutionEventIngress::Sourced(event) => {
+                    AsyncRunner::handle_sourced_exec_event(event);
+                }
+            }
             drained += 1;
         }
 
@@ -3611,6 +3746,7 @@ struct RunnerReceivers<'a> {
     system_evt: &'a mut tokio::sync::mpsc::UnboundedReceiver<SystemEvent>,
     system_cmd: &'a mut tokio::sync::mpsc::UnboundedReceiver<SystemCommand>,
     exec_evt: &'a mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    sourced_exec: &'a mut SourcedExecutionIngress,
     exec_cmd: &'a mut tokio::sync::mpsc::UnboundedReceiver<TradingCommandMessage>,
     data_evt: &'a mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
     data_cmd: &'a mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
@@ -3661,6 +3797,7 @@ fn flush_all_pending(
     system_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemEvent>,
     system_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemCommand>,
     exec_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    sourced_exec: &mut SourcedExecutionIngress,
     exec_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TradingCommandMessage>,
     data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
     data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
@@ -3686,33 +3823,8 @@ fn flush_all_pending(
         pending.data_cmds.push(cmd);
     }
 
-    while let Ok(evt) = exec_evt_rx.try_recv() {
-        match evt {
-            ExecutionEvent::Account(_) => {
-                AsyncRunner::handle_exec_event(evt);
-            }
-            ExecutionEvent::Report(report) => {
-                pending.exec_reports.push(report);
-            }
-            ExecutionEvent::Order(order_evt) => {
-                pending.order_evts.push(order_evt);
-            }
-            ExecutionEvent::OrderSubmittedBatch(batch) => {
-                for submitted in batch {
-                    pending.order_evts.push(OrderEventAny::Submitted(submitted));
-                }
-            }
-            ExecutionEvent::OrderAcceptedBatch(batch) => {
-                for accepted in batch {
-                    pending.order_evts.push(OrderEventAny::Accepted(accepted));
-                }
-            }
-            ExecutionEvent::OrderCanceledBatch(batch) => {
-                for canceled in batch {
-                    pending.order_evts.push(OrderEventAny::Canceled(canceled));
-                }
-            }
-        }
+    while let Some(ingress) = sourced_exec.try_recv(exec_evt_rx) {
+        pending.buffer_execution_ingress(ingress);
     }
 
     while let Ok(cmd) = exec_cmd_rx.try_recv() {
@@ -3724,8 +3836,9 @@ fn flush_all_pending(
 
 /// Drives a future to completion while buffering channel events.
 ///
-/// Time events are handled immediately. Account events are forwarded directly.
-/// All other events are buffered in `pending` for later processing.
+/// Time events are handled immediately. Legacy account events are forwarded directly.
+/// All sourced execution events are buffered FIFO within their lane; every other execution event
+/// is buffered in its existing legacy pending category.
 #[expect(
     clippy::too_many_arguments,
     reason = "startup buffering owns one future plus the pending state and all runner receivers"
@@ -3737,6 +3850,7 @@ async fn drive_with_event_buffering<F: std::future::Future>(
     system_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemEvent>,
     system_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemCommand>,
     exec_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    sourced_exec: &mut SourcedExecutionIngress,
     exec_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TradingCommandMessage>,
     data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
     data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
@@ -3759,36 +3873,8 @@ async fn drive_with_event_buffering<F: std::future::Future>(
             Some(command) = system_cmd_rx.recv() => {
                 pending.system_commands.push(command);
             }
-            Some(evt) = exec_evt_rx.recv() => {
-                // Account events are safe to process immediately. Report and
-                // Order events need ExecEngine borrow_mut which may conflict
-                // with the borrow held by the driven future.
-                match evt {
-                    ExecutionEvent::Account(_) => {
-                        AsyncRunner::handle_exec_event(evt);
-                    }
-                    ExecutionEvent::Report(report) => {
-                        pending.exec_reports.push(report);
-                    }
-                    ExecutionEvent::Order(order_evt) => {
-                        pending.order_evts.push(order_evt);
-                    }
-                    ExecutionEvent::OrderSubmittedBatch(batch) => {
-                        for submitted in batch {
-                            pending.order_evts.push(OrderEventAny::Submitted(submitted));
-                        }
-                    }
-                    ExecutionEvent::OrderAcceptedBatch(batch) => {
-                        for accepted in batch {
-                            pending.order_evts.push(OrderEventAny::Accepted(accepted));
-                        }
-                    }
-                    ExecutionEvent::OrderCanceledBatch(batch) => {
-                        for canceled in batch {
-                            pending.order_evts.push(OrderEventAny::Canceled(canceled));
-                        }
-                    }
-                }
+            Some(ingress) = sourced_exec.recv(exec_evt_rx) => {
+                pending.buffer_execution_ingress(ingress);
             }
             Some(cmd) = exec_cmd_rx.recv() => {
                 pending.exec_cmds.push(cmd);
@@ -3811,6 +3897,7 @@ struct PendingEvents {
     data_cmds: Vec<DataCommand>,
     exec_reports: Vec<ExecutionReport>,
     order_evts: Vec<OrderEventAny>,
+    sourced_exec_evts: Vec<SourcedExecutionEvent>,
     exec_cmds: Vec<TradingCommandMessage>,
 }
 
@@ -3822,6 +3909,7 @@ impl PendingEvents {
             && self.data_cmds.is_empty()
             && self.exec_reports.is_empty()
             && self.order_evts.is_empty()
+            && self.sourced_exec_evts.is_empty()
             && self.exec_cmds.is_empty()
     }
 
@@ -3857,16 +3945,19 @@ impl PendingEvents {
             + self.data_cmds.len()
             + self.exec_reports.len()
             + self.order_evts.len()
+            + self.sourced_exec_evts.len()
             + self.exec_cmds.len();
 
         if total > 0 {
             log::debug!(
                 "Processing {total} events/commands queued during startup \
-                 (data_evts={}, data_cmds={}, exec_reports={}, order_evts={}, exec_cmds={})",
+                 (data_evts={}, data_cmds={}, exec_reports={}, order_evts={}, \
+                 sourced_exec_evts={}, exec_cmds={})",
                 self.data_evts.len(),
                 self.data_cmds.len(),
                 self.exec_reports.len(),
                 self.order_evts.len(),
+                self.sourced_exec_evts.len(),
                 self.exec_cmds.len()
             );
         }
@@ -3887,8 +3978,35 @@ impl PendingEvents {
             AsyncRunner::handle_exec_event(ExecutionEvent::Order(evt));
         }
 
+        for evt in self.sourced_exec_evts.drain(..) {
+            AsyncRunner::handle_sourced_exec_event(evt);
+        }
+
         for cmd in self.exec_cmds.drain(..) {
             AsyncRunner::handle_trading_command(cmd);
+        }
+    }
+
+    fn buffer_execution_ingress(&mut self, ingress: ExecutionEventIngress) {
+        match ingress {
+            ExecutionEventIngress::Sourced(event) => self.sourced_exec_evts.push(event),
+            ExecutionEventIngress::Legacy(event) => match event {
+                ExecutionEvent::Account(_) => AsyncRunner::handle_exec_event(event),
+                ExecutionEvent::Report(report) => self.exec_reports.push(report),
+                ExecutionEvent::Order(order_evt) => self.order_evts.push(order_evt),
+                ExecutionEvent::OrderSubmittedBatch(batch) => {
+                    self.order_evts
+                        .extend(batch.into_iter().map(OrderEventAny::Submitted));
+                }
+                ExecutionEvent::OrderAcceptedBatch(batch) => {
+                    self.order_evts
+                        .extend(batch.into_iter().map(OrderEventAny::Accepted));
+                }
+                ExecutionEvent::OrderCanceledBatch(batch) => {
+                    self.order_evts
+                        .extend(batch.into_iter().map(OrderEventAny::Canceled));
+                }
+            },
         }
     }
 
@@ -4554,6 +4672,165 @@ mod tests {
 
         let close_ids = node.observe_exec_event_before_dispatch(&event);
         assert_eq!(close_ids, None);
+    }
+
+    #[rstest]
+    fn test_sourced_runtime_report_validates_before_exact_source_dispatch() {
+        msgbus::get_message_bus().borrow_mut().dispose();
+        let config = LiveNodeConfig {
+            exec_engine: crate::config::LiveExecutionEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut node = LiveNode::build("SourcedReportNode".to_string(), Some(config)).unwrap();
+        let instrument = crypto_perpetual_ethusdt();
+        let instrument_id = instrument.id();
+        let account_id = AccountId::from("SHARED-SOURCED-ACCOUNT");
+        let venue_client_id = ClientId::from("VENUE-SOURCED-A");
+        let source_client_id = ClientId::from("SOURCE-SOURCED-B");
+        let venue_client = StubExecutionClient::new(
+            venue_client_id,
+            account_id,
+            instrument_id.venue,
+            OmsType::Netting,
+            None,
+        );
+        let venue_registrations = venue_client.registered_external_order_ids();
+        let source_client = StubExecutionClient::new(
+            source_client_id,
+            account_id,
+            Venue::from("SOURCE-SOURCED-B"),
+            OmsType::Netting,
+            None,
+        )
+        .with_handles_all_order_venues();
+        let source_registrations = source_client.registered_external_order_ids();
+        {
+            let mut engine = node.kernel.exec_engine.borrow_mut();
+            engine.register_client(Box::new(venue_client)).unwrap();
+            engine.register_client(Box::new(source_client)).unwrap();
+            engine
+                .cache()
+                .borrow_mut()
+                .add_instrument(InstrumentAny::CryptoPerpetual(instrument))
+                .unwrap();
+        }
+
+        let invalid_order_id = ClientOrderId::from("O-SOURCED-INVALID");
+        let valid_order_id = ClientOrderId::from("O-SOURCED-VALID");
+        let report = |client_order_id, venue_order_id| {
+            ExecutionReport::Order(Box::new(OrderStatusReport::new(
+                account_id,
+                instrument_id,
+                Some(client_order_id),
+                venue_order_id,
+                OrderSide::Buy.into(),
+                OrderType::Market,
+                TimeInForce::Gtc,
+                OrderStatus::Accepted,
+                Quantity::from("1.0"),
+                Quantity::from("0.0"),
+                UnixNanos::from(1),
+                UnixNanos::from(2),
+                UnixNanos::from(3),
+                None,
+            )))
+        };
+
+        node.process_sourced_exec_event(SourcedExecutionEvent {
+            client_id: ClientId::from("UNREGISTERED-SOURCE"),
+            event: ExecutionEvent::Report(report(
+                invalid_order_id,
+                VenueOrderId::from("V-SOURCED-INVALID"),
+            )),
+        });
+        assert!(
+            node.kernel
+                .cache
+                .borrow()
+                .order(&invalid_order_id)
+                .is_none()
+        );
+        assert!(venue_registrations.borrow().is_empty());
+        assert!(source_registrations.borrow().is_empty());
+
+        node.process_sourced_exec_event(SourcedExecutionEvent {
+            client_id: source_client_id,
+            event: ExecutionEvent::Report(report(
+                valid_order_id,
+                VenueOrderId::from("V-SOURCED-VALID"),
+            )),
+        });
+
+        assert_eq!(
+            node.kernel.cache.borrow().client_id(&valid_order_id),
+            Some(&source_client_id)
+        );
+        assert!(venue_registrations.borrow().is_empty());
+        assert_eq!(source_registrations.borrow().as_slice(), &[valid_order_id]);
+    }
+
+    #[rstest]
+    fn test_sourced_recent_fill_runs_preflight_before_deduplication() {
+        let (mut node, fill_event, instrument) =
+            recent_fill_test_fixture("SourcedRecentFillPreflightNode");
+        let OrderEventAny::Filled(fill) = fill_event else {
+            unreachable!();
+        };
+        let ExecutionEvent::Report(ExecutionReport::Fill(report)) = fill_report_event(&fill) else {
+            unreachable!();
+        };
+        node.exec_manager.mark_fill_processed(
+            report.account_id,
+            report.instrument_id,
+            report.trade_id,
+        );
+
+        let report_count = node.kernel.exec_engine.borrow().report_count();
+        let event_count = node.kernel.exec_engine.borrow().event_count();
+        let cached_event_count = node
+            .kernel
+            .cache
+            .borrow()
+            .order(&fill.client_order_id)
+            .unwrap()
+            .event_count();
+
+        let rejected = node.process_strict_sourced_exec_report(
+            ClientId::from("UNREGISTERED-SOURCE"),
+            ExecutionReport::Fill(Box::new((*report).clone())),
+        );
+
+        let source_client_id = ClientId::from("TEST-RECENT-FILL");
+        let source_client = StubExecutionClient::new(
+            source_client_id,
+            report.account_id,
+            instrument.id().venue,
+            OmsType::Netting,
+            None,
+        );
+        let source_registrations = source_client.registered_external_order_ids();
+        node.kernel
+            .exec_engine
+            .borrow_mut()
+            .register_client(Box::new(source_client))
+            .unwrap();
+
+        let deduplicated = node
+            .process_strict_sourced_exec_report(source_client_id, ExecutionReport::Fill(report));
+
+        assert_eq!(rejected, StrictSourcedReportResult::PreflightRejected);
+        assert_eq!(deduplicated, StrictSourcedReportResult::RecentlyProcessed);
+        assert!(source_registrations.borrow().is_empty());
+        let engine = node.kernel.exec_engine.borrow();
+        assert_eq!(engine.report_count(), report_count);
+        assert_eq!(engine.event_count(), event_count);
+        let cache = engine.cache().borrow();
+        let cached = cache.order(&fill.client_order_id).unwrap();
+        assert_eq!(cached.status(), OrderStatus::Accepted);
+        assert_eq!(cached.event_count(), cached_event_count);
     }
 
     #[rstest]
@@ -8096,6 +8373,9 @@ mod tests {
         let (data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
             tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        let (_sourced_exec_evt_tx, sourced_exec_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SourcedExecutionEvent>();
+        let mut sourced_exec = SourcedExecutionIngress::new(sourced_exec_evt_rx);
         let (exec_cmd_tx, mut exec_cmd_rx) =
             tokio::sync::mpsc::unbounded_channel::<TradingCommandMessage>();
 
@@ -8128,6 +8408,7 @@ mod tests {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
@@ -8189,6 +8470,9 @@ mod tests {
         let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
             tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        let (_sourced_exec_evt_tx, sourced_exec_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SourcedExecutionEvent>();
+        let mut sourced_exec = SourcedExecutionIngress::new(sourced_exec_evt_rx);
         let (_exec_cmd_tx, mut exec_cmd_rx) =
             tokio::sync::mpsc::unbounded_channel::<TradingCommandMessage>();
 
@@ -8203,6 +8487,7 @@ mod tests {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
@@ -8225,6 +8510,9 @@ mod tests {
         let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
             tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        let (_sourced_exec_evt_tx, sourced_exec_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SourcedExecutionEvent>();
+        let mut sourced_exec = SourcedExecutionIngress::new(sourced_exec_evt_rx);
         let (_exec_cmd_tx, mut exec_cmd_rx) =
             tokio::sync::mpsc::unbounded_channel::<TradingCommandMessage>();
 
@@ -8238,6 +8526,7 @@ mod tests {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
@@ -8248,6 +8537,72 @@ mod tests {
         assert!(pending.order_evts.is_empty());
         assert!(pending.exec_cmds.is_empty());
         assert!(exec_evt_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_shutdown_drain_processes_sourced_lane_fifo() {
+        msgbus::get_message_bus().borrow_mut().dispose();
+        let received = Rc::new(RefCell::new(Vec::new()));
+        let received_handler = received.clone();
+        msgbus::register_account_state_endpoint(
+            MessagingSwitchboard::portfolio_update_account(),
+            TypedHandler::from(move |account: &AccountState| {
+                received_handler.borrow_mut().push(account.account_id);
+            }),
+        );
+
+        let (_time_tx, mut time_rx) = tokio::sync::mpsc::unbounded_channel::<TimeEventMessage>();
+        let (_system_evt_tx, mut system_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SystemEvent>();
+        let (_system_cmd_tx, mut system_cmd_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SystemCommand>();
+        let (_exec_evt_tx, mut exec_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        let (sourced_exec_evt_tx, sourced_exec_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SourcedExecutionEvent>();
+        let mut sourced_exec = SourcedExecutionIngress::new(sourced_exec_evt_rx);
+        let (_exec_cmd_tx, mut exec_cmd_rx) =
+            tokio::sync::mpsc::unbounded_channel::<TradingCommandMessage>();
+        let (_data_evt_tx, mut data_evt_rx) = tokio::sync::mpsc::unbounded_channel::<DataEvent>();
+        let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
+
+        for account_id in ["SOURCE-DRAIN-001", "SOURCE-DRAIN-002"] {
+            sourced_exec_evt_tx
+                .send(SourcedExecutionEvent {
+                    client_id: ClientId::from("SOURCE-DRAIN"),
+                    event: ExecutionEvent::Account(AccountState::new(
+                        AccountId::from(account_id),
+                        AccountType::Cash,
+                        vec![],
+                        vec![],
+                        true,
+                        UUID4::new(),
+                        UnixNanos::from(1),
+                        UnixNanos::from(2),
+                        None,
+                    )),
+                })
+                .unwrap();
+        }
+
+        LiveNode::drain_channels(
+            &mut time_rx,
+            &mut system_evt_rx,
+            &mut system_cmd_rx,
+            &mut exec_evt_rx,
+            &mut sourced_exec,
+            &mut exec_cmd_rx,
+            &mut data_evt_rx,
+            &mut data_cmd_rx,
+        );
+
+        assert_eq!(
+            received.borrow().as_slice(),
+            &[
+                AccountId::from("SOURCE-DRAIN-001"),
+                AccountId::from("SOURCE-DRAIN-002")
+            ]
+        );
     }
 
     #[rstest]
@@ -8271,6 +8626,44 @@ mod tests {
         pending.data_cmds.push(stub_data_command());
 
         assert!(!pending.is_empty());
+    }
+
+    #[rstest]
+    fn test_pending_buffers_sourced_execution_lane_in_fifo_order() {
+        use nautilus_model::{events::order::spec::OrderSubmittedSpec, identifiers::ClientOrderId};
+
+        let source_id = ClientId::from("SOURCE-PENDING");
+        let mut pending = PendingEvents::default();
+        for client_order_id in ["O-SOURCED-001", "O-SOURCED-002"] {
+            pending.buffer_execution_ingress(ExecutionEventIngress::Sourced(
+                SourcedExecutionEvent {
+                    client_id: source_id,
+                    event: ExecutionEvent::Order(OrderEventAny::Submitted(
+                        OrderSubmittedSpec::builder()
+                            .client_order_id(ClientOrderId::from(client_order_id))
+                            .build(),
+                    )),
+                },
+            ));
+        }
+
+        let buffered_ids = pending
+            .sourced_exec_evts
+            .iter()
+            .map(|sourced| match &sourced.event {
+                ExecutionEvent::Order(event) => event.client_order_id(),
+                _ => panic!("Expected sourced order event"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            buffered_ids,
+            [
+                ClientOrderId::from("O-SOURCED-001"),
+                ClientOrderId::from("O-SOURCED-002")
+            ]
+        );
+        assert!(pending.exec_reports.is_empty());
+        assert!(pending.order_evts.is_empty());
     }
 
     #[rstest]
@@ -8400,6 +8793,9 @@ mod tests {
         let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
             tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        let (_sourced_exec_evt_tx, sourced_exec_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SourcedExecutionEvent>();
+        let mut sourced_exec = SourcedExecutionIngress::new(sourced_exec_evt_rx);
         let (_exec_cmd_tx, mut exec_cmd_rx) =
             tokio::sync::mpsc::unbounded_channel::<TradingCommandMessage>();
 
@@ -8413,6 +8809,7 @@ mod tests {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
@@ -8434,6 +8831,9 @@ mod tests {
         let (_data_cmd_tx, mut data_cmd_rx) = tokio::sync::mpsc::unbounded_channel::<DataCommand>();
         let (exec_evt_tx, mut exec_evt_rx) =
             tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        let (_sourced_exec_evt_tx, sourced_exec_evt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<SourcedExecutionEvent>();
+        let mut sourced_exec = SourcedExecutionIngress::new(sourced_exec_evt_rx);
         let (_exec_cmd_tx, mut exec_cmd_rx) =
             tokio::sync::mpsc::unbounded_channel::<TradingCommandMessage>();
 
@@ -8447,6 +8847,7 @@ mod tests {
             &mut system_evt_rx,
             &mut system_cmd_rx,
             &mut exec_evt_rx,
+            &mut sourced_exec,
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,

--- a/crates/live/src/runner.rs
+++ b/crates/live/src/runner.rs
@@ -45,7 +45,8 @@
 //! - **Integrated**: call [`AsyncRunner::take_channels`] to extract the
 //!   receivers and run the `select!` loop directly inside `LiveNode::run`,
 //!   where it is interleaved with startup, reconciliation, and shutdown
-//!   phases.
+//!   phases. Use [`AsyncRunner::handle_next_exec_event`] for the execution
+//!   branch so both legacy and sourced execution lanes remain serviceable.
 //!
 //! # Invariants
 //!
@@ -63,12 +64,19 @@
 //!   arbitration prevents either ready lane from starving, but no global order
 //!   is defined across the two lanes.
 
-use std::{cell::RefCell, fmt::Debug, sync::Arc};
+use std::{
+    cell::RefCell,
+    fmt::Debug,
+    future::poll_fn,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 use nautilus_common::{
     live::runner::{
-        replace_data_event_sender, replace_exec_event_sender, replace_system_command_sender,
-        replace_system_event_sender,
+        get_exec_event_sender, replace_data_event_sender, replace_exec_event_sender,
+        replace_system_command_sender, replace_system_event_sender,
     },
     messages::{
         DataEvent, ExecutionEvent, ExecutionReport, SystemCommand, SystemEvent,
@@ -86,6 +94,7 @@ use nautilus_model::{events::OrderEventAny, identifiers::ClientId};
 
 thread_local! {
     static SOURCED_EXEC_EVENT_SENDER: RefCell<Option<tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>>> = const { RefCell::new(None) };
+    static INTEGRATED_SOURCED_EXEC_INGRESS: RefCell<Option<SourcedExecutionIngress>> = const { RefCell::new(None) };
 }
 
 /// An execution-event sender permanently bound to one execution client.
@@ -97,25 +106,35 @@ thread_local! {
 pub struct SourcedExecutionEventSink {
     client_id: ClientId,
     sender: tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>,
+    public_exec_sender: tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
 }
 
 impl SourcedExecutionEventSink {
     pub(crate) fn new(
         client_id: ClientId,
         sender: tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>,
+        public_exec_sender: tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
     ) -> Self {
-        Self { client_id, sender }
+        Self {
+            client_id,
+            sender,
+            public_exec_sender,
+        }
     }
 
     /// Sends an execution event through the sourced ingress lane.
     ///
     /// # Errors
     ///
-    /// Returns the original event when the sourced ingress receiver is closed.
+    /// Returns the original event when the sourced ingress or paired public execution receiver
+    /// is closed.
     pub(crate) fn send(
         &self,
         event: ExecutionEvent,
     ) -> Result<(), Box<tokio::sync::mpsc::error::SendError<ExecutionEvent>>> {
+        if self.public_exec_sender.is_closed() {
+            return Err(Box::new(tokio::sync::mpsc::error::SendError(event)));
+        }
         self.sender
             .send(SourcedExecutionEvent::new(self.client_id, event))
             .map_err(|e| Box::new(tokio::sync::mpsc::error::SendError(e.0.event)))
@@ -138,6 +157,7 @@ pub fn get_sourced_exec_event_sink(client_id: ClientId) -> SourcedExecutionEvent
                 .as_ref()
                 .expect("sourced execution-event sender is not bound")
                 .clone(),
+            get_exec_event_sender(),
         )
     })
 }
@@ -197,37 +217,66 @@ impl SourcedExecutionIngress {
         &mut self,
         legacy_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
     ) -> Option<ExecutionEventIngress> {
-        let ingress = if self.prefer_sourced {
-            tokio::select! {
-                biased;
+        poll_fn(|cx| self.poll_recv(cx, legacy_rx)).await
+    }
 
-                Some(event) = self.receiver.recv() => {
-                    Some(ExecutionEventIngress::Sourced(event))
-                }
-                Some(event) = legacy_rx.recv() => {
-                    Some(ExecutionEventIngress::Legacy(event))
-                }
-                else => None,
-            }
-        } else {
-            tokio::select! {
-                biased;
-
-                Some(event) = legacy_rx.recv() => {
-                    Some(ExecutionEventIngress::Legacy(event))
-                }
-                Some(event) = self.receiver.recv() => {
-                    Some(ExecutionEventIngress::Sourced(event))
-                }
-                else => None,
-            }
-        };
-
-        if let Some(ingress) = &ingress {
-            self.prefer_sourced = matches!(ingress, ExecutionEventIngress::Legacy(_));
+    fn poll_recv(
+        &mut self,
+        cx: &mut Context<'_>,
+        legacy_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    ) -> Poll<Option<ExecutionEventIngress>> {
+        if legacy_rx.is_closed() {
+            self.receiver.close();
         }
 
-        ingress
+        if self.prefer_sourced {
+            let sourced_closed = match Pin::new(&mut self.receiver).poll_recv(cx) {
+                Poll::Ready(Some(event)) => {
+                    return self.ready(ExecutionEventIngress::Sourced(event));
+                }
+                Poll::Ready(None) => true,
+                Poll::Pending => false,
+            };
+            let legacy_closed = match Pin::new(legacy_rx).poll_recv(cx) {
+                Poll::Ready(Some(event)) => {
+                    return self.ready(ExecutionEventIngress::Legacy(event));
+                }
+                Poll::Ready(None) => true,
+                Poll::Pending => false,
+            };
+
+            return if sourced_closed && legacy_closed {
+                Poll::Ready(None)
+            } else {
+                Poll::Pending
+            };
+        }
+
+        let legacy_closed = match Pin::new(&mut *legacy_rx).poll_recv(cx) {
+            Poll::Ready(Some(event)) => {
+                return self.ready(ExecutionEventIngress::Legacy(event));
+            }
+            Poll::Ready(None) => true,
+            Poll::Pending => false,
+        };
+        let sourced_closed = match Pin::new(&mut self.receiver).poll_recv(cx) {
+            Poll::Ready(Some(event)) => {
+                return self.ready(ExecutionEventIngress::Sourced(event));
+            }
+            Poll::Ready(None) => true,
+            Poll::Pending => false,
+        };
+
+        if legacy_closed && sourced_closed {
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn ready(&mut self, ingress: ExecutionEventIngress) -> Poll<Option<ExecutionEventIngress>> {
+        self.prefer_sourced = matches!(&ingress, ExecutionEventIngress::Legacy(_));
+        Poll::Ready(Some(ingress))
     }
 
     #[cfg(any(test, feature = "node"))]
@@ -255,6 +304,12 @@ impl SourcedExecutionIngress {
 
         ingress
     }
+}
+
+fn replace_integrated_sourced_exec_ingress(ingress: Option<SourcedExecutionIngress>) {
+    INTEGRATED_SOURCED_EXEC_INGRESS.with(|slot| {
+        *slot.borrow_mut() = ingress;
+    });
 }
 
 /// Asynchronous implementation of `DataCommandSender` for live environments.
@@ -448,6 +503,7 @@ impl AsyncRunner {
     /// and again before entering the event loop to reclaim ownership if another
     /// runner was constructed on this thread in the interim.
     pub fn bind_senders(&self) {
+        replace_integrated_sourced_exec_ingress(None);
         replace_time_event_sender(Arc::new(AsyncTimeEventSender::new(
             self.time_evt_tx.clone(),
         )));
@@ -482,10 +538,53 @@ impl AsyncRunner {
     /// Consumes the runner and returns the channel receivers for direct event loop driving.
     ///
     /// This is used when the event loop needs to run on the same thread as the msgbus
-    /// endpoints (which use thread-local storage).
+    /// endpoints (which use thread-local storage). Drive `exec_evt_rx` through
+    /// [`Self::handle_next_exec_event`] so the private sourced lane is also serviced.
     #[must_use]
     pub fn take_channels(self) -> AsyncRunnerChannels {
-        self.channels
+        let Self {
+            channels,
+            sourced_exec_ingress,
+            ..
+        } = self;
+        replace_integrated_sourced_exec_ingress(Some(sourced_exec_ingress));
+        channels
+    }
+
+    /// Receives and handles the next execution event for an integrated runner.
+    ///
+    /// This fairly services both the public legacy receiver and the private sourced sidecar
+    /// installed by [`Self::take_channels`]. Poll this future on the same thread that extracted
+    /// the channels so the thread-local sourced ingress and message bus remain aligned.
+    ///
+    /// Returns `false` after both execution lanes close.
+    pub async fn handle_next_exec_event(
+        exec_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    ) -> bool {
+        let ingress = poll_fn(|cx| {
+            INTEGRATED_SOURCED_EXEC_INGRESS.with(|slot| {
+                let mut slot = slot.borrow_mut();
+                if let Some(sourced) = slot.as_mut() {
+                    sourced.poll_recv(cx, exec_evt_rx)
+                } else {
+                    match Pin::new(&mut *exec_evt_rx).poll_recv(cx) {
+                        Poll::Ready(Some(event)) => {
+                            Poll::Ready(Some(ExecutionEventIngress::Legacy(event)))
+                        }
+                        Poll::Ready(None) => Poll::Ready(None),
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+            })
+        })
+        .await;
+
+        match ingress {
+            Some(ExecutionEventIngress::Legacy(event)) => Self::handle_exec_event(event),
+            Some(ExecutionEventIngress::Sourced(event)) => Self::handle_sourced_exec_event(event),
+            None => return false,
+        }
+        true
     }
 
     /// Consumes the runner and returns its public channels plus the internal sourced sidecar.
@@ -1371,16 +1470,19 @@ mod tests {
 
         let mut legacy_ids = Vec::new();
         let mut sourced_ids = Vec::new();
+        let mut ingress_order = Vec::new();
 
         for _ in 0..4 {
             match runner.recv().await.unwrap() {
                 PendingRunnerEvent::ExecEvent(ExecutionEvent::Order(event)) => {
+                    ingress_order.push("legacy");
                     legacy_ids.push(event.client_order_id());
                 }
                 PendingRunnerEvent::SourcedExecEvent(SourcedExecutionEvent {
                     event: ExecutionEvent::Order(event),
                     ..
                 }) => {
+                    ingress_order.push("sourced");
                     sourced_ids.push(event.client_order_id());
                 }
                 _ => panic!("Unexpected runner event"),
@@ -1401,6 +1503,7 @@ mod tests {
                 ClientOrderId::from("O-SOURCED-1")
             ]
         );
+        assert_eq!(ingress_order, ["legacy", "sourced", "legacy", "sourced"]);
     }
 
     #[rstest]
@@ -1452,12 +1555,188 @@ mod tests {
         assert!(channels.exec_evt_rx.try_recv().is_err());
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_take_channels_services_prebound_sourced_account_event() {
+        msgbus::get_message_bus().borrow_mut().dispose();
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let sink = get_sourced_exec_event_sink(ClientId::from("SOURCE-INTEGRATED"));
+        let received = Rc::new(RefCell::new(Vec::new()));
+        let received_handler = received.clone();
+        msgbus::register_account_state_endpoint(
+            MessagingSwitchboard::portfolio_update_account(),
+            TypedHandler::from(move |account: &AccountState| {
+                received_handler.borrow_mut().push(account.account_id);
+            }),
+        );
+        let AsyncRunnerChannels {
+            time_evt_rx: _,
+            system_evt_rx: _,
+            system_cmd_rx: _,
+            mut exec_evt_rx,
+            exec_cmd_rx: _,
+            data_evt_rx: _,
+            data_cmd_rx: _,
+        } = runner.take_channels();
+
+        sink.send(ExecutionEvent::Account(AccountState::new(
+            AccountId::from("SOURCE-INTEGRATED-001"),
+            AccountType::Cash,
+            vec![],
+            vec![],
+            true,
+            UUID4::new(),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            None,
+        )))
+        .unwrap();
+
+        assert!(AsyncRunner::handle_next_exec_event(&mut exec_evt_rx).await);
+        assert_eq!(
+            received.borrow().as_slice(),
+            &[AccountId::from("SOURCE-INTEGRATED-001")]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_integrated_runner_dispatches_strict_reports_with_source() {
+        msgbus::get_message_bus().borrow_mut().dispose();
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let source_id = ClientId::from("SOURCE-INTEGRATED-STRICT");
+        let sink = get_sourced_exec_event_sink(source_id);
+        let received = Rc::new(RefCell::new(Vec::new()));
+        let received_handler = received.clone();
+        msgbus::register_sourced_execution_report_endpoint(
+            MessagingSwitchboard::exec_engine_reconcile_sourced_execution_report(),
+            TypedIntoHandler::from(move |report: SourcedExecutionReport| {
+                let kind = match report.report {
+                    ExecutionReport::Order(_) => "order",
+                    ExecutionReport::Fill(_) => "fill",
+                    _ => panic!("Unexpected non-strict execution report"),
+                };
+                received_handler.borrow_mut().push((report.client_id, kind));
+            }),
+        );
+        let mut channels = runner.take_channels();
+        let account_id = AccountId::from("SOURCE-INTEGRATED-STRICT-001");
+        let instrument_id = InstrumentId::from("EUR/USD.SIM");
+        let client_order_id = ClientOrderId::from("O-INTEGRATED-STRICT");
+        let venue_order_id = VenueOrderId::from("V-INTEGRATED-STRICT");
+        let order = OrderStatusReport::new(
+            account_id,
+            instrument_id,
+            Some(client_order_id),
+            venue_order_id,
+            OrderSide::Buy.into(),
+            OrderType::Market,
+            TimeInForce::Gtc,
+            OrderStatus::Accepted,
+            Quantity::from(100_000),
+            Quantity::from(0),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            UnixNanos::from(3),
+            None,
+        );
+        let fill = FillReport::new(
+            account_id,
+            instrument_id,
+            venue_order_id,
+            TradeId::from("T-INTEGRATED-STRICT"),
+            OrderSide::Buy,
+            Quantity::from(100_000),
+            Price::from("1.10000"),
+            Money::from("1 USD"),
+            LiquiditySide::Taker,
+            Some(client_order_id),
+            None,
+            UnixNanos::from(4),
+            UnixNanos::from(5),
+            None,
+        );
+
+        sink.send(ExecutionEvent::Report(ExecutionReport::Order(Box::new(
+            order,
+        ))))
+        .unwrap();
+        sink.send(ExecutionEvent::Report(ExecutionReport::Fill(Box::new(
+            fill,
+        ))))
+        .unwrap();
+
+        assert!(AsyncRunner::handle_next_exec_event(&mut channels.exec_evt_rx).await);
+        assert!(AsyncRunner::handle_next_exec_event(&mut channels.exec_evt_rx).await);
+        assert_eq!(
+            received.borrow().as_slice(),
+            [(source_id, "order"), (source_id, "fill")]
+        );
+    }
+
+    #[rstest]
+    fn test_sourced_sink_closes_with_integrated_channels() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let sink = get_sourced_exec_event_sink(ClientId::from("SOURCE-INTEGRATED-CLOSED"));
+        let channels = runner.take_channels();
+        drop(channels);
+
+        let error = sink
+            .send(ExecutionEvent::Account(AccountState::new(
+                AccountId::from("SOURCE-INTEGRATED-CLOSED-001"),
+                AccountType::Cash,
+                vec![],
+                vec![],
+                true,
+                UUID4::new(),
+                UnixNanos::from(1),
+                UnixNanos::from(2),
+                None,
+            )))
+            .expect_err("sourced sink must close with the public integrated channels");
+
+        assert!(matches!(error.0, ExecutionEvent::Account(_)));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_integrated_runner_drains_sourced_lane_before_closing() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let sink = get_sourced_exec_event_sink(ClientId::from("SOURCE-INTEGRATED-DRAIN"));
+        let mut channels = runner.take_channels();
+
+        sink.send(ExecutionEvent::Account(AccountState::new(
+            AccountId::from("SOURCE-INTEGRATED-DRAIN-001"),
+            AccountType::Cash,
+            vec![],
+            vec![],
+            true,
+            UUID4::new(),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            None,
+        )))
+        .unwrap();
+        channels.exec_evt_rx.close();
+
+        assert!(AsyncRunner::handle_next_exec_event(&mut channels.exec_evt_rx).await);
+        let handled = tokio::time::timeout(
+            Duration::from_millis(100),
+            AsyncRunner::handle_next_exec_event(&mut channels.exec_evt_rx),
+        )
+        .await
+        .expect("integrated sourced lane should close after draining");
+        assert!(!handled);
+    }
+
     #[rstest]
     fn test_sourced_sink_closed_lane_returns_event_without_legacy_fallback() {
         let (sourced_tx, sourced_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (_legacy_tx, mut legacy_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        let (legacy_tx, mut legacy_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
         drop(sourced_rx);
-        let sink = SourcedExecutionEventSink::new(ClientId::from("SOURCE-CLOSED"), sourced_tx);
+        let sink =
+            SourcedExecutionEventSink::new(ClientId::from("SOURCE-CLOSED"), sourced_tx, legacy_tx);
 
         let error = sink
             .send(ExecutionEvent::Account(AccountState::new(

--- a/crates/live/src/runner.rs
+++ b/crates/live/src/runner.rs
@@ -15,20 +15,21 @@
 
 //! Async event loop runner for live and sandbox trading nodes.
 //!
-//! `AsyncRunner` owns seven tokio mpsc channel pairs plus a shutdown
-//! signal channel. Construction creates the channels without side
+//! `AsyncRunner` owns the seven public tokio mpsc channel pairs, an internal
+//! sourced-execution sidecar pair, and a shutdown signal channel. Construction creates the channels without side
 //! effects. The sender halves are placed into thread-local storage
 //! via [`AsyncRunner::bind_senders`] so that adapters and engine
 //! components can resolve them through the `get_*_sender()` accessors
 //! in `nautilus_common::runner` and `nautilus_common::live::runner`.
 //!
-//! Channel pairs:
+//! Public channel pairs:
 //!
 //! - **Time events**: timer callbacks dispatched by the clock.
 //! - **System events**: system notifications handled by the live node.
 //! - **System commands**: control requests handled by the live node.
 //! - **Execution events**: fills, order updates, and account state from
-//!   execution clients to the execution engine.
+//!   execution clients to the execution engine. Opted-in clients use a private
+//!   source-bound sidecar lane; legacy clients retain the public execution channel.
 //! - **Trading commands**: deferred order actions routed to their direct endpoint.
 //! - **Data events**: market data from adapters to the data engine.
 //! - **Data commands**: subscribe/unsubscribe requests to data clients.
@@ -58,8 +59,11 @@
 //! - Only one runner at a time should own the TLS slots on a given
 //!   thread. `bind_senders` overwrites any existing TLS contents on the
 //!   thread, so the last caller wins.
+//! - The legacy and sourced execution lanes each preserve FIFO order. Fair
+//!   arbitration prevents either ready lane from starving, but no global order
+//!   is defined across the two lanes.
 
-use std::{fmt::Debug, sync::Arc};
+use std::{cell::RefCell, fmt::Debug, sync::Arc};
 
 use nautilus_common::{
     live::runner::{
@@ -67,8 +71,9 @@ use nautilus_common::{
         replace_system_event_sender,
     },
     messages::{
-        DataEvent, ExecutionEvent, ExecutionReport, SystemCommand, SystemEvent, data::DataCommand,
-        execution::TradingCommand,
+        DataEvent, ExecutionEvent, ExecutionReport, SystemCommand, SystemEvent,
+        data::DataCommand,
+        execution::{SourcedExecutionReport, TradingCommand},
     },
     msgbus::{self, MessagingSwitchboard},
     runner::{
@@ -77,7 +82,180 @@ use nautilus_common::{
         replace_time_event_sender,
     },
 };
-use nautilus_model::events::OrderEventAny;
+use nautilus_model::{events::OrderEventAny, identifiers::ClientId};
+
+thread_local! {
+    static SOURCED_EXEC_EVENT_SENDER: RefCell<Option<tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>>> = const { RefCell::new(None) };
+}
+
+/// An execution-event sender permanently bound to one execution client.
+///
+/// Sending through this sink uses only the sourced ingress lane. A closed sourced lane returns
+/// the original event to the caller and never falls back to the legacy lane.
+#[derive(Clone, Debug)]
+#[doc(hidden)]
+pub struct SourcedExecutionEventSink {
+    client_id: ClientId,
+    sender: tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>,
+}
+
+impl SourcedExecutionEventSink {
+    pub(crate) fn new(
+        client_id: ClientId,
+        sender: tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>,
+    ) -> Self {
+        Self { client_id, sender }
+    }
+
+    /// Sends an execution event through the sourced ingress lane.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original event when the sourced ingress receiver is closed.
+    pub(crate) fn send(
+        &self,
+        event: ExecutionEvent,
+    ) -> Result<(), Box<tokio::sync::mpsc::error::SendError<ExecutionEvent>>> {
+        self.sender
+            .send(SourcedExecutionEvent::new(self.client_id, event))
+            .map_err(|e| Box::new(tokio::sync::mpsc::error::SendError(e.0.event)))
+    }
+}
+
+/// Returns a sourced execution-event sink bound to `client_id` for the current thread.
+///
+/// # Panics
+///
+/// Panics if no async runner has bound the sourced ingress sender on this thread.
+#[must_use]
+#[doc(hidden)]
+pub fn get_sourced_exec_event_sink(client_id: ClientId) -> SourcedExecutionEventSink {
+    SOURCED_EXEC_EVENT_SENDER.with(|sender| {
+        SourcedExecutionEventSink::new(
+            client_id,
+            sender
+                .borrow()
+                .as_ref()
+                .expect("sourced execution-event sender is not bound")
+                .clone(),
+        )
+    })
+}
+
+fn replace_sourced_exec_event_sender(
+    sender: tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>,
+) {
+    SOURCED_EXEC_EVENT_SENDER.with(|slot| {
+        *slot.borrow_mut() = Some(sender);
+    });
+}
+
+#[derive(Debug)]
+pub(crate) struct SourcedExecutionEvent {
+    pub(crate) client_id: ClientId,
+    pub(crate) event: ExecutionEvent,
+}
+
+impl SourcedExecutionEvent {
+    const fn new(client_id: ClientId, event: ExecutionEvent) -> Self {
+        Self { client_id, event }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ExecutionEventIngress {
+    Legacy(ExecutionEvent),
+    Sourced(SourcedExecutionEvent),
+}
+
+#[derive(Debug)]
+pub(crate) struct SourcedExecutionIngress {
+    receiver: tokio::sync::mpsc::UnboundedReceiver<SourcedExecutionEvent>,
+    prefer_sourced: bool,
+}
+
+impl SourcedExecutionIngress {
+    pub(crate) const fn new(
+        receiver: tokio::sync::mpsc::UnboundedReceiver<SourcedExecutionEvent>,
+    ) -> Self {
+        Self {
+            receiver,
+            prefer_sourced: false,
+        }
+    }
+
+    #[cfg(any(test, feature = "node"))]
+    pub(crate) fn len(&self) -> usize {
+        self.receiver.len()
+    }
+
+    /// Receives fairly from the independent legacy and sourced execution lanes.
+    ///
+    /// Arbitration preserves FIFO within each lane and guarantees bounded progress when both
+    /// lanes remain ready, without defining a global order across lanes.
+    pub(crate) async fn recv(
+        &mut self,
+        legacy_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    ) -> Option<ExecutionEventIngress> {
+        let ingress = if self.prefer_sourced {
+            tokio::select! {
+                biased;
+
+                Some(event) = self.receiver.recv() => {
+                    Some(ExecutionEventIngress::Sourced(event))
+                }
+                Some(event) = legacy_rx.recv() => {
+                    Some(ExecutionEventIngress::Legacy(event))
+                }
+                else => None,
+            }
+        } else {
+            tokio::select! {
+                biased;
+
+                Some(event) = legacy_rx.recv() => {
+                    Some(ExecutionEventIngress::Legacy(event))
+                }
+                Some(event) = self.receiver.recv() => {
+                    Some(ExecutionEventIngress::Sourced(event))
+                }
+                else => None,
+            }
+        };
+
+        if let Some(ingress) = &ingress {
+            self.prefer_sourced = matches!(ingress, ExecutionEventIngress::Legacy(_));
+        }
+
+        ingress
+    }
+
+    #[cfg(any(test, feature = "node"))]
+    pub(crate) fn try_recv(
+        &mut self,
+        legacy_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    ) -> Option<ExecutionEventIngress> {
+        let ingress = if self.prefer_sourced {
+            self.receiver
+                .try_recv()
+                .map(ExecutionEventIngress::Sourced)
+                .or_else(|_| legacy_rx.try_recv().map(ExecutionEventIngress::Legacy))
+                .ok()
+        } else {
+            legacy_rx
+                .try_recv()
+                .map(ExecutionEventIngress::Legacy)
+                .or_else(|_| self.receiver.try_recv().map(ExecutionEventIngress::Sourced))
+                .ok()
+        };
+
+        if let Some(ingress) = &ingress {
+            self.prefer_sourced = matches!(ingress, ExecutionEventIngress::Legacy(_));
+        }
+
+        ingress
+    }
+}
 
 /// Asynchronous implementation of `DataCommandSender` for live environments.
 #[derive(Debug)]
@@ -171,6 +349,7 @@ pub(crate) enum PendingRunnerEvent {
     SystemEvent(SystemEvent),
     SystemCommand(SystemCommand),
     ExecEvent(ExecutionEvent),
+    SourcedExecEvent(SourcedExecutionEvent),
     ExecCommand(TradingCommandMessage),
     DataEvent(DataEvent),
     DataCommand(DataCommand),
@@ -184,6 +363,8 @@ pub struct AsyncRunner {
     signal_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
     signal_tx: tokio::sync::mpsc::UnboundedSender<()>,
     exec_evt_tx: tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
+    sourced_exec_ingress: SourcedExecutionIngress,
+    sourced_exec_evt_tx: tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>,
     exec_cmd_tx: tokio::sync::mpsc::UnboundedSender<TradingCommandMessage>,
     data_evt_tx: tokio::sync::mpsc::UnboundedSender<DataEvent>,
     data_cmd_tx: tokio::sync::mpsc::UnboundedSender<DataCommand>,
@@ -231,6 +412,8 @@ impl AsyncRunner {
         let (system_cmd_tx, system_cmd_rx) = unbounded_channel::<SystemCommand>();
         let (signal_tx, signal_rx) = unbounded_channel::<()>();
         let (exec_evt_tx, exec_evt_rx) = unbounded_channel::<ExecutionEvent>();
+        let (sourced_exec_evt_tx, sourced_exec_evt_rx) =
+            unbounded_channel::<SourcedExecutionEvent>();
         let (exec_cmd_tx, exec_cmd_rx) = unbounded_channel::<TradingCommandMessage>();
         let (data_evt_tx, data_evt_rx) = unbounded_channel::<DataEvent>();
         let (data_cmd_tx, data_cmd_rx) = unbounded_channel::<DataCommand>();
@@ -251,6 +434,8 @@ impl AsyncRunner {
             signal_rx,
             signal_tx,
             exec_evt_tx,
+            sourced_exec_ingress: SourcedExecutionIngress::new(sourced_exec_evt_rx),
+            sourced_exec_evt_tx,
             exec_cmd_tx,
             data_evt_tx,
             data_cmd_tx,
@@ -269,6 +454,7 @@ impl AsyncRunner {
         replace_system_event_sender(self.system_evt_tx.clone());
         replace_system_command_sender(self.system_cmd_tx.clone());
         replace_exec_event_sender(self.exec_evt_tx.clone());
+        replace_sourced_exec_event_sender(self.sourced_exec_evt_tx.clone());
         replace_exec_cmd_sender(Arc::new(AsyncTradingCommandSender::new(
             self.exec_cmd_tx.clone(),
         )));
@@ -300,6 +486,15 @@ impl AsyncRunner {
     #[must_use]
     pub fn take_channels(self) -> AsyncRunnerChannels {
         self.channels
+    }
+
+    /// Consumes the runner and returns its public channels plus the internal sourced sidecar.
+    #[must_use]
+    #[cfg(any(test, feature = "node"))]
+    pub(crate) fn take_channels_with_sourced(
+        self,
+    ) -> (AsyncRunnerChannels, SourcedExecutionIngress) {
+        (self.channels, self.sourced_exec_ingress)
     }
 
     /// Flushes all pending data events and commands from the channels.
@@ -389,8 +584,15 @@ impl AsyncRunner {
                 Some(command) = self.channels.system_cmd_rx.recv() => {
                     log::error!("System command {command:?} requires the LiveNode runner");
                 },
-                Some(evt) = self.channels.exec_evt_rx.recv() => {
-                    Self::handle_exec_event(evt);
+                Some(ingress) = self.sourced_exec_ingress.recv(
+                    &mut self.channels.exec_evt_rx,
+                ) => {
+                    match ingress {
+                        ExecutionEventIngress::Legacy(event) => Self::handle_exec_event(event),
+                        ExecutionEventIngress::Sourced(event) => {
+                            Self::handle_sourced_exec_event(event);
+                        }
+                    }
                 },
                 Some(cmd) = self.channels.exec_cmd_rx.recv() => {
                     Self::handle_trading_command(cmd);
@@ -509,6 +711,32 @@ impl AsyncRunner {
         }
     }
 
+    /// Handles an execution event from a source-bound ingress lane.
+    ///
+    /// Only order and fill reports use strict source-aware reconciliation. Every other event
+    /// retains its existing legacy dispatch semantics without being requeued.
+    #[inline]
+    pub(crate) fn handle_sourced_exec_event(event: SourcedExecutionEvent) {
+        let SourcedExecutionEvent { client_id, event } = event;
+        match event {
+            ExecutionEvent::Report(
+                report @ (ExecutionReport::Order(_) | ExecutionReport::Fill(_)),
+            ) => {
+                Self::handle_sourced_exec_report(client_id, report);
+            }
+            event => Self::handle_exec_event(event),
+        }
+    }
+
+    #[inline]
+    fn handle_sourced_exec_report(client_id: ClientId, report: ExecutionReport) {
+        let endpoint = MessagingSwitchboard::exec_engine_reconcile_sourced_execution_report();
+        msgbus::send_sourced_execution_report(
+            endpoint,
+            SourcedExecutionReport::new(client_id, report),
+        );
+    }
+
     #[inline]
     pub fn handle_exec_report(report: ExecutionReport) {
         let endpoint = MessagingSwitchboard::exec_engine_reconcile_execution_report();
@@ -526,6 +754,7 @@ impl AsyncRunner {
             self.channels.system_evt_rx.len(),
             self.channels.system_cmd_rx.len(),
             self.channels.exec_evt_rx.len(),
+            self.sourced_exec_ingress.len(),
             self.channels.exec_cmd_rx.len(),
             self.channels.data_evt_rx.len(),
             self.channels.data_cmd_rx.len(),
@@ -549,27 +778,28 @@ impl AsyncRunner {
             PendingRunnerEvent::SystemCommand,
             &mut process,
         );
-        processed += poll_channel(
+        processed += poll_execution_channels(
             &mut self.channels.exec_evt_rx,
+            &mut self.sourced_exec_ingress,
             pending.3,
-            PendingRunnerEvent::ExecEvent,
+            pending.4,
             &mut process,
         );
         processed += poll_channel(
             &mut self.channels.exec_cmd_rx,
-            pending.4,
+            pending.5,
             PendingRunnerEvent::ExecCommand,
             &mut process,
         );
         processed += poll_channel(
             &mut self.channels.data_evt_rx,
-            pending.5,
+            pending.6,
             PendingRunnerEvent::DataEvent,
             &mut process,
         );
         processed += poll_channel(
             &mut self.channels.data_cmd_rx,
-            pending.6,
+            pending.7,
             PendingRunnerEvent::DataCommand,
             &mut process,
         );
@@ -589,8 +819,17 @@ impl AsyncRunner {
             Some(command) = self.channels.system_cmd_rx.recv() => {
                 Some(PendingRunnerEvent::SystemCommand(command))
             }
-            Some(event) = self.channels.exec_evt_rx.recv() => {
-                Some(PendingRunnerEvent::ExecEvent(event))
+            Some(ingress) = self.sourced_exec_ingress.recv(
+                &mut self.channels.exec_evt_rx,
+            ) => {
+                match ingress {
+                    ExecutionEventIngress::Legacy(event) => {
+                        Some(PendingRunnerEvent::ExecEvent(event))
+                    }
+                    ExecutionEventIngress::Sourced(event) => {
+                        Some(PendingRunnerEvent::SourcedExecEvent(event))
+                    }
+                }
             }
             Some(command) = self.channels.exec_cmd_rx.recv() => {
                 Some(PendingRunnerEvent::ExecCommand(command))
@@ -604,6 +843,65 @@ impl AsyncRunner {
             else => None,
         }
     }
+}
+
+#[cfg(feature = "node")]
+fn poll_execution_channels(
+    legacy_rx: &mut tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    sourced: &mut SourcedExecutionIngress,
+    legacy_pending: usize,
+    sourced_pending: usize,
+    process: &mut impl FnMut(PendingRunnerEvent),
+) -> usize {
+    let mut processed = 0;
+    let mut legacy_remaining = legacy_pending;
+    let mut sourced_remaining = sourced_pending;
+
+    while legacy_remaining > 0 || sourced_remaining > 0 {
+        let ingress = if sourced.prefer_sourced {
+            let sourced = (sourced_remaining > 0)
+                .then(|| sourced.receiver.try_recv().ok())
+                .flatten()
+                .map(ExecutionEventIngress::Sourced);
+            sourced.or_else(|| {
+                (legacy_remaining > 0)
+                    .then(|| legacy_rx.try_recv().ok())
+                    .flatten()
+                    .map(ExecutionEventIngress::Legacy)
+            })
+        } else {
+            let legacy = (legacy_remaining > 0)
+                .then(|| legacy_rx.try_recv().ok())
+                .flatten()
+                .map(ExecutionEventIngress::Legacy);
+            legacy.or_else(|| {
+                (sourced_remaining > 0)
+                    .then(|| sourced.receiver.try_recv().ok())
+                    .flatten()
+                    .map(ExecutionEventIngress::Sourced)
+            })
+        };
+        let Some(ingress) = ingress else {
+            break;
+        };
+
+        let event = match ingress {
+            ExecutionEventIngress::Legacy(event) => {
+                legacy_remaining -= 1;
+                sourced.prefer_sourced = true;
+                PendingRunnerEvent::ExecEvent(event)
+            }
+            ExecutionEventIngress::Sourced(event) => {
+                sourced_remaining -= 1;
+                sourced.prefer_sourced = false;
+                PendingRunnerEvent::SourcedExecEvent(event)
+            }
+        };
+        process(event);
+        processed += 1;
+    }
+
+    processed
 }
 
 #[cfg(feature = "node")]
@@ -644,7 +942,7 @@ mod tests {
             execution::{CancelAllOrders, TradingCommand},
             system::{ReconnectSocket, SocketState, SocketStateChange},
         },
-        msgbus::{TypedIntoHandler, stubs::get_typed_into_message_saving_handler},
+        msgbus::{TypedHandler, TypedIntoHandler, stubs::get_typed_into_message_saving_handler},
         runner::{
             TimeEventMessage, get_data_cmd_sender, get_time_event_sender, get_trading_cmd_sender,
             replace_exec_cmd_sender, try_get_time_event_sender, try_get_trading_cmd_sender,
@@ -652,11 +950,11 @@ mod tests {
         timer::{TimeEvent, TimeEventCallback},
     };
     use nautilus_core::{UUID4, UnixNanos};
-    use nautilus_execution::engine::ExecutionEngine;
+    use nautilus_execution::engine::{ExecutionEngine, stubs::StubExecutionClient};
     use nautilus_model::{
         data::{Data, DataType, quote::QuoteTick},
         enums::{
-            AccountType, LiquiditySide, OrderSide, OrderStatus, OrderType, PositionSide,
+            AccountType, LiquiditySide, OmsType, OrderSide, OrderStatus, OrderType, PositionSide,
             TimeInForce,
         },
         events::{
@@ -668,7 +966,8 @@ mod tests {
             AccountId, ClientId, ClientOrderId, InstrumentId, PositionId, StrategyId, TradeId,
             TraderId, Venue, VenueOrderId,
         },
-        reports::{FillReport, OrderStatusReport, PositionStatusReport},
+        instruments::{Instrument, stubs::audusd_sim},
+        reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
         types::{Money, Price, Quantity},
     };
     use rstest::rstest;
@@ -725,6 +1024,7 @@ mod tests {
         let (data_evt_tx, _) = tokio::sync::mpsc::unbounded_channel();
         let (data_cmd_tx, _) = tokio::sync::mpsc::unbounded_channel();
         let (exec_evt_tx, _) = tokio::sync::mpsc::unbounded_channel();
+        let (sourced_exec_evt_tx, sourced_exec_evt_rx) = tokio::sync::mpsc::unbounded_channel();
         let (exec_cmd_tx, _) = tokio::sync::mpsc::unbounded_channel();
 
         AsyncRunner {
@@ -741,6 +1041,8 @@ mod tests {
             system_evt_tx,
             system_cmd_tx,
             exec_evt_tx,
+            sourced_exec_ingress: SourcedExecutionIngress::new(sourced_exec_evt_rx),
+            sourced_exec_evt_tx,
             exec_cmd_tx,
             data_evt_tx,
             data_cmd_tx,
@@ -821,6 +1123,17 @@ mod tests {
             signal_tx,
         );
         runner.bind_senders();
+        runner
+            .sourced_exec_evt_tx
+            .send(SourcedExecutionEvent::new(
+                ClientId::from("SOURCE-POLL"),
+                ExecutionEvent::Order(OrderEventAny::Submitted(
+                    OrderSubmittedSpec::builder()
+                        .client_order_id(ClientOrderId::from("O-SOURCED-POLL-001"))
+                        .build(),
+                )),
+            ))
+            .unwrap();
         get_system_command_sender()
             .send(test_system_command())
             .unwrap();
@@ -846,6 +1159,10 @@ mod tests {
                 processed_by_channel[3] += 1;
                 processed_order.push("exec_event");
             }
+            PendingRunnerEvent::SourcedExecEvent(_) => {
+                processed_by_channel[3] += 1;
+                processed_order.push("sourced_exec_event");
+            }
             PendingRunnerEvent::ExecCommand(_) => {
                 processed_by_channel[4] += 1;
                 processed_order.push("exec_command");
@@ -870,22 +1187,113 @@ mod tests {
             _ => panic!("Unexpected runner event"),
         });
 
-        assert_eq!(first, 8);
+        assert_eq!(first, 9);
         assert_eq!(second, 1);
-        assert_eq!(processed_by_channel, [1, 2, 1, 1, 1, 2, 1]);
+        assert_eq!(processed_by_channel, [1, 2, 1, 2, 1, 2, 1]);
         assert_eq!(
-            processed_order,
-            [
-                "time",
-                "system_event",
-                "system_event",
-                "system_command",
-                "exec_event",
-                "exec_command",
-                "data_event",
-                "data_command",
-                "data_event",
-            ]
+            &processed_order[..4],
+            ["time", "system_event", "system_event", "system_command"]
+        );
+        let mut execution_lanes = processed_order[4..6].to_vec();
+        execution_lanes.sort_unstable();
+        assert_eq!(execution_lanes, ["exec_event", "sourced_exec_event"]);
+        assert_eq!(
+            &processed_order[6..],
+            ["exec_command", "data_event", "data_command", "data_event"]
+        );
+    }
+
+    #[cfg(feature = "node")]
+    #[rstest]
+    fn test_poll_pending_new_sourced_event_does_not_displace_entry_legacy_events() {
+        let mut runner = AsyncRunner::new();
+        let sourced_tx = runner.sourced_exec_evt_tx.clone();
+        for client_order_id in ["O-LEGACY-SNAPSHOT-001", "O-LEGACY-SNAPSHOT-002"] {
+            runner
+                .exec_evt_tx
+                .send(ExecutionEvent::Order(OrderEventAny::Submitted(
+                    OrderSubmittedSpec::builder()
+                        .client_order_id(ClientOrderId::from(client_order_id))
+                        .build(),
+                )))
+                .unwrap();
+        }
+
+        let mut legacy_seen = 0;
+        let first = runner.poll_pending(|event| match event {
+            PendingRunnerEvent::ExecEvent(_) => {
+                legacy_seen += 1;
+                if legacy_seen == 1 {
+                    sourced_tx
+                        .send(SourcedExecutionEvent::new(
+                            ClientId::from("SOURCE-REENTRANT"),
+                            ExecutionEvent::Order(OrderEventAny::Submitted(
+                                OrderSubmittedSpec::builder()
+                                    .client_order_id(ClientOrderId::from("O-SOURCED-REENTRANT"))
+                                    .build(),
+                            )),
+                        ))
+                        .unwrap();
+                }
+            }
+            _ => panic!("Only entry-snapshot legacy events should be processed"),
+        });
+
+        assert_eq!(first, 2);
+        assert_eq!(legacy_seen, 2);
+        assert_eq!(runner.sourced_exec_ingress.len(), 1);
+        assert_eq!(
+            runner.poll_pending(|event| {
+                assert!(matches!(event, PendingRunnerEvent::SourcedExecEvent(_)));
+            }),
+            1
+        );
+    }
+
+    #[cfg(feature = "node")]
+    #[rstest]
+    fn test_poll_pending_new_legacy_event_does_not_displace_entry_sourced_events() {
+        let mut runner = AsyncRunner::new();
+        let legacy_tx = runner.exec_evt_tx.clone();
+        for client_order_id in ["O-SOURCED-SNAPSHOT-001", "O-SOURCED-SNAPSHOT-002"] {
+            runner
+                .sourced_exec_evt_tx
+                .send(SourcedExecutionEvent::new(
+                    ClientId::from("SOURCE-SNAPSHOT"),
+                    ExecutionEvent::Order(OrderEventAny::Submitted(
+                        OrderSubmittedSpec::builder()
+                            .client_order_id(ClientOrderId::from(client_order_id))
+                            .build(),
+                    )),
+                ))
+                .unwrap();
+        }
+
+        let mut sourced_seen = 0;
+        let first = runner.poll_pending(|event| match event {
+            PendingRunnerEvent::SourcedExecEvent(_) => {
+                sourced_seen += 1;
+                if sourced_seen == 1 {
+                    legacy_tx
+                        .send(ExecutionEvent::Order(OrderEventAny::Submitted(
+                            OrderSubmittedSpec::builder()
+                                .client_order_id(ClientOrderId::from("O-LEGACY-REENTRANT"))
+                                .build(),
+                        )))
+                        .unwrap();
+                }
+            }
+            _ => panic!("Only entry-snapshot sourced events should be processed"),
+        });
+
+        assert_eq!(first, 2);
+        assert_eq!(sourced_seen, 2);
+        assert_eq!(runner.channels.exec_evt_rx.len(), 1);
+        assert_eq!(
+            runner.poll_pending(|event| {
+                assert!(matches!(event, PendingRunnerEvent::ExecEvent(_)));
+            }),
+            1
         );
     }
 
@@ -919,6 +1327,273 @@ mod tests {
             runner.recv().await,
             Some(PendingRunnerEvent::SystemCommand(_))
         ));
+    }
+
+    #[cfg(feature = "node")]
+    #[tokio::test]
+    async fn test_recv_fairly_services_ready_execution_lanes_without_starvation() {
+        let (_time_evt_tx, time_evt_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_data_evt_tx, data_evt_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_data_cmd_tx, data_cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (exec_evt_tx, exec_evt_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_exec_cmd_tx, exec_cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (signal_tx, signal_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut runner = create_test_runner(
+            time_evt_rx,
+            data_evt_rx,
+            data_cmd_rx,
+            exec_evt_rx,
+            exec_cmd_rx,
+            signal_rx,
+            signal_tx,
+        );
+
+        for index in 0..2 {
+            exec_evt_tx
+                .send(ExecutionEvent::Order(OrderEventAny::Submitted(
+                    OrderSubmittedSpec::builder()
+                        .client_order_id(ClientOrderId::from(format!("O-LEGACY-{index}")))
+                        .build(),
+                )))
+                .unwrap();
+            runner
+                .sourced_exec_evt_tx
+                .send(SourcedExecutionEvent::new(
+                    ClientId::from("SOURCE-RECV"),
+                    ExecutionEvent::Order(OrderEventAny::Submitted(
+                        OrderSubmittedSpec::builder()
+                            .client_order_id(ClientOrderId::from(format!("O-SOURCED-{index}")))
+                            .build(),
+                    )),
+                ))
+                .unwrap();
+        }
+
+        let mut legacy_ids = Vec::new();
+        let mut sourced_ids = Vec::new();
+
+        for _ in 0..4 {
+            match runner.recv().await.unwrap() {
+                PendingRunnerEvent::ExecEvent(ExecutionEvent::Order(event)) => {
+                    legacy_ids.push(event.client_order_id());
+                }
+                PendingRunnerEvent::SourcedExecEvent(SourcedExecutionEvent {
+                    event: ExecutionEvent::Order(event),
+                    ..
+                }) => {
+                    sourced_ids.push(event.client_order_id());
+                }
+                _ => panic!("Unexpected runner event"),
+            }
+        }
+
+        assert_eq!(
+            legacy_ids,
+            [
+                ClientOrderId::from("O-LEGACY-0"),
+                ClientOrderId::from("O-LEGACY-1")
+            ]
+        );
+        assert_eq!(
+            sourced_ids,
+            [
+                ClientOrderId::from("O-SOURCED-0"),
+                ClientOrderId::from("O-SOURCED-1")
+            ]
+        );
+    }
+
+    #[rstest]
+    fn test_sourced_sink_uses_only_source_bound_lane_for_entire_event_stream() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let source_id = ClientId::from("SOURCE-ONLY");
+        let sink = get_sourced_exec_event_sink(source_id);
+        let account = AccountState::new(
+            AccountId::from("SOURCE-ONLY-001"),
+            AccountType::Cash,
+            vec![],
+            vec![],
+            true,
+            UUID4::new(),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            None,
+        );
+        let report = PositionStatusReport::new(
+            AccountId::from("SOURCE-ONLY-001"),
+            InstrumentId::from("EUR/USD.SIM"),
+            PositionSide::Long,
+            Quantity::from(100_000),
+            UnixNanos::from(3),
+            UnixNanos::from(4),
+            None,
+            Some(PositionId::from("P-SOURCE-ONLY")),
+            None,
+        );
+
+        sink.send(ExecutionEvent::Account(account)).unwrap();
+        sink.send(ExecutionEvent::Report(ExecutionReport::Position(Box::new(
+            report,
+        ))))
+        .unwrap();
+
+        let (mut channels, mut sourced) = runner.take_channels_with_sourced();
+        let first = sourced.receiver.try_recv().unwrap();
+        let second = sourced.receiver.try_recv().unwrap();
+        assert_eq!(sink.client_id, source_id);
+        assert_eq!(first.client_id, source_id);
+        assert!(matches!(first.event, ExecutionEvent::Account(_)));
+        assert_eq!(second.client_id, source_id);
+        assert!(matches!(
+            second.event,
+            ExecutionEvent::Report(ExecutionReport::Position(_))
+        ));
+        assert!(channels.exec_evt_rx.try_recv().is_err());
+    }
+
+    #[rstest]
+    fn test_sourced_sink_closed_lane_returns_event_without_legacy_fallback() {
+        let (sourced_tx, sourced_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_legacy_tx, mut legacy_rx) = tokio::sync::mpsc::unbounded_channel::<ExecutionEvent>();
+        drop(sourced_rx);
+        let sink = SourcedExecutionEventSink::new(ClientId::from("SOURCE-CLOSED"), sourced_tx);
+
+        let error = sink
+            .send(ExecutionEvent::Account(AccountState::new(
+                AccountId::from("SOURCE-CLOSED-001"),
+                AccountType::Cash,
+                vec![],
+                vec![],
+                true,
+                UUID4::new(),
+                UnixNanos::from(1),
+                UnixNanos::from(2),
+                None,
+            )))
+            .expect_err("closed sourced lane must return the original event");
+
+        assert!(matches!(error.0, ExecutionEvent::Account(_)));
+        assert!(legacy_rx.try_recv().is_err());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_standalone_runner_dispatches_sourced_non_report_event() {
+        msgbus::get_message_bus().borrow_mut().dispose();
+        let mut runner = AsyncRunner::new();
+        let source_tx = runner.sourced_exec_evt_tx.clone();
+        let signal_tx = runner.signal_tx.clone();
+        let received = Rc::new(RefCell::new(Vec::new()));
+        let received_handler = received.clone();
+        msgbus::register_account_state_endpoint(
+            MessagingSwitchboard::portfolio_update_account(),
+            TypedHandler::from(move |account: &AccountState| {
+                received_handler.borrow_mut().push(account.account_id);
+                signal_tx.send(()).unwrap();
+            }),
+        );
+        source_tx
+            .send(SourcedExecutionEvent::new(
+                ClientId::from("SOURCE-STANDALONE"),
+                ExecutionEvent::Account(AccountState::new(
+                    AccountId::from("SOURCE-STANDALONE-001"),
+                    AccountType::Cash,
+                    vec![],
+                    vec![],
+                    true,
+                    UUID4::new(),
+                    UnixNanos::from(1),
+                    UnixNanos::from(2),
+                    None,
+                )),
+            ))
+            .unwrap();
+
+        runner.run().await;
+
+        assert_eq!(
+            received.borrow().as_slice(),
+            &[AccountId::from("SOURCE-STANDALONE-001")]
+        );
+    }
+
+    #[rstest]
+    fn test_sourced_non_strict_reports_dispatch_directly_to_legacy_endpoint() {
+        msgbus::get_message_bus().borrow_mut().dispose();
+        let legacy_reports = Rc::new(RefCell::new(Vec::new()));
+        let legacy_handler = legacy_reports.clone();
+        msgbus::register_execution_report_endpoint(
+            MessagingSwitchboard::exec_engine_reconcile_execution_report(),
+            TypedIntoHandler::from(move |report: ExecutionReport| {
+                legacy_handler.borrow_mut().push(report);
+            }),
+        );
+        let strict_reports = Rc::new(RefCell::new(Vec::new()));
+        let strict_handler = strict_reports.clone();
+        msgbus::register_sourced_execution_report_endpoint(
+            MessagingSwitchboard::exec_engine_reconcile_sourced_execution_report(),
+            TypedIntoHandler::from(move |report: SourcedExecutionReport| {
+                strict_handler.borrow_mut().push(report);
+            }),
+        );
+        let source_client_id = ClientId::from("SOURCE-NON-STRICT");
+        let account_id = AccountId::from("SOURCE-NON-STRICT-001");
+        let instrument_id = InstrumentId::from("EUR/USD.SIM");
+        let order_report = OrderStatusReport::new(
+            account_id,
+            instrument_id,
+            Some(ClientOrderId::from("O-SOURCE-NON-STRICT")),
+            VenueOrderId::from("V-SOURCE-NON-STRICT"),
+            OrderSide::Buy.into(),
+            OrderType::Market,
+            TimeInForce::Gtc,
+            OrderStatus::Accepted,
+            Quantity::from(100_000),
+            Quantity::from(0),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            UnixNanos::from(3),
+            None,
+        );
+        let position_report = PositionStatusReport::new(
+            account_id,
+            instrument_id,
+            PositionSide::Long,
+            Quantity::from(100_000),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            None,
+            Some(PositionId::from("P-SOURCE-POSITION")),
+            None,
+        );
+        let mass_status = ExecutionMassStatus::new(
+            source_client_id,
+            account_id,
+            instrument_id.venue,
+            UnixNanos::from(4),
+            None,
+        );
+
+        for report in [
+            ExecutionReport::OrderWithFills(Box::new(order_report), Vec::new()),
+            ExecutionReport::Position(Box::new(position_report)),
+            ExecutionReport::MassStatus(Box::new(mass_status)),
+        ] {
+            AsyncRunner::handle_sourced_exec_event(SourcedExecutionEvent::new(
+                source_client_id,
+                ExecutionEvent::Report(report),
+            ));
+        }
+
+        assert!(matches!(
+            legacy_reports.borrow().as_slice(),
+            [
+                ExecutionReport::OrderWithFills(_, _),
+                ExecutionReport::Position(_),
+                ExecutionReport::MassStatus(_),
+            ]
+        ));
+        assert!(strict_reports.borrow().is_empty());
     }
 
     #[rstest]
@@ -1492,6 +2167,173 @@ mod tests {
             }
             _ => panic!("Expected OrderStatusReport"),
         }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum AmbiguousRuntimeReportKind {
+        OrderStatus,
+        Fill,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum RuntimeReportIngressLane {
+        Legacy,
+        Sourced,
+    }
+
+    #[rstest]
+    #[case::sourced_order(
+        AmbiguousRuntimeReportKind::OrderStatus,
+        RuntimeReportIngressLane::Sourced
+    )]
+    #[case::sourced_fill(AmbiguousRuntimeReportKind::Fill, RuntimeReportIngressLane::Sourced)]
+    #[case::legacy_order(
+        AmbiguousRuntimeReportKind::OrderStatus,
+        RuntimeReportIngressLane::Legacy
+    )]
+    #[case::legacy_fill(AmbiguousRuntimeReportKind::Fill, RuntimeReportIngressLane::Legacy)]
+    fn test_runtime_report_routing_respects_ingress_source_compatibility(
+        #[case] report_kind: AmbiguousRuntimeReportKind,
+        #[case] ingress_lane: RuntimeReportIngressLane,
+    ) {
+        std::thread::spawn(move || {
+            msgbus::get_message_bus().borrow_mut().dispose();
+
+            let clock = Rc::new(RefCell::new(TestClock::new()));
+            let cache = Rc::new(RefCell::new(Cache::default()));
+            let exec_engine = Rc::new(RefCell::new(ExecutionEngine::new(
+                clock,
+                cache.clone(),
+                None,
+            )));
+            let instrument = audusd_sim();
+            let account_id = AccountId::from("SHARED-ACCOUNT");
+            let venue_router_id = ClientId::from("VENUE-A");
+            let source_id = ClientId::from("SOURCE-B");
+
+            let venue_router = StubExecutionClient::new(
+                venue_router_id,
+                account_id,
+                instrument.id().venue,
+                OmsType::Netting,
+                None,
+            );
+            let venue_router_registrations = venue_router.registered_external_order_ids();
+            let source = StubExecutionClient::new(
+                source_id,
+                account_id,
+                Venue::from("SOURCE-B"),
+                OmsType::Netting,
+                None,
+            )
+            .with_handles_all_order_venues();
+            let source_registrations = source.registered_external_order_ids();
+
+            {
+                let mut engine = exec_engine.borrow_mut();
+                engine.register_client(Box::new(venue_router)).unwrap();
+                engine.register_client(Box::new(source)).unwrap();
+                engine
+                    .cache()
+                    .borrow_mut()
+                    .add_instrument(instrument.clone().into())
+                    .unwrap();
+            }
+            ExecutionEngine::register_msgbus_handlers(&exec_engine);
+
+            let runner = AsyncRunner::new();
+            runner.bind_senders();
+            let (client_order_id, event) = match report_kind {
+                AmbiguousRuntimeReportKind::OrderStatus => {
+                    let client_order_id = ClientOrderId::from("O-RUNTIME-ORDER");
+                    let report = OrderStatusReport::new(
+                        account_id,
+                        instrument.id(),
+                        Some(client_order_id),
+                        VenueOrderId::from("V-RUNTIME-ORDER"),
+                        OrderSide::Buy.into(),
+                        OrderType::Market,
+                        TimeInForce::Gtc,
+                        OrderStatus::Accepted,
+                        Quantity::from(100_000),
+                        Quantity::from(0),
+                        UnixNanos::from(1),
+                        UnixNanos::from(2),
+                        UnixNanos::from(3),
+                        None,
+                    );
+                    (
+                        client_order_id,
+                        ExecutionEvent::Report(ExecutionReport::Order(Box::new(report))),
+                    )
+                }
+                AmbiguousRuntimeReportKind::Fill => {
+                    let client_order_id = ClientOrderId::from("O-RUNTIME-FILL");
+                    let report = FillReport::new(
+                        account_id,
+                        instrument.id(),
+                        VenueOrderId::from("V-RUNTIME-FILL"),
+                        TradeId::from("T-RUNTIME-FILL"),
+                        OrderSide::Buy,
+                        Quantity::from(100_000),
+                        Price::from("1.10000"),
+                        Money::from("1 USD"),
+                        LiquiditySide::Taker,
+                        Some(client_order_id),
+                        None,
+                        UnixNanos::from(1),
+                        UnixNanos::from(2),
+                        None,
+                    );
+                    (
+                        client_order_id,
+                        ExecutionEvent::Report(ExecutionReport::Fill(Box::new(report))),
+                    )
+                }
+            };
+
+            match ingress_lane {
+                RuntimeReportIngressLane::Sourced => {
+                    get_sourced_exec_event_sink(source_id).send(event).unwrap();
+                    let (channels, mut sourced) = runner.take_channels_with_sourced();
+                    AsyncRunner::handle_sourced_exec_event(
+                        sourced
+                            .receiver
+                            .try_recv()
+                            .expect("runtime report should reach the sourced execution-event lane"),
+                    );
+                    assert!(channels.exec_evt_rx.is_empty());
+                }
+                RuntimeReportIngressLane::Legacy => {
+                    get_exec_event_sender().send(event).unwrap();
+                    let (mut channels, sourced) = runner.take_channels_with_sourced();
+                    AsyncRunner::handle_exec_event(
+                        channels
+                            .exec_evt_rx
+                            .try_recv()
+                            .expect("runtime report should reach the legacy execution-event lane"),
+                    );
+                    assert_eq!(sourced.len(), 0);
+                }
+            }
+
+            let origin = cache.borrow().client_id(&client_order_id).copied();
+            let venue_router_registered = venue_router_registrations.borrow().clone();
+            let source_registered = source_registrations.borrow().clone();
+            let expected = match ingress_lane {
+                RuntimeReportIngressLane::Sourced => {
+                    (Some(source_id), Vec::new(), vec![client_order_id])
+                }
+                RuntimeReportIngressLane::Legacy => (None, vec![client_order_id], Vec::new()),
+            };
+            assert_eq!(
+                (origin, venue_router_registered, source_registered),
+                expected,
+                "only the opted-in sourced lane may enforce the emitting execution client",
+            );
+        })
+        .join()
+        .unwrap();
     }
 
     #[tokio::test]

--- a/crates/live/src/runner.rs
+++ b/crates/live/src/runner.rs
@@ -90,7 +90,10 @@ use nautilus_common::{
         replace_time_event_sender,
     },
 };
-use nautilus_model::{events::OrderEventAny, identifiers::ClientId};
+use nautilus_model::{
+    events::{AccountState, OrderEventAny},
+    identifiers::ClientId,
+};
 
 thread_local! {
     static SOURCED_EXEC_EVENT_SENDER: RefCell<Option<tokio::sync::mpsc::UnboundedSender<SourcedExecutionEvent>>> = const { RefCell::new(None) };
@@ -132,12 +135,37 @@ impl SourcedExecutionEventSink {
         &self,
         event: ExecutionEvent,
     ) -> Result<(), Box<tokio::sync::mpsc::error::SendError<ExecutionEvent>>> {
+        self.send_with_purpose(SourcedExecutionEvent::runtime(self.client_id, event))
+    }
+
+    fn send_with_purpose(
+        &self,
+        event: SourcedExecutionEvent,
+    ) -> Result<(), Box<tokio::sync::mpsc::error::SendError<ExecutionEvent>>> {
         if self.public_exec_sender.is_closed() {
+            let (_, event) = event.into_parts();
             return Err(Box::new(tokio::sync::mpsc::error::SendError(event)));
         }
-        self.sender
-            .send(SourcedExecutionEvent::new(self.client_id, event))
-            .map_err(|e| Box::new(tokio::sync::mpsc::error::SendError(e.0.event)))
+        self.sender.send(event).map_err(|e| {
+            let (_, event) = e.0.into_parts();
+            Box::new(tokio::sync::mpsc::error::SendError(event))
+        })
+    }
+
+    /// Sends a source-bound startup account barrier through the sourced ingress lane.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original account event when the sourced ingress or paired public execution
+    /// receiver is closed.
+    pub(crate) fn send_bootstrap_account(
+        &self,
+        state: AccountState,
+    ) -> Result<(), Box<tokio::sync::mpsc::error::SendError<ExecutionEvent>>> {
+        self.send_with_purpose(SourcedExecutionEvent::bootstrap_account(
+            self.client_id,
+            state,
+        ))
     }
 }
 
@@ -170,15 +198,38 @@ fn replace_sourced_exec_event_sender(
     });
 }
 
+#[allow(
+    clippy::large_enum_variant,
+    reason = "sourced runtime events are consumed immediately; boxing would add routing allocations"
+)]
 #[derive(Debug)]
-pub(crate) struct SourcedExecutionEvent {
-    pub(crate) client_id: ClientId,
-    pub(crate) event: ExecutionEvent,
+pub(crate) enum SourcedExecutionEvent {
+    Runtime {
+        client_id: ClientId,
+        event: ExecutionEvent,
+    },
+    BootstrapAccount {
+        client_id: ClientId,
+        state: AccountState,
+    },
 }
 
 impl SourcedExecutionEvent {
-    const fn new(client_id: ClientId, event: ExecutionEvent) -> Self {
-        Self { client_id, event }
+    pub(crate) const fn runtime(client_id: ClientId, event: ExecutionEvent) -> Self {
+        Self::Runtime { client_id, event }
+    }
+
+    pub(crate) const fn bootstrap_account(client_id: ClientId, state: AccountState) -> Self {
+        Self::BootstrapAccount { client_id, state }
+    }
+
+    pub(crate) fn into_parts(self) -> (ClientId, ExecutionEvent) {
+        match self {
+            Self::Runtime { client_id, event } => (client_id, event),
+            Self::BootstrapAccount { client_id, state } => {
+                (client_id, ExecutionEvent::Account(state))
+            }
+        }
     }
 }
 
@@ -816,7 +867,7 @@ impl AsyncRunner {
     /// retains its existing legacy dispatch semantics without being requeued.
     #[inline]
     pub(crate) fn handle_sourced_exec_event(event: SourcedExecutionEvent) {
-        let SourcedExecutionEvent { client_id, event } = event;
+        let (client_id, event) = event.into_parts();
         match event {
             ExecutionEvent::Report(
                 report @ (ExecutionReport::Order(_) | ExecutionReport::Fill(_)),
@@ -1224,7 +1275,7 @@ mod tests {
         runner.bind_senders();
         runner
             .sourced_exec_evt_tx
-            .send(SourcedExecutionEvent::new(
+            .send(SourcedExecutionEvent::runtime(
                 ClientId::from("SOURCE-POLL"),
                 ExecutionEvent::Order(OrderEventAny::Submitted(
                     OrderSubmittedSpec::builder()
@@ -1324,7 +1375,7 @@ mod tests {
                 legacy_seen += 1;
                 if legacy_seen == 1 {
                     sourced_tx
-                        .send(SourcedExecutionEvent::new(
+                        .send(SourcedExecutionEvent::runtime(
                             ClientId::from("SOURCE-REENTRANT"),
                             ExecutionEvent::Order(OrderEventAny::Submitted(
                                 OrderSubmittedSpec::builder()
@@ -1357,7 +1408,7 @@ mod tests {
         for client_order_id in ["O-SOURCED-SNAPSHOT-001", "O-SOURCED-SNAPSHOT-002"] {
             runner
                 .sourced_exec_evt_tx
-                .send(SourcedExecutionEvent::new(
+                .send(SourcedExecutionEvent::runtime(
                     ClientId::from("SOURCE-SNAPSHOT"),
                     ExecutionEvent::Order(OrderEventAny::Submitted(
                         OrderSubmittedSpec::builder()
@@ -1457,7 +1508,7 @@ mod tests {
                 .unwrap();
             runner
                 .sourced_exec_evt_tx
-                .send(SourcedExecutionEvent::new(
+                .send(SourcedExecutionEvent::runtime(
                     ClientId::from("SOURCE-RECV"),
                     ExecutionEvent::Order(OrderEventAny::Submitted(
                         OrderSubmittedSpec::builder()
@@ -1478,7 +1529,7 @@ mod tests {
                     ingress_order.push("legacy");
                     legacy_ids.push(event.client_order_id());
                 }
-                PendingRunnerEvent::SourcedExecEvent(SourcedExecutionEvent {
+                PendingRunnerEvent::SourcedExecEvent(SourcedExecutionEvent::Runtime {
                     event: ExecutionEvent::Order(event),
                     ..
                 }) => {
@@ -1544,29 +1595,33 @@ mod tests {
         let (mut channels, mut sourced) = runner.take_channels_with_sourced();
         let first = sourced.receiver.try_recv().unwrap();
         let second = sourced.receiver.try_recv().unwrap();
+        let (first_client_id, first_event) = first.into_parts();
+        let (second_client_id, second_event) = second.into_parts();
         assert_eq!(sink.client_id, source_id);
-        assert_eq!(first.client_id, source_id);
-        assert!(matches!(first.event, ExecutionEvent::Account(_)));
-        assert_eq!(second.client_id, source_id);
+        assert_eq!(first_client_id, source_id);
+        assert!(matches!(first_event, ExecutionEvent::Account(_)));
+        assert_eq!(second_client_id, source_id);
         assert!(matches!(
-            second.event,
+            second_event,
             ExecutionEvent::Report(ExecutionReport::Position(_))
         ));
         assert!(channels.exec_evt_rx.try_recv().is_err());
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_take_channels_services_prebound_sourced_account_event() {
+    async fn test_take_channels_services_prebound_sourced_account_events() {
         msgbus::get_message_bus().borrow_mut().dispose();
         let runner = AsyncRunner::new();
         runner.bind_senders();
         let sink = get_sourced_exec_event_sink(ClientId::from("SOURCE-INTEGRATED"));
+        let runtime_event_id = UUID4::new();
+        let bootstrap_event_id = UUID4::new();
         let received = Rc::new(RefCell::new(Vec::new()));
         let received_handler = received.clone();
         msgbus::register_account_state_endpoint(
             MessagingSwitchboard::portfolio_update_account(),
             TypedHandler::from(move |account: &AccountState| {
-                received_handler.borrow_mut().push(account.account_id);
+                received_handler.borrow_mut().push(account.event_id);
             }),
         );
         let AsyncRunnerChannels {
@@ -1585,18 +1640,55 @@ mod tests {
             vec![],
             vec![],
             true,
-            UUID4::new(),
+            runtime_event_id,
             UnixNanos::from(1),
             UnixNanos::from(2),
             None,
         )))
         .unwrap();
+        sink.send_bootstrap_account(AccountState::new(
+            AccountId::from("SOURCE-INTEGRATED-001"),
+            AccountType::Cash,
+            vec![],
+            vec![],
+            true,
+            bootstrap_event_id,
+            UnixNanos::from(3),
+            UnixNanos::from(4),
+            None,
+        ))
+        .unwrap();
 
+        assert!(AsyncRunner::handle_next_exec_event(&mut exec_evt_rx).await);
         assert!(AsyncRunner::handle_next_exec_event(&mut exec_evt_rx).await);
         assert_eq!(
             received.borrow().as_slice(),
-            &[AccountId::from("SOURCE-INTEGRATED-001")]
+            &[runtime_event_id, bootstrap_event_id]
         );
+    }
+
+    #[rstest]
+    fn test_bootstrap_send_rejects_closed_public_receiver_before_sourced_enqueue() {
+        let runner = AsyncRunner::new();
+        runner.bind_senders();
+        let sink = get_sourced_exec_event_sink(ClientId::from("SOURCE-CLOSED-PUBLIC"));
+        let (mut channels, mut sourced) = runner.take_channels_with_sourced();
+        channels.exec_evt_rx.close();
+
+        let result = sink.send_bootstrap_account(AccountState::new(
+            AccountId::from("SOURCE-CLOSED-PUBLIC-001"),
+            AccountType::Cash,
+            vec![],
+            vec![],
+            true,
+            UUID4::new(),
+            UnixNanos::from(1),
+            UnixNanos::from(2),
+            None,
+        ));
+
+        assert!(result.is_err());
+        assert!(sourced.receiver.try_recv().is_err());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1772,7 +1864,7 @@ mod tests {
             }),
         );
         source_tx
-            .send(SourcedExecutionEvent::new(
+            .send(SourcedExecutionEvent::runtime(
                 ClientId::from("SOURCE-STANDALONE"),
                 ExecutionEvent::Account(AccountState::new(
                     AccountId::from("SOURCE-STANDALONE-001"),
@@ -1858,7 +1950,7 @@ mod tests {
             ExecutionReport::Position(Box::new(position_report)),
             ExecutionReport::MassStatus(Box::new(mass_status)),
         ] {
-            AsyncRunner::handle_sourced_exec_event(SourcedExecutionEvent::new(
+            AsyncRunner::handle_sourced_exec_event(SourcedExecutionEvent::runtime(
                 source_client_id,
                 ExecutionEvent::Report(report),
             ));

--- a/docs/integrations/bybit.md
+++ b/docs/integrations/bybit.md
@@ -782,28 +782,29 @@ The product types for each client must be specified in the configurations.
 
 ### Execution client configuration options
 
-| Option                      | Default    | Description                                                                                                     |
-| --------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------- |
-| `product_types`             | `[LINEAR]` | Sequence of `BybitProductType` values to enable.                                                                |
-| `environment`               | `MAINNET`  | Bybit environment enum. Use `BybitEnvironment.MAINNET`, `BybitEnvironment.DEMO`, or `BybitEnvironment.TESTNET`. |
-| `api_key`                   | `None`     | API key; loaded from the matching environment variable when omitted.                                            |
-| `api_secret`                | `None`     | API secret; loaded from the matching environment variable when omitted.                                         |
-| `base_url_http`             | `None`     | Override for the REST base URL.                                                                                 |
-| `base_url_ws_private`       | `None`     | Override for the private WebSocket base URL.                                                                    |
-| `base_url_ws_trade`         | `None`     | Override for the trade WebSocket base URL.                                                                      |
-| `proxy_url`                 | `None`     | Optional proxy URL for HTTP and WebSocket transports.                                                           |
-| `http_timeout_secs`         | `60`       | Timeout (seconds) for REST requests.                                                                            |
-| `max_retries`               | `3`        | Maximum retry attempts for REST requests.                                                                       |
-| `retry_delay_initial_ms`    | `1,000`    | Initial retry delay (milliseconds).                                                                             |
-| `retry_delay_max_ms`        | `10,000`   | Maximum retry delay (milliseconds).                                                                             |
-| `heartbeat_interval_secs`   | `5`        | Heartbeat interval (seconds) for WebSocket clients.                                                             |
-| `auth_timeout_secs`         | `None`     | Optional WebSocket authentication timeout (seconds).                                                            |
-| `recv_window_ms`            | `5,000`    | Receive window (milliseconds) for signed REST and trade WebSocket requests.                                     |
-| `account_id`                | `None`     | Optional account ID associated with this client.                                                                |
-| `use_spot_position_reports` | `False`    | Report Spot wallet balances as positions for scoped requests; bulk reports omit Spot (no pair attribution).     |
-| `auto_repay_spot_borrows`   | `False`    | Automatically repay tracked Spot margin borrows after BUY orders fully fill.                                    |
-| `margin_mode`               | `None`     | Unified margin mode setting for the account.                                                                    |
-| `transport_backend`         | `Sockudo`  | WebSocket transport backend.                                                                                    |
+| Option                         | Default    | Description                                                                                                     |
+| ------------------------------ | ---------- | --------------------------------------------------------------------------------------------------------------- |
+| `product_types`                | `[LINEAR]` | Sequence of `BybitProductType` values to enable.                                                                |
+| `environment`                  | `MAINNET`  | Bybit environment enum. Use `BybitEnvironment.MAINNET`, `BybitEnvironment.DEMO`, or `BybitEnvironment.TESTNET`. |
+| `api_key`                      | `None`     | API key; loaded from the matching environment variable when omitted.                                            |
+| `api_secret`                   | `None`     | API secret; loaded from the matching environment variable when omitted.                                         |
+| `base_url_http`                | `None`     | Override for the REST base URL.                                                                                 |
+| `base_url_ws_private`          | `None`     | Override for the private WebSocket base URL.                                                                    |
+| `base_url_ws_trade`            | `None`     | Override for the trade WebSocket base URL.                                                                      |
+| `proxy_url`                    | `None`     | Optional proxy URL for HTTP and WebSocket transports.                                                           |
+| `http_timeout_secs`            | `60`       | Timeout (seconds) for REST requests.                                                                            |
+| `max_retries`                  | `3`        | Maximum retry attempts for REST requests.                                                                       |
+| `retry_delay_initial_ms`       | `1,000`    | Initial retry delay (milliseconds).                                                                             |
+| `retry_delay_max_ms`           | `10,000`   | Maximum retry delay (milliseconds).                                                                             |
+| `heartbeat_interval_secs`      | `5`        | Heartbeat interval (seconds) for WebSocket clients.                                                             |
+| `auth_timeout_secs`            | `None`     | Optional WebSocket authentication timeout (seconds).                                                            |
+| `recv_window_ms`               | `5,000`    | Receive window (milliseconds) for signed REST and trade WebSocket requests.                                     |
+| `account_id`                   | `None`     | Optional account ID associated with this client.                                                                |
+| `use_spot_position_reports`    | `False`    | Report Spot wallet balances as positions for scoped requests; bulk reports omit Spot (no pair attribution).     |
+| `auto_repay_spot_borrows`      | `False`    | Automatically repay tracked Spot margin borrows after BUY orders fully fill.                                    |
+| `margin_mode`                  | `None`     | Unified margin mode setting for the account.                                                                    |
+| `transport_backend`            | `Sockudo`  | WebSocket transport backend.                                                                                    |
+| `use_sourced_execution_events` | `False`    | Route all runtime events through the source-bound lane; strictly validate order and fill reports.               |
 
 The compiled default is Sockudo when the `transport-sockudo` Cargo feature is enabled and
 Tungstenite otherwise.

--- a/python/nautilus_trader/adapters/bybit/__init__.pyi
+++ b/python/nautilus_trader/adapters/bybit/__init__.pyi
@@ -152,10 +152,10 @@ class BybitExecutionClientConfig:
         recv_window_ms: int | None = None,
         account_id: model.AccountId | None = None,
         use_spot_position_reports: bool | None = None,
-        use_sourced_execution_events: bool | None = None,
         auto_repay_spot_borrows: bool | None = None,
         margin_mode: BybitMarginMode | None = None,
         transport_backend: network.TransportBackend | None = None,
+        use_sourced_execution_events: bool | None = None,
     ) -> None: ...
     @property
     def has_proxy_url(self) -> bool: ...

--- a/python/nautilus_trader/adapters/bybit/__init__.pyi
+++ b/python/nautilus_trader/adapters/bybit/__init__.pyi
@@ -126,6 +126,8 @@ class BybitExecutionClientConfig:
     @property
     def use_spot_position_reports(self) -> bool: ...
     @property
+    def use_sourced_execution_events(self) -> bool: ...
+    @property
     def auto_repay_spot_borrows(self) -> bool: ...
     @property
     def margin_mode(self) -> BybitMarginMode | None: ...
@@ -150,6 +152,7 @@ class BybitExecutionClientConfig:
         recv_window_ms: int | None = None,
         account_id: model.AccountId | None = None,
         use_spot_position_reports: bool | None = None,
+        use_sourced_execution_events: bool | None = None,
         auto_repay_spot_borrows: bool | None = None,
         margin_mode: BybitMarginMode | None = None,
         transport_backend: network.TransportBackend | None = None,


### PR DESCRIPTION
# Pull Request

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

> External contributions must not modify files under `.github/workflows` or `.github/actions`;
> workflow changes are maintainer-only.

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [ ] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [ ] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Add an adapter-scoped `use_sourced_execution_events` opt-in for Bybit, fixed at client construction
and defaulting to `false`. When enabled, the complete Bybit `ExecutionEvent` stream uses a
source-bound ingress; legacy and sourced lanes are serviced fairly with per-lane FIFO,
exactly-one-lane delivery, and no fallback to the legacy lane. Only sourced `OrderStatusReport` and
`FillReport` values use strict source, account, handled-venue, cached-origin, and order-ID validation
with exact-source external-order registration; other variants retain legacy semantics, while the
public event shape, existing sender/emitter APIs, raw topics, and capture payloads remain unchanged.

## Related issues/PRs

Related to #4782.

Builds on #4797 and implements the Bybit pilot requested in the maintainer's
[scope review](https://github.com/nautechsystems/nautilus_trader/pull/4818#issuecomment-5385114946),
with the transport contract confirmed in the
[follow-up](https://github.com/nautechsystems/nautilus_trader/pull/4818#issuecomment-5392028856).

The pre-split reference implementation remains available on the
[`source-runtime-execution-reports-reference`](https://github.com/xxxxxx-oss/nautilus_trader/tree/source-runtime-execution-reports-reference)
branch as requested.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable. The opt-in defaults to `false`. Existing `ExecutionEvent` variants, sender/emitter
method signatures, the seven-field `AsyncRunnerChannels` shape, `take_channels(self)`, raw report
topics, bare capture payloads, and legacy-client behavior remain unchanged.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [x] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation files changed. The generated Bybit Python stub includes the additive opt-in
configuration.

## Testing

**New or changed logic must be covered by tests.** Select all that apply:

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Ubuntu validation completed across the pilot implementation; the final submitted patch also passed
the full pre-commit suite:

- Execution engine integration tests: 262 passed; execution library tests: 598 passed.
- Focused live sourced-ingress tests: 14 passed; Bybit library tests: 513 passed.
- Common message-bus tests: 62 passed.
- Bybit Python config and binding tests passed with Python 3.12, 3.13, and 3.14.
- `make py-stubs` passed and produced the committed stub.
- `UV_PYTHON=3.13 make pre-commit` passed in full.

Coverage includes the original two-client routing case for both order and fill reports,
exact-source external-order materialization and registration, the strict rejection matrix,
post-publication re-entrant validation, preflight-before-deduplication, database persistence failure
after an in-memory cache commit, per-lane FIFO, fair progress, startup/pending preservation, and
closed sourced-lane behavior without legacy fallback. Pull-request CI independently revalidates the
submitted head.
