### PR TITLE
Prevent L2/L3 matching against a deleted touch

### DIFF
--- a/crates/execution/src/matching_engine/mod.rs
+++ b/crates/execution/src/matching_engine/mod.rs
@@ -3704,12 +3704,20 @@ impl OrderMatchingEngine {
         // where `process_trade_tick` overrides both sides to the trade
         // price; without it the override is undone here.
         if aggressor_side == AggressorSide::NoAggressor && self.last_trade_size.is_none() {
-            if let Some(bid) = self.book.best_bid_price() {
-                self.core.set_bid_raw(bid);
-            }
+            if self.book_type == BookType::L1_MBP {
+                if let Some(bid) = self.book.best_bid_price() {
+                    self.core.set_bid_raw(bid);
+                }
 
-            if let Some(ask) = self.book.best_ask_price() {
-                self.core.set_ask_raw(ask);
+                if let Some(ask) = self.book.best_ask_price() {
+                    self.core.set_ask_raw(ask);
+                }
+            } else {
+                // L2/L3 books are authoritative. Assigning the complete options
+                // propagates an empty side before matching and prevents fills
+                // or triggers from a stale touch.
+                self.core.bid = self.book.best_bid_price();
+                self.core.ask = self.book.best_ask_price();
             }
         }
 

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -1506,6 +1506,70 @@ fn test_process_limit_post_only_order_that_would_be_a_taker(
 }
 
 #[rstest]
+fn test_l2_delete_final_ask_does_not_fill_resting_bid_from_stale_touch(
+    instrument_eth_usdt: InstrumentAny,
+    order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    account_id: AccountId,
+) {
+    let mut engine =
+        get_order_matching_engine_l2(instrument_eth_usdt.clone(), None, None, None, None);
+
+    let resting_bid_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    let mut resting_bid = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1500.00"))
+        .quantity(Quantity::from("1.000"))
+        .client_order_id(resting_bid_id)
+        .submit(true)
+        .build();
+    engine.process_order(&mut resting_bid, account_id);
+    clear_order_event_handler_messages(&order_event_handler);
+
+    // While paused, publish an opposing touch. The iteration cannot match,
+    // but its final synchronization stores the ask in the matching core.
+    engine.process_status(MarketStatusAction::Pause);
+    let add_ask = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+        .book_action(BookAction::Add)
+        .book_order(BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("1.000"),
+            1,
+        ))
+        .sequence(1)
+        .build();
+    engine.process_order_book_delta(&add_ask).unwrap();
+    assert_eq!(engine.get_core().ask, Some(Price::from("1500.00")));
+
+    // Reopen without iterating, then delete the final ask. The delete invokes
+    // one iteration. It must clear the stale core ask before matching.
+    engine.process_status(MarketStatusAction::Trading);
+    let delete_ask = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+        .book_action(BookAction::Delete)
+        .book_order(BookOrder::new(
+            OrderSide::Sell,
+            Price::from("1500.00"),
+            Quantity::from("0.000"),
+            1,
+        ))
+        .sequence(2)
+        .build();
+    engine.process_order_book_delta(&delete_ask).unwrap();
+
+    let saved_messages = get_order_event_handler_messages(&order_event_handler);
+    assert!(
+        saved_messages
+            .iter()
+            .all(|event| !matches!(event, OrderEventAny::Filled(_))),
+        "deleting the final ask must not fill from a stale touch, was {saved_messages:?}",
+    );
+    assert!(engine.order_exists(resting_bid_id));
+    assert_eq!(engine.best_ask_price(), None);
+    assert_eq!(engine.get_core().ask, None);
+}
+
+#[rstest]
 fn test_process_limit_order_not_matched_and_canceled_fok_order(
     instrument_eth_usdt: InstrumentAny,
     order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,

--- a/crates/execution/tests/matching_engine.rs
+++ b/crates/execution/tests/matching_engine.rs
@@ -1526,10 +1526,67 @@ fn test_l2_delete_final_ask_does_not_fill_resting_bid_from_stale_touch(
     engine.process_order(&mut resting_bid, account_id);
     clear_order_event_handler_messages(&order_event_handler);
 
+    process_stale_ask_deletion(&mut engine, instrument_eth_usdt.id());
+
+    let saved_messages = get_order_event_handler_messages(&order_event_handler);
+    assert!(
+        saved_messages.is_empty(),
+        "deleting the final ask must not fill from a stale touch, was {saved_messages:?}",
+    );
+    assert!(engine.order_exists(resting_bid_id));
+    assert_eq!(engine.best_ask_price(), None);
+    assert_eq!(engine.get_core().ask, None);
+}
+
+#[rstest]
+fn test_l2_delete_final_ask_does_not_trigger_stop_limit_from_stale_touch(
+    instrument_eth_usdt: InstrumentAny,
+    order_event_handler: TypedIntoMessageSavingHandler<OrderEventAny>,
+    account_id: AccountId,
+) {
+    let config = OrderMatchingEngineConfig {
+        reject_stop_orders: false,
+        ..Default::default()
+    };
+    let mut engine =
+        get_order_matching_engine_l2(instrument_eth_usdt.clone(), None, None, None, Some(config));
+
+    let stop_order_id = ClientOrderId::from("O-19700101-000000-001-001-1");
+    let mut stop_order = OrderTestBuilder::new(OrderType::StopLimit)
+        .instrument_id(instrument_eth_usdt.id())
+        .side(OrderSide::Buy)
+        .trigger_price(Price::from("1500.00"))
+        .price(Price::from("1490.00"))
+        .quantity(Quantity::from("1.000"))
+        .client_order_id(stop_order_id)
+        .submit(true)
+        .build();
+    engine.process_order(&mut stop_order, account_id);
+    clear_order_event_handler_messages(&order_event_handler);
+
+    process_stale_ask_deletion(&mut engine, instrument_eth_usdt.id());
+
+    let saved_messages = get_order_event_handler_messages(&order_event_handler);
+    let resting = engine
+        .get_core()
+        .get_order(stop_order_id)
+        .copied()
+        .expect("stop-limit should remain in the matching core");
+    assert!(
+        saved_messages.is_empty(),
+        "deleting the final ask must not trigger from a stale touch, was {saved_messages:?}",
+    );
+    assert_eq!(resting.trigger_price, Some(Price::from("1500.00")));
+    assert_eq!(resting.limit_price, Some(Price::from("1490.00")));
+    assert_eq!(engine.best_ask_price(), None);
+    assert_eq!(engine.get_core().ask, None);
+}
+
+fn process_stale_ask_deletion(engine: &mut OrderMatchingEngine, instrument_id: InstrumentId) {
     // While paused, publish an opposing touch. The iteration cannot match,
     // but its final synchronization stores the ask in the matching core.
     engine.process_status(MarketStatusAction::Pause);
-    let add_ask = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+    let add_ask = OrderBookDeltaTestBuilder::new(instrument_id)
         .book_action(BookAction::Add)
         .book_order(BookOrder::new(
             OrderSide::Sell,
@@ -1543,9 +1600,9 @@ fn test_l2_delete_final_ask_does_not_fill_resting_bid_from_stale_touch(
     assert_eq!(engine.get_core().ask, Some(Price::from("1500.00")));
 
     // Reopen without iterating, then delete the final ask. The delete invokes
-    // one iteration. It must clear the stale core ask before matching.
+    // one iteration and must clear the stale ask before matching.
     engine.process_status(MarketStatusAction::Trading);
-    let delete_ask = OrderBookDeltaTestBuilder::new(instrument_eth_usdt.id())
+    let delete_ask = OrderBookDeltaTestBuilder::new(instrument_id)
         .book_action(BookAction::Delete)
         .book_order(BookOrder::new(
             OrderSide::Sell,
@@ -1556,17 +1613,6 @@ fn test_l2_delete_final_ask_does_not_fill_resting_bid_from_stale_touch(
         .sequence(2)
         .build();
     engine.process_order_book_delta(&delete_ask).unwrap();
-
-    let saved_messages = get_order_event_handler_messages(&order_event_handler);
-    assert!(
-        saved_messages
-            .iter()
-            .all(|event| !matches!(event, OrderEventAny::Filled(_))),
-        "deleting the final ask must not fill from a stale touch, was {saved_messages:?}",
-    );
-    assert!(engine.order_exists(resting_bid_id));
-    assert_eq!(engine.best_ask_price(), None);
-    assert_eq!(engine.get_core().ask, None);
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

Synchronize the matching core from the authoritative L2/L3 order book **before matching** so deleting the final level on one side cannot leave a stale touch active during the same iteration.

Polymarket's valid one-sided books made this easier to observe, but the invariant and fix are generic to L2/L3 matching.

## Problem

`iterate` previously copied a book touch into the matching core only when `best_bid_price()` / `best_ask_price()` returned `Some(price)`. If a delta changed a side from `Some(price)` to `None`, the old core price remained until the synchronization at the end of the iteration.

That end-of-iteration synchronization restores the final state, but it is too late: resting orders and stops may already have been processed against the deleted touch during that iteration.

## Change

For non-trade L2/L3 iterations, assign the complete option values before matching:

```rust
self.core.bid = self.book.best_bid_price();
self.core.ask = self.book.best_ask_price();
```

This propagates both present and empty sides. Existing L1 quote/trade behavior is unchanged.

The earlier post-trade restoration change has been removed because `iterate` already restores both core touches from the book at the end of every pass.

## Regression coverage

The regression test creates the pre-match stale-touch window:

1. Submit a resting buy at 1500 with an empty L2 book.
2. Pause the market.
3. Add an ask at 1500; matching is blocked, while end-of-iteration sync records the ask in the core.
4. Reopen the market without iterating.
5. Delete the final ask; this invokes one iteration.
6. Assert the resting buy is not filled from the deleted ask and remains open.

The production implementation before this patch enters the matching pass with the stale `core.ask = 1500`; the patch clears it to `None` before matching.

## Verification

- `rustfmt --check` on both changed Rust files.
- `git diff --check`.
- Targeted local Rust build was attempted, but this Windows host lacks the MSVC `link.exe`; the pushed CI run provides the executable regression result.