### PR TITLE
Fix Bybit order book depth validation

### DIFF
--- a/crates/adapters/bybit/src/common/consts.rs
+++ b/crates/adapters/bybit/src/common/consts.rs
@@ -49,3 +49,9 @@ pub const BYBIT_WS_TESTNET_PRIVATE_URL: &str = "wss://stream-testnet.bybit.com/v
 pub const BYBIT_WS_TOPIC_DELIMITER: char = '.';
 
 pub const BYBIT_DEFAULT_ORDERBOOK_DEPTH: u32 = 50;
+
+/// Valid WebSocket order book depths for Bybit spot, linear and inverse.
+///
+/// See <https://bybit-exchange.github.io/docs/v5/websocket/public/orderbook>
+/// for further details.
+pub const BYBIT_BOOK_DEPTHS: [u32; 4] = [1, 50, 200, 1000];

--- a/crates/adapters/bybit/src/data.rs
+++ b/crates/adapters/bybit/src/data.rs
@@ -64,7 +64,7 @@ use ustr::Ustr;
 
 use crate::{
     common::{
-        consts::{BYBIT_DEFAULT_ORDERBOOK_DEPTH, BYBIT_VENUE},
+        consts::{BYBIT_BOOK_DEPTHS, BYBIT_DEFAULT_ORDERBOOK_DEPTH, BYBIT_VENUE},
         enums::BybitProductType,
         instruments::diff_and_emit_instruments,
         parse::{extract_raw_symbol, make_bybit_symbol},
@@ -325,6 +325,14 @@ fn send_data(sender: &tokio::sync::mpsc::UnboundedSender<DataEvent>, data: Data)
     if let Err(e) = sender.send(DataEvent::Data(data)) {
         log::error!("Failed to emit data event: {e}");
     }
+}
+
+fn validate_orderbook_depth(depth: u32) -> anyhow::Result<()> {
+    if !BYBIT_BOOK_DEPTHS.contains(&depth) {
+        anyhow::bail!("invalid depth {depth}; valid values are {BYBIT_BOOK_DEPTHS:?}");
+    }
+
+    Ok(())
 }
 
 /// Cached funding state per symbol: (funding_rate, next_funding_time, funding_interval_hour).
@@ -877,9 +885,7 @@ impl DataClient for BybitDataClient {
             .depth
             .map_or(BYBIT_DEFAULT_ORDERBOOK_DEPTH, |d| d.get() as u32);
 
-        if !matches!(depth, 1 | 50 | 200 | 500) {
-            anyhow::bail!("invalid depth {depth}; valid values are 1, 50, 200, or 500");
-        }
+        validate_orderbook_depth(depth)?;
 
         let instrument_id = cmd.instrument_id;
         let product_type = self
@@ -1965,7 +1971,7 @@ mod tests {
     use rstest::rstest;
     use ustr::Ustr;
 
-    use super::handle_ws_message;
+    use super::{handle_ws_message, validate_orderbook_depth};
     use crate::{
         common::{
             enums::BybitProductType,
@@ -2037,6 +2043,21 @@ mod tests {
             Arc::new(AtomicSet::new()),
             Arc::new(AtomicMap::new()),
         )
+    }
+
+    #[rstest]
+    fn test_validate_orderbook_depth_accepts_1000() {
+        assert!(validate_orderbook_depth(1000).is_ok());
+    }
+
+    #[rstest]
+    fn test_validate_orderbook_depth_rejects_500() {
+        let e = validate_orderbook_depth(500).unwrap_err();
+
+        assert_eq!(
+            e.to_string(),
+            "invalid depth 500; valid values are [1, 50, 200, 1000]"
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`BybitDataClient::subscribe_book_deltas` validated the requested order book depth against
`1 | 50 | 200 | 500`, but Bybit's WebSocket `orderbook` topic serves `1 | 50 | 200 | 1000`
for the spot, linear and inverse categories. The check therefore rejected the deepest tier the
venue offers and accepted one it removed on 2025-09-11. Both failure modes were silent: depth
1000 was rejected locally and never reached the exchange, while depth 500 produced a
subscription the venue answered with an error that surfaced only as a WARN, leaving the client
logged as subscribed with no deltas arriving.

This corrects the accepted set, lifts it into `BYBIT_BOOK_DEPTHS` next to the existing
`BYBIT_DEFAULT_ORDERBOOK_DEPTH` following the `BINANCE_BOOK_DEPTHS` and
`DERIBIT_BOOK_VALID_DEPTHS` precedent, and pins both directions with tests. Users who
previously passed `depth=500` now receive an error at subscribe time rather than a
subscription that silently delivers nothing.

Deliberately left out of scope, as discussed in the issue: the REST depth limits in
`http/client.rs` (spot 200 / option 25 / linear-inverse 500 are the correct
`GET /v5/market/orderbook` limits and genuinely differ from the WebSocket tiers), the
`option` category which the venue serves at 25/100 and this validation cannot express, and
propagating venue subscription errors to the caller.

## Related issues/PRs

Closes #4820

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not a breaking change. Depth 500 passed validation before this change but never produced data,
because the venue rejected the resulting subscription; it now fails fast with an accurate
error instead.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation changes. `docs/integrations/bybit.md` does not document depth tiers, and the
new constant is not exposed through PyO3, so no stub regeneration is required. The REST depth
limits documented on `BybitHttpClient::request_orderbook_snapshot` are unaffected and remain
correct.

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

`test_validate_orderbook_depth_accepts_1000` and `test_validate_orderbook_depth_rejects_500`
pin the corrected set from both sides, the second also asserting the user-facing error text.
Both were confirmed non-vacuous by temporarily restoring the old list, against which they
fail.

The venue behavior was verified directly against `wss://stream.bybit.com` across the linear,
spot and inverse categories before filing the issue; the table, the venue's rejection messages
and a standalone reproduction script are in #4820.

Validation run locally: `make format`, `make pre-commit`,
`cargo clippy -p nautilus-bybit --all-targets -- -D warnings`, and `cargo nextest run -p
nautilus-bybit`.
