### PR TITLE
Order betfair subscription test teardown with a signal

### DIFF
--- a/crates/adapters/betfair/tests/data_client.rs
+++ b/crates/adapters/betfair/tests/data_client.rs
@@ -431,6 +431,8 @@ async fn test_data_client_deduplicates_same_market_subscription() {
     let (addr, _state) = start_mock_http().await;
     let (stream_port, listener) = start_mock_stream().await;
     let (mut client, _rx) = create_test_data_client(addr, stream_port);
+    let (observation_tx, observation_rx) = tokio::sync::oneshot::channel();
+    let (teardown_tx, teardown_rx) = tokio::sync::oneshot::channel();
 
     let server = tokio::spawn(async move {
         let (mut reader, write_half) = accept_and_auth(&listener).await;
@@ -447,13 +449,13 @@ async fn test_data_client_deduplicates_same_market_subscription() {
         )
         .await;
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        drop(write_half);
-
-        (
+        let observation = (
             first_line.trim().to_string(),
             matches!(second_result, Ok(Ok(bytes)) if bytes > 0),
-        )
+        );
+        let _ = observation_tx.send(observation);
+        let _ = teardown_rx.await;
+        drop(write_half);
     });
 
     client.connect().await.unwrap();
@@ -497,15 +499,17 @@ async fn test_data_client_deduplicates_same_market_subscription() {
     client.subscribe_book_deltas(first_cmd).unwrap();
     client.subscribe_book_deltas(second_cmd).unwrap();
 
-    let (first_msg, saw_second_message) = server.await.unwrap();
+    let (first_msg, saw_second_message) = observation_rx.await.unwrap();
+    client.disconnect().await.unwrap();
+    let _ = teardown_tx.send(());
+    server.await.unwrap();
+
     let json: Value = serde_json::from_str(&first_msg).unwrap();
     assert_eq!(json["op"], "marketSubscription");
     assert!(
         !saw_second_message,
         "Expected only one subscription for the same market"
     );
-
-    client.disconnect().await.unwrap();
 }
 
 #[rstest]


### PR DESCRIPTION
`test_data_client_deduplicates_same_market_subscription` orders its teardown with a fixed sleep rather than a signal, which costs a mandatory second and closes the stream while the client is still connected.

## The teardown is ordered by elapsed time

The mock stream server in `crates/adapters/betfair/tests/data_client.rs` reads the first subscription line, waits up to 500ms for a second one, then sleeps `Duration::from_secs(1)`, drops its write half, and only then returns the observed tuple. The main task blocks on `server.await` before it can assert, so the sleep sits on the critical path and the test cannot finish in under 1.5s however fast the client is. Dropping the socket at that point also leaves the client connected, so the EOF starts a lower-level `SocketClient` reconnect attempt that cannot succeed, and `client.disconnect()` runs afterwards.

The observed tuple is fully determined once the 500ms window closes, so it no longer waits for teardown: the server sends it over a oneshot at that point, then waits on a second oneshot before dropping the write half. The main task receives the observation, disconnects the client, signals teardown, awaits the server, and asserts last. Assertions run after cleanup so that a failing assertion cannot panic past the disconnect and leave the server task holding the socket.

The 500ms window is unchanged. It still opens only after the server has accepted, authenticated, and read the first subscription line, so a duplicate has the same opportunity to arrive as before.

## Testing

Test-only; no production code changes.

Locally the test falls from 1.85s to 0.83s, consistent with removing exactly one mandatory second.

Deleting the `subscribed_market_ids` early return in `BetfairDataClient::subscribe_book_deltas` makes the test fail on `Expected only one subscription for the same market`, deterministically across three runs. The mutated runs finish faster than the passing one, since the duplicate arrives early and cuts the observation window short.

A second send delayed beyond 500ms would still pass. Closing that off would need a positive acknowledgement that every spawned subscription task has run, which the current interface does not expose.
