### PR TITLE
Fix dYdX retry tests to exercise the operation timeout

### DIFF
--- a/crates/adapters/dydx/src/http/client.rs
+++ b/crates/adapters/dydx/src/http/client.rs
@@ -1785,7 +1785,13 @@ impl DydxHttpClient {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
     use axum::{Router, routing::get};
+    use nautilus_common::testing::wait_until_async;
     use nautilus_model::identifiers::Symbol;
     use rstest::rstest;
 
@@ -1882,13 +1888,18 @@ mod tests {
     async fn test_http_timeout_respects_configuration_and_does_not_block() {
         use tokio::net::TcpListener;
 
-        async fn slow_handler() -> &'static str {
-            // Sleep longer than the configured HTTP timeout.
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            "ok"
-        }
-
-        let router = Router::new().route("/v4/slow", get(slow_handler));
+        let handler_entered = Arc::new(AtomicBool::new(false));
+        let handler_entered_clone = Arc::clone(&handler_entered);
+        let router = Router::new()
+            .route(
+                "/v4/slow",
+                get(move || async move {
+                    handler_entered_clone.store(true, Ordering::SeqCst);
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    "ok"
+                }),
+            )
+            .route("/health", get(|| async { "ok" }));
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1901,12 +1912,28 @@ mod tests {
 
         let base_url = format!("http://{addr}");
 
+        // The measured request must reach the slow route, so establish that the server is
+        // accepting before starting the clock: binding the listener makes the port
+        // connectable before the serve task has reached its accept loop.
+        let ready_url = format!("{base_url}/health");
+        let probe =
+            HttpClient::new(HashMap::new(), Vec::new(), Vec::new(), None, None, None).unwrap();
+        wait_until_async(
+            || {
+                let url = ready_url.clone();
+                let probe = probe.clone();
+                async move { probe.get(url, None, None, Some(1), None).await.is_ok() }
+            },
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+
         // Configure a small operation timeout and no retries so the request
         // fails quickly even though the handler sleeps for 5 seconds.
         let retry_config = RetryConfig {
             max_retries: 0,
-            initial_delay_ms: 0,
-            max_delay_ms: 0,
+            initial_delay_ms: 1,
+            max_delay_ms: 1,
             backoff_factor: 1.0,
             jitter_ms: 0,
             operation_timeout_ms: Some(500),
@@ -1930,9 +1957,18 @@ mod tests {
             client.send_request(Method::GET, "/v4/slow", None).await;
         let elapsed = start.elapsed();
 
-        // Request should fail (timeout or client error), but without blocking the thread
-        // for the full handler duration.
-        assert!(result.is_err());
+        let expected = RetryError::OperationTimeout { timeout_ms: 500 }.to_string();
+        assert!(
+            matches!(
+                &result,
+                Err(error::DydxHttpError::HttpClientError(message)) if message == &expected
+            ),
+            "Expected operation timeout, received {result:?}"
+        );
+        assert!(
+            handler_entered.load(Ordering::SeqCst),
+            "Slow route was never entered"
+        );
         assert!(elapsed < std::time::Duration::from_secs(3));
     }
 }

--- a/crates/adapters/dydx/tests/http.rs
+++ b/crates/adapters/dydx/tests/http.rs
@@ -15,7 +15,15 @@
 
 //! Integration tests for dYdX HTTP client using a mock Axum server.
 
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use axum::{
     Router,
@@ -31,13 +39,19 @@ use nautilus_dydx::{
         consts::DYDX_VENUE,
         enums::{DydxCandleResolution, DydxNetwork},
     },
-    http::client::{DydxHttpClient, DydxRawHttpClient},
+    http::{
+        client::{DydxHttpClient, DydxRawHttpClient},
+        error::DydxHttpError,
+    },
 };
 use nautilus_model::{
     identifiers::{InstrumentId, Symbol},
     instruments::Instrument,
 };
-use nautilus_network::{http::HttpClient, retry::RetryConfig};
+use nautilus_network::{
+    http::HttpClient,
+    retry::{RetryConfig, RetryError},
+};
 use rstest::rstest;
 use serde_json::{Value, json};
 
@@ -1487,10 +1501,13 @@ async fn test_concurrent_requests() {
 #[tokio::test]
 async fn test_request_timeout_short() {
     let state = TestServerState::default();
+    let handler_entered = Arc::new(AtomicBool::new(false));
+    let handler_entered_clone = Arc::clone(&handler_entered);
     let router = Router::new()
         .route(
             "/v4/time",
-            get(|| async {
+            get(move || async move {
+                handler_entered_clone.store(true, Ordering::SeqCst);
                 tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
                 Json(json!({
                     "iso": "2024-01-01T00:00:00.000Z",
@@ -1514,8 +1531,8 @@ async fn test_request_timeout_short() {
     let base_url = format!("http://{addr}");
     let retry_config = RetryConfig {
         max_retries: 0,
-        initial_delay_ms: 0,
-        max_delay_ms: 0,
+        initial_delay_ms: 1,
+        max_delay_ms: 1,
         backoff_factor: 1.0,
         jitter_ms: 0,
         operation_timeout_ms: Some(1_000),
@@ -1524,7 +1541,7 @@ async fn test_request_timeout_short() {
     };
     let client = DydxRawHttpClient::new(
         Some(base_url),
-        1,
+        60,
         None,
         DydxNetwork::Mainnet,
         Some(retry_config),
@@ -1535,9 +1552,20 @@ async fn test_request_timeout_short() {
     let result = client.get_time().await;
     let duration = start.elapsed();
 
-    assert!(result.is_err());
+    let expected = RetryError::OperationTimeout { timeout_ms: 1_000 }.to_string();
     assert!(
-        duration.as_secs() < 5,
+        matches!(
+            &result,
+            Err(DydxHttpError::HttpClientError(message)) if message == &expected
+        ),
+        "Expected operation timeout, received {result:?}"
+    );
+    assert!(
+        handler_entered.load(Ordering::SeqCst),
+        "Slow route was never entered"
+    );
+    assert!(
+        duration < Duration::from_secs(5),
         "Should timeout before server response, took {duration:?}"
     );
 }


### PR DESCRIPTION
Both dYdX tests covering the retry operation timeout pass without ever reaching it, so a regression in that timeout would go undetected.

## The tests fail on configuration before the request is issued

`ExponentialBackoff::new` rejects a zero initial delay (`crates/network/src/backoff.rs:126`), and `RetryManager::execute_with_retry_inner_delay` constructs the backoff before its retry loop, unconditionally - `max_retries: 0` does not bypass it (`crates/network/src/retry.rs:206-217`). A `RetryConfig` carrying `initial_delay_ms: 0` therefore returns `RetryError::InvalidConfiguration` in microseconds, which the dYdX adapter maps to `DydxHttpError::ValidationError`, and the operation closure never runs.

`test_request_timeout_short` (`crates/adapters/dydx/tests/http.rs`) and `test_http_timeout_respects_configuration_and_does_not_block` (`crates/adapters/dydx/src/http/client.rs`) both build that config and then assert only `result.is_err()` and a loose wall-clock bound. The configuration error satisfies both. Neither test reaches its slow route, and neither exercises `operation_timeout_ms`. They complete in 0.28s and 0.05s against nominal timeouts of 1000ms and 500ms.

The predicate landed in `19de9b697b` (May 2025); both tests were written six months later, so they have never enforced what they are named for.

Both configs now use `initial_delay_ms: 1`, `max_delay_ms: 1`. With zero retries the delay is never calculated or slept: the operation timeout produces the error, `should_retry` returns true, and `attempt >= max_retries` returns immediately.

`test_invalid_configuration_reason` (`crates/network/src/retry.rs`) also sets `initial_delay_ms: 0` and is left untouched - it is the test for that error.

## The assertions could not distinguish a timeout from a setup failure

`assert!(result.is_err())` is what allowed the defect to persist, so both tests now assert the concrete failure: `DydxHttpError::HttpClientError` carrying the payload built from `RetryError::OperationTimeout { timeout_ms }`, which separates an operation timeout from a `ValidationError` and from a transport error. Each slow route also records entry, so the tests prove the request reached the server rather than timing out ahead of dispatch.

`test_request_timeout_short` additionally passed `1` as `timeout_secs` while its operation timeout was 1000ms; once the request is actually issued those two timers race, so the client timeout is now 60s and only the operation timeout can produce the failure. The `client.rs` test gained a readiness handshake against a fast route, since binding a listener makes the port connectable before the serve task reaches its accept loop.

## Testing

No production code changes; the diff is test-only.

Restoring `initial_delay_ms: 0` fails both tests on the error assertion with `Expected operation timeout, received Err(ValidationError("Invalid configuration: delay_initial must be non-zero"))`, and the handler-entry assertion reports the route was never entered.

The wall-clock bounds are kept as secondary guards at 3s and 5s against 5s and 10s handlers, loose enough to tolerate a loaded runner since the error assertion carries the claim. One limitation: the adapter erases `RetryError` into a string, so the tests match on the message rather than the variant. That message is unique to the operation-timeout path, but it is a string comparison rather than a type assertion.
