### PR TITLE
Route a trigger-carrying modify to the order emulator

### DIFF
--- a/crates/trading/src/strategy/mod.rs
+++ b/crates/trading/src/strategy/mod.rs
@@ -461,7 +461,9 @@ pub trait Strategy: DataActor {
             None, // correlation_id
         );
 
-        if order.is_emulated() {
+        if matches!(order.emulation_trigger(), Some(trigger) if trigger != TriggerType::NoTrigger)
+            || order.is_emulated()
+        {
             send_emulator_command(TradingCommand::ModifyOrder(command));
         } else if let Some(algo_id) = order
             .exec_algorithm_id()
@@ -2323,10 +2325,13 @@ mod tests {
     use std::{cell::RefCell, rc::Rc};
 
     use nautilus_common::{
-        actor::DataActor,
+        actor::{
+            DataActor,
+            registry::{deregister_actor, try_get_actor_unchecked},
+        },
         cache::{Cache, ORDER_NOT_FOUND},
         clock::{Clock, TestClock},
-        component::Component,
+        component::{Component, deregister_component, register_component_actor},
         enums::ComponentState,
         msgbus::{
             self, MessagingSwitchboard, TypedHandler, TypedIntoHandler,
@@ -2386,6 +2391,12 @@ mod tests {
         started: bool,
     }
 
+    #[derive(Debug)]
+    struct InitializedModifyStrategy {
+        core: StrategyCore,
+        modified_quantity: Quantity,
+    }
+
     impl DataActor for CoreFreeStrategy {
         fn on_start(&mut self) -> anyhow::Result<()> {
             self.started = true;
@@ -2394,6 +2405,22 @@ mod tests {
     }
 
     impl Strategy for CoreFreeStrategy {}
+
+    impl DataActor for InitializedModifyStrategy {}
+
+    nautilus_strategy!(InitializedModifyStrategy, {
+        fn on_order_initialized(&mut self, event: OrderInitialized) {
+            self.modify_order(
+                event.client_order_id,
+                Some(self.modified_quantity),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        }
+    });
 
     impl TestStrategy {
         fn new(config: StrategyConfig) -> Self {
@@ -3667,6 +3694,107 @@ mod tests {
                 if command.client_order_id == order.client_order_id()
         ));
         assert!(risk_messages.get_messages().is_empty());
+    }
+
+    #[rstest]
+    fn test_modify_order_routes_initialized_trigger_order_to_emulator_reentrantly() {
+        let strategy_id = StrategyId::from("REENTRANT-001");
+        let modified_quantity = Quantity::from(200_000);
+        let mut strategy = InitializedModifyStrategy {
+            core: StrategyCore::new(StrategyConfig {
+                strategy_id: Some(strategy_id),
+                ..Default::default()
+            }),
+            modified_quantity,
+        };
+        let trader_id = TraderId::from("TRADER-001");
+        let clock = Rc::new(RefCell::new(TestClock::new()));
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let portfolio = Rc::new(RefCell::new(Portfolio::new(
+            clock.clone(),
+            cache.clone(),
+            None,
+        )));
+        strategy
+            .core
+            .register(trader_id, clock, cache, portfolio)
+            .unwrap();
+        strategy.initialize().unwrap();
+        strategy.start().unwrap();
+
+        let actor_id = strategy.actor_id().inner();
+        register_component_actor(strategy);
+        let order_handler = TypedHandler::from(move |event: &OrderEventAny| {
+            let mut strategy =
+                try_get_actor_unchecked::<InitializedModifyStrategy>(&actor_id).unwrap();
+            strategy.handle_order_event(event.clone());
+        });
+        let topic = format!("events.order.{strategy_id}");
+        msgbus::subscribe_order_events(topic.clone().into(), order_handler.clone(), None);
+
+        let (emulator_handler, emulator_messages): (
+            _,
+            TypedIntoMessageSavingHandler<TradingCommand>,
+        ) = get_typed_into_message_saving_handler(Some(Ustr::from("OrderEmulator.execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::order_emulator_execute(),
+            emulator_handler,
+        );
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let (algo_handler, algo_messages) =
+            get_any_saving_handler::<TradingCommand>(Some(Ustr::from("TWAP.execute")));
+        msgbus::register_any("TWAP.execute".into(), algo_handler);
+
+        let order = OrderTestBuilder::new(OrderType::StopMarket)
+            .trader_id(trader_id)
+            .strategy_id(strategy_id)
+            .instrument_id(InstrumentId::from("BTCUSDT.BINANCE"))
+            .client_order_id(ClientOrderId::from("O-REENTRANT-001"))
+            .side(OrderSide::Buy)
+            .trigger_price(Price::from("51000.0"))
+            .quantity(Quantity::from(100_000))
+            .emulation_trigger(TriggerType::BidAsk)
+            .build();
+        let client_order_id = order.client_order_id();
+
+        let mut strategy = try_get_actor_unchecked::<InitializedModifyStrategy>(&actor_id).unwrap();
+        strategy.submit_order(order, None, None, None).unwrap();
+        drop(strategy);
+
+        msgbus::unsubscribe_order_events(topic.into(), &order_handler);
+        deregister_component(&strategy_id.inner());
+        deregister_actor(&actor_id);
+
+        let emulator_messages = emulator_messages.get_messages();
+        assert_eq!(emulator_messages.len(), 2);
+        assert!(matches!(
+            emulator_messages.first(),
+            Some(TradingCommand::ModifyOrder(command))
+                if command.client_order_id == client_order_id
+                    && command.quantity == Some(modified_quantity)
+        ));
+        assert!(
+            risk_messages
+                .get_messages()
+                .iter()
+                .all(|command| !matches!(command, TradingCommand::ModifyOrder(_)))
+        );
+        assert!(
+            algo_messages
+                .get_messages()
+                .iter()
+                .all(|command| !matches!(command, TradingCommand::ModifyOrder(_)))
+        );
+        assert!(matches!(
+            emulator_messages.get(1),
+            Some(TradingCommand::SubmitOrder(command))
+                if command.client_order_id == client_order_id
+        ));
     }
 
     #[rstest]


### PR DESCRIPTION
A follow-up to the execution-algorithm routing work in #4793.

## `modify_order` decides emulator ownership from status, not from the trigger

`Strategy::submit_order` and `Strategy::cancel_order` route a command to the `OrderEmulator` when the order carries a non-`NoTrigger` `emulation_trigger()`. `modify_order` instead branches on `is_emulated()`, which is an order status. An order is not `Emulated` until the emulator has received it and applied the transition, so a trigger-carrying order is emulator-owned before it is emulator-known, and a modify issued inside that window is routed elsewhere.

The window is reachable from an ordinary strategy. `submit_order` adds the order to the cache, publishes `OrderInitialized`, and only then sends `SubmitOrder` to the emulator. `publish_typed` dispatches handlers synchronously and releases the message bus borrow before doing so, explicitly to support re-entrant publishes, and the trader subscribes every strategy to `events.order.{strategy_id}`. So `on_order_initialized` runs while the order is cached, still `Initialized`, and not yet handed to the emulator. A `modify_order` from that callback fails `is_emulated()` and, with no `exec_algorithm_id`, reaches the risk engine, which does not reject an `Initialized` order either and can forward it toward execution for an order the venue has never seen.

The request is not recorded anywhere: `mark_order_pending_update` returns early for an active-local order, so there is no `PendingUpdate` transition and no cache update. The emulator's later `SubmitOrder` reads the unmodified order, so the modification is lost. With an `exec_algorithm_id` set, the same window routes the command to `{algo_id}.execute`, whose handler logs and returns for an active-local order, losing it the same way. Order lists and algorithm-spawned children reach the window too, since each caches and publishes a member before routing it.

`modify_order` now uses the ownership predicate `cancel_order` already uses verbatim. This reaches wider than the initialized case: any modifiable status still carrying a live trigger routes to the emulator, not only `Emulated` ones. That follows the existing ownership rule rather than adding a second status-specific exception to it. The normal release path clears the trigger to `NoTrigger` before an order becomes `Released`, so released orders keep their existing route, and `NoTrigger` and absent triggers are unaffected.

The emulator applies the modification in this window rather than dropping it. `handle_modify_order` resolves the order from the shared cache rather than from its own submit-command map, sends `OrderUpdated` to the execution engine, and only afterwards consults that map, returning early when the submit has not yet arrived. The early return skips matching-state setup, not the update, and the later `handle_submit_order` re-reads the order from the cache, so the emulated order carries the modified values.

## Testing

`test_modify_order_routes_initialized_trigger_order_to_emulator_reentrantly` reproduces the synchronous window rather than placing an `Initialized` order in the cache by hand: it registers a strategy whose `on_order_initialized` calls `modify_order`, then submits a `StopMarket` carrying a `BidAsk` emulation trigger. It asserts the emulator receives exactly two commands, that the first is the `ModifyOrder` with the changed quantity, that the second is the `SubmitOrder`, and that no `ModifyOrder` reached the risk engine or the algorithm endpoint.

Against the previous predicate the first assertion fails, with the `ModifyOrder` arriving at the risk engine instead.

One adjacent observation, not addressed here: `ExecutionAlgorithm::submit_order` sends a spawned child's `SubmitOrder` to the risk engine even when that child carries an emulation trigger, so emulator ownership is never established for it. This change stops such a child's modify being discarded, but the submission routing is a separate question. I am happy to take that in a follow-up if you want it fixed the same way.
