### PR TITLE
Add optional venue to Lighter data and execution clients

### DIFF
--- a/crates/adapters/lighter/src/common/symbol.rs
+++ b/crates/adapters/lighter/src/common/symbol.rs
@@ -21,7 +21,7 @@
 //! on every WebSocket frame and outbound transaction.
 
 use dashmap::DashMap;
-use nautilus_model::identifiers::{InstrumentId, Symbol};
+use nautilus_model::identifiers::{InstrumentId, Symbol, Venue};
 use ustr::Ustr;
 
 use super::{consts::LIGHTER_VENUE, enums::LighterProductType};
@@ -34,15 +34,27 @@ pub const SPOT_SUFFIX: &str = "-SPOT";
 
 /// Builds a Nautilus [`InstrumentId`] from a venue symbol and product type.
 ///
-/// The venue symbol is upper-cased and combined with the product suffix
-/// (`-PERP` or `-SPOT`) before being qualified by the Lighter venue.
+/// Qualifies the instrument id with [`LIGHTER_VENUE`].
 #[must_use]
 pub fn format_instrument_id(venue_symbol: &str, product_type: LighterProductType) -> InstrumentId {
+    format_instrument_id_with_venue(venue_symbol, product_type, *LIGHTER_VENUE)
+}
+
+/// Builds a Nautilus [`InstrumentId`] with the given venue qualifier.
+///
+/// The venue symbol is upper-cased and combined with the product suffix
+/// (`-PERP` or `-SPOT`) before being qualified by `venue`.
+#[must_use]
+pub fn format_instrument_id_with_venue(
+    venue_symbol: &str,
+    product_type: LighterProductType,
+    venue: Venue,
+) -> InstrumentId {
     let suffix = product_suffix(product_type);
     let trimmed = venue_symbol.trim();
     let upper = trimmed.to_ascii_uppercase();
     let symbol = format!("{upper}{suffix}");
-    InstrumentId::new(Symbol::from_str_unchecked(&symbol), *LIGHTER_VENUE)
+    InstrumentId::new(Symbol::from_str_unchecked(&symbol), venue)
 }
 
 /// Returns the venue-native symbol for an instrument id by stripping any
@@ -96,18 +108,42 @@ fn canonical_symbol_key(venue_symbol: &str) -> Ustr {
 /// as relists must be coordinated by the caller (e.g. quiesce consumers
 /// before reinserting) to avoid concurrent readers observing partial
 /// state.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct MarketRegistry {
+    venue: Venue,
     by_index: DashMap<i16, InstrumentId>,
     by_id: DashMap<InstrumentId, i16>,
     by_raw_symbol: DashMap<(Ustr, LighterProductType), InstrumentId>,
 }
 
+impl Default for MarketRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MarketRegistry {
-    /// Returns a new empty registry.
+    /// Returns a new empty registry that qualifies instrument ids with [`LIGHTER_VENUE`].
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self::new_with_venue(*LIGHTER_VENUE)
+    }
+
+    /// Returns a new empty registry that qualifies instrument ids with `venue`.
+    #[must_use]
+    pub fn new_with_venue(venue: Venue) -> Self {
+        Self {
+            venue,
+            by_index: DashMap::new(),
+            by_id: DashMap::new(),
+            by_raw_symbol: DashMap::new(),
+        }
+    }
+
+    /// Returns the venue used to qualify registered instrument ids.
+    #[must_use]
+    pub const fn venue(&self) -> Venue {
+        self.venue
     }
 
     /// Registers a market and returns the resulting [`InstrumentId`].
@@ -122,7 +158,8 @@ impl MarketRegistry {
         venue_symbol: &str,
         product_type: LighterProductType,
     ) -> InstrumentId {
-        let instrument_id = format_instrument_id(venue_symbol, product_type);
+        let instrument_id =
+            format_instrument_id_with_venue(venue_symbol, product_type, self.venue);
         let canonical = canonical_symbol_key(venue_symbol);
 
         // Evict any prior mapping that shared this market_index but pointed
@@ -231,6 +268,14 @@ mod tests {
     }
 
     #[rstest]
+    fn format_instrument_id_uses_provided_venue() {
+        let venue = Venue::new("LIGHTER_ALT");
+        let id = format_instrument_id_with_venue("eth", LighterProductType::Perp, venue);
+        assert_eq!(id.symbol.as_str(), "ETH-PERP");
+        assert_eq!(id.venue, venue);
+    }
+
+    #[rstest]
     #[case::leading("  ETH", "ETH-PERP")]
     #[case::trailing("ETH  ", "ETH-PERP")]
     #[case::both_sides("  eth  ", "ETH-PERP")]
@@ -269,6 +314,24 @@ mod tests {
             Some(LighterProductType::Spot),
         );
         assert_eq!(product_type_from_instrument_id(&none), None);
+    }
+
+    #[rstest]
+    fn registry_qualifies_instrument_ids_with_configured_venue() {
+        let default_registry = MarketRegistry::new();
+        let alt_venue = Venue::new("LIGHTER_ALT");
+        let alt_registry = MarketRegistry::new_with_venue(alt_venue);
+
+        let default_id = default_registry.insert(0, "ETH", LighterProductType::Perp);
+        let alt_id = alt_registry.insert(0, "ETH", LighterProductType::Perp);
+
+        assert_eq!(default_registry.venue(), *LIGHTER_VENUE);
+        assert_eq!(alt_registry.venue(), alt_venue);
+        assert_eq!(default_id.venue, *LIGHTER_VENUE);
+        assert_eq!(alt_id.venue, alt_venue);
+        assert_eq!(default_id.symbol.as_str(), "ETH-PERP");
+        assert_eq!(alt_id.symbol.as_str(), "ETH-PERP");
+        assert_ne!(default_id, alt_id);
     }
 
     #[rstest]

--- a/crates/adapters/lighter/src/config.rs
+++ b/crates/adapters/lighter/src/config.rs
@@ -18,11 +18,12 @@
 use std::fmt::Debug;
 
 use nautilus_core::string::secret::REDACTED;
-use nautilus_model::identifiers::AccountId;
+use nautilus_model::identifiers::{AccountId, Venue};
 use nautilus_network::websocket::TransportBackend;
 use serde::{Deserialize, Serialize};
 
 use crate::common::{
+    consts::LIGHTER_VENUE,
     credential::credential_env_vars,
     enums::LighterEnvironment,
     urls::{lighter_http_base_url, lighter_ws_url},
@@ -75,6 +76,12 @@ pub struct LighterDataClientConfig {
     /// WebSocket transport backend.
     #[builder(default)]
     pub transport_backend: TransportBackend,
+    /// Optional venue override for this client.
+    ///
+    /// Unset keeps [`LIGHTER_VENUE`]. Set this when `base_url_http` /
+    /// `base_url_ws` point at a second Lighter-protocol host so instrument
+    /// ids and engine routing do not collide with the default venue.
+    pub venue: Option<Venue>,
 }
 
 #[cfg(feature = "python")]
@@ -89,6 +96,7 @@ nautilus_core::impl_pyo3_config_getters!(LighterDataClientConfig {
     update_instruments_interval_mins: u64,
     rest_quota_per_min: Option<u32>,
     transport_backend: TransportBackend,
+    venue: Option<Venue>,
 });
 
 impl Default for LighterDataClientConfig {
@@ -137,6 +145,12 @@ impl LighterDataClientConfig {
 
         has_key && has_account && has_secret
     }
+
+    /// Returns the configured venue, defaulting to [`LIGHTER_VENUE`].
+    #[must_use]
+    pub fn resolved_venue(&self) -> Venue {
+        self.venue.unwrap_or(*LIGHTER_VENUE)
+    }
 }
 
 impl Debug for LighterDataClientConfig {
@@ -157,6 +171,7 @@ impl Debug for LighterDataClientConfig {
             )
             .field("rest_quota_per_min", &self.rest_quota_per_min)
             .field("transport_backend", &self.transport_backend)
+            .field("venue", &self.venue)
             .finish()
     }
 }
@@ -244,6 +259,11 @@ pub struct LighterExecutionClientConfig {
     /// WebSocket transport backend.
     #[builder(default)]
     pub transport_backend: TransportBackend,
+    /// Optional venue override for this client.
+    ///
+    /// Unset keeps [`LIGHTER_VENUE`]. Must match the paired data client's
+    /// venue so submit routing and instrument ids stay on one host.
+    pub venue: Option<Venue>,
 }
 
 #[cfg(feature = "python")]
@@ -260,6 +280,7 @@ nautilus_core::impl_pyo3_config_getters!(LighterExecutionClientConfig {
     rest_quota_per_min: Option<u32>,
     sendtx_quota_per_min: Option<u32>,
     transport_backend: TransportBackend,
+    venue: Option<Venue>,
 });
 
 impl Default for LighterExecutionClientConfig {
@@ -285,6 +306,7 @@ impl Debug for LighterExecutionClientConfig {
             .field("rest_quota_per_min", &self.rest_quota_per_min)
             .field("sendtx_quota_per_min", &self.sendtx_quota_per_min)
             .field("transport_backend", &self.transport_backend)
+            .field("venue", &self.venue)
             .finish()
     }
 }
@@ -318,6 +340,12 @@ impl LighterExecutionClientConfig {
         self.base_url_ws
             .clone()
             .unwrap_or_else(|| lighter_ws_url(self.environment).to_string())
+    }
+
+    /// Returns the configured venue, defaulting to [`LIGHTER_VENUE`].
+    #[must_use]
+    pub fn resolved_venue(&self) -> Venue {
+        self.venue.unwrap_or(*LIGHTER_VENUE)
     }
 }
 
@@ -421,6 +449,7 @@ mod tests {
             rest_quota_per_min: None,
             sendtx_quota_per_min: None,
             transport_backend: TransportBackend::default(),
+            venue: None,
         };
 
         let dbg_out = format!("{config:?}");
@@ -438,5 +467,43 @@ mod tests {
         };
 
         assert_eq!(config.ws_url(), "wss://mainnet.zklighter.elliot.ai/stream");
+    }
+
+    #[rstest]
+    fn data_config_resolved_venue_defaults_to_lighter() {
+        let config = LighterDataClientConfig::default();
+
+        assert!(config.venue.is_none());
+        assert_eq!(config.resolved_venue(), *LIGHTER_VENUE);
+    }
+
+    #[rstest]
+    fn data_config_resolved_venue_uses_override() {
+        let venue = Venue::new("LIGHTER_ALT");
+        let config = LighterDataClientConfig {
+            venue: Some(venue),
+            ..Default::default()
+        };
+
+        assert_eq!(config.resolved_venue(), venue);
+    }
+
+    #[rstest]
+    fn exec_config_resolved_venue_defaults_to_lighter() {
+        let config = LighterExecutionClientConfig::default();
+
+        assert!(config.venue.is_none());
+        assert_eq!(config.resolved_venue(), *LIGHTER_VENUE);
+    }
+
+    #[rstest]
+    fn exec_config_resolved_venue_uses_override() {
+        let venue = Venue::new("LIGHTER_ALT");
+        let config = LighterExecutionClientConfig {
+            venue: Some(venue),
+            ..Default::default()
+        };
+
+        assert_eq!(config.resolved_venue(), venue);
     }
 }

--- a/crates/adapters/lighter/src/data/mod.rs
+++ b/crates/adapters/lighter/src/data/mod.rs
@@ -63,7 +63,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     common::{
-        consts::{DISCONNECT_TIMEOUT, LIGHTER_VENUE},
+        consts::DISCONNECT_TIMEOUT,
         credential::Credential,
         enums::{LighterCandleResolution, LighterMarketStatus},
         rate_limit::resolve_quota,
@@ -125,7 +125,8 @@ impl LighterDataClient {
     pub fn new(client_id: ClientId, config: LighterDataClientConfig) -> anyhow::Result<Self> {
         let clock = get_atomic_clock_realtime();
         let data_sender = get_data_event_sender();
-        let socket_factory = SocketControlFactory::new(client_id, Some(*LIGHTER_VENUE));
+        let venue = config.resolved_venue();
+        let socket_factory = SocketControlFactory::new(client_id, Some(venue));
 
         let credential = if config.has_credentials() {
             // Mirror `has_credentials()`: a blank or whitespace-only `private_key`
@@ -146,7 +147,7 @@ impl LighterDataClient {
             None
         };
 
-        let registry = Arc::new(MarketRegistry::new());
+        let registry = Arc::new(MarketRegistry::new_with_venue(venue));
 
         let raw_http = LighterRawHttpClient::new_with_quotas(
             config.environment,
@@ -185,7 +186,7 @@ impl LighterDataClient {
     }
 
     fn venue(&self) -> Venue {
-        *LIGHTER_VENUE
+        self.config.resolved_venue()
     }
 
     /// Returns `true` when the data client holds resolved Lighter credentials.
@@ -1721,7 +1722,7 @@ mod tests {
             TradeTick,
         },
         enums::{AggregationSource, AggressorSide, BarAggregation, PriceType},
-        identifiers::{InstrumentId, Symbol, TradeId},
+        identifiers::{InstrumentId, Symbol, TradeId, Venue},
         instruments::{CryptoPerpetual, CurrencyPair},
         types::{Currency, Price, Quantity},
     };
@@ -1734,7 +1735,10 @@ mod tests {
         *,
     };
     use crate::{
-        common::enums::{LighterFundingResolution, LighterProductType},
+        common::{
+            consts::LIGHTER_VENUE,
+            enums::{LighterFundingResolution, LighterProductType},
+        },
         http::query::{LighterFundingsQuery, LighterRecentTradesQuery},
     };
 
@@ -1794,6 +1798,24 @@ mod tests {
         assert_eq!(
             client.ws_client.url(),
             "wss://mainnet.zklighter.elliot.ai/stream?readonly=true",
+        );
+    }
+
+    #[rstest]
+    fn test_new_uses_configured_venue_for_identity_and_instruments() {
+        let venue = Venue::new("LIGHTER_ALT");
+        let config = LighterDataClientConfig {
+            venue: Some(venue),
+            ..Default::default()
+        };
+        let client = create_data_client_with_receiver_and_config_for_test(config).0;
+        let instrument_id = cache_test_instrument(&client, 0, "ETH", LighterProductType::Perp);
+
+        assert_eq!(client.venue(), venue);
+        assert_eq!(DataClient::venue(&client), Some(venue));
+        assert_eq!(
+            instrument_id,
+            InstrumentId::new(Symbol::new("ETH-PERP"), venue),
         );
     }
 

--- a/crates/adapters/lighter/src/execution.rs
+++ b/crates/adapters/lighter/src/execution.rs
@@ -80,7 +80,7 @@ use crate::{
     common::{
         consts::{
             DISCONNECT_TIMEOUT, LIGHTER_ERROR_CODE_INVALID_NONCE, LIGHTER_MAX_BATCH_TX,
-            LIGHTER_NAUTILUS_INTEGRATOR_ACCOUNT_INDEX, LIGHTER_VENUE,
+            LIGHTER_NAUTILUS_INTEGRATOR_ACCOUNT_INDEX,
         },
         credential::{Credential, scrub_auth},
         enums::{
@@ -250,7 +250,8 @@ impl LighterExecutionClient {
         )
         .context("failed to resolve Lighter credentials")?;
 
-        let registry = Arc::new(MarketRegistry::new());
+        let venue = config.resolved_venue();
+        let registry = Arc::new(MarketRegistry::new_with_venue(venue));
 
         // One transaction limiter shared across the HTTP and WebSocket sendTx
         // paths so their combined rate honours the single per-account venue bucket.
@@ -278,7 +279,7 @@ impl LighterExecutionClient {
         );
         let ws_client = ws_client.with_socket_control(SocketControl::new(
             core.client_id,
-            Some(*LIGHTER_VENUE),
+            Some(venue),
             USER_STREAMS_ENDPOINT,
         ));
 
@@ -3659,7 +3660,7 @@ impl ExecutionClient for LighterExecutionClient {
     }
 
     fn venue(&self) -> Venue {
-        *LIGHTER_VENUE
+        self.core.venue
     }
 
     fn oms_type(&self) -> OmsType {
@@ -4803,7 +4804,7 @@ impl ExecutionClient for LighterExecutionClient {
         let mut mass_status = ExecutionMassStatus::new(
             self.core.client_id,
             self.core.account_id,
-            *LIGHTER_VENUE,
+            self.core.venue,
             ts_init,
             None,
         );
@@ -5870,6 +5871,7 @@ mod tests {
     };
     use nautilus_common::{
         cache::Cache,
+        clients::ExecutionClient,
         clock::TestClock,
         factories::OrderFactory,
         messages::{ExecutionEvent, ExecutionReport as EngineExecutionReport},
@@ -5880,7 +5882,7 @@ mod tests {
         enums::{LiquiditySide, OrderStatus, TimeInForce},
         events::{OrderCanceled, OrderEventAny, OrderPendingCancel, OrderTriggered},
         identifiers::{
-            InstrumentId, OrderListId, StrategyId, Symbol, TradeId, TraderId, VenueOrderId,
+            InstrumentId, OrderListId, StrategyId, Symbol, TradeId, TraderId, Venue, VenueOrderId,
         },
         instruments::CryptoPerpetual,
         orders::{LimitOrder, OrderList},
@@ -5977,6 +5979,7 @@ mod tests {
             rest_quota_per_min: None,
             sendtx_quota_per_min: None,
             transport_backend: Default::default(),
+            venue: None,
         }
     }
 
@@ -5999,6 +6002,19 @@ mod tests {
             Some("0-1700003600".to_string()),
         );
         assert_eq!(format_between_timestamps(None, None, now), None);
+    }
+
+    #[rstest]
+    fn execution_client_uses_configured_venue() {
+        let venue = Venue::new("LIGHTER_ALT");
+        let config = LighterExecutionClientConfig {
+            venue: Some(venue),
+            ..test_config()
+        };
+        let (client, _, _) = create_execution_client_with_config(config);
+
+        assert_eq!(client.venue(), venue);
+        assert_eq!(client.registry.venue(), venue);
     }
 
     #[rstest]
@@ -6131,7 +6147,7 @@ mod tests {
         let core = ExecutionClientCore::new(
             trader_id(),
             client_id(),
-            *LIGHTER_VENUE,
+            config.resolved_venue(),
             OmsType::Netting,
             account_id(),
             AccountType::Margin,

--- a/crates/adapters/lighter/src/factories.rs
+++ b/crates/adapters/lighter/src/factories.rs
@@ -30,7 +30,7 @@ use nautilus_model::{
 };
 
 use crate::{
-    common::consts::{LIGHTER, LIGHTER_VENUE},
+    common::consts::LIGHTER,
     config::{LighterDataClientConfig, LighterExecutionClientConfig},
     data::LighterDataClient,
     execution::LighterExecutionClient,
@@ -143,7 +143,7 @@ impl ExecutionClientFactory for LighterExecutionClientFactory {
         let core = ExecutionClientCore::new(
             trader_id,
             ClientId::from(name),
-            *LIGHTER_VENUE,
+            lighter_config.resolved_venue(),
             OmsType::Netting,
             lighter_config.account_id,
             AccountType::Margin,
@@ -172,11 +172,13 @@ mod tests {
         cache::Cache,
         clock::TestClock,
         factories::{ClientConfig, DataClientFactory, ExecutionClientFactory},
+        live::runner::replace_data_event_sender,
     };
-    use nautilus_model::identifiers::{AccountId, TraderId};
+    use nautilus_model::identifiers::{AccountId, TraderId, Venue};
     use rstest::rstest;
 
     use super::*;
+    use crate::common::consts::LIGHTER_VENUE;
 
     const PRIVATE_KEY_HEX: &str =
         "0b8e0f63c24d8baacd9d29ad4e9a4b73c4a8d2bb8b16dc4fa9d7c2e1d3a8b1f0e8d3a4c5b6e7f001";
@@ -254,6 +256,52 @@ mod tests {
             .expect("expected client to construct");
 
         assert!(!client.is_connected());
+        assert_eq!(client.venue(), *LIGHTER_VENUE);
+    }
+
+    #[rstest]
+    fn test_lighter_execution_client_factory_uses_configured_venue() {
+        let factory = LighterExecutionClientFactory::new();
+        let venue = Venue::new("LIGHTER_ALT");
+        let config = LighterExecutionClientConfig::builder()
+            .account_id(AccountId::from("LIGHTER-001"))
+            .account_index(12_345)
+            .api_key_index(5)
+            .private_key(PRIVATE_KEY_HEX.to_string())
+            .venue(venue)
+            .build();
+        let cache = Rc::new(RefCell::new(Cache::default()));
+
+        let client = factory
+            .create(
+                TraderId::from("TRADER-001"),
+                "LIGHTER-ALT",
+                &config,
+                cache.into(),
+            )
+            .expect("expected client to construct");
+
+        assert_eq!(client.venue(), venue);
+    }
+
+    #[rstest]
+    fn test_lighter_data_client_factory_uses_configured_venue() {
+        let factory = LighterDataClientFactory::new();
+        let venue = Venue::new("LIGHTER_ALT");
+        let config = LighterDataClientConfig {
+            venue: Some(venue),
+            ..Default::default()
+        };
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        replace_data_event_sender(sender);
+
+        let client = factory
+            .create("LIGHTER-ALT", &config, cache.into(), clock)
+            .expect("expected data client to construct");
+
+        assert_eq!(client.venue(), Some(venue));
     }
 
     #[rstest]

--- a/crates/adapters/lighter/src/http/parse.rs
+++ b/crates/adapters/lighter/src/http/parse.rs
@@ -35,7 +35,7 @@ use crate::{
         parse::{
             parse_millis_to_nanos, parse_secs_to_nanos, price_from_decimal, quantity_from_decimal,
         },
-        symbol::{MarketRegistry, format_instrument_id},
+        symbol::{MarketRegistry, format_instrument_id_with_venue},
     },
     http::models::{
         LighterCandle, LighterFunding, LighterFundingDirection, LighterOrderBook,
@@ -447,7 +447,11 @@ fn parse_perp_instrument(
     ts_init: UnixNanos,
 ) -> anyhow::Result<InstrumentAny> {
     let order_book = &detail.order_book;
-    let instrument_id = format_instrument_id(order_book.symbol.as_str(), order_book.market_type);
+    let instrument_id = format_instrument_id_with_venue(
+        order_book.symbol.as_str(),
+        order_book.market_type,
+        registry.venue(),
+    );
     let raw_symbol = Symbol::from_ustr_unchecked(order_book.symbol);
     let (base_currency, quote_currency) = symbol_currencies(order_book.symbol.as_str(), "USDC");
     let settlement_currency = quote_currency;
@@ -499,7 +503,11 @@ fn parse_spot_instrument(
     ts_init: UnixNanos,
 ) -> anyhow::Result<InstrumentAny> {
     let order_book = &detail.order_book;
-    let instrument_id = format_instrument_id(order_book.symbol.as_str(), order_book.market_type);
+    let instrument_id = format_instrument_id_with_venue(
+        order_book.symbol.as_str(),
+        order_book.market_type,
+        registry.venue(),
+    );
     let raw_symbol = Symbol::from_ustr_unchecked(order_book.symbol);
     let (base_currency, quote_currency) = spot_symbol_currencies(order_book.symbol.as_str())?;
     let price_increment = price_increment(detail.price_decimals)?;
@@ -1322,6 +1330,23 @@ mod tests {
         assert_eq!(book.best_bid_size(), Some(Quantity::from("3.4125")));
         assert_eq!(book.best_ask_price(), Some(Price::from("2361.32")));
         assert_eq!(book.best_ask_size(), Some(Quantity::from("0.0317")));
+    }
+
+    #[rstest]
+    fn test_parse_order_book_details_instruments_uses_registry_venue() {
+        let venue = Venue::new("LIGHTER_ALT");
+        let registry = MarketRegistry::new_with_venue(venue);
+        let details = vec![stub_perp_detail("ETH", 0)];
+
+        let instruments =
+            parse_order_book_details_instruments(&registry, &details, &[], UnixNanos::from(1))
+                .unwrap();
+
+        let expected = InstrumentId::new(Symbol::new("ETH-PERP"), venue);
+        assert_eq!(instruments.len(), 1);
+        assert_eq!(instruments[0].id(), expected);
+        assert_eq!(registry.market_index(&expected), Some(0));
+        assert_eq!(registry.market_index(&instrument_id("ETH-PERP")), None);
     }
 
     #[rstest]

--- a/crates/adapters/lighter/src/python/config.rs
+++ b/crates/adapters/lighter/src/python/config.rs
@@ -15,7 +15,7 @@
 
 //! Python bindings for Lighter configuration.
 
-use nautilus_model::identifiers::AccountId;
+use nautilus_model::identifiers::{AccountId, Venue};
 use nautilus_network::websocket::TransportBackend;
 use pyo3::pymethods;
 
@@ -42,6 +42,7 @@ impl LighterDataClientConfig {
         update_instruments_interval_mins = None,
         rest_quota_per_min = None,
         transport_backend = None,
+        venue = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -57,6 +58,7 @@ impl LighterDataClientConfig {
         update_instruments_interval_mins: Option<u64>,
         rest_quota_per_min: Option<u32>,
         transport_backend: Option<TransportBackend>,
+        venue: Option<Venue>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -73,6 +75,7 @@ impl LighterDataClientConfig {
                 .unwrap_or(defaults.update_instruments_interval_mins),
             rest_quota_per_min,
             transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
+            venue,
         }
     }
 
@@ -106,6 +109,7 @@ impl LighterExecutionClientConfig {
         rest_quota_per_min = None,
         sendtx_quota_per_min = None,
         transport_backend = None,
+        venue = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     fn py_new(
@@ -123,6 +127,7 @@ impl LighterExecutionClientConfig {
         rest_quota_per_min: Option<u32>,
         sendtx_quota_per_min: Option<u32>,
         transport_backend: Option<TransportBackend>,
+        venue: Option<Venue>,
     ) -> Self {
         let defaults = Self::default();
         Self {
@@ -141,6 +146,7 @@ impl LighterExecutionClientConfig {
             rest_quota_per_min,
             sendtx_quota_per_min,
             transport_backend: transport_backend.unwrap_or(defaults.transport_backend),
+            venue,
         }
     }
 

--- a/crates/adapters/lighter/tests/data_client.rs
+++ b/crates/adapters/lighter/tests/data_client.rs
@@ -78,7 +78,7 @@ use nautilus_live::{SocketReconnectRegistry, SocketReconnectRequestOutcome};
 use nautilus_model::{
     data::{BarSpecification, BarType, Data, OrderBookDeltas},
     enums::{AggregationSource, BarAggregation, BookAction, BookType, PriceType, RecordFlag},
-    identifiers::{ClientId, InstrumentId},
+    identifiers::{ClientId, InstrumentId, Venue},
     instruments::Instrument,
     orderbook::{OrderBook, analysis::book_check_integrity},
     types::Price,
@@ -2118,6 +2118,25 @@ async fn test_socket_state_events_survive_websocket_client_replacement() {
 
     client.disconnect().await.expect("disconnect");
     assert!(registry.handle(client_id(), endpoint).is_none());
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_socket_state_events_use_configured_venue() {
+    let (addr, state) = start_server().await;
+    let venue = Venue::new("LIGHTER_ALT");
+    let mut config = build_config(addr);
+    config.venue = Some(venue);
+    let (mut client, _rx, mut system_rx) = build_client_with_system_events(config);
+
+    client.connect().await.expect("connect");
+    let change = next_socket_state(&mut system_rx).await;
+
+    assert_eq!(DataClient::venue(&client), Some(venue));
+    assert_eq!(change.venue, Some(venue));
+
+    client.disconnect().await.expect("disconnect");
+    await_connection_count(&state, 0).await;
 }
 
 #[rstest]

--- a/crates/adapters/lighter/tests/exec_client.rs
+++ b/crates/adapters/lighter/tests/exec_client.rs
@@ -93,7 +93,7 @@ use nautilus_model::{
     events::{AccountState, OrderAccepted, OrderEventAny, OrderPendingCancel, OrderPendingUpdate},
     identifiers::{
         AccountId, ClientId, ClientOrderId, InstrumentId, OrderListId, StrategyId, Symbol, TradeId,
-        TraderId, VenueOrderId,
+        TraderId, Venue, VenueOrderId,
     },
     instruments::{CryptoPerpetual, CurrencyPair, InstrumentAny},
     orders::{Order, OrderAny, OrderList, OrderTestBuilder},
@@ -771,6 +771,7 @@ fn build_config(addr: SocketAddr) -> LighterExecutionClientConfig {
         rest_quota_per_min: None,
         sendtx_quota_per_min: None,
         transport_backend: Default::default(),
+        venue: None,
     }
 }
 
@@ -926,7 +927,7 @@ fn build_client_with_cache(
     let core = ExecutionClientCore::new(
         trader_id(),
         client_id(),
-        *LIGHTER_VENUE,
+        config.resolved_venue(),
         OmsType::Netting,
         account_id(),
         AccountType::Margin,
@@ -1453,6 +1454,31 @@ async fn connect_reports_socket_state_on_the_user_streams_endpoint() {
 
     client.disconnect().await.expect("disconnect");
     assert!(registry.handle(client_id(), endpoint).is_none());
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn connect_reports_configured_venue_on_socket_state() {
+    let (addr, _state) = start_server().await;
+    let venue = Venue::new("LIGHTER_ALT");
+    let mut config = build_config(addr);
+    config.venue = Some(venue);
+    let (system_sender, mut system_rx) = tokio::sync::mpsc::unbounded_channel();
+    replace_system_event_sender(system_sender);
+    let (mut client, _rx, _cache) = build_client_with(config);
+
+    client.connect().await.expect("connect");
+
+    let event = tokio::time::timeout(Duration::from_secs(2), system_rx.recv())
+        .await
+        .expect("timed out waiting for a socket state change")
+        .expect("system event channel closed");
+    let SystemEvent::SocketState(change) = event;
+
+    assert_eq!(client.venue(), venue);
+    assert_eq!(change.venue, Some(venue));
+
+    client.disconnect().await.expect("disconnect");
 }
 
 #[rstest]

--- a/docs/integrations/lighter.md
+++ b/docs/integrations/lighter.md
@@ -102,7 +102,8 @@ Lighter identifies markets by numeric `market_index` values. The adapter bootstr
 | Spot              | `{BASE}/{QUOTE}-SPOT.LIGHTER` | `ETH/USDC-SPOT.LIGHTER` | Raw venue symbol `ETH/USDC`. |
 
 The suffix separates spot and perpetual listings. Outbound requests strip it and use the cached
-`market_index`; spot symbols retain the venue pair.
+`market_index`; spot symbols retain the venue pair. A configured `venue` override replaces the
+`.LIGHTER` qualifier (for example `ETH-PERP.LIGHTER_ALT`).
 
 ## Environments
 
@@ -163,6 +164,47 @@ Lighter API keys authorize trading, private account access, and some withdrawal 
 the private key in a secret manager or protected environment configuration. Do not commit it to a
 repository or share it in logs.
 :::
+
+## Multiple Lighter-protocol hosts
+
+A second Lighter-protocol host in the same node needs its own `venue` on the data
+client and on the matching live execution client or sandbox client. Unset keeps
+`LIGHTER`. Pass distinct client names into `add_data_client` /
+`add_exec_client`; `None` both resolve to `"LIGHTER"` and the second
+registration fails.
+
+```python
+from nautilus_trader.adapters.lighter import LighterDataClientConfig
+from nautilus_trader.adapters.lighter import LighterExecutionClientConfig
+from nautilus_trader.adapters.sandbox import SandboxExecutionClientConfig
+from nautilus_trader.model import AccountId
+from nautilus_trader.model import BookType
+from nautilus_trader.model import Currency
+from nautilus_trader.model import Money
+from nautilus_trader.model import Venue
+
+alt_venue = Venue("LIGHTER_ALT")
+alt_data = LighterDataClientConfig(
+    base_url_http="https://example-lighter-host",
+    base_url_ws="wss://example-lighter-host/stream",
+    venue=alt_venue,
+)
+sandbox_alt = SandboxExecutionClientConfig(
+    venue=alt_venue,
+    starting_balances=[Money(100000.0, Currency.from_str("USDC"))],
+    book_type=BookType.L2_MBP,
+    trade_execution=True,
+    queue_position=True,
+)
+alt_exec = LighterExecutionClientConfig(
+    account_id=AccountId.from_str("LIGHTER-ALT-001"),
+    venue=alt_venue,
+)
+```
+
+Instrument ids from `alt_data` use that venue, for example `ETH-PERP.LIGHTER_ALT`.
+A host on another L2 chain also needs a `chain_id` override for signed
+transactions; that is not covered here.
 
 ## Integrator attribution
 
@@ -716,6 +758,7 @@ endpoints.
 | `update_instruments_interval_mins` | `60`      | Instrument metadata refresh interval in minutes.         |
 | `rest_quota_per_min`               | `None`    | REST quota override; unset keeps 60 req/min.             |
 | `transport_backend`                | Default   | WebSocket transport backend.                             |
+| `venue`                            | `None`    | Optional venue override; unset keeps `LIGHTER`.          |
 
 ### Execution client configuration options
 
@@ -735,6 +778,7 @@ endpoints.
 | `rest_quota_per_min`        | `None`        | REST quota override; unset keeps 60 req/min.             |
 | `sendtx_quota_per_min`      | `None`        | Transaction quota override; unset keeps 60 req/min.      |
 | `transport_backend`         | Default       | WebSocket transport backend.                             |
+| `venue`                     | `None`        | Optional venue override; unset keeps `LIGHTER`.          |
 
 ### Configuration example
 

--- a/python/nautilus_trader/adapters/lighter/__init__.pyi
+++ b/python/nautilus_trader/adapters/lighter/__init__.pyi
@@ -44,6 +44,8 @@ class LighterDataClientConfig:
     def rest_quota_per_min(self) -> int | None: ...
     @property
     def transport_backend(self) -> network.TransportBackend: ...
+    @property
+    def venue(self) -> model.Venue | None: ...
     def __init__(
         self,
         base_url_http: str | None = None,
@@ -58,6 +60,7 @@ class LighterDataClientConfig:
         update_instruments_interval_mins: int | None = None,
         rest_quota_per_min: int | None = None,
         transport_backend: network.TransportBackend | None = None,
+        venue: model.Venue | None = None,
     ) -> None: ...
     @property
     def has_proxy_url(self) -> bool: ...
@@ -93,6 +96,8 @@ class LighterExecutionClientConfig:
     def sendtx_quota_per_min(self) -> int | None: ...
     @property
     def transport_backend(self) -> network.TransportBackend: ...
+    @property
+    def venue(self) -> model.Venue | None: ...
     def __init__(
         self,
         account_id: model.AccountId,
@@ -109,6 +114,7 @@ class LighterExecutionClientConfig:
         rest_quota_per_min: int | None = None,
         sendtx_quota_per_min: int | None = None,
         transport_backend: network.TransportBackend | None = None,
+        venue: model.Venue | None = None,
     ) -> None: ...
     @property
     def has_proxy_url(self) -> bool: ...

--- a/python/tests/unit/adapters/lighter/test_lighter_factories.py
+++ b/python/tests/unit/adapters/lighter/test_lighter_factories.py
@@ -30,9 +30,41 @@ from nautilus_trader.live import LiveNode
 from nautilus_trader.live import LiveRiskEngineConfig
 from nautilus_trader.model import AccountId
 from nautilus_trader.model import TraderId
+from nautilus_trader.model import Venue
 
 
 lighter_exec_tester = load_example_module("lighter", "exec_tester")
+
+
+def test_lighter_data_config_venue_defaults_to_none() -> None:
+    config = LighterDataClientConfig()
+
+    assert config.venue is None
+
+
+def test_lighter_data_config_venue_override() -> None:
+    venue = Venue("LIGHTER_ALT")
+    config = LighterDataClientConfig(venue=venue)
+
+    assert config.venue == venue
+
+
+def test_lighter_exec_config_venue_defaults_to_none() -> None:
+    config = LighterExecutionClientConfig(
+        account_id=AccountId.from_str("LIGHTER-001"),
+    )
+
+    assert config.venue is None
+
+
+def test_lighter_exec_config_venue_override() -> None:
+    venue = Venue("LIGHTER_ALT")
+    config = LighterExecutionClientConfig(
+        account_id=AccountId.from_str("LIGHTER-001"),
+        venue=venue,
+    )
+
+    assert config.venue == venue
 
 
 def test_lighter_factories_expose_python_names() -> None:
@@ -44,6 +76,37 @@ def test_lighter_factories_expose_python_names() -> None:
 
     assert data_factory.name() == LIGHTER
     assert exec_factory.name() == LIGHTER
+
+
+def test_live_node_accepts_two_lighter_exec_clients_with_distinct_venues() -> None:
+    trader_id = TraderId.from_str("TESTER-001")
+    rh_venue = Venue("LIGHTER_RH")
+
+    node = (
+        LiveNode.builder("LIGHTER-DUAL-EXEC-PYTEST-001", trader_id, Environment.LIVE)
+        .with_risk_engine_config(LiveRiskEngineConfig(bypass=True))
+        .with_reconciliation(False)
+        .add_exec_client(
+            "LIGHTER",
+            LighterExecutionClientFactory(),
+            LighterExecutionClientConfig(
+                account_id=AccountId.from_str("LIGHTER-001"),
+                environment=LighterEnvironment.TESTNET,
+            ),
+        )
+        .add_exec_client(
+            "LIGHTER_RH",
+            LighterExecutionClientFactory(),
+            LighterExecutionClientConfig(
+                account_id=AccountId.from_str("LIGHTER_RH-001"),
+                environment=LighterEnvironment.TESTNET,
+                venue=rh_venue,
+            ),
+        )
+        .build()
+    )
+
+    assert node.trader_id == trader_id
 
 
 def test_live_node_builder_accepts_lighter_data_factory() -> None:


### PR DESCRIPTION
# Pull Request

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

- [ ] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [ ] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

Opened as a **draft** so maintainers can agree on scope. #4838 is untriaged. The issue text
covers the data client; this also adds the same optional `venue` on the execution client because
`ExecutionEngine::register_client` rejects a second client for `LIGHTER`.

## Summary

`LighterDataClientConfig` already allows REST/WS URL overrides, but instrument identity and engine
routing stayed hardcoded to `LIGHTER`. Two Lighter-protocol hosts in one node therefore collided:
`DataEngine` overwrites `venue → client` routing, and `ExecutionEngine` errors on a second client
for the same venue. Sandbox paper trading also subscribes to `data.book.deltas.{venue}.*`, so the
sandbox venue must match the data client's instrument venue.

This adds optional `venue` on both `LighterDataClientConfig` and `LighterExecClientConfig`. Unset
keeps `LIGHTER`. The value is used for `MarketRegistry` / `format_instrument_id`,
`DataClient::venue()` / `ExecutionClient::venue()`, socket-control tagging, and mass status.

## Related issues/PRs

Closes #4838

## Type of change

- [x] New feature (non-breaking)
- [x] Documentation update

## Breaking change details (if applicable)

Not a breaking change. Existing clients omit `venue` and keep `LIGHTER`. PyO3 appends
`venue=None` after current kwargs.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [x] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

`docs/integrations/lighter.md` documents the optional venue, distinct client names, and that a
different L2 chain still needs a later `chain_id` override.

## Testing

- [x] I added/updated tests to cover new or changed logic

Tests that fail without the venue wiring:

```text
cargo test -p nautilus-lighter --lib --features python -- \
  registry_qualifies_instrument_ids_with_configured_venue \
  format_instrument_id_uses_provided_venue \
  test_parse_order_book_details_instruments_uses_registry_venue \
  test_new_uses_configured_venue_for_identity_and_instruments \
  execution_client_uses_configured_venue \
  test_lighter_data_client_factory_uses_configured_venue \
  test_lighter_execution_client_factory_uses_configured_venue \
  data_config_resolved_venue \
  exec_config_resolved_venue
# 11 passed

cargo test -p nautilus-lighter --test data_client -- test_socket_state_events_use_configured_venue
cargo test -p nautilus-lighter --test exec_client -- connect_reports_configured_venue_on_socket_state

.venv/bin/pytest python/tests/unit/adapters/lighter/test_lighter_factories.py -q
# 9 passed, including two exec clients with distinct venues on one LiveNode
```

Also ran `prek run --all-files` locally (passed). `make py-stubs` is idempotent on this branch.

Not in this PR: `chain_id` override for a Domain on another L2. Signed txs still use
`lighter_chain_id(environment)` (304/300). Dual-host live on the same Lighter chain is covered;
a Robinhood Domain on another chain needs a follow-up.

## Follow-ups

- Optional `chain_id` on `LighterExecClientConfig` for a Lighter-protocol host on another L2.