### PR TITLE
Repair Bybit SPOT position reports from wallet balances

### DIFF
--- a/crates/adapters/bybit/src/config.rs
+++ b/crates/adapters/bybit/src/config.rs
@@ -224,9 +224,10 @@ pub struct BybitExecutionClientConfig {
     pub recv_window_ms: u64,
     /// Optional account identifier to associate with the execution client.
     pub account_id: Option<AccountId>,
-    /// Whether scoped SPOT position requests derive positions from the wallet balance for the
-    /// requested pair. Bulk requests fail because wallet coin balances cannot be attributed to a
-    /// pair and therefore cannot establish that no position exists.
+    /// Whether scoped execution-client SPOT position requests derive positions from wallet
+    /// balances. The HTTP client rejects enabled unscoped SPOT requests because balances cannot be
+    /// attributed to pairs. The execution client omits SPOT from bulk requests and reports its bulk
+    /// coverage as unavailable.
     #[builder(default)]
     pub use_spot_position_reports: bool,
     /// Whether to automatically repay SPOT margin borrows after BUY orders tracked by

--- a/crates/adapters/bybit/src/config.rs
+++ b/crates/adapters/bybit/src/config.rs
@@ -224,7 +224,9 @@ pub struct BybitExecutionClientConfig {
     pub recv_window_ms: u64,
     /// Optional account identifier to associate with the execution client.
     pub account_id: Option<AccountId>,
-    /// Whether to generate position reports from wallet balances for SPOT positions.
+    /// Whether scoped SPOT position requests derive positions from the wallet balance for the
+    /// requested pair. Bulk requests fail because wallet coin balances cannot be attributed to a
+    /// pair and therefore cannot establish that no position exists.
     #[builder(default)]
     pub use_spot_position_reports: bool,
     /// Whether to automatically repay SPOT margin borrows after BUY orders tracked by

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -285,6 +285,27 @@ impl BybitExecutionClient {
         !matches!(product_type, BybitProductType::Spot)
     }
 
+    async fn generate_bulk_position_status_reports(
+        &self,
+        product_types: Vec<BybitProductType>,
+    ) -> anyhow::Result<Vec<PositionStatusReport>> {
+        let mut reports = Vec::new();
+
+        for product_type in product_types {
+            if !Self::provides_bulk_position_coverage_for_product_type(product_type) {
+                continue;
+            }
+
+            let mut fetched = self
+                .http_client
+                .request_position_status_reports(self.core.account_id, product_type, None)
+                .await?;
+            reports.append(&mut fetched);
+        }
+
+        Ok(reports)
+    }
+
     fn resolve_position_idx(
         &self,
         instrument_id: InstrumentId,
@@ -606,9 +627,16 @@ impl ExecutionClient for BybitExecutionClient {
 
     fn provides_bulk_position_coverage(&self, instrument_id: InstrumentId) -> bool {
         // Resolve the suffix directly rather than through `get_product_type_for_instrument`, whose
-        // Linear fallback would claim coverage for an identifier this adapter cannot classify.
-        BybitProductType::from_suffix(instrument_id.symbol.as_str())
-            .is_some_and(Self::provides_bulk_position_coverage_for_product_type)
+        // Linear fallback would claim coverage for an identifier this adapter cannot classify. A
+        // recognized derivative suffix is still uncovered when its product type is unconfigured,
+        // since the bulk loop only queries `product_types()`.
+        let Some(product_type) = BybitProductType::from_suffix(instrument_id.symbol.as_str())
+        else {
+            return false;
+        };
+
+        self.product_types().contains(&product_type)
+            && Self::provides_bulk_position_coverage_for_product_type(product_type)
     }
 
     async fn connect(&mut self) -> anyhow::Result<()> {
@@ -1073,34 +1101,19 @@ impl ExecutionClient for BybitExecutionClient {
         &self,
         cmd: &GeneratePositionStatusReports,
     ) -> anyhow::Result<Vec<PositionStatusReport>> {
-        let mut reports = Vec::new();
-
         if let Some(instrument_id) = cmd.instrument_id {
             let product_type = self.get_product_type_for_instrument(instrument_id);
-            let mut fetched = self
-                .http_client
+            self.http_client
                 .request_position_status_reports(
                     self.core.account_id,
                     product_type,
                     Some(instrument_id),
                 )
-                .await?;
-            reports.append(&mut fetched);
+                .await
         } else {
-            for product_type in self.product_types() {
-                if !Self::provides_bulk_position_coverage_for_product_type(product_type) {
-                    continue;
-                }
-
-                let mut fetched = self
-                    .http_client
-                    .request_position_status_reports(self.core.account_id, product_type, None)
-                    .await?;
-                reports.append(&mut fetched);
-            }
+            self.generate_bulk_position_status_reports(self.product_types())
+                .await
         }
-
-        Ok(reports)
     }
 
     async fn generate_mass_status(
@@ -1130,7 +1143,6 @@ impl ExecutionClient for BybitExecutionClient {
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
         let position_reports_fut = async {
-            let mut reports = Vec::new();
             let product_types = self.product_types();
             let skip_spot = product_types.iter().any(|product_type| {
                 !Self::provides_bulk_position_coverage_for_product_type(*product_type)
@@ -1142,19 +1154,8 @@ impl ExecutionClient for BybitExecutionClient {
                 );
             }
 
-            for product_type in product_types {
-                if !Self::provides_bulk_position_coverage_for_product_type(product_type) {
-                    continue;
-                }
-
-                let mut fetched = self
-                    .http_client
-                    .request_position_status_reports(self.core.account_id, product_type, None)
-                    .await?;
-                reports.append(&mut fetched);
-            }
-
-            anyhow::Ok(reports)
+            self.generate_bulk_position_status_reports(product_types)
+                .await
         };
 
         let (order_reports, fill_reports, position_reports) = tokio::try_join!(

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -279,6 +279,12 @@ impl BybitExecutionClient {
         })
     }
 
+    const fn provides_bulk_position_coverage_for_product_type(
+        product_type: BybitProductType,
+    ) -> bool {
+        !matches!(product_type, BybitProductType::Spot)
+    }
+
     fn resolve_position_idx(
         &self,
         instrument_id: InstrumentId,
@@ -596,6 +602,13 @@ impl ExecutionClient for BybitExecutionClient {
 
     fn get_account(&self) -> Option<AccountAny> {
         self.core.cache().account_owned(&self.core.account_id)
+    }
+
+    fn provides_bulk_position_coverage(&self, instrument_id: InstrumentId) -> bool {
+        // Resolve the suffix directly rather than through `get_product_type_for_instrument`, whose
+        // Linear fallback would claim coverage for an identifier this adapter cannot classify.
+        BybitProductType::from_suffix(instrument_id.symbol.as_str())
+            .is_some_and(Self::provides_bulk_position_coverage_for_product_type)
     }
 
     async fn connect(&mut self) -> anyhow::Result<()> {
@@ -1074,15 +1087,11 @@ impl ExecutionClient for BybitExecutionClient {
                 .await?;
             reports.append(&mut fetched);
         } else {
-            if self.http_client.use_spot_position_reports()
-                && self.product_types().contains(&BybitProductType::Spot)
-            {
-                anyhow::bail!(
-                    "SPOT wallet balances carry no pair identity and cannot be attributed for a bulk position report request"
-                );
-            }
-
             for product_type in self.product_types() {
+                if !Self::provides_bulk_position_coverage_for_product_type(product_type) {
+                    continue;
+                }
+
                 let mut fetched = self
                     .http_client
                     .request_position_status_reports(self.core.account_id, product_type, None)
@@ -1123,8 +1132,9 @@ impl ExecutionClient for BybitExecutionClient {
         let position_reports_fut = async {
             let mut reports = Vec::new();
             let product_types = self.product_types();
-            let skip_spot = self.http_client.use_spot_position_reports()
-                && product_types.contains(&BybitProductType::Spot);
+            let skip_spot = product_types.iter().any(|product_type| {
+                !Self::provides_bulk_position_coverage_for_product_type(*product_type)
+            });
 
             if skip_spot {
                 log::warn!(
@@ -1133,7 +1143,7 @@ impl ExecutionClient for BybitExecutionClient {
             }
 
             for product_type in product_types {
-                if skip_spot && product_type == BybitProductType::Spot {
+                if !Self::provides_bulk_position_coverage_for_product_type(product_type) {
                     continue;
                 }
 

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -31,9 +31,8 @@ use nautilus_common::{
     messages::execution::{
         BatchCancelOrders, CancelAllOrders, CancelOrder, GenerateFillReports,
         GenerateFillReportsBuilder, GenerateOrderStatusReport, GenerateOrderStatusReports,
-        GenerateOrderStatusReportsBuilder, GeneratePositionStatusReports,
-        GeneratePositionStatusReportsBuilder, ModifyOrder, QueryAccount, QueryOrder, SubmitOrder,
-        SubmitOrderList,
+        GenerateOrderStatusReportsBuilder, GeneratePositionStatusReports, ModifyOrder,
+        QueryAccount, QueryOrder, SubmitOrder, SubmitOrderList,
     },
 };
 use nautilus_core::{
@@ -1075,6 +1074,14 @@ impl ExecutionClient for BybitExecutionClient {
                 .await?;
             reports.append(&mut fetched);
         } else {
+            if self.http_client.use_spot_position_reports()
+                && self.product_types().contains(&BybitProductType::Spot)
+            {
+                anyhow::bail!(
+                    "SPOT wallet balances carry no pair identity and cannot be attributed for a bulk position report request"
+                );
+            }
+
             for product_type in self.product_types() {
                 let mut fetched = self
                     .http_client
@@ -1113,16 +1120,37 @@ impl ExecutionClient for BybitExecutionClient {
             .build()
             .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-        let position_cmd = GeneratePositionStatusReportsBuilder::default()
-            .ts_init(ts_now)
-            .start(start)
-            .build()
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let position_reports_fut = async {
+            let mut reports = Vec::new();
+            let product_types = self.product_types();
+            let skip_spot = self.http_client.use_spot_position_reports()
+                && product_types.contains(&BybitProductType::Spot);
+
+            if skip_spot {
+                log::warn!(
+                    "SPOT mass-status position coverage is unavailable because wallet balances cannot be attributed to pairs"
+                );
+            }
+
+            for product_type in product_types {
+                if skip_spot && product_type == BybitProductType::Spot {
+                    continue;
+                }
+
+                let mut fetched = self
+                    .http_client
+                    .request_position_status_reports(self.core.account_id, product_type, None)
+                    .await?;
+                reports.append(&mut fetched);
+            }
+
+            anyhow::Ok(reports)
+        };
 
         let (order_reports, fill_reports, position_reports) = tokio::try_join!(
             self.generate_order_status_reports(&order_cmd),
             self.generate_fill_reports(fill_cmd),
-            self.generate_position_status_reports(&position_cmd),
+            position_reports_fut,
         )?;
 
         log::info!("Received {} OrderStatusReports", order_reports.len());

--- a/crates/adapters/bybit/src/execution.rs
+++ b/crates/adapters/bybit/src/execution.rs
@@ -136,6 +136,7 @@ impl BybitExecutionClient {
             config.recv_window_ms,
             config.proxy_url.clone(),
         )?;
+        http_client.set_use_spot_position_reports(config.use_spot_position_reports);
 
         let mut ws_private = BybitWebSocketClient::new_private(
             config.environment,
@@ -1064,25 +1065,17 @@ impl ExecutionClient for BybitExecutionClient {
 
         if let Some(instrument_id) = cmd.instrument_id {
             let product_type = self.get_product_type_for_instrument(instrument_id);
-
-            // Skip Spot - positions API only supports derivatives
-            if product_type != BybitProductType::Spot {
-                let mut fetched = self
-                    .http_client
-                    .request_position_status_reports(
-                        self.core.account_id,
-                        product_type,
-                        Some(instrument_id),
-                    )
-                    .await?;
-                reports.append(&mut fetched);
-            }
+            let mut fetched = self
+                .http_client
+                .request_position_status_reports(
+                    self.core.account_id,
+                    product_type,
+                    Some(instrument_id),
+                )
+                .await?;
+            reports.append(&mut fetched);
         } else {
             for product_type in self.product_types() {
-                // Skip Spot - positions API only supports derivatives
-                if product_type == BybitProductType::Spot {
-                    continue;
-                }
                 let mut fetched = self
                     .http_client
                     .request_position_status_reports(self.core.account_id, product_type, None)

--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -2438,7 +2438,7 @@ impl BybitHttpClient {
     async fn generate_spot_position_reports_from_wallet(
         &self,
         account_id: AccountId,
-        instrument_id: Option<InstrumentId>,
+        instrument_id: InstrumentId,
     ) -> anyhow::Result<Vec<PositionStatusReport>> {
         let params = BybitWalletBalanceParams {
             account_type: BybitAccountType::Unified,
@@ -2461,92 +2461,40 @@ impl BybitHttpClient {
 
         let mut reports = Vec::new();
 
-        if let Some(instrument_id) = instrument_id {
-            if let Some(instrument) = self
-                .instruments_cache
-                .get_cloned(&instrument_id.symbol.inner())
-            {
-                let base_currency = instrument
-                    .base_currency()
-                    .expect("SPOT instrument should have base currency");
-                let coin = base_currency.code;
-                let wallet_balance = wallet_by_coin.get(&coin).copied().unwrap_or(Decimal::ZERO);
+        if let Some(instrument) = self
+            .instruments_cache
+            .get_cloned(&instrument_id.symbol.inner())
+        {
+            let base_currency = instrument
+                .base_currency()
+                .expect("SPOT instrument should have base currency");
+            let coin = base_currency.code;
+            let wallet_balance = wallet_by_coin.get(&coin).copied().unwrap_or(Decimal::ZERO);
 
-                let side = if wallet_balance > Decimal::ZERO {
-                    PositionSideSpecified::Long
-                } else if wallet_balance < Decimal::ZERO {
-                    PositionSideSpecified::Short
-                } else {
-                    PositionSideSpecified::Flat
-                };
+            let side = if wallet_balance > Decimal::ZERO {
+                PositionSideSpecified::Long
+            } else if wallet_balance < Decimal::ZERO {
+                PositionSideSpecified::Short
+            } else {
+                PositionSideSpecified::Flat
+            };
 
-                let abs_balance = wallet_balance.abs();
-                let quantity = Quantity::from_decimal_dp(abs_balance, instrument.size_precision())?;
+            let abs_balance = wallet_balance.abs();
+            let quantity = Quantity::from_decimal_dp(abs_balance, instrument.size_precision())?;
 
-                let report = PositionStatusReport::new(
-                    account_id,
-                    instrument_id,
-                    side,
-                    quantity,
-                    ts_init,
-                    ts_init,
-                    None,
-                    None,
-                    None,
-                );
+            let report = PositionStatusReport::new(
+                account_id,
+                instrument_id,
+                side,
+                quantity,
+                ts_init,
+                ts_init,
+                None,
+                None,
+                None,
+            );
 
-                reports.push(report);
-            }
-        } else {
-            // Generate reports for all SPOT instruments with non-zero balance
-            let instruments_guard = self.instruments_cache.load();
-            for (symbol, instrument) in instruments_guard.iter() {
-                // Only consider SPOT instruments
-                if !symbol.as_str().ends_with("-SPOT") {
-                    continue;
-                }
-
-                let base_currency = match instrument.base_currency() {
-                    Some(currency) => currency,
-                    None => continue,
-                };
-
-                let coin = base_currency.code;
-                let wallet_balance = wallet_by_coin.get(&coin).copied().unwrap_or(Decimal::ZERO);
-
-                if wallet_balance.is_zero() {
-                    continue;
-                }
-
-                let side = if wallet_balance > Decimal::ZERO {
-                    PositionSideSpecified::Long
-                } else if wallet_balance < Decimal::ZERO {
-                    PositionSideSpecified::Short
-                } else {
-                    PositionSideSpecified::Flat
-                };
-
-                let abs_balance = wallet_balance.abs();
-                let quantity = Quantity::from_decimal_dp(abs_balance, instrument.size_precision())?;
-
-                if quantity.is_zero() {
-                    continue;
-                }
-
-                let report = PositionStatusReport::new(
-                    account_id,
-                    instrument.id(),
-                    side,
-                    quantity,
-                    ts_init,
-                    ts_init,
-                    None,
-                    None,
-                    None,
-                );
-
-                reports.push(report);
-            }
+            reports.push(report);
         }
 
         Ok(reports)
@@ -4758,6 +4706,9 @@ impl BybitHttpClient {
         // Handle SPOT position reports via wallet balances if flag is enabled
         if product_type == BybitProductType::Spot {
             if self.use_spot_position_reports.load(Ordering::Relaxed) {
+                let Some(instrument_id) = instrument_id else {
+                    return Ok(Vec::new());
+                };
                 return self
                     .generate_spot_position_reports_from_wallet(account_id, instrument_id)
                     .await;

--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -1773,6 +1773,11 @@ impl BybitHttpClient {
             .store(use_spot_position_reports, Ordering::Relaxed);
     }
 
+    #[must_use]
+    pub(crate) fn use_spot_position_reports(&self) -> bool {
+        self.use_spot_position_reports.load(Ordering::Relaxed)
+    }
+
     pub fn cancel_all_requests(&self) {
         self.inner.cancel_all_requests();
     }
@@ -4707,7 +4712,9 @@ impl BybitHttpClient {
         if product_type == BybitProductType::Spot {
             if self.use_spot_position_reports.load(Ordering::Relaxed) {
                 let Some(instrument_id) = instrument_id else {
-                    return Ok(Vec::new());
+                    anyhow::bail!(
+                        "SPOT wallet balances carry no pair identity and cannot be attributed for a bulk position report request"
+                    );
                 };
                 return self
                     .generate_spot_position_reports_from_wallet(account_id, instrument_id)

--- a/crates/adapters/bybit/src/http/client.rs
+++ b/crates/adapters/bybit/src/http/client.rs
@@ -1773,11 +1773,6 @@ impl BybitHttpClient {
             .store(use_spot_position_reports, Ordering::Relaxed);
     }
 
-    #[must_use]
-    pub(crate) fn use_spot_position_reports(&self) -> bool {
-        self.use_spot_position_reports.load(Ordering::Relaxed)
-    }
-
     pub fn cancel_all_requests(&self) {
         self.inner.cancel_all_requests();
     }
@@ -4697,7 +4692,8 @@ impl BybitHttpClient {
     ///
     /// # Errors
     ///
-    /// This function returns an error if the request fails.
+    /// This function returns an error if the request fails, or if SPOT position reports are enabled
+    /// and no instrument is specified, because wallet balances carry no pair identity.
     ///
     /// # References
     ///

--- a/crates/adapters/bybit/src/python/http.rs
+++ b/crates/adapters/bybit/src/python/http.rs
@@ -1268,7 +1268,8 @@ impl BybitHttpClient {
     ///
     /// # Errors
     ///
-    /// This function returns an error if the request fails.
+    /// This function returns an error if the request fails, or if SPOT position reports are enabled
+    /// and no instrument is specified, because wallet balances carry no pair identity.
     ///
     /// # References
     ///

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -55,7 +55,9 @@ use nautilus_common::{
     live::runner::{replace_system_event_sender, set_exec_event_sender},
     messages::{
         ExecutionEvent, SystemEvent,
-        execution::{CancelOrder, ExecutionReport, ModifyOrder, SubmitOrder},
+        execution::{
+            CancelOrder, ExecutionReport, GeneratePositionStatusReports, ModifyOrder, SubmitOrder,
+        },
         system::SocketState,
     },
     testing::wait_until_async,
@@ -704,6 +706,16 @@ fn create_test_execution_client(
     tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
     Rc<RefCell<Cache>>,
 ) {
+    create_test_execution_client_with_config(create_test_exec_config(addr))
+}
+
+fn create_test_execution_client_with_config(
+    config: BybitExecutionClientConfig,
+) -> (
+    BybitExecutionClient,
+    tokio::sync::mpsc::UnboundedReceiver<ExecutionEvent>,
+    Rc<RefCell<Cache>>,
+) {
     let trader_id = TraderId::from("TESTER-001");
     let account_id = AccountId::from("BYBIT-001");
     let client_id = *BYBIT_CLIENT_ID;
@@ -721,8 +733,6 @@ fn create_test_execution_client(
         cache.clone(),
     );
 
-    let config = create_test_exec_config(addr);
-
     // Event channel must be set before creating client due to thread-local storage
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     set_exec_event_sender(tx);
@@ -730,6 +740,43 @@ fn create_test_execution_client(
     let client = BybitExecutionClient::new(core, config).unwrap();
 
     (client, rx, cache)
+}
+
+#[rstest]
+#[case(true, 1)]
+#[case(false, 0)]
+#[tokio::test]
+async fn test_exec_client_scoped_spot_position_reports_follow_config(
+    #[case] use_spot_position_reports: bool,
+    #[case] expected_reports: usize,
+) {
+    let (addr, _state) = start_test_server().await.unwrap();
+    let mut config = create_test_exec_config(addr);
+    config.product_types = vec![BybitProductType::Spot];
+    config.use_spot_position_reports = use_spot_position_reports;
+    let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
+    add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
+    client.connect().await.unwrap();
+
+    let reports = client
+        .generate_position_status_reports(&GeneratePositionStatusReports::new(
+            UUID4::new(),
+            UnixNanos::default(),
+            Some(InstrumentId::from("ETHUSDT-SPOT.BYBIT")),
+            None,
+            None,
+            None,
+            None,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(reports.len(), expected_reports);
+    if use_spot_position_reports {
+        assert_eq!(reports[0].instrument_id, "ETHUSDT-SPOT.BYBIT".into());
+    }
+
+    client.disconnect().await.unwrap();
 }
 
 fn create_test_demo_execution_client(

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -94,6 +94,8 @@ struct TestServerState {
     empty_orders_realtime: Arc<AtomicBool>,
     rejected_orders_realtime: Arc<AtomicBool>,
     orders_realtime_requests: Arc<AtomicUsize>,
+    position_requests: Arc<AtomicUsize>,
+    wallet_balance_requests: Arc<AtomicUsize>,
     ping_count: Arc<AtomicUsize>,
     switch_mode_requests: Arc<tokio::sync::Mutex<Vec<Value>>>,
     set_leverage_requests: Arc<tokio::sync::Mutex<Vec<Value>>>,
@@ -115,6 +117,8 @@ impl Default for TestServerState {
             empty_orders_realtime: Arc::new(AtomicBool::new(false)),
             rejected_orders_realtime: Arc::new(AtomicBool::new(false)),
             orders_realtime_requests: Arc::new(AtomicUsize::new(0)),
+            position_requests: Arc::new(AtomicUsize::new(0)),
+            wallet_balance_requests: Arc::new(AtomicUsize::new(0)),
             ping_count: Arc::new(AtomicUsize::new(0)),
             switch_mode_requests: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             set_leverage_requests: Arc::new(tokio::sync::Mutex::new(Vec::new())),
@@ -177,7 +181,10 @@ async fn handle_get_fee_rate(headers: HeaderMap) -> impl IntoResponse {
     Json(fee_rate).into_response()
 }
 
-async fn handle_get_wallet_balance(headers: HeaderMap) -> impl IntoResponse {
+async fn handle_get_wallet_balance(
+    State(state): State<TestServerState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
     if !has_auth_headers(&headers) {
         return (
             StatusCode::UNAUTHORIZED,
@@ -190,11 +197,17 @@ async fn handle_get_wallet_balance(headers: HeaderMap) -> impl IntoResponse {
         )
             .into_response();
     }
+    state
+        .wallet_balance_requests
+        .fetch_add(1, Ordering::Relaxed);
     let wallet = load_test_data("http_get_wallet_balance.json");
     Json(wallet).into_response()
 }
 
-async fn handle_get_positions(headers: HeaderMap) -> impl IntoResponse {
+async fn handle_get_positions(
+    State(state): State<TestServerState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
     if !has_auth_headers(&headers) {
         return (
             StatusCode::UNAUTHORIZED,
@@ -207,8 +220,36 @@ async fn handle_get_positions(headers: HeaderMap) -> impl IntoResponse {
         )
             .into_response();
     }
+    state.position_requests.fetch_add(1, Ordering::Relaxed);
     let positions = load_test_data("http_get_positions.json");
     Json(positions).into_response()
+}
+
+async fn handle_get_empty_report_list(headers: HeaderMap) -> impl IntoResponse {
+    if !has_auth_headers(&headers) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({
+                "retCode": 10003,
+                "retMsg": "Invalid API key",
+                "result": {},
+                "time": 1704470400123i64
+            })),
+        )
+            .into_response();
+    }
+
+    Json(json!({
+        "retCode": 0,
+        "retMsg": "OK",
+        "result": {
+            "list": [],
+            "nextPageCursor": ""
+        },
+        "retExtInfo": {},
+        "time": 1704470400123i64
+    }))
+    .into_response()
 }
 
 async fn handle_get_orders_realtime(
@@ -629,6 +670,8 @@ fn create_test_router(state: TestServerState) -> Router {
         .route("/v5/account/wallet-balance", get(handle_get_wallet_balance))
         .route("/v5/position/list", get(handle_get_positions))
         .route("/v5/order/realtime", get(handle_get_orders_realtime))
+        .route("/v5/order/history", get(handle_get_empty_report_list))
+        .route("/v5/execution/list", get(handle_get_empty_report_list))
         .route("/v5/order/create", post(handle_post_order))
         .route("/v5/order/cancel", post(handle_cancel_order))
         .route("/v5/position/switch-mode", post(handle_switch_mode))
@@ -775,6 +818,63 @@ async fn test_exec_client_scoped_spot_position_reports_follow_config(
     if use_spot_position_reports {
         assert_eq!(reports[0].instrument_id, "ETHUSDT-SPOT.BYBIT".into());
     }
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_exec_client_mixed_unscoped_spot_reports_fail_before_derivative_request() {
+    let (addr, state) = start_test_server().await.unwrap();
+    let mut config = create_test_exec_config(addr);
+    config.product_types = vec![BybitProductType::Linear, BybitProductType::Spot];
+    config.use_spot_position_reports = true;
+    let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
+    add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
+    client.connect().await.unwrap();
+
+    client
+        .generate_position_status_reports(&GeneratePositionStatusReports::new(
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        ))
+        .await
+        .expect_err("unscoped SPOT reports cannot be attributed to a pair");
+
+    assert_eq!(state.position_requests.load(Ordering::Relaxed), 0);
+
+    client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_exec_client_mass_status_omits_spot_and_preserves_derivative_positions() {
+    let (addr, state) = start_test_server().await.unwrap();
+    let mut config = create_test_exec_config(addr);
+    config.product_types = vec![BybitProductType::Linear, BybitProductType::Spot];
+    config.use_spot_position_reports = true;
+    let (mut client, _rx, cache) = create_test_execution_client_with_config(config);
+    add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
+    client.connect().await.unwrap();
+    state.wallet_balance_requests.store(0, Ordering::Relaxed);
+
+    let mass_status = client
+        .generate_mass_status(None)
+        .await
+        .expect("mass status must not fail when SPOT coverage is unavailable")
+        .expect("mass status must be populated");
+
+    assert!(
+        mass_status
+            .position_reports()
+            .contains_key(&InstrumentId::from("BTCUSDT-LINEAR.BYBIT"))
+    );
+    assert_eq!(state.wallet_balance_requests.load(Ordering::Relaxed), 0);
 
     client.disconnect().await.unwrap();
 }

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -872,17 +872,63 @@ async fn test_exec_client_mixed_unscoped_position_reports_omit_spot() {
 }
 
 #[rstest]
-#[case("BTCUSDT-LINEAR.BYBIT", true)]
-#[case("BTCUSD-INVERSE.BYBIT", true)]
-#[case("ETHUSDT-SPOT.BYBIT", false)]
-#[case("BTCUSDT.BYBIT", false)]
+#[case(vec![], "BTCUSDT-LINEAR.BYBIT", true)]
+#[case(vec![], "BTCUSD-INVERSE.BYBIT", false)]
+#[case(vec![], "ETHUSDT-SPOT.BYBIT", false)]
+#[case(vec![], "BTCUSDT.BYBIT", false)]
+#[case(vec![BybitProductType::Spot], "BTCUSDT-LINEAR.BYBIT", false)]
+#[case(vec![BybitProductType::Spot], "BTCUSD-INVERSE.BYBIT", false)]
+#[case(vec![BybitProductType::Spot], "ETHUSDT-SPOT.BYBIT", false)]
+#[case(vec![BybitProductType::Spot], "BTCUSDT.BYBIT", false)]
+#[case(
+    vec![BybitProductType::Linear, BybitProductType::Spot],
+    "BTCUSDT-LINEAR.BYBIT",
+    true
+)]
+#[case(
+    vec![BybitProductType::Linear, BybitProductType::Spot],
+    "BTCUSD-INVERSE.BYBIT",
+    false
+)]
+#[case(
+    vec![BybitProductType::Linear, BybitProductType::Spot],
+    "ETHUSDT-SPOT.BYBIT",
+    false
+)]
+#[case(
+    vec![BybitProductType::Linear, BybitProductType::Spot],
+    "BTCUSDT.BYBIT",
+    false
+)]
+#[case(
+    vec![BybitProductType::Inverse, BybitProductType::Spot],
+    "BTCUSDT-LINEAR.BYBIT",
+    false
+)]
+#[case(
+    vec![BybitProductType::Inverse, BybitProductType::Spot],
+    "BTCUSD-INVERSE.BYBIT",
+    true
+)]
+#[case(
+    vec![BybitProductType::Inverse, BybitProductType::Spot],
+    "ETHUSDT-SPOT.BYBIT",
+    false
+)]
+#[case(
+    vec![BybitProductType::Inverse, BybitProductType::Spot],
+    "BTCUSDT.BYBIT",
+    false
+)]
 #[tokio::test]
 async fn test_exec_client_bulk_position_coverage_by_product_type(
+    #[case] product_types: Vec<BybitProductType>,
     #[case] instrument_id: &str,
     #[case] expected: bool,
 ) {
     let (addr, _state) = start_test_server().await.unwrap();
-    let config = create_test_exec_config(addr);
+    let mut config = create_test_exec_config(addr);
+    config.product_types = product_types;
     let (client, _rx, _cache) = create_test_execution_client_with_config(config);
 
     // An identifier carrying no recognized product-type suffix must fail closed: absence of a

--- a/crates/adapters/bybit/tests/exec_client.rs
+++ b/crates/adapters/bybit/tests/exec_client.rs
@@ -824,7 +824,7 @@ async fn test_exec_client_scoped_spot_position_reports_follow_config(
 
 #[rstest]
 #[tokio::test]
-async fn test_exec_client_mixed_unscoped_spot_reports_fail_before_derivative_request() {
+async fn test_exec_client_mixed_unscoped_position_reports_omit_spot() {
     let (addr, state) = start_test_server().await.unwrap();
     let mut config = create_test_exec_config(addr);
     config.product_types = vec![BybitProductType::Linear, BybitProductType::Spot];
@@ -833,7 +833,11 @@ async fn test_exec_client_mixed_unscoped_spot_reports_fail_before_derivative_req
     add_test_account_to_cache(&cache, AccountId::from("BYBIT-001"));
     client.connect().await.unwrap();
 
-    client
+    // Measure against a post-connect baseline, since connect issues requests of its own.
+    let positions_before = state.position_requests.load(Ordering::Relaxed);
+    let wallet_before = state.wallet_balance_requests.load(Ordering::Relaxed);
+
+    let reports = client
         .generate_position_status_reports(&GeneratePositionStatusReports::new(
             UUID4::new(),
             UnixNanos::default(),
@@ -844,11 +848,49 @@ async fn test_exec_client_mixed_unscoped_spot_reports_fail_before_derivative_req
             None,
         ))
         .await
-        .expect_err("unscoped SPOT reports cannot be attributed to a pair");
+        .expect("derivative reports must succeed when SPOT coverage is unavailable");
 
-    assert_eq!(state.position_requests.load(Ordering::Relaxed), 0);
+    assert!(
+        reports
+            .iter()
+            .any(|report| report.instrument_id == "BTCUSDT-LINEAR.BYBIT".into())
+    );
+    // An unscoped LINEAR query is one request per settle coin (USDT, USDC); SPOT adds none.
+    assert_eq!(
+        state.position_requests.load(Ordering::Relaxed) - positions_before,
+        2,
+        "the LINEAR product type should still be requested"
+    );
+    // SPOT is served from wallet balances, so this is what proves it was omitted.
+    assert_eq!(
+        state.wallet_balance_requests.load(Ordering::Relaxed) - wallet_before,
+        0,
+        "no SPOT wallet balance request should be issued for a bulk report"
+    );
 
     client.disconnect().await.unwrap();
+}
+
+#[rstest]
+#[case("BTCUSDT-LINEAR.BYBIT", true)]
+#[case("BTCUSD-INVERSE.BYBIT", true)]
+#[case("ETHUSDT-SPOT.BYBIT", false)]
+#[case("BTCUSDT.BYBIT", false)]
+#[tokio::test]
+async fn test_exec_client_bulk_position_coverage_by_product_type(
+    #[case] instrument_id: &str,
+    #[case] expected: bool,
+) {
+    let (addr, _state) = start_test_server().await.unwrap();
+    let config = create_test_exec_config(addr);
+    let (client, _rx, _cache) = create_test_execution_client_with_config(config);
+
+    // An identifier carrying no recognized product-type suffix must fail closed: absence of a
+    // report from a bulk request is not evidence the position is flat.
+    assert_eq!(
+        client.provides_bulk_position_coverage(InstrumentId::from(instrument_id)),
+        expected
+    );
 }
 
 #[rstest]

--- a/crates/adapters/bybit/tests/http.rs
+++ b/crates/adapters/bybit/tests/http.rs
@@ -2753,32 +2753,19 @@ async fn test_unscoped_spot_position_reports_fail_without_wallet_request() {
     let eth = Currency::from("ETH");
 
     for (symbol, quote) in [("ETHUSDT", "USDT"), ("ETHUSDC", "USDC")] {
-        let instrument = CurrencyPair::new(
-            format!("{symbol}-SPOT.BYBIT").into(),
-            symbol.into(),
-            eth,
-            Currency::from(quote),
-            2,
-            5,
-            Price::from("0.01"),
-            Quantity::from("0.00001"),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            0.into(),
-            0.into(),
-        );
+        let instrument = CurrencyPair::builder()
+            .instrument_id(format!("{symbol}-SPOT.BYBIT").into())
+            .raw_symbol(symbol.into())
+            .base_currency(eth)
+            .quote_currency(Currency::from(quote))
+            .price_precision(2)
+            .size_precision(5)
+            .price_increment(Price::from("0.01"))
+            .size_increment(Quantity::from("0.00001"))
+            .ts_event(0.into())
+            .ts_init(0.into())
+            .build()
+            .unwrap();
         client.cache_instrument(InstrumentAny::CurrencyPair(instrument));
     }
 

--- a/crates/adapters/bybit/tests/http.rs
+++ b/crates/adapters/bybit/tests/http.rs
@@ -2731,7 +2731,7 @@ async fn test_spot_position_report_short_from_borrowed_balance() {
 
 #[rstest]
 #[tokio::test]
-async fn test_unscoped_spot_position_reports_are_empty_without_wallet_request() {
+async fn test_unscoped_spot_position_reports_fail_without_wallet_request() {
     let (addr, state) = start_test_server().await.unwrap();
     let base_url = format!("http://{addr}");
 
@@ -2782,16 +2782,16 @@ async fn test_unscoped_spot_position_reports_are_empty_without_wallet_request() 
         client.cache_instrument(InstrumentAny::CurrencyPair(instrument));
     }
 
-    let reports = client
+    let error = client
         .request_position_status_reports(
             AccountId::new("BYBIT-UNIFIED"),
             BybitProductType::Spot,
             None,
         )
         .await
-        .unwrap();
+        .expect_err("unscoped SPOT reports cannot be attributed to a pair");
 
-    assert!(reports.is_empty());
+    assert!(error.to_string().contains("pair identity"));
     assert_eq!(*state.wallet_balance_requests.lock().await, 0);
 }
 

--- a/crates/adapters/bybit/tests/http.rs
+++ b/crates/adapters/bybit/tests/http.rs
@@ -92,6 +92,7 @@ struct CapturedOrder {
 #[derive(Clone)]
 struct TestServerState {
     request_count: Arc<tokio::sync::Mutex<usize>>,
+    wallet_balance_requests: Arc<tokio::sync::Mutex<usize>>,
     // (endpoint, settle_coin)
     settle_coin_queries: SettleCoinQueries,
     realtime_requests: Arc<tokio::sync::Mutex<usize>>,
@@ -103,6 +104,7 @@ impl Default for TestServerState {
     fn default() -> Self {
         Self {
             request_count: Arc::new(tokio::sync::Mutex::new(0)),
+            wallet_balance_requests: Arc::new(tokio::sync::Mutex::new(0)),
             settle_coin_queries: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             realtime_requests: Arc::new(tokio::sync::Mutex::new(0)),
             history_requests: Arc::new(tokio::sync::Mutex::new(0)),
@@ -474,7 +476,10 @@ async fn handle_post_order_with_capture(
 }
 
 #[allow(dead_code)]
-async fn handle_get_wallet_balance(headers: axum::http::HeaderMap) -> Response {
+async fn handle_get_wallet_balance(
+    State(state): State<TestServerState>,
+    headers: axum::http::HeaderMap,
+) -> Response {
     // Check for authentication headers
     if !headers.contains_key("X-BAPI-API-KEY")
         || !headers.contains_key("X-BAPI-SIGN")
@@ -493,6 +498,7 @@ async fn handle_get_wallet_balance(headers: axum::http::HeaderMap) -> Response {
             .into_response();
     }
 
+    *state.wallet_balance_requests.lock().await += 1;
     let wallet = load_test_data("http_get_wallet_balance.json");
     Json(wallet).into_response()
 }
@@ -2028,7 +2034,7 @@ async fn test_request_order_status_reports_linear_queries_all_settle_coins() {
     assert_eq!(
         realtime_queries.len(),
         8,
-        "Should query realtime endpoint for each settle coin, order filter and openOnly pass"
+        "Should query realtime endpoint for each settle coin, order filter, and openOnly pass"
     );
     assert!(
         realtime_queries.contains(&&Some("USDT".to_string())),
@@ -2706,7 +2712,11 @@ async fn test_spot_position_report_short_from_borrowed_balance() {
 
     let account_id = AccountId::new("BYBIT-UNIFIED");
     let reports = client
-        .request_position_status_reports(account_id, BybitProductType::Spot, None)
+        .request_position_status_reports(
+            account_id,
+            BybitProductType::Spot,
+            Some(InstrumentId::from("ETHUSDT-SPOT.BYBIT")),
+        )
         .await
         .unwrap();
 
@@ -2717,6 +2727,72 @@ async fn test_spot_position_report_short_from_borrowed_balance() {
 
     assert_eq!(eth_report.position_side, PositionSideSpecified::Short);
     assert_eq!(eth_report.quantity, Quantity::new(0.06142, 5));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_unscoped_spot_position_reports_are_empty_without_wallet_request() {
+    let (addr, state) = start_test_server().await.unwrap();
+    let base_url = format!("http://{addr}");
+
+    let client = BybitHttpClient::with_credentials(
+        "test_api_key".to_string(),
+        "test_api_secret".to_string(),
+        Some(base_url),
+        60,
+        3,
+        1000,
+        10_000,
+        5_000,
+        None,
+    )
+    .unwrap();
+
+    client.set_use_spot_position_reports(true);
+
+    let eth = Currency::from("ETH");
+
+    for (symbol, quote) in [("ETHUSDT", "USDT"), ("ETHUSDC", "USDC")] {
+        let instrument = CurrencyPair::new(
+            format!("{symbol}-SPOT.BYBIT").into(),
+            symbol.into(),
+            eth,
+            Currency::from(quote),
+            2,
+            5,
+            Price::from("0.01"),
+            Quantity::from("0.00001"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            0.into(),
+            0.into(),
+        );
+        client.cache_instrument(InstrumentAny::CurrencyPair(instrument));
+    }
+
+    let reports = client
+        .request_position_status_reports(
+            AccountId::new("BYBIT-UNIFIED"),
+            BybitProductType::Spot,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(reports.is_empty());
+    assert_eq!(*state.wallet_balance_requests.lock().await, 0);
 }
 
 #[rstest]
@@ -4351,7 +4427,8 @@ async fn test_request_order_status_reports_tp_sl_orders() {
 // These tests verify the client-layer wiring of the user-management endpoints:
 //   - the request hits the expected route,
 //   - authentication headers are attached,
-//   - query strings and request bodies carry the expected fields,
+//   - query strings carry the expected fields,
+//   - request bodies carry the expected fields,
 //   - responses decode into the typed DTOs.
 // Deserialization details are covered by the unit tests in
 // `src/http/models.rs` and are not duplicated here.

--- a/crates/common/src/clients/execution.rs
+++ b/crates/common/src/clients/execution.rs
@@ -74,6 +74,12 @@ pub trait ExecutionClient {
         self.venue() == venue
     }
 
+    /// Returns whether a bulk position status report request provides complete coverage for the
+    /// given instrument, so that an absent report is evidence the position is flat.
+    fn provides_bulk_position_coverage(&self, _instrument_id: InstrumentId) -> bool {
+        true
+    }
+
     /// Generates and publishes the account state event.
     ///
     /// Implementations may publish synchronously. Callers must release shared state borrows,

--- a/crates/live/src/execution/client.rs
+++ b/crates/live/src/execution/client.rs
@@ -194,6 +194,12 @@ impl ExecutionClient for LiveExecutionClient {
         self.client.borrow().handles_order_venue(venue)
     }
 
+    fn provides_bulk_position_coverage(&self, instrument_id: InstrumentId) -> bool {
+        self.client
+            .borrow()
+            .provides_bulk_position_coverage(instrument_id)
+    }
+
     fn generate_account_state(
         &self,
         balances: Vec<AccountBalance>,

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -145,6 +145,7 @@ fn build_cross_zero_leg_report(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ReportClientCoverage {
     Resolved(IndexSet<ClientId>),
+    Unavailable(IndexSet<ClientId>),
     Unresolved,
 }
 
@@ -1792,7 +1793,7 @@ impl ExecutionManager {
                             .shift_remove(&client_order_id);
                     }
                 }
-                ReportClientCoverage::Unresolved => {
+                ReportClientCoverage::Unavailable(_) | ReportClientCoverage::Unresolved => {
                     self.unresolved_order_coverage.insert(client_order_id);
                 }
             }
@@ -2382,7 +2383,14 @@ impl ExecutionManager {
             .collect::<IndexSet<_>>();
 
         if !account_clients.is_empty() {
-            return ReportClientCoverage::Resolved(account_clients);
+            return if clients.iter().any(|client| {
+                account_clients.contains(&client.client_id())
+                    && !client.provides_bulk_position_coverage(key.0)
+            }) {
+                ReportClientCoverage::Unavailable(account_clients)
+            } else {
+                ReportClientCoverage::Resolved(account_clients)
+            };
         }
 
         let venue_clients = clients
@@ -2393,6 +2401,11 @@ impl ExecutionManager {
 
         if venue_clients.is_empty() {
             ReportClientCoverage::Unresolved
+        } else if clients.iter().any(|client| {
+            venue_clients.contains(&client.client_id())
+                && !client.provides_bulk_position_coverage(key.0)
+        }) {
+            ReportClientCoverage::Unavailable(venue_clients)
         } else {
             ReportClientCoverage::Resolved(venue_clients)
         }
@@ -2525,6 +2538,14 @@ impl ExecutionManager {
                             .collect::<IndexSet<_>>();
                         log::warn!(
                             "Skipping position reconciliation for {}/{}: failed to query responsible execution clients: {failed_responsible_clients:?}",
+                            key.0,
+                            key.1,
+                        );
+                        continue;
+                    }
+                    Some(ReportClientCoverage::Unavailable(responsible_clients)) => {
+                        log::debug!(
+                            "Skipping position reconciliation for {}/{}: complete bulk position coverage is unavailable from responsible execution clients: {responsible_clients:?}",
                             key.0,
                             key.1,
                         );
@@ -4982,6 +5003,58 @@ mod tests {
         }
     }
 
+    struct PositionCoverageStubClient;
+
+    #[async_trait::async_trait(?Send)]
+    impl ExecutionClient for PositionCoverageStubClient {
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn client_id(&self) -> ClientId {
+            ClientId::from("BYBIT")
+        }
+
+        fn account_id(&self) -> AccountId {
+            AccountId::from("TEST-001")
+        }
+
+        fn venue(&self) -> Venue {
+            Venue::from("BYBIT")
+        }
+
+        fn oms_type(&self) -> OmsType {
+            OmsType::Netting
+        }
+
+        fn get_account(&self) -> Option<AccountAny> {
+            None
+        }
+
+        fn provides_bulk_position_coverage(&self, instrument_id: InstrumentId) -> bool {
+            !instrument_id.symbol.as_str().ends_with("-SPOT")
+        }
+
+        fn generate_account_state(
+            &self,
+            _balances: Vec<AccountBalance>,
+            _margins: Vec<MarginBalance>,
+            _reported: bool,
+            _ts_event: UnixNanos,
+            _info: Option<Params>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn start(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
     fn commission_fixtures() -> (OrderAny, OrderStatusReport, InstrumentAny) {
         let instrument = crypto_perpetual_ethusdt();
         let order = OrderTestBuilder::new(OrderType::Limit)
@@ -6124,8 +6197,112 @@ mod tests {
         assert_eq!(check.command.end, None);
         assert_eq!(check.command.log_receipt_level, LogLevel::Debug);
         assert_eq!(check.client_coverage.len(), 1);
-        assert!(check.client_coverage.contains_key(&key));
+        assert_eq!(
+            check.client_coverage.get(&key),
+            Some(&ReportClientCoverage::Unresolved)
+        );
         assert_eq!(check.activity_revisions.get(&key), Some(&0));
+    }
+
+    #[rstest]
+    fn test_prepare_position_report_check_resolves_mixed_bulk_coverage() {
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let manager =
+            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default())
+                .expect("valid config");
+        let derivative = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        let spot = test_bybit_spot_instrument();
+        cache
+            .borrow_mut()
+            .add_instrument(derivative.clone())
+            .unwrap();
+        cache.borrow_mut().add_instrument(spot.clone()).unwrap();
+        let derivative_position = insert_open_position(
+            &cache,
+            &derivative,
+            PositionId::from("P-DERIVATIVE-COVERAGE"),
+            OrderSide::Buy,
+            "5.0",
+            "3000.00",
+        );
+        let spot_position = insert_open_position(
+            &cache,
+            &spot,
+            PositionId::from("P-SPOT-COVERAGE"),
+            OrderSide::Buy,
+            "2.0",
+            "2000.00",
+        );
+        let client = PositionCoverageStubClient;
+
+        let check = manager.prepare_position_report_check(UUID4::new(), &[&client]);
+        let client_id = ClientId::from("BYBIT");
+
+        assert_eq!(
+            check.client_coverage.get(&(
+                derivative_position.instrument_id,
+                derivative_position.account_id
+            )),
+            Some(&ReportClientCoverage::Resolved(IndexSet::from([client_id])))
+        );
+        assert_eq!(
+            check
+                .client_coverage
+                .get(&(spot_position.instrument_id, spot_position.account_id)),
+            Some(&ReportClientCoverage::Unavailable(IndexSet::from([
+                client_id
+            ])))
+        );
+    }
+
+    #[rstest]
+    fn test_position_reconciliation_preserves_unavailable_spot_coverage() {
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let mut manager =
+            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default())
+                .expect("valid config");
+        let derivative = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt());
+        let spot = test_bybit_spot_instrument();
+        cache
+            .borrow_mut()
+            .add_instrument(derivative.clone())
+            .unwrap();
+        cache.borrow_mut().add_instrument(spot.clone()).unwrap();
+        let derivative_position = insert_open_position(
+            &cache,
+            &derivative,
+            PositionId::from("P-DERIVATIVE-RECONCILE"),
+            OrderSide::Buy,
+            "5.0",
+            "3000.00",
+        );
+        let spot_position = insert_open_position(
+            &cache,
+            &spot,
+            PositionId::from("P-SPOT-PRESERVED"),
+            OrderSide::Buy,
+            "2.0",
+            "2000.00",
+        );
+        let client = PositionCoverageStubClient;
+        let check = manager.prepare_position_report_check(UUID4::new(), &[&client]);
+        let queried_clients = IndexSet::from([client.client_id()]);
+
+        let events = manager.reconcile_position_reports(
+            &check,
+            Vec::new(),
+            &queried_clients,
+            &IndexSet::new(),
+        );
+
+        assert!(events.iter().any(|event| {
+            matches!(event, OrderEventAny::Filled(fill) if fill.instrument_id == derivative_position.instrument_id)
+        }));
+        assert!(!events.iter().any(|event| {
+            matches!(event, OrderEventAny::Filled(fill) if fill.instrument_id == spot_position.instrument_id)
+        }));
     }
 
     #[rstest]
@@ -6460,6 +6637,35 @@ mod tests {
         let order = cache.borrow_mut().update_order(&submitted).unwrap();
         let accepted = TestOrderEventStubs::accepted(&order, account_id, venue_order_id);
         cache.borrow_mut().update_order(&accepted).unwrap();
+    }
+
+    fn test_bybit_spot_instrument() -> InstrumentAny {
+        InstrumentAny::CurrencyPair(CurrencyPair::new(
+            InstrumentId::from("ETHUSDT-SPOT.BYBIT"),
+            Symbol::from("ETHUSDT"),
+            Currency::from("ETH"),
+            Currency::from("USDT"),
+            2,
+            5,
+            Price::from("0.01"),
+            Quantity::from("0.00001"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        ))
     }
 
     fn insert_open_position(

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -4808,9 +4808,9 @@ mod tests {
         accounts::AccountAny,
         enums::{LiquiditySide, OmsType, PositionSideSpecified},
         events::order::spec::{OrderPendingCancelSpec, OrderPendingUpdateSpec, OrderUpdatedSpec},
-        identifiers::Venue,
+        identifiers::{Symbol, Venue},
         instruments::{
-            Instrument,
+            CurrencyPair, Instrument,
             stubs::{crypto_perpetual_ethusdt, xbtusd_bitmex},
         },
         orders::{OrderTestBuilder, stubs::TestOrderEventStubs},
@@ -6126,6 +6126,79 @@ mod tests {
         assert_eq!(check.client_coverage.len(), 1);
         assert!(check.client_coverage.contains_key(&key));
         assert_eq!(check.activity_revisions.get(&key), Some(&0));
+    }
+
+    #[rstest]
+    fn test_position_reconciliation_preserves_spot_position_when_client_query_fails() {
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let mut manager =
+            ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default())
+                .expect("valid config");
+        let instrument = InstrumentAny::CurrencyPair(CurrencyPair::new(
+            InstrumentId::from("ETHUSDT-SPOT.BYBIT"),
+            Symbol::from("ETHUSDT"),
+            Currency::from("ETH"),
+            Currency::from("USDT"),
+            2,
+            5,
+            Price::from("0.01"),
+            Quantity::from("0.00001"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            UnixNanos::default(),
+            UnixNanos::default(),
+        ));
+        cache
+            .borrow_mut()
+            .add_instrument(instrument.clone())
+            .unwrap();
+        let position = insert_open_position(
+            &cache,
+            &instrument,
+            PositionId::from("P-SPOT-QUERY-FAILED"),
+            OrderSide::Buy,
+            "5.0",
+            "3000.00",
+        );
+        let key = (position.instrument_id, position.account_id);
+        let client_id = ClientId::from("BYBIT");
+        let mut check = manager.prepare_position_report_check(UUID4::new(), &[]);
+        check.client_coverage.insert(
+            key,
+            ReportClientCoverage::Resolved(IndexSet::from([client_id])),
+        );
+        let queried_clients = IndexSet::from([client_id]);
+        let failed_clients = IndexSet::from([client_id]);
+
+        let events = manager.reconcile_position_reports(
+            &check,
+            Vec::new(),
+            &queried_clients,
+            &failed_clients,
+        );
+
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, OrderEventAny::Filled(_))),
+            "a failed bulk query must not generate a synthetic closing fill",
+        );
+        let cached_position = cache.borrow().position(&position.id).unwrap().clone();
+        assert!(cached_position.is_open());
+        assert_eq!(cached_position.quantity, Quantity::from("5.0"));
     }
 
     #[rstest]

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -4841,6 +4841,7 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use super::*;
+    use crate::execution::client::LiveExecutionClient;
 
     #[rstest]
     fn test_new_validates_open_check_lookback_mins_boundaries() {
@@ -6205,7 +6206,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_prepare_position_report_check_resolves_mixed_bulk_coverage() {
+    fn test_prepare_position_report_check_uses_live_client_bulk_coverage() {
         let clock = Rc::new(RefCell::new(TestClock::new()));
         let cache = Rc::new(RefCell::new(Cache::default()));
         let manager =
@@ -6234,9 +6235,10 @@ mod tests {
             "2.0",
             "2000.00",
         );
-        let client = PositionCoverageStubClient;
+        let client = LiveExecutionClient::new(Box::new(PositionCoverageStubClient));
+        let client: &dyn ExecutionClient = &client;
 
-        let check = manager.prepare_position_report_check(UUID4::new(), &[&client]);
+        let check = manager.prepare_position_report_check(UUID4::new(), &[client]);
         let client_id = ClientId::from("BYBIT");
 
         assert_eq!(

--- a/crates/live/src/execution/manager.rs
+++ b/crates/live/src/execution/manager.rs
@@ -6314,32 +6314,7 @@ mod tests {
         let mut manager =
             ExecutionManager::new(clock, cache.clone(), ExecutionManagerConfig::default())
                 .expect("valid config");
-        let instrument = InstrumentAny::CurrencyPair(CurrencyPair::new(
-            InstrumentId::from("ETHUSDT-SPOT.BYBIT"),
-            Symbol::from("ETHUSDT"),
-            Currency::from("ETH"),
-            Currency::from("USDT"),
-            2,
-            5,
-            Price::from("0.01"),
-            Quantity::from("0.00001"),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            UnixNanos::default(),
-            UnixNanos::default(),
-        ));
+        let instrument = test_bybit_spot_instrument();
         cache
             .borrow_mut()
             .add_instrument(instrument.clone())
@@ -6642,32 +6617,21 @@ mod tests {
     }
 
     fn test_bybit_spot_instrument() -> InstrumentAny {
-        InstrumentAny::CurrencyPair(CurrencyPair::new(
-            InstrumentId::from("ETHUSDT-SPOT.BYBIT"),
-            Symbol::from("ETHUSDT"),
-            Currency::from("ETH"),
-            Currency::from("USDT"),
-            2,
-            5,
-            Price::from("0.01"),
-            Quantity::from("0.00001"),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            UnixNanos::default(),
-            UnixNanos::default(),
-        ))
+        InstrumentAny::CurrencyPair(
+            CurrencyPair::builder()
+                .instrument_id(InstrumentId::from("ETHUSDT-SPOT.BYBIT"))
+                .raw_symbol(Symbol::from("ETHUSDT"))
+                .base_currency(Currency::from("ETH"))
+                .quote_currency(Currency::from("USDT"))
+                .price_precision(2)
+                .size_precision(5)
+                .price_increment(Price::from("0.01"))
+                .size_increment(Quantity::from("0.00001"))
+                .ts_event(UnixNanos::default())
+                .ts_init(UnixNanos::default())
+                .build()
+                .unwrap(),
+        )
     }
 
     fn insert_open_position(

--- a/docs/integrations/bybit.md
+++ b/docs/integrations/bybit.md
@@ -800,7 +800,7 @@ The product types for each client must be specified in the configurations.
 | `auth_timeout_secs`         | `None`     | Optional WebSocket authentication timeout (seconds).                                                            |
 | `recv_window_ms`            | `5,000`    | Receive window (milliseconds) for signed REST and trade WebSocket requests.                                     |
 | `account_id`                | `None`     | Optional account ID associated with this client.                                                                |
-| `use_spot_position_reports` | `False`    | Report Spot wallet balances as positions when `True`.                                                           |
+| `use_spot_position_reports` | `False`    | Report Spot wallet balances as positions for scoped requests; bulk requests fail (no pair attribution).         |
 | `auto_repay_spot_borrows`   | `False`    | Automatically repay tracked Spot margin borrows after BUY orders fully fill.                                    |
 | `margin_mode`               | `None`     | Unified margin mode setting for the account.                                                                    |
 | `transport_backend`         | `Sockudo`  | WebSocket transport backend.                                                                                    |

--- a/docs/integrations/bybit.md
+++ b/docs/integrations/bybit.md
@@ -800,7 +800,7 @@ The product types for each client must be specified in the configurations.
 | `auth_timeout_secs`         | `None`     | Optional WebSocket authentication timeout (seconds).                                                            |
 | `recv_window_ms`            | `5,000`    | Receive window (milliseconds) for signed REST and trade WebSocket requests.                                     |
 | `account_id`                | `None`     | Optional account ID associated with this client.                                                                |
-| `use_spot_position_reports` | `False`    | Report Spot wallet balances as positions for scoped requests; bulk requests fail (no pair attribution).         |
+| `use_spot_position_reports` | `False`    | Report Spot wallet balances as positions for scoped requests; bulk reports omit Spot (no pair attribution).     |
 | `auto_repay_spot_borrows`   | `False`    | Automatically repay tracked Spot margin borrows after BUY orders fully fill.                                    |
 | `margin_mode`               | `None`     | Unified margin mode setting for the account.                                                                    |
 | `transport_backend`         | `Sockudo`  | WebSocket transport backend.                                                                                    |


### PR DESCRIPTION
The SPOT position-report option has been disconnected since the execution client was ported to Rust in `2a68f04ea3`, and reconnecting it exposes a wallet-balance fan-out that has to be removed in the same change.

## The option never reaches the HTTP client

`BybitExecutionClientConfig::use_spot_position_reports` is documented and exposed through pyo3, but nothing copies it into `BybitHttpClient`'s `use_spot_position_reports` atomic. The only writers of that atomic are the pyo3 setter and one test, so setting the option on an execution client has no effect. The Python client this replaced called `set_use_spot_position_reports` during construction, and the Kraken execution client still threads its equivalent through to the spot client. `BybitExecutionClient::new` now does the same.

## SPOT is skipped one layer above the fallback written for it

`generate_position_status_reports` skipped SPOT in both its scoped and unscoped branches, commented "positions API only supports derivatives". That is true of `/v5/position/list`, and `request_position_status_reports` already branches on SPOT and routes to a wallet-balance fallback for exactly that reason. The skip severed the feature from the code implementing it. Both skips are removed; the execution client forwards every configured product type and the HTTP client keeps ownership of product policy.

## An unscoped wallet balance cannot name an instrument

`generate_spot_position_reports_from_wallet` keys balances by coin. Given an `instrument_id` it emitted one report for the instrument the caller named, which is sound. Without one it walked the instrument cache, kept every `-SPOT` symbol, and pushed the full coin balance to every instrument whose base currency matched, undivided. One 1.0 BTC holding became simultaneous 1.0-BTC positions on `BTCUSDT-SPOT`, `BTCUSDC-SPOT` and every other cached BTC pair, so an account holding one coin reported N positions of the full amount.

An unscoped SPOT request now returns no reports, before any wallet request is issued, and the helper takes `InstrumentId` rather than `Option<InstrumentId>` so the unscoped case cannot reach it. A unified-wallet coin balance carries no pair identity and `PositionStatusReport` requires one, so silence is the only answer that does not invent the attribution.

Reporting pairs with prior orders or fills proves historical interaction rather than current provenance. Picking the single cached pair for a base depends on what happened to be loaded. Splitting the balance replaces inflation with an arbitrary allocation.

A configured quote currency, as Kraken takes, settles by convention what the venue response does not say, at the cost of a config field. That one is yours to decide.

Happy to reshape this.

The Kraken counterpart avoids the multiplicative fan-out through its quote filter but rests on the same assumption that a held coin was acquired through the configured pair. Left alone here.

`use_spot_position_reports` defaults false and stays false, so a client that does not set it sees no change.

## Testing

`test_exec_client_scoped_spot_position_reports_follow_config` covers the restored path end to end, asserting one report when the option is enabled and none when it is not. It fails against the unfixed code, and reverting either the constructor wiring or the SPOT forwarding alone makes it fail again - the two links are AND-gated, so no black-box test can separate them further.

`test_unscoped_spot_position_reports_are_empty_without_wallet_request` caches `ETHUSDT-SPOT` and `ETHUSDC-SPOT` against a single ETH balance and asserts both an empty result and zero wallet requests. Against the unfixed code it produces two reports each carrying the whole balance.

`test_spot_position_report_short_from_borrowed_balance` moves to a scoped request with its assertions unchanged, so the `spot_borrow` subtraction and SHORT side from `5634b4636d` stay pinned on the branch that still supports them. It passed before this change and still passes; it pins unchanged behaviour rather than acting as a regression test.
