### PR TITLE
Fix Interactive Brokers adaptive limit order parsing

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/parse.rs
+++ b/crates/adapters/interactive_brokers/src/execution/parse.rs
@@ -226,7 +226,7 @@ pub fn parse_order_status_to_report(
 
     // Map order type from IB order if available
     let order_type = order
-        .map(|order| map_ib_order_type(&order.order_type))
+        .map(|order| map_ib_order_type(&order.order_type, order.limit_price))
         .unwrap_or(OrderType::Market);
 
     // Map time in force from IB order if available
@@ -293,8 +293,13 @@ pub fn parse_order_status_to_report(
     Ok(report)
 }
 
-fn map_ib_order_type(order_type: &str) -> OrderType {
-    IbOrderType::from_str(order_type).map_or(OrderType::Market, IbOrderType::nautilus_order_type)
+fn map_ib_order_type(order_type: &str, limit_price: Option<f64>) -> OrderType {
+    if order_type == "IBALGO" && limit_price.is_some_and(|price| price != 0.0) {
+        OrderType::Limit
+    } else {
+        IbOrderType::from_str(order_type)
+            .map_or(OrderType::Market, IbOrderType::nautilus_order_type)
+    }
 }
 
 fn parse_ib_order_pricing_fields(
@@ -485,6 +490,11 @@ mod tests {
     }
 
     use rstest::rstest;
+
+    #[rstest]
+    fn test_ibalgo_with_zero_limit_price_maps_to_market() {
+        assert_eq!(map_ib_order_type("IBALGO", Some(0.0)), OrderType::Market);
+    }
 
     #[rstest]
     fn test_parse_execution_time_hyphenated_format() {
@@ -826,6 +836,32 @@ mod tests {
         None,
         OrderType::Limit,
         Some(Price::new(185.0, 0)),
+        None,
+        None,
+        None,
+        TrailingOffsetType::NoTrailingOffset
+    )]
+    #[case(
+        "IBALGO",
+        Some(185.0),
+        None,
+        None,
+        None,
+        OrderType::Limit,
+        Some(Price::new(185.0, 0)),
+        None,
+        None,
+        None,
+        TrailingOffsetType::NoTrailingOffset
+    )]
+    #[case(
+        "IBALGO",
+        None,
+        None,
+        None,
+        None,
+        OrderType::Market,
+        None,
         None,
         None,
         None,


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Resolve Interactive Brokers `IBALGO` reports from the returned limit price. Adaptive limit orders now retain `OrderType::Limit`, while algo orders without a limit price remain market orders.

## Related issues/PRs

Resolves #4824

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Validated the focused 9-case regression, all 410 adapter tests, `cargo check`, Clippy, `cargo doc`, rustfmt, and applicable pre-commit hooks. Full `make pre-commit` could not complete because unrelated Go and Node hook environments repeatedly timed out during setup; no relevant hook or code check failed.