### PR TITLE
Preserve Polymarket Gamma resolution metadata

### DIFF
--- a/crates/adapters/polymarket/src/http/models.rs
+++ b/crates/adapters/polymarket/src/http/models.rs
@@ -297,7 +297,19 @@ pub struct CryptoMarketConfig {
     pub asset: String,
     pub duration: String,
     pub twap_enabled: bool,
-    pub twap_lookback_seconds: Option<u64>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_non_null_i64"
+    )]
+    pub twap_lookback_seconds: Option<i64>,
+}
+
+fn deserialize_optional_non_null_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    i64::deserialize(deserializer).map(Some)
 }
 
 /// An event response from the Gamma API `GET /events`.
@@ -847,25 +859,69 @@ mod tests {
     }
 
     #[rstest]
-    #[case(serde_json::json!({
-        "id": "btc-5m",
-        "asset": "btc",
-        "duration": "5m",
-        "twapEnabled": false,
-    }))]
-    #[case(serde_json::json!({
-        "id": "btc-5m",
-        "asset": "btc",
-        "duration": "5m",
-        "twapEnabled": false,
-        "twapLookbackSeconds": null,
-    }))]
-    fn test_crypto_market_config_optional_twap_lookback(
-        #[case] crypto_market_config: serde_json::Value,
-    ) {
-        let config: CryptoMarketConfig = serde_json::from_value(crypto_market_config).unwrap();
+    fn test_crypto_market_config_absent_twap_lookback_serializes_omitted() {
+        let crypto_market_config = serde_json::json!({
+            "id": "btc-5m",
+            "asset": "btc",
+            "duration": "5m",
+            "twapEnabled": false,
+        });
 
-        assert!(config.twap_lookback_seconds.is_none());
+        let config: CryptoMarketConfig = serde_json::from_value(crypto_market_config).unwrap();
+        let encoded = serde_json::to_value(config).unwrap();
+
+        assert!(encoded.get("twapLookbackSeconds").is_none());
+    }
+
+    #[rstest]
+    fn test_crypto_market_config_rejects_null_twap_lookback() {
+        let crypto_market_config = serde_json::json!({
+            "id": "btc-5m",
+            "asset": "btc",
+            "duration": "5m",
+            "twapEnabled": false,
+            "twapLookbackSeconds": null,
+        });
+
+        let result = serde_json::from_value::<CryptoMarketConfig>(crypto_market_config);
+
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case(serde_json::json!(-37))]
+    #[case(serde_json::json!(i64::MIN))]
+    #[case(serde_json::json!(i64::MAX))]
+    fn test_crypto_market_config_signed_twap_lookback_roundtrip(
+        #[case] twap_lookback_seconds: serde_json::Value,
+    ) {
+        let crypto_market_config = serde_json::json!({
+            "id": "eth-15m",
+            "asset": "eth",
+            "duration": "15m",
+            "twapEnabled": true,
+            "twapLookbackSeconds": twap_lookback_seconds,
+        });
+
+        let config: CryptoMarketConfig = serde_json::from_value(crypto_market_config).unwrap();
+        let encoded = serde_json::to_value(config).unwrap();
+
+        assert_eq!(encoded["twapLookbackSeconds"], twap_lookback_seconds);
+    }
+
+    #[rstest]
+    fn test_crypto_market_config_rejects_twap_lookback_above_i64_max() {
+        let crypto_market_config = serde_json::json!({
+            "id": "eth-15m",
+            "asset": "eth",
+            "duration": "15m",
+            "twapEnabled": true,
+            "twapLookbackSeconds": 9_223_372_036_854_775_808u64,
+        });
+
+        let result = serde_json::from_value::<CryptoMarketConfig>(crypto_market_config);
+
+        assert!(result.is_err());
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/http/models.rs
+++ b/crates/adapters/polymarket/src/http/models.rs
@@ -169,6 +169,8 @@ pub struct GammaMarket {
     pub description: Option<String>,
     /// Market start date (ISO 8601).
     pub start_date: Option<String>,
+    /// Event window start time (ISO 8601).
+    pub event_start_time: Option<String>,
     /// Market end date (ISO 8601).
     pub end_date: Option<String>,
     /// Whether market is active.
@@ -826,30 +828,25 @@ mod tests {
 
     #[rstest]
     fn test_gamma_market_crypto_market_config_fields() {
-        let mut value: serde_json::Value = load("gamma_market.json");
-        value["resolutionSource"] =
-            serde_json::json!("https://data.chain.link/streams/btc-usd-twap-60s-streams");
-        value["cryptoMarketConfig"] = serde_json::json!({
-            "id": "btc-5m-twap-60",
-            "asset": "btc",
-            "duration": "5m",
-            "twapEnabled": true,
-            "twapLookbackSeconds": 60,
-            "futureField": "ignored",
-        });
-
-        let market: GammaMarket = serde_json::from_value(value).unwrap();
-        let config = market.crypto_market_config.unwrap();
+        let market: GammaMarket = load("gamma_market_crypto_twap.json");
+        let config = market.crypto_market_config.as_ref().unwrap();
 
         assert_eq!(config.id, "btc-5m-twap-60");
         assert_eq!(config.asset, "btc");
         assert_eq!(config.duration, "5m");
         assert!(config.twap_enabled);
         assert_eq!(config.twap_lookback_seconds, Some(60));
+        assert_eq!(
+            market.resolution_source.as_deref(),
+            Some("https://data.chain.link/streams/btc-usd-twap-60s-streams")
+        );
+        assert_eq!(
+            market.event_start_time.as_deref(),
+            Some("2026-08-22T16:00:00Z")
+        );
     }
 
     #[rstest]
-    #[case(serde_json::Value::Null)]
     #[case(serde_json::json!({
         "id": "btc-5m",
         "asset": "btc",
@@ -863,26 +860,22 @@ mod tests {
         "twapEnabled": false,
         "twapLookbackSeconds": null,
     }))]
-    fn test_gamma_market_optional_crypto_twap_lookback(
+    fn test_crypto_market_config_optional_twap_lookback(
         #[case] crypto_market_config: serde_json::Value,
     ) {
-        let mut value: serde_json::Value = load("gamma_market.json");
-        value["cryptoMarketConfig"] = crypto_market_config;
+        let config: CryptoMarketConfig = serde_json::from_value(crypto_market_config).unwrap();
 
-        let market: GammaMarket = serde_json::from_value(value).unwrap();
-
-        assert!(
-            market
-                .crypto_market_config
-                .as_ref()
-                .is_none_or(|config| config.twap_lookback_seconds.is_none())
-        );
+        assert!(config.twap_lookback_seconds.is_none());
     }
 
     #[rstest]
     fn test_gamma_market_enriched_fields() {
         let market: GammaMarket = load("gamma_market.json");
 
+        assert_eq!(
+            market.event_start_time.as_deref(),
+            Some("2026-03-12T09:20:00Z")
+        );
         assert_eq!(market.best_bid, Some(0.5));
         assert_eq!(market.best_ask, Some(0.51));
         assert_eq!(market.spread, Some(0.009));
@@ -927,6 +920,7 @@ mod tests {
         assert!(market.category.is_none());
         assert!(market.neg_risk_market_id.is_none());
         assert!(market.crypto_market_config.is_none());
+        assert!(market.event_start_time.is_none());
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/http/models.rs
+++ b/crates/adapters/polymarket/src/http/models.rs
@@ -183,6 +183,8 @@ pub struct GammaMarket {
     pub uma_resolution_statuses: Option<String>,
     /// Source used to resolve the market.
     pub resolution_source: Option<String>,
+    /// Crypto market resolution configuration.
+    pub crypto_market_config: Option<CryptoMarketConfig>,
     /// Whether CLOB is accepting orders.
     pub accepting_orders: Option<bool>,
     /// Whether order book trading is enabled.
@@ -283,6 +285,17 @@ pub struct FeeSchedule {
         deserialize_with = "deserialize_decimal_from_json_number"
     )]
     pub rebate_rate: Decimal,
+}
+
+/// Crypto market resolution configuration returned by Gamma.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CryptoMarketConfig {
+    pub id: String,
+    pub asset: String,
+    pub duration: String,
+    pub twap_enabled: bool,
+    pub twap_lookback_seconds: Option<u64>,
 }
 
 /// An event response from the Gamma API `GET /events`.
@@ -812,6 +825,61 @@ mod tests {
     }
 
     #[rstest]
+    fn test_gamma_market_crypto_market_config_fields() {
+        let mut value: serde_json::Value = load("gamma_market.json");
+        value["resolutionSource"] =
+            serde_json::json!("https://data.chain.link/streams/btc-usd-twap-60s-streams");
+        value["cryptoMarketConfig"] = serde_json::json!({
+            "id": "btc-5m-twap-60",
+            "asset": "btc",
+            "duration": "5m",
+            "twapEnabled": true,
+            "twapLookbackSeconds": 60,
+            "futureField": "ignored",
+        });
+
+        let market: GammaMarket = serde_json::from_value(value).unwrap();
+        let config = market.crypto_market_config.unwrap();
+
+        assert_eq!(config.id, "btc-5m-twap-60");
+        assert_eq!(config.asset, "btc");
+        assert_eq!(config.duration, "5m");
+        assert!(config.twap_enabled);
+        assert_eq!(config.twap_lookback_seconds, Some(60));
+    }
+
+    #[rstest]
+    #[case(serde_json::Value::Null)]
+    #[case(serde_json::json!({
+        "id": "btc-5m",
+        "asset": "btc",
+        "duration": "5m",
+        "twapEnabled": false,
+    }))]
+    #[case(serde_json::json!({
+        "id": "btc-5m",
+        "asset": "btc",
+        "duration": "5m",
+        "twapEnabled": false,
+        "twapLookbackSeconds": null,
+    }))]
+    fn test_gamma_market_optional_crypto_twap_lookback(
+        #[case] crypto_market_config: serde_json::Value,
+    ) {
+        let mut value: serde_json::Value = load("gamma_market.json");
+        value["cryptoMarketConfig"] = crypto_market_config;
+
+        let market: GammaMarket = serde_json::from_value(value).unwrap();
+
+        assert!(
+            market
+                .crypto_market_config
+                .as_ref()
+                .is_none_or(|config| config.twap_lookback_seconds.is_none())
+        );
+    }
+
+    #[rstest]
     fn test_gamma_market_enriched_fields() {
         let market: GammaMarket = load("gamma_market.json");
 
@@ -858,6 +926,7 @@ mod tests {
         assert!(market.competitive.is_none());
         assert!(market.category.is_none());
         assert!(market.neg_risk_market_id.is_none());
+        assert!(market.crypto_market_config.is_none());
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/http/parse.rs
+++ b/crates/adapters/polymarket/src/http/parse.rs
@@ -28,7 +28,7 @@ use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use ustr::Ustr;
 
-use super::models::{FeeSchedule, GammaMarket};
+use super::models::{CryptoMarketConfig, FeeSchedule, GammaMarket};
 use crate::common::{
     consts::{POLYMARKET_VENUE, PUSD},
     enums::PolymarketOutcome,
@@ -80,6 +80,10 @@ pub struct PolymarketInstrumentDef {
     pub market_slug: Option<String>,
     /// Whether the market uses the neg-risk CTF exchange contract.
     pub neg_risk: Option<bool>,
+    /// Source used to resolve the market.
+    pub resolution_source: Option<String>,
+    /// Crypto market resolution configuration.
+    pub crypto_market_config: Option<CryptoMarketConfig>,
     /// Fee schedule for this market.
     pub fee_schedule: Option<FeeSchedule>,
     /// Game ID for sport markets, kept verbatim because Gamma emits both
@@ -164,6 +168,8 @@ pub fn parse_gamma_market(market: &GammaMarket) -> anyhow::Result<Vec<Polymarket
             closed: market.closed.unwrap_or(false),
             market_slug: market.market_slug.clone(),
             neg_risk,
+            resolution_source: market.resolution_source.clone(),
+            crypto_market_config: market.crypto_market_config.clone(),
             fee_schedule: market.fee_schedule.clone(),
             game_id: game_id.clone(),
         });
@@ -348,6 +354,19 @@ fn build_info_json(def: &PolymarketInstrumentDef) -> serde_json::Value {
 
     if let Some(neg_risk) = def.neg_risk {
         map.insert("neg_risk".to_string(), serde_json::Value::Bool(neg_risk));
+    }
+
+    if let Some(resolution_source) = &def.resolution_source {
+        map.insert(
+            "resolution_source".to_string(),
+            serde_json::Value::String(resolution_source.clone()),
+        );
+    }
+
+    if let Some(crypto_market_config) = &def.crypto_market_config
+        && let Ok(value) = serde_json::to_value(crypto_market_config)
+    {
+        map.insert("crypto_market_config".to_string(), value);
     }
 
     if let Some(min_size) = def.min_size {
@@ -641,6 +660,48 @@ mod tests {
         assert_eq!(info.get_str("min_order_size"), Some("5"));
         assert_eq!(info.get_bool("neg_risk"), Some(false));
         assert_eq!(info.get("fee_schedule"), None);
+    }
+
+    #[rstest]
+    fn test_create_instrument_info_includes_resolution_and_crypto_market_config() {
+        let mut value: serde_json::Value = {
+            let content = std::fs::read_to_string("test_data/gamma_market.json")
+                .expect("Failed to read test data");
+            serde_json::from_str(&content).expect("Failed to parse test data")
+        };
+        value["resolutionSource"] =
+            serde_json::json!("https://data.chain.link/streams/btc-usd-twap-60s-streams");
+        value["cryptoMarketConfig"] = serde_json::json!({
+            "id": "btc-5m-twap-60",
+            "asset": "btc",
+            "duration": "5m",
+            "twapEnabled": true,
+            "twapLookbackSeconds": 60,
+        });
+        let market: GammaMarket = serde_json::from_value(value).unwrap();
+
+        let defs = parse_gamma_market(&market).unwrap();
+        let instrument =
+            create_instrument_from_def(&defs[0], UnixNanos::from(1_000_000_000u64)).unwrap();
+        let InstrumentAny::BinaryOption(binary) = instrument else {
+            panic!("Expected BinaryOption");
+        };
+        let info = binary.info.as_ref().expect("info should be Some");
+
+        assert_eq!(
+            info.get_str("resolution_source"),
+            Some("https://data.chain.link/streams/btc-usd-twap-60s-streams")
+        );
+        assert_eq!(
+            info.get("crypto_market_config"),
+            Some(&serde_json::json!({
+                "id": "btc-5m-twap-60",
+                "asset": "btc",
+                "duration": "5m",
+                "twapEnabled": true,
+                "twapLookbackSeconds": 60,
+            }))
+        );
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/http/parse.rs
+++ b/crates/adapters/polymarket/src/http/parse.rs
@@ -69,6 +69,8 @@ pub struct PolymarketInstrumentDef {
     pub taker_fee: Option<Decimal>,
     /// Market start timestamp (ISO 8601).
     pub start_date: Option<String>,
+    /// Event window start timestamp (ISO 8601).
+    pub event_start_time: Option<String>,
     /// Market end timestamp (ISO 8601).
     pub end_date: Option<String>,
     /// Whether the market is active and accepting orders.
@@ -163,6 +165,7 @@ pub fn parse_gamma_market(market: &GammaMarket) -> anyhow::Result<Vec<Polymarket
             maker_fee,
             taker_fee,
             start_date: market.start_date.clone(),
+            event_start_time: market.event_start_time.clone(),
             end_date: market.end_date.clone(),
             active,
             closed: market.closed.unwrap_or(false),
@@ -349,6 +352,13 @@ fn build_info_json(def: &PolymarketInstrumentDef) -> serde_json::Value {
         map.insert(
             "market_slug".to_string(),
             serde_json::Value::String(slug.clone()),
+        );
+    }
+
+    if let Some(event_start_time) = &def.event_start_time {
+        map.insert(
+            "event_start_time".to_string(),
+            serde_json::Value::String(event_start_time.clone()),
         );
     }
 
@@ -656,6 +666,10 @@ mod tests {
             info.get_str("market_slug"),
             Some("btc-updown-5m-1773307200")
         );
+        assert_eq!(
+            info.get_str("event_start_time"),
+            Some("2026-03-12T09:20:00Z")
+        );
         assert_eq!(info.get_str("game_id"), None);
         assert_eq!(info.get_str("min_order_size"), Some("5"));
         assert_eq!(info.get_bool("neg_risk"), Some(false));
@@ -664,21 +678,7 @@ mod tests {
 
     #[rstest]
     fn test_create_instrument_info_includes_resolution_and_crypto_market_config() {
-        let mut value: serde_json::Value = {
-            let content = std::fs::read_to_string("test_data/gamma_market.json")
-                .expect("Failed to read test data");
-            serde_json::from_str(&content).expect("Failed to parse test data")
-        };
-        value["resolutionSource"] =
-            serde_json::json!("https://data.chain.link/streams/btc-usd-twap-60s-streams");
-        value["cryptoMarketConfig"] = serde_json::json!({
-            "id": "btc-5m-twap-60",
-            "asset": "btc",
-            "duration": "5m",
-            "twapEnabled": true,
-            "twapLookbackSeconds": 60,
-        });
-        let market: GammaMarket = serde_json::from_value(value).unwrap();
+        let market = load_gamma_market("gamma_market_crypto_twap.json");
 
         let defs = parse_gamma_market(&market).unwrap();
         let instrument =

--- a/crates/adapters/polymarket/src/http/parse.rs
+++ b/crates/adapters/polymarket/src/http/parse.rs
@@ -681,6 +681,7 @@ mod tests {
         let market = load_gamma_market("gamma_market_crypto_twap.json");
 
         let defs = parse_gamma_market(&market).unwrap();
+        assert_eq!(defs[0].end_date.as_deref(), Some("2026-08-22T16:05:00Z"));
         let instrument =
             create_instrument_from_def(&defs[0], UnixNanos::from(1_000_000_000u64)).unwrap();
         let InstrumentAny::BinaryOption(binary) = instrument else {

--- a/crates/adapters/polymarket/src/http/parse.rs
+++ b/crates/adapters/polymarket/src/http/parse.rs
@@ -362,6 +362,13 @@ fn build_info_json(def: &PolymarketInstrumentDef) -> serde_json::Value {
         );
     }
 
+    if let Some(end_date) = &def.end_date {
+        map.insert(
+            "end_date".to_string(),
+            serde_json::Value::String(end_date.clone()),
+        );
+    }
+
     if let Some(neg_risk) = def.neg_risk {
         map.insert("neg_risk".to_string(), serde_json::Value::Bool(neg_risk));
     }
@@ -689,6 +696,7 @@ mod tests {
         };
         let info = binary.info.as_ref().expect("info should be Some");
 
+        assert_eq!(info.get_str("end_date"), Some("2026-08-22T16:05:00Z"));
         assert_eq!(
             info.get_str("resolution_source"),
             Some("https://data.chain.link/streams/btc-usd-twap-60s-streams")

--- a/crates/adapters/polymarket/src/python/loader.rs
+++ b/crates/adapters/polymarket/src/python/loader.rs
@@ -341,7 +341,10 @@ impl PyPolymarketDataLoader {
         &self.condition_id
     }
 
-    /// Returns resolution-bearing metadata excluded from `instrument.info`.
+    /// Returns resolution lifecycle metadata retained separately from `instrument.info`.
+    ///
+    /// Shared market identity such as `resolutionSource` is also available from
+    /// `instrument.info["resolution_source"]`.
     #[getter]
     fn resolution_metadata(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         value_to_pyobject(py, &self.resolution_metadata)
@@ -669,7 +672,7 @@ mod tests {
     }
 
     #[rstest]
-    fn build_loader_selects_token_and_separates_resolution_metadata() {
+    fn build_loader_selects_token_and_retains_resolution_lifecycle_metadata() {
         let loader = build_loader_from_details(gamma_market(), &clob_market(), 1, data_api())
             .expect("loader should build");
         let info = loader.instrument.info.as_ref().expect("instrument info");
@@ -683,6 +686,10 @@ mod tests {
         assert_eq!(loader.instrument.taker_fee.to_string(), "0.02");
         assert_eq!(loader.resolution_metadata["closed"], true);
         assert_eq!(loader.resolution_metadata["tokens"][0]["winner"], true);
+        assert_eq!(
+            info.get_str("resolution_source"),
+            Some("https://example.com/result")
+        );
         assert!(!info.contains_key("closed"));
         assert!(!info.contains_key("closedTime"));
         assert!(!info.contains_key("umaResolutionStatus"));

--- a/crates/adapters/polymarket/src/python/loader.rs
+++ b/crates/adapters/polymarket/src/python/loader.rs
@@ -654,6 +654,19 @@ mod tests {
         .expect("valid Gamma market")
     }
 
+    fn gamma_market_with_distinct_crypto_config() -> GammaMarket {
+        let mut value = serde_json::to_value(gamma_market()).expect("serializable Gamma market");
+        value["cryptoMarketConfig"] = json!({
+            "id": "eth-15m-twap-negative-37",
+            "asset": "eth",
+            "duration": "15m",
+            "twapEnabled": true,
+            "twapLookbackSeconds": -37,
+        });
+
+        serde_json::from_value(value).expect("valid distinct crypto market config")
+    }
+
     fn clob_market() -> ClobMarketResponse {
         serde_json::from_value(json!({
             "condition_id": "0xcondition",
@@ -725,6 +738,82 @@ mod tests {
                     .expect("closed metadata")
                     .extract::<bool>()
                     .expect("closed bool"),
+            );
+        });
+    }
+
+    #[rstest]
+    fn build_loader_preserves_distinct_crypto_config_in_rust_and_python_instrument_info() {
+        let loader = build_loader_from_details(
+            gamma_market_with_distinct_crypto_config(),
+            &clob_market(),
+            0,
+            data_api(),
+        )
+        .expect("loader should build");
+        let info = loader.instrument.info.as_ref().expect("instrument info");
+        let expected = json!({
+            "id": "eth-15m-twap-negative-37",
+            "asset": "eth",
+            "duration": "15m",
+            "twapEnabled": true,
+            "twapLookbackSeconds": -37,
+        });
+
+        assert_eq!(info.get("crypto_market_config"), Some(&expected));
+
+        Python::initialize();
+        Python::attach(|py| {
+            let py_loader = Py::new(py, loader).expect("Python loader");
+            let instrument = py_loader
+                .getattr(py, "instrument")
+                .expect("instrument getter");
+            let info = instrument
+                .getattr(py, "info")
+                .expect("instrument info getter");
+            let config = info
+                .bind(py)
+                .get_item("crypto_market_config")
+                .expect("crypto market config");
+
+            assert_eq!(
+                config
+                    .get_item("id")
+                    .expect("config ID")
+                    .extract::<String>()
+                    .expect("config ID string"),
+                "eth-15m-twap-negative-37",
+            );
+            assert_eq!(
+                config
+                    .get_item("asset")
+                    .expect("config asset")
+                    .extract::<String>()
+                    .expect("config asset string"),
+                "eth",
+            );
+            assert_eq!(
+                config
+                    .get_item("duration")
+                    .expect("config duration")
+                    .extract::<String>()
+                    .expect("config duration string"),
+                "15m",
+            );
+            assert!(
+                config
+                    .get_item("twapEnabled")
+                    .expect("TWAP enabled")
+                    .extract::<bool>()
+                    .expect("TWAP enabled bool"),
+            );
+            assert_eq!(
+                config
+                    .get_item("twapLookbackSeconds")
+                    .expect("TWAP lookback")
+                    .extract::<i64>()
+                    .expect("TWAP lookback integer"),
+                -37,
             );
         });
     }

--- a/crates/adapters/polymarket/test_data/gamma_market_crypto_twap.json
+++ b/crates/adapters/polymarket/test_data/gamma_market_crypto_twap.json
@@ -1,0 +1,36 @@
+{
+  "id": "3763487",
+  "conditionId": "0x2eea28aa905ace2f5cace17ea2b9e0e7b85a27f32ee14ed292f02fa104956bc4",
+  "questionID": "0xe3a10df6f8a162859a9a8a496ea5670f9837f800d78cfe3a5aa2e0fa11d079ba",
+  "clobTokenIds": "[\"113013382422133157315656090194075928009220145127085300671933810669470922115281\", \"38034349155375505476764349018583065542443879908961992019053731521216367745079\"]",
+  "outcomes": "[\"Up\", \"Down\"]",
+  "outcomePrices": "[\"0.555\", \"0.445\"]",
+  "question": "Bitcoin Up or Down - August 22, 12:00PM-12:05PM ET",
+  "startDate": "2026-08-21T16:08:38.248161Z",
+  "eventStartTime": "2026-08-22T16:00:00Z",
+  "endDate": "2026-08-22T16:05:00Z",
+  "active": true,
+  "closed": false,
+  "resolutionSource": "https://data.chain.link/streams/btc-usd-twap-60s-streams",
+  "acceptingOrders": true,
+  "enableOrderBook": true,
+  "orderPriceMinTickSize": 0.01,
+  "orderMinSize": 5,
+  "makerBaseFee": 1000,
+  "takerBaseFee": 1000,
+  "slug": "btc-updown-5m-1787414400",
+  "negRisk": false,
+  "feeSchedule": {
+    "exponent": 1,
+    "rate": 0.07,
+    "takerOnly": true,
+    "rebateRate": 0.2
+  },
+  "cryptoMarketConfig": {
+    "id": "btc-5m-twap-60",
+    "asset": "btc",
+    "duration": "5m",
+    "twapEnabled": true,
+    "twapLookbackSeconds": 60
+  }
+}

--- a/crates/adapters/polymarket/test_data/gamma_market_crypto_twap.source.md
+++ b/crates/adapters/polymarket/test_data/gamma_market_crypto_twap.source.md
@@ -1,0 +1,11 @@
+# Fixture source
+
+`gamma_market_crypto_twap.json` is a reduced, field-preserving subset of the
+Gamma response from:
+
+<https://gamma-api.polymarket.com/markets?slug=btc-updown-5m-1787414400>
+
+It was captured read-only on 2026-08-23. The original response fixture had
+SHA-256 `e6f7216e8364eb7bac549c0a2cac29d78d806a65e4082283c2434f553fa2cbb9`.
+Only fields not needed to deserialize or verify the transported metadata were
+removed; the retained values are unchanged.


### PR DESCRIPTION
# Pull Request

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

> External contributions must not modify files under `.github/workflows` or `.github/actions`;
> workflow changes are maintainer-only.

- [ ] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Preserve Polymarket Gamma's typed `cryptoMarketConfig`, `resolutionSource`, `eventStartTime`, and
`endDate` metadata through `PolymarketInstrumentDef` and instrument `info`. This keeps the
provider-declared resolution metadata attached to the instrument without adding market selection,
boundary selection, TWAP calculation, or trading policy.

## Related issues/PRs

Related to #4840.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [x] Breaking change (impacts existing behavior)
- [x] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

This adds fields to the public `GammaMarket` and `PolymarketInstrumentDef` Rust structs. Downstream
Rust code using exhaustive struct literals or patterns must include or ignore the new fields. Gamma
wire deserialization remains backward compatible when the optional market fields are absent.

## Documentation

- [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [x] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

The wrapped loader documentation now states that shared resolution identity is retained in
`instrument.info`. Generated Python stubs have no drift.

## Testing

**New or changed logic must be covered by tests.** Select all that apply:

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Validated with `make format`, `make pre-commit`, the Polymarket library tests, a focused
Python-feature loader test, strict Clippy, and `make py-stubs`.
