### PR TITLE
fix(kraken): resolve spot instrument fees from TradeVolume

### DIFF
--- a/crates/adapters/kraken/src/common/parse.rs
+++ b/crates/adapters/kraken/src/common/parse.rs
@@ -182,6 +182,7 @@ fn parse_futures_trigger_type(
 pub fn parse_spot_instrument(
     pair_name: &str,
     definition: &AssetPairInfo,
+    fee_override: Option<(Decimal, Decimal)>,
     ts_event: UnixNanos,
     ts_init: UnixNanos,
 ) -> anyhow::Result<InstrumentAny> {
@@ -214,13 +215,21 @@ pub fn parse_spot_instrument(
         .map(|s| parse_quantity(s, "ordermin"))
         .transpose()?;
 
-    // Use base tier fees, convert from percentage
-    let taker_fee = definition.fees.first().map(|(_, fee)| *fee / dec!(100));
+    // Use account fee override when available; otherwise fall back to the AssetPairs base tier.
+    let (maker_fee, taker_fee) = match fee_override {
+        Some((maker_fee, taker_fee)) => (Some(maker_fee), Some(taker_fee)),
+        None => {
+            // Fall back to the public AssetPairs base tier.
+            let taker_fee = definition.fees.first().map(|(_, fee)| *fee / dec!(100));
 
-    let maker_fee = definition
-        .fees_maker
-        .first()
-        .map(|(_, fee)| *fee / dec!(100));
+            let maker_fee = definition
+                .fees_maker
+                .first()
+                .map(|(_, fee)| *fee / dec!(100));
+
+            (maker_fee, taker_fee)
+        }
+    };
 
     let instrument = CurrencyPair::new(
         instrument_id,
@@ -1273,8 +1282,7 @@ mod tests {
 
         let (pair_name, definition) = pairs.iter().next().unwrap();
 
-        let instrument = parse_spot_instrument(pair_name, definition, TS, TS).unwrap();
-
+        let instrument = parse_spot_instrument(pair_name, definition, None, TS, TS).unwrap();
         match instrument {
             InstrumentAny::CurrencyPair(pair) => {
                 assert_eq!(pair.id.venue.as_str(), "KRAKEN");
@@ -1287,6 +1295,32 @@ mod tests {
                 assert_eq!(pair.taker_fee, dec!(0.004));
                 assert_eq!(pair.margin_init, dec!(0));
                 assert_eq!(pair.margin_maint, dec!(0));
+            }
+            _ => panic!("Expected CurrencyPair"),
+        }
+    }
+
+    #[rstest]
+    fn test_parse_spot_instrument_with_fee_override() {
+        let json = load_test_json("http_asset_pairs.json");
+        let response: KrakenResponse<AssetPairsResponse> = serde_json::from_str(&json).unwrap();
+        let pairs = response.result.unwrap();
+
+        let (pair_name, definition) = pairs.iter().next().unwrap();
+
+        let instrument = parse_spot_instrument(
+            pair_name,
+            definition,
+            Some((dec!(0.004), dec!(0.008))),
+            TS,
+            TS,
+        )
+        .unwrap();
+
+        match instrument {
+            InstrumentAny::CurrencyPair(pair) => {
+                assert_eq!(pair.maker_fee, dec!(0.004));
+                assert_eq!(pair.taker_fee, dec!(0.008));
             }
             _ => panic!("Expected CurrencyPair"),
         }

--- a/crates/adapters/kraken/src/http/spot/client.rs
+++ b/crates/adapters/kraken/src/http/spot/client.rs
@@ -1200,6 +1200,92 @@ impl KrakenSpotRawHttpClient {
         })
     }
 
+    /// Requests account trade volume and current fee rates (requires authentication).
+    pub async fn get_trade_volume(
+        &self,
+        params: &SpotTradeVolumeParams,
+    ) -> anyhow::Result<SpotTradeVolumeResponse, KrakenHttpError> {
+        let credential = self
+            .credential
+            .as_ref()
+            .ok_or(KrakenHttpError::MissingCredentials)?;
+
+        // Serialize authenticated requests so nonces reach Kraken in order.
+        let _guard = self.auth_mutex.lock().await;
+
+        let endpoint = "/0/private/TradeVolume";
+        let nonce = self.generate_nonce();
+
+        let json_body = serde_json::json!({
+            "nonce": nonce.to_string(),
+            "pair": &params.pair,
+        });
+
+        let json_str = serde_json::to_string(&json_body).map_err(|e| {
+            KrakenHttpError::RequestNotStarted(format!(
+                "Failed to serialize TradeVolume request: {e}"
+            ))
+        })?;
+
+        let signature = credential
+            .sign_spot_json(endpoint, nonce, &json_str)
+            .map_err(|e| {
+                KrakenHttpError::AuthenticationError(format!(
+                    "Failed to sign TradeVolume request: {e}"
+                ))
+            })?;
+
+        let mut headers = Self::default_headers();
+        headers.insert("API-Key".to_string(), credential.api_key().to_string());
+        headers.insert("API-Sign".to_string(), signature);
+        headers.insert("Content-Type".to_string(), "application/json".to_string());
+
+        let url = format!("{}{endpoint}", self.base_url);
+        let rate_limit_keys = Self::rate_limit_keys(endpoint);
+
+        let response = self
+            .client
+            .request(
+                Method::POST,
+                url,
+                None,
+                Some(headers),
+                Some(json_str.into_bytes()),
+                None,
+                Some(rate_limit_keys),
+            )
+            .await
+            .map_err(|e| KrakenHttpError::NetworkError(e.to_string()))?;
+
+        if response.status.as_u16() >= 400 {
+            let status = response.status.as_u16();
+            let body = String::from_utf8_lossy(&response.body).to_string();
+
+            if status == 401 || status == 403 {
+                return Err(KrakenHttpError::AuthenticationError(format!(
+                    "HTTP error {status}: {body}"
+                )));
+            }
+
+            return Err(KrakenHttpError::NetworkError(format!(
+                "HTTP error {status}: {body}"
+            )));
+        }
+
+        let parsed: KrakenResponse<SpotTradeVolumeResponse> =
+            serde_json::from_slice(&response.body).map_err(|e| {
+                KrakenHttpError::ParseError(format!("Failed to parse TradeVolume response: {e}"))
+            })?;
+
+        if !parsed.error.is_empty() {
+            return Err(KrakenHttpError::ApiError(parsed.error));
+        }
+
+        parsed.result.ok_or_else(|| {
+            KrakenHttpError::ParseError("Missing result in TradeVolume response".to_string())
+        })
+    }
+
     /// Requests open spot margin positions (requires authentication).
     pub async fn get_open_positions(
         &self,
@@ -1487,11 +1573,61 @@ impl KrakenSpotHttpClient {
     ) -> anyhow::Result<Vec<InstrumentAny>, KrakenHttpError> {
         let ts_init = self.generate_ts_init();
         let asset_pairs = self.inner.get_asset_pairs(pairs.clone(), None).await?;
+        let fee_overrides = {
+            let pair_names = asset_pairs.keys().cloned().collect::<Vec<_>>().join(",");
 
+            if pair_names.is_empty() {
+                std::collections::HashMap::new()
+            } else {
+                let params = SpotTradeVolumeParams { pair: pair_names };
+
+                match self.inner.get_trade_volume(&params).await {
+                    Ok(trade_volume) => {
+                        let mut overrides = std::collections::HashMap::new();
+
+                        for pair_name in asset_pairs.keys() {
+                            let taker = trade_volume.fees.get(pair_name).ok_or_else(|| {
+                                KrakenHttpError::ParseError(format!(
+                                    "TradeVolume response missing taker fee for {pair_name}"
+                                ))
+                            })?;
+
+                            let maker = trade_volume.fees_maker.get(pair_name).unwrap_or(taker);
+
+                            let maker_fee =
+                                crate::common::parse::parse_decimal(&maker.fee).map_err(|e| {
+                                    KrakenHttpError::ParseError(format!(
+                                        "Failed to parse TradeVolume maker fee for {pair_name}: {e}"
+                                    ))
+                                })? / rust_decimal::Decimal::from(100u32);
+
+                            let taker_fee =
+                                crate::common::parse::parse_decimal(&taker.fee).map_err(|e| {
+                                    KrakenHttpError::ParseError(format!(
+                                        "Failed to parse TradeVolume taker fee for {pair_name}: {e}"
+                                    ))
+                                })? / rust_decimal::Decimal::from(100u32);
+
+                            overrides.insert(pair_name.clone(), (maker_fee, taker_fee));
+                        }
+
+                        overrides
+                    }
+                    Err(KrakenHttpError::MissingCredentials) => std::collections::HashMap::new(),
+                    Err(e) => return Err(e),
+                }
+            }
+        };
         let mut instruments: Vec<InstrumentAny> = asset_pairs
             .iter()
             .filter_map(|(pair_name, definition)| {
-                match parse_spot_instrument(pair_name, definition, ts_init, ts_init) {
+                match parse_spot_instrument(
+                    pair_name,
+                    definition,
+                    fee_overrides.get(pair_name).cloned(),
+                    ts_init,
+                    ts_init,
+                ) {
                     Ok(instrument) => Some((instrument, definition)),
                     Err(e) => {
                         log::warn!("Failed to parse instrument {pair_name}: {e}");

--- a/crates/adapters/kraken/src/http/spot/models.rs
+++ b/crates/adapters/kraken/src/http/spot/models.rs
@@ -135,6 +135,17 @@ impl<'de> Deserialize<'de> for SpotOpenPositionsResponse {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpotTradeVolumeFee {
+    pub fee: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpotTradeVolumeResponse {
+    pub fees: IndexMap<String, SpotTradeVolumeFee>,
+    #[serde(default)]
+    pub fees_maker: IndexMap<String, SpotTradeVolumeFee>,
+}
 // Asset Pairs (Instruments) Models
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/adapters/kraken/src/http/spot/query.rs
+++ b/crates/adapters/kraken/src/http/spot/query.rs
@@ -358,6 +358,13 @@ pub struct SpotTradeBalanceParams {
     pub asset: Option<String>,
 }
 
+/// Parameters for `POST /0/private/TradeVolume`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SpotTradeVolumeParams {
+    /// Comma-delimited Kraken spot pair names for which to retrieve fee information.
+    pub pair: String,
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/crates/adapters/kraken/tests/exec_client.rs
+++ b/crates/adapters/kraken/tests/exec_client.rs
@@ -354,6 +354,10 @@ async fn handle_http_request(State(state): State<TestServerState>, req: Request)
             }
         }
         "/0/public/AssetPairs" => json_response(load_test_data("http_asset_pairs.json")),
+        "/0/private/TradeVolume" => json_response(
+            r#"{"error":[],"result":{"fees":{"XBTUSDT":{"fee":"0.8000"}},"fees_maker":{"XBTUSDT":{"fee":"0.4000"}}}}"#
+                .to_string(),
+        ),
         "/0/private/GetWebSocketsToken" => json_response(
             r#"{"error":[],"result":{"token":"TEST-TOKEN","expires":900}}"#.to_string(),
         ),

--- a/crates/adapters/kraken/tests/http.rs
+++ b/crates/adapters/kraken/tests/http.rs
@@ -581,6 +581,27 @@ async fn mock_handler(req: Request, state: Arc<TestServerState>) -> Response {
             mock_trades(query, state.clone()).await
         }
         "/0/private/GetWebSocketsToken" => mock_websockets_token(req.headers().clone()).await,
+        "/0/private/TradeVolume" => Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{
+            "error": [],
+            "result": {
+                "fees": {
+                    "XBTUSDT": {
+                        "fee": "0.8000"
+                    }
+                },
+                "fees_maker": {
+                    "XBTUSDT": {
+                        "fee": "0.4000"
+                    }
+                }
+            }
+        }"#,
+            ))
+            .unwrap(),
         "/0/private/Balance" => mock_spot_balance().await,
         "/0/private/TradeBalance" => {
             let body_bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
@@ -1087,6 +1108,53 @@ async fn test_spot_domain_request_instruments() {
 
 #[rstest]
 #[tokio::test]
+async fn test_spot_domain_request_instruments_with_account_fees() {
+    let state = Arc::new(TestServerState::default());
+    let app = create_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    wait_for_server(addr, "/0/public/Time").await;
+
+    let client = KrakenSpotHttpClient::with_credentials(
+        "test_api_key".to_string(),
+        "dGVzdF9hcGlfc2VjcmV0X2Jhc2U2NA==".to_string(),
+        KrakenEnvironment::Live,
+        Some(base_url),
+        10,
+        None,
+        None,
+        None,
+        None,
+        5,
+    )
+    .unwrap();
+
+    let instruments = client
+        .request_instruments(None)
+        .await
+        .expect("Failed to request instruments");
+
+    let instrument = instruments
+        .iter()
+        .find(|instrument| instrument.raw_symbol().as_str() == "XBTUSDT")
+        .expect("XBTUSDT instrument not found");
+
+    match instrument {
+        InstrumentAny::CurrencyPair(pair) => {
+            assert_eq!(pair.maker_fee, rust_decimal::Decimal::new(4, 3));
+            assert_eq!(pair.taker_fee, rust_decimal::Decimal::new(8, 3));
+        }
+        _ => panic!("Expected CurrencyPair"),
+    }
+}
+#[rstest]
+#[tokio::test]
 async fn test_spot_domain_request_instrument_statuses() {
     let state = Arc::new(TestServerState::default());
     let app = create_router(state);
@@ -1414,7 +1482,55 @@ async fn test_spot_raw_get_websockets_token_with_credentials() {
     assert_eq!(token.token, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
     assert_eq!(token.expires, 900);
 }
+#[rstest]
+#[tokio::test]
+async fn test_spot_raw_get_trade_volume_with_credentials() {
+    use nautilus_kraken::http::SpotTradeVolumeParams;
+    let state = Arc::new(TestServerState::default());
+    let app = create_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
 
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    wait_for_server(addr, "/0/public/Time").await;
+
+    let client = KrakenSpotRawHttpClient::with_credentials(
+        "test_api_key".to_string(),
+        "dGVzdF9hcGlfc2VjcmV0X2Jhc2U2NA==".to_string(),
+        KrakenEnvironment::Live,
+        Some(base_url),
+        10,
+        None,
+        None,
+        None,
+        None,
+        5,
+    )
+    .unwrap();
+
+    let params = SpotTradeVolumeParams {
+        pair: "XBTUSDT".to_string(),
+    };
+
+    let result = client.get_trade_volume(&params).await;
+    assert!(result.is_ok(), "Failed to get TradeVolume: {result:?}");
+
+    let trade_volume = result.unwrap();
+
+    let taker = trade_volume.fees.get("XBTUSDT").expect("Missing taker fee");
+
+    let maker = trade_volume
+        .fees_maker
+        .get("XBTUSDT")
+        .expect("Missing maker fee");
+
+    assert_eq!(taker.fee, "0.8000");
+    assert_eq!(maker.fee, "0.4000");
+}
 #[rstest]
 #[tokio::test]
 async fn test_spot_domain_request_trades_missing_cached_instrument_returns_parse_error() {

--- a/docs/integrations/kraken.md
+++ b/docs/integrations/kraken.md
@@ -152,6 +152,15 @@ InstrumentId.from_str("BTC/USDT.KRAKEN")  # Spot BTC/USDT
 InstrumentId.from_str("ETH/BTC.KRAKEN")  # Spot ETH/BTC (normalized from ETH/XBT)
 ```
 
+:::note
+**Spot instrument fees**: When API credentials are available, the adapter
+resolves maker and taker fees for Spot currency-pair instruments from Kraken's
+private `TradeVolume` endpoint for the connected account. Without credentials,
+the adapter falls back to the base-tier fees reported by the public `AssetPairs`
+endpoint. Kraken's public `AssetPairs` fee ladder can lag the currently
+published fee schedule, so unauthenticated instrument fee values may be stale.
+:::
+
 ### Futures markets
 
 Kraken Futures instruments use a specific naming convention with prefixes:


### PR DESCRIPTION
## Summary

Fixes #4789 for ordinary Kraken Spot currency-pair instruments.

- resolves account-specific maker/taker fees from Kraken's private `TradeVolume` endpoint when credentials are configured
- preserves the public `AssetPairs` base-tier fees as the fallback when credentials are unavailable
- passes resolved account fees into Spot instrument construction without changing the `Instrument` model
- documents that unauthenticated `AssetPairs` fee data may be stale
- adds regression coverage for both credentialed and uncredentialed instrument loading

## Scope

This draft currently applies the `TradeVolume` fee path to ordinary Kraken Spot currency pairs.

`request_instruments()` also loads tokenized assets/xStocks. I asked in #4789 whether those should be included in the account-specific fee path or retain their existing `AssetPairs` handling for this change. I have left that path unchanged pending confirmation.

## Verification

- `cargo check -p nautilus-kraken`
- `cargo test -p nautilus-kraken`
- `git diff --check`

The full `nautilus-kraken` test suite passes locally.