### PR TITLE
Expose client order ID options for GridMarketMaker

### DIFF
--- a/crates/trading/src/python/examples.rs
+++ b/crates/trading/src/python/examples.rs
@@ -191,6 +191,8 @@ impl GridMarketMakerConfig {
         requote_threshold_bps=5,
         expire_time_secs=None,
         on_cancel_resubmit=false,
+        use_uuid_client_order_ids=false,
+        use_hyphens_in_client_order_ids=true,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -205,6 +207,8 @@ impl GridMarketMakerConfig {
         requote_threshold_bps: u32,
         expire_time_secs: Option<u64>,
         on_cancel_resubmit: bool,
+        use_uuid_client_order_ids: bool,
+        use_hyphens_in_client_order_ids: bool,
     ) -> Self {
         let mut config = Self::builder()
             .instrument_id(instrument_id)
@@ -225,6 +229,9 @@ impl GridMarketMakerConfig {
         if let Some(tag) = order_id_tag {
             config.base.order_id_tag = Some(tag);
         }
+
+        config.base.use_uuid_client_order_ids = use_uuid_client_order_ids;
+        config.base.use_hyphens_in_client_order_ids = use_hyphens_in_client_order_ids;
 
         config
     }
@@ -272,6 +279,16 @@ impl GridMarketMakerConfig {
     #[getter]
     fn on_cancel_resubmit(&self) -> bool {
         self.on_cancel_resubmit
+    }
+
+    #[getter]
+    fn use_uuid_client_order_ids(&self) -> bool {
+        self.base.use_uuid_client_order_ids
+    }
+
+    #[getter]
+    fn use_hyphens_in_client_order_ids(&self) -> bool {
+        self.base.use_hyphens_in_client_order_ids
     }
 }
 

--- a/python/nautilus_trader/trading/__init__.pyi
+++ b/python/nautilus_trader/trading/__init__.pyi
@@ -226,6 +226,8 @@ class GridMarketMakerConfig:
         requote_threshold_bps: int = 5,
         expire_time_secs: int | None = None,
         on_cancel_resubmit: bool = False,
+        use_uuid_client_order_ids: bool = False,
+        use_hyphens_in_client_order_ids: bool = True,
     ) -> None: ...
     @property
     def instrument_id(self) -> model.InstrumentId: ...
@@ -245,6 +247,10 @@ class GridMarketMakerConfig:
     def expire_time_secs(self) -> int | None: ...
     @property
     def on_cancel_resubmit(self) -> bool: ...
+    @property
+    def use_uuid_client_order_ids(self) -> bool: ...
+    @property
+    def use_hyphens_in_client_order_ids(self) -> bool: ...
 
 @typing.final
 class HurstVpinDirectionalConfig:

--- a/python/tests/unit/trading/test_example_configs.py
+++ b/python/tests/unit/trading/test_example_configs.py
@@ -85,3 +85,25 @@ def test_delta_neutral_vol_config_iv_param_key_readback() -> None:
     )
 
     assert config.iv_param_key == "mark_iv"
+
+
+def test_grid_market_maker_config_client_order_id_settings() -> None:
+    config = GridMarketMakerConfig(
+        instrument_id=INSTRUMENT_ID,
+        max_position=Quantity.from_str("1"),
+        use_uuid_client_order_ids=True,
+        use_hyphens_in_client_order_ids=False,
+    )
+
+    assert config.use_uuid_client_order_ids is True
+    assert config.use_hyphens_in_client_order_ids is False
+
+
+def test_grid_market_maker_config_client_order_id_defaults() -> None:
+    config = GridMarketMakerConfig(
+        instrument_id=INSTRUMENT_ID,
+        max_position=Quantity.from_str("1"),
+    )
+
+    assert config.use_uuid_client_order_ids is False
+    assert config.use_hyphens_in_client_order_ids is True


### PR DESCRIPTION
# Pull Request

- [x] This is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed `CONTRIBUTING.md` and `AI_POLICY.md`
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally
- [x] I have not modified `RELEASES.md`

## Summary

Expose the base strategy client-order-ID options on Python's `GridMarketMakerConfig`. This allows the built-in strategy to disable hyphens and use UUIDs for venues such as OKX while preserving the existing defaults.

## Related issues/PRs

Closes #4817

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

None.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [x] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

The focused Python test module passes (8 tests). Generated Python stubs, Ruff checks, and Rust formatting checks also pass. The full pre-commit command could not complete locally because hook downloads stalled; no hook reported a code failure.
