### PR TITLE
Fix Feather writer runtime safety

### DIFF
--- a/crates/persistence/src/backend/feather.rs
+++ b/crates/persistence/src/backend/feather.rs
@@ -858,8 +858,7 @@ impl FeatherWriter {
     ///
     /// The writer must be wrapped in `Rc<RefCell<>>` to be shareable with the message bus handler.
     ///
-    /// Note: The handler spawns async tasks to write data, so writes happen asynchronously
-    /// and won't block the message bus.
+    /// The handler blocks each write to completion using the shared Nautilus runtime.
     ///
     /// # Errors
     ///
@@ -867,21 +866,30 @@ impl FeatherWriter {
     pub fn subscribe_to_message_bus(
         writer: Rc<RefCell<Self>>,
     ) -> Result<ShareableMessageHandler, Box<dyn std::error::Error>> {
+        let handler = Self::create_any_message_handler(writer);
+        subscribe_any(MStr::pattern("*"), handler.clone(), None);
+        Ok(handler)
+    }
+
+    #[expect(
+        clippy::await_holding_refcell_ref,
+        reason = "The synchronous bus bridge blocks each write to completion"
+    )]
+    fn create_any_message_handler(writer: Rc<RefCell<Self>>) -> ShareableMessageHandler {
         let runtime = writer.borrow().runtime.clone();
 
         // Create handler that downcasts messages and writes them
-        // Note: We use Handle::enter() to allow blocking in the handler context
-        // This works when the handler is called from outside an async runtime
-        let handler = ShareableMessageHandler::from_any(move |message: &dyn Any| {
-            // Enter the runtime context to allow blocking
-            let _guard = runtime.enter();
-
+        ShareableMessageHandler::from_any(move |message: &dyn Any| {
             // Try to downcast to various data types and write them
             macro_rules! try_write {
                 ($message:expr, $type:ty, $name:literal) => {
                     if let Some(value) = $message.downcast_ref::<$type>() {
-                        let mut writer = writer.borrow_mut();
-                        if let Err(e) = runtime.block_on(writer.write(value.clone())) {
+                        let result = super::block_on(&runtime, async {
+                            let mut writer = writer.borrow_mut();
+                            writer.write(value.clone()).await
+                        });
+
+                        if let Err(e) = result {
                             log::warn!("Failed to write {}: {e}", $name);
                         }
                         return;
@@ -931,32 +939,35 @@ impl FeatherWriter {
 
             if let Some(deltas) = message.downcast_ref::<OrderBookDeltas>() {
                 // Batch write so chunk_metadata can skip a leading BookAction::Clear sentinel
-                let mut writer = writer.borrow_mut();
-                if let Err(e) = runtime.block_on(writer.write_batch(deltas.deltas.clone())) {
+                let result = super::block_on(&runtime, async {
+                    let mut writer = writer.borrow_mut();
+                    writer.write_batch(deltas.deltas.clone()).await
+                });
+
+                if let Err(e) = result {
                     log::warn!("Failed to write OrderBookDeltas: {e}");
                 }
             } else if let Some(custom) = message.downcast_ref::<CustomData>() {
-                let mut writer = writer.borrow_mut();
-                if let Err(e) = runtime.block_on(writer.write_data(Data::Custom(custom.clone()))) {
+                let result = super::block_on(&runtime, async {
+                    let mut writer = writer.borrow_mut();
+                    writer.write_data(Data::Custom(custom.clone())).await
+                });
+
+                if let Err(e) = result {
                     log::warn!("Failed to write CustomData: {e}");
                 }
             } else if let Some(instrument) = message.downcast_ref::<InstrumentAny>() {
-                let mut writer = writer.borrow_mut();
-                if let Err(e) = runtime.block_on(writer.write_instrument(instrument.clone())) {
+                let result = super::block_on(&runtime, async {
+                    let mut writer = writer.borrow_mut();
+                    writer.write_instrument(instrument.clone()).await
+                });
+
+                if let Err(e) = result {
                     log::warn!("Failed to write InstrumentAny: {e}");
                 }
             }
             // Silently ignore unsupported message types.
-        });
-
-        // Subscribe to all messages using wildcard pattern
-        subscribe_any(
-            MStr::pattern("*"),
-            handler.clone(),
-            None, // No priority
-        );
-
-        Ok(handler)
+        })
     }
 
     /// Unsubscribes from the message bus.

--- a/crates/persistence/src/python/feather.rs
+++ b/crates/persistence/src/python/feather.rs
@@ -18,6 +18,7 @@
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
+    future::Future,
     rc::Rc,
 };
 
@@ -50,6 +51,13 @@ use crate::{
     backend::feather::{FeatherWriter, RotationConfig},
     parquet::{ObjectStoreLocationKind, create_object_store_location_from_path},
 };
+
+fn block_on_python_future<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    crate::backend::block_on(get_runtime().handle(), future)
+}
 
 /// Python binding for the Rust `FeatherWriter`.
 ///
@@ -137,7 +145,6 @@ impl PyStreamingFeatherWriter {
 
         // Handle replace parameter - delete existing files if requested
         if replace {
-            let runtime = get_runtime();
             let store_ref = object_store.clone();
             let prefix = if base_path.is_empty() {
                 if !is_local_store {
@@ -149,25 +156,22 @@ impl PyStreamingFeatherWriter {
             } else {
                 Some(object_store::path::Path::from(base_path.clone()))
             };
-            runtime
-                .block_on(async {
-                    let mut stream = store_ref.list(prefix.as_ref());
-                    let mut to_delete = Vec::new();
+            block_on_python_future(async {
+                let mut stream = store_ref.list(prefix.as_ref());
+                let mut to_delete = Vec::new();
 
-                    while let Some(result) = futures::StreamExt::next(&mut stream).await {
-                        if let Ok(meta) = result {
-                            to_delete.push(meta.location);
-                        }
+                while let Some(result) = futures::StreamExt::next(&mut stream).await {
+                    if let Ok(meta) = result {
+                        to_delete.push(meta.location);
                     }
+                }
 
-                    for path in to_delete {
-                        let _ = store_ref.delete(&path).await;
-                    }
-                    Ok::<(), anyhow::Error>(())
-                })
-                .map_err(|e| {
-                    PyIOError::new_err(format!("Failed to replace existing files: {e}"))
-                })?;
+                for path in to_delete {
+                    let _ = store_ref.delete(&path).await;
+                }
+                Ok::<(), anyhow::Error>(())
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to replace existing files: {e}")))?;
         }
 
         // Convert rotation mode to RotationConfig
@@ -276,12 +280,9 @@ impl PyStreamingFeatherWriter {
             ($type:ty, $name:literal) => {
                 if let Ok(value) = data.extract::<$type>(py) {
                     let mut writer = self.writer.borrow_mut();
-                    let runtime = get_runtime();
-                    return runtime
-                        .block_on(async { writer.write(value).await })
-                        .map_err(|e| {
-                            PyIOError::new_err(format!("Failed to write {}: {e}", $name))
-                        });
+                    return block_on_python_future(async { writer.write(value).await }).map_err(
+                        |e| PyIOError::new_err(format!("Failed to write {}: {e}", $name)),
+                    );
                 }
             };
         }
@@ -289,74 +290,66 @@ impl PyStreamingFeatherWriter {
         // Try to convert from common pyo3 data types
         if let Ok(quote) = data.extract::<QuoteTick>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Quote(quote)).await })
+            return block_on_python_future(async { writer.write_data(Data::Quote(quote)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write QuoteTick: {e}")));
         }
 
         if let Ok(trade) = data.extract::<TradeTick>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Trade(trade)).await })
+            return block_on_python_future(async { writer.write_data(Data::Trade(trade)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write TradeTick: {e}")));
         }
 
         if let Ok(bar) = data.extract::<Bar>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Bar(bar)).await })
+            return block_on_python_future(async { writer.write_data(Data::Bar(bar)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write Bar: {e}")));
         }
 
         if let Ok(delta) = data.extract::<OrderBookDelta>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Delta(delta)).await })
+            return block_on_python_future(async { writer.write_data(Data::Delta(delta)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write OrderBookDelta: {e}")));
         }
 
         if let Ok(depth) = data.extract::<OrderBookDepth10>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Depth10(Box::new(depth))).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write OrderBookDepth10: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::Depth10(Box::new(depth))).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write OrderBookDepth10: {e}")));
         }
 
         if let Ok(price) = data.extract::<IndexPriceUpdate>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::IndexPrice(price)).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write IndexPriceUpdate: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::IndexPrice(price)).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write IndexPriceUpdate: {e}")));
         }
 
         if let Ok(price) = data.extract::<MarkPriceUpdate>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::MarkPrice(price)).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write MarkPriceUpdate: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::MarkPrice(price)).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write MarkPriceUpdate: {e}")));
         }
 
         if let Ok(greeks) = data.extract::<OptionGreeks>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::OptionGreeks(greeks)).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write OptionGreeks: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::OptionGreeks(greeks)).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write OptionGreeks: {e}")));
         }
 
         if let Ok(close) = data.extract::<InstrumentClose>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::InstrumentClose(close)).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write InstrumentClose: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::InstrumentClose(close)).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write InstrumentClose: {e}")));
         }
 
         try_write!(FundingRateUpdate, "FundingRateUpdate");
@@ -393,9 +386,7 @@ impl PyStreamingFeatherWriter {
         // Try instrument types (uses type_str attribute for dispatch)
         if let Ok(instrument) = pyobject_to_instrument_any(py, data.clone_ref(py)) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_instrument(instrument).await })
+            return block_on_python_future(async { writer.write_instrument(instrument).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write instrument: {e}")));
         }
 
@@ -410,10 +401,8 @@ impl PyStreamingFeatherWriter {
     /// be called manually by the client.
     pub fn flush(&self) -> PyResult<()> {
         let mut writer = self.writer.borrow_mut();
-        let runtime = get_runtime();
 
-        runtime
-            .block_on(async { writer.flush().await })
+        block_on_python_future(async { writer.flush().await })
             .map_err(|e| PyIOError::new_err(format!("Failed to flush: {e}")))
     }
 
@@ -422,10 +411,8 @@ impl PyStreamingFeatherWriter {
     /// After calling this, no further writes should be performed.
     pub fn close(&self) -> PyResult<()> {
         let mut writer = self.writer.borrow_mut();
-        let runtime = get_runtime();
 
-        runtime
-            .block_on(async { writer.close().await })
+        block_on_python_future(async { writer.close().await })
             .map_err(|e| PyIOError::new_err(format!("Failed to close: {e}")))
     }
 

--- a/crates/persistence/tests/test_feather.rs
+++ b/crates/persistence/tests/test_feather.rs
@@ -16,7 +16,10 @@
 use std::{cell::RefCell, collections::HashSet, fs::File, rc::Rc, sync::Arc};
 
 use datafusion::arrow::ipc::reader::StreamReader;
-use nautilus_common::clock::{Clock, TestClock};
+use nautilus_common::{
+    clock::{Clock, TestClock},
+    msgbus::{self, MessageBus, typed_handler::ShareableMessageHandler},
+};
 use nautilus_core::UnixNanos;
 use nautilus_model::{
     data::{
@@ -30,6 +33,92 @@ use nautilus_persistence::backend::feather::{FeatherWriter, RotationConfig};
 use object_store::{ObjectStore, local::LocalFileSystem};
 use rstest::rstest;
 use tempfile::TempDir;
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_direct_writer_lifecycle_inside_multi_thread_runtime() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_path = temp_dir.path().to_str().unwrap().to_string();
+    let local_fs = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(local_fs);
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let mut writer = FeatherWriter::new(
+        base_path,
+        store,
+        clock,
+        RotationConfig::NoRotation,
+        Some(HashSet::from(["quotes".to_string()])),
+        None,
+        None,
+    );
+    let quote = QuoteTick::new(
+        InstrumentId::from("AUD/USD.SIM"),
+        Price::from("1.00001"),
+        Price::from("1.00002"),
+        Quantity::from("1000"),
+        Quantity::from("1001"),
+        UnixNanos::from(1_000),
+        UnixNanos::from(1_000),
+    );
+
+    writer.write(quote).await.unwrap();
+    writer.flush().await.unwrap();
+    writer.close().await.unwrap();
+
+    assert!(writer.is_closed());
+    assert_eq!(collect_feather_files(temp_dir.path()).len(), 1);
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[expect(
+    clippy::await_holding_refcell_ref,
+    reason = "The message-bus writer is single-threaded and the test awaits its final close before reading files"
+)]
+async fn test_legacy_message_bus_subscription_persists_any_route_and_unsubscribes() {
+    let _bus = MessageBus::default().register_message_bus();
+    let temp_dir = TempDir::new().unwrap();
+    let base_path = temp_dir.path().to_str().unwrap().to_string();
+    let local_fs = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(local_fs);
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let writer = Rc::new(RefCell::new(FeatherWriter::new(
+        base_path,
+        store,
+        clock,
+        RotationConfig::NoRotation,
+        Some(HashSet::from(["quotes".to_string()])),
+        None,
+        None,
+    )));
+    let quote = QuoteTick::new(
+        InstrumentId::from("AUD/USD.SIM"),
+        Price::from("1.00001"),
+        Price::from("1.00002"),
+        Quantity::from("1000"),
+        Quantity::from("1001"),
+        UnixNanos::from(1_000),
+        UnixNanos::from(1_000),
+    );
+
+    let handler: ShareableMessageHandler =
+        FeatherWriter::subscribe_to_message_bus(Rc::clone(&writer)).unwrap();
+    msgbus::publish_any("data.quotes.AUD/USD.SIM".into(), &quote);
+    FeatherWriter::unsubscribe_from_message_bus(&handler);
+    msgbus::publish_any("data.quotes.AUD/USD.SIM".into(), &quote);
+    writer.borrow_mut().close().await.unwrap();
+
+    let files = collect_feather_files(temp_dir.path());
+    assert_eq!(files.len(), 1);
+    let row_count: usize = StreamReader::try_new(File::open(&files[0]).unwrap(), None)
+        .unwrap()
+        .map(|batch| batch.unwrap().num_rows())
+        .sum();
+    assert_eq!(
+        row_count, 1,
+        "legacy unsubscribe must prevent the second write"
+    );
+}
 
 #[rstest]
 #[tokio::test]


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md`

## Summary

This fixes `StreamingFeatherWriter.write()` when it is called from a Rust `LiveNode` callback.

It now uses the existing runtime safely. It no longer tries to start another Tokio runtime and panic.

The same safety applies to flush, close, replace, and the the message-bus handler. The released Rust API remains unchanged.

## Related issues/PRs

Closes #4846

## Type of change

- [x] Bug fix (non-breaking)

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Focused Feather tests cover direct writes and legacy `publish_any()` messages from inside a multi-thread Tokio runtime.