### PR TITLE
Skip Nautilus integrator attribution on Lighter testnet

### DIFF
--- a/crates/adapters/lighter/src/execution.rs
+++ b/crates/adapters/lighter/src/execution.rs
@@ -81,8 +81,8 @@ use crate::{
         },
         credential::{Credential, scrub_auth},
         enums::{
-            LighterAccountTier, LighterPositionMarginMode, LighterProductType, LighterTxStatus,
-            LighterTxType,
+            LighterAccountTier, LighterEnvironment, LighterPositionMarginMode, LighterProductType,
+            LighterTxStatus, LighterTxType,
         },
         rate_limit::{LighterTxRateLimiter, await_tx_quota, build_tx_rate_limiter, resolve_quota},
         symbol::{MarketRegistry, product_type_from_instrument_id},
@@ -507,6 +507,15 @@ impl LighterExecutionClient {
         let Some(credential) = &self.credential else {
             return Ok(());
         };
+
+        if matches!(self.config.environment, LighterEnvironment::Testnet) {
+            log::info!(
+                "Skipping Lighter integrator auto-approval on testnet: the Nautilus \
+                 integrator account exists on mainnet only; orders are submitted \
+                 unattributed"
+            );
+            return Ok(());
+        }
 
         let mut maker_only_check_failed = false;
 
@@ -1736,7 +1745,7 @@ impl LighterExecutionClient {
             base_amount,
             price: price_ticks,
             trigger_price: trigger_price_ticks,
-            attributes: integrator_attributes(),
+            attributes: integrator_attributes(self.config.environment),
         };
 
         let signed = sign_tx(
@@ -2491,7 +2500,7 @@ impl FanoutDispatchContext {
                 trigger_price: plan.trigger_price,
                 order_expiry: plan.order_expiry,
             },
-            attributes: integrator_attributes(),
+            attributes: integrator_attributes(self.environment),
         };
         let signed = sign_tx(
             &tx,
@@ -3465,9 +3474,16 @@ fn rollback_tx_dispatch_indices(
     }
 }
 
-fn integrator_attributes() -> L2TxAttributes {
+fn integrator_attributes(environment: LighterEnvironment) -> L2TxAttributes {
+    // The Nautilus integrator account exists on mainnet only. Tagging testnet
+    // transactions with it fails at the venue (21100 on approval, 21149 on
+    // every order), so testnet transactions are submitted unattributed.
+    let integrator_account_index = match environment {
+        LighterEnvironment::Mainnet => LIGHTER_NAUTILUS_INTEGRATOR_ACCOUNT_INDEX,
+        LighterEnvironment::Testnet => 0,
+    };
     L2TxAttributes {
-        integrator_account_index: LIGHTER_NAUTILUS_INTEGRATOR_ACCOUNT_INDEX,
+        integrator_account_index,
         integrator_taker_fee: 0,
         integrator_maker_fee: 0,
         skip_nonce: 0,
@@ -8558,12 +8574,14 @@ mod tests {
     }
 
     #[rstest]
-    fn integrator_attributes_tags_nautilus_account_at_zero_fees() {
-        let attrs = integrator_attributes();
-        assert_eq!(
-            attrs.integrator_account_index,
-            LIGHTER_NAUTILUS_INTEGRATOR_ACCOUNT_INDEX,
-        );
+    #[case(LighterEnvironment::Mainnet, LIGHTER_NAUTILUS_INTEGRATOR_ACCOUNT_INDEX)]
+    #[case(LighterEnvironment::Testnet, 0)]
+    fn integrator_attributes_match_environment(
+        #[case] environment: LighterEnvironment,
+        #[case] expected_integrator: u64,
+    ) {
+        let attrs = integrator_attributes(environment);
+        assert_eq!(attrs.integrator_account_index, expected_integrator);
         assert_eq!(attrs.integrator_taker_fee, 0);
         assert_eq!(attrs.integrator_maker_fee, 0);
         assert_eq!(attrs.skip_nonce, 0);
@@ -11151,12 +11169,26 @@ mod tests {
     #[tokio::test]
     async fn integrator_approval_api_rejection_releases_reservation_and_nonce() {
         let mut config = test_config();
+        config.environment = LighterEnvironment::Mainnet;
         config.base_url_http = Some(spawn_integrator_approval_rejection_server().await);
         let (client, _cache, _rx) = create_execution_client_with_config(config);
 
         let err = client.submit_integrator_auto_approval().await.unwrap_err();
 
         assert!(format!("{err:#}").contains("invalid approval"));
+        assert_nonce_reusable(&client.dispatch);
+    }
+
+    #[tokio::test]
+    async fn integrator_auto_approval_skipped_on_testnet() {
+        let (client, _cache, _rx) = create_execution_client_with_config(test_config());
+
+        // test_config points HTTP at an unreachable address, so a returned Ok
+        // proves approval was skipped without any venue call.
+        client
+            .submit_integrator_auto_approval()
+            .await
+            .expect("testnet must skip approval without any venue call");
         assert_nonce_reusable(&client.dispatch);
     }
 

--- a/crates/adapters/lighter/tests/exec_client.rs
+++ b/crates/adapters/lighter/tests/exec_client.rs
@@ -775,6 +775,16 @@ fn build_config(addr: SocketAddr) -> LighterExecClientConfig {
     }
 }
 
+fn build_mainnet_config(addr: SocketAddr) -> LighterExecClientConfig {
+    // The integrator auto-approval flow is mainnet-only (see
+    // `submit_integrator_auto_approval`); tests pinning it must not use the
+    // default testnet fixture.
+    LighterExecClientConfig {
+        environment: LighterEnvironment::Mainnet,
+        ..build_config(addr)
+    }
+}
+
 fn build_config_no_credentials(addr: SocketAddr) -> LighterExecClientConfig {
     LighterExecClientConfig {
         private_key: None,
@@ -1430,7 +1440,7 @@ async fn connect_reports_socket_state_on_the_user_streams_endpoint() {
 #[tokio::test(flavor = "multi_thread")]
 async fn connect_submits_l2_only_integrator_auto_approval() {
     let (addr, state) = start_server().await;
-    let (mut client, _rx, _cache) = build_client(addr);
+    let (mut client, _rx, _cache) = build_client_with(build_mainnet_config(addr));
 
     client.connect().await.expect("connect");
 
@@ -1476,7 +1486,7 @@ async fn connect_skips_integrator_auto_approval_for_maker_only_api_key() {
         .lock()
         .await
         .push(i64::from(TEST_API_KEY_INDEX));
-    let (mut client, _rx, _cache) = build_client(addr);
+    let (mut client, _rx, _cache) = build_client_with(build_mainnet_config(addr));
 
     client.connect().await.expect("connect");
 
@@ -1495,7 +1505,7 @@ async fn connect_bails_when_integrator_auto_approval_reports_unapproved() {
         "code": 21149,
         "message": "integrator is not approved",
     }));
-    let (mut client, _rx, _cache) = build_client(addr);
+    let (mut client, _rx, _cache) = build_client_with(build_mainnet_config(addr));
 
     let err = client.connect().await.unwrap_err();
     let msg = format!("{err:#}");
@@ -1509,6 +1519,20 @@ async fn connect_bails_when_integrator_auto_approval_reports_unapproved() {
     assert_eq!(state.rest_send_txs().await.len(), 1);
     assert!(!client.is_connected());
     assert_eq!(*state.connection_count.lock().await, 0);
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn connect_skips_integrator_auto_approval_on_testnet() {
+    let (addr, state) = start_server().await;
+    let (mut client, _rx, _cache) = build_client(addr);
+
+    client.connect().await.expect("connect");
+
+    assert_eq!(state.maker_only_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(state.rest_send_txs().await.len(), 0);
+
+    client.disconnect().await.expect("disconnect");
 }
 
 /// Pins the per-stream marker dispatch in the execution consumption loop.

--- a/docs/integrations/lighter.md
+++ b/docs/integrations/lighter.md
@@ -121,6 +121,9 @@ Create and modify transactions carry the NautilusTrader integrator account index
 client submits the required **zero-fee** `ApproveIntegrator` approval during startup when the API
 key is not maker-only.
 
+The integrator account exists on mainnet only. On testnet the adapter submits transactions
+unattributed and skips the startup approval entirely.
+
 Maker-only API keys cannot submit `ApproveIntegrator`. The execution client detects these keys and
 skips automatic approval. Approval is account-scoped, so a non-maker-only key on the same account
 must approve the integrator before a maker-only key can trade through the adapter.


### PR DESCRIPTION
## Body

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md`

## Summary

The Lighter adapter tags all create/modify transactions with the Nautilus integrator account index
(723813), which exists on mainnet only. On testnet this fails at the venue for every user: the
startup auto-approval errors with 21100 "account not found" and each order is rejected with 21149
"integrator is not approved". Submit testnet transactions unattributed (integrator index 0,
matching `lighter-go` defaults) and skip the startup approval there; mainnet attribution and
approval flow are unchanged.

## Related issues/PRs

Closes #4833

## Type of change

- [x] Bug fix (non-breaking)
- [x] Documentation update

## Testing

- [x] I added/updated tests to cover new or changed logic

Unit tests: `integrator_attributes` now parameterized over environment (mainnet keeps 723813,
testnet yields 0); new `integrator_auto_approval_skipped_on_testnet` proves approval is skipped
without any venue call; the existing API-rejection test now pins to mainnet (approval path). All
adapter `integrator` tests pass locally.

Also validated live against Lighter testnet (account 824): with this change the startup approval
is skipped, both post-only limit orders are accepted, and real maker fills occur (previously
rejected 21149); position closed flat on shutdown.

Limitation: `make pre-commit` (prek, all files) was not run in the contributor environment; the
Rust change was verified with `cargo +nightly fmt --check` on the touched crate (clean) and
`cargo test -p nautilus-lighter`.
