### PR TITLE
Fix feather typed routes subscription

### DIFF
--- a/crates/persistence/src/backend/catalog.rs
+++ b/crates/persistence/src/backend/catalog.rs
@@ -4208,7 +4208,8 @@ impl ParquetDataCatalog {
         data_name.starts_with("custom/")
             || matches!(
                 data_name,
-                "quotes"
+                "instruments"
+                    | "quotes"
                     | "trades"
                     | "order_book_deltas"
                     | "order_book_depths"

--- a/crates/persistence/src/backend/feather.rs
+++ b/crates/persistence/src/backend/feather.rs
@@ -858,8 +858,7 @@ impl FeatherWriter {
     ///
     /// The writer must be wrapped in `Rc<RefCell<>>` to be shareable with the message bus handler.
     ///
-    /// Note: The handler spawns async tasks to write data, so writes happen asynchronously
-    /// and won't block the message bus.
+    /// The handler blocks each write to completion using the shared Nautilus runtime.
     ///
     /// # Errors
     ///
@@ -867,21 +866,30 @@ impl FeatherWriter {
     pub fn subscribe_to_message_bus(
         writer: Rc<RefCell<Self>>,
     ) -> Result<ShareableMessageHandler, Box<dyn std::error::Error>> {
+        let handler = Self::create_any_message_handler(writer);
+        subscribe_any(MStr::pattern("*"), handler.clone(), None);
+        Ok(handler)
+    }
+
+    #[expect(
+        clippy::await_holding_refcell_ref,
+        reason = "The synchronous bus bridge blocks each write to completion"
+    )]
+    fn create_any_message_handler(writer: Rc<RefCell<Self>>) -> ShareableMessageHandler {
         let runtime = writer.borrow().runtime.clone();
 
         // Create handler that downcasts messages and writes them
-        // Note: We use Handle::enter() to allow blocking in the handler context
-        // This works when the handler is called from outside an async runtime
-        let handler = ShareableMessageHandler::from_any(move |message: &dyn Any| {
-            // Enter the runtime context to allow blocking
-            let _guard = runtime.enter();
-
+        ShareableMessageHandler::from_any(move |message: &dyn Any| {
             // Try to downcast to various data types and write them
             macro_rules! try_write {
                 ($message:expr, $type:ty, $name:literal) => {
                     if let Some(value) = $message.downcast_ref::<$type>() {
-                        let mut writer = writer.borrow_mut();
-                        if let Err(e) = runtime.block_on(writer.write(value.clone())) {
+                        let result = super::block_on(&runtime, async {
+                            let mut writer = writer.borrow_mut();
+                            writer.write(value.clone()).await
+                        });
+
+                        if let Err(e) = result {
                             log::warn!("Failed to write {}: {e}", $name);
                         }
                         return;
@@ -931,32 +939,35 @@ impl FeatherWriter {
 
             if let Some(deltas) = message.downcast_ref::<OrderBookDeltas>() {
                 // Batch write so chunk_metadata can skip a leading BookAction::Clear sentinel
-                let mut writer = writer.borrow_mut();
-                if let Err(e) = runtime.block_on(writer.write_batch(deltas.deltas.clone())) {
+                let result = super::block_on(&runtime, async {
+                    let mut writer = writer.borrow_mut();
+                    writer.write_batch(deltas.deltas.clone()).await
+                });
+
+                if let Err(e) = result {
                     log::warn!("Failed to write OrderBookDeltas: {e}");
                 }
             } else if let Some(custom) = message.downcast_ref::<CustomData>() {
-                let mut writer = writer.borrow_mut();
-                if let Err(e) = runtime.block_on(writer.write_data(Data::Custom(custom.clone()))) {
+                let result = super::block_on(&runtime, async {
+                    let mut writer = writer.borrow_mut();
+                    writer.write_data(Data::Custom(custom.clone())).await
+                });
+
+                if let Err(e) = result {
                     log::warn!("Failed to write CustomData: {e}");
                 }
             } else if let Some(instrument) = message.downcast_ref::<InstrumentAny>() {
-                let mut writer = writer.borrow_mut();
-                if let Err(e) = runtime.block_on(writer.write_instrument(instrument.clone())) {
+                let result = super::block_on(&runtime, async {
+                    let mut writer = writer.borrow_mut();
+                    writer.write_instrument(instrument.clone()).await
+                });
+
+                if let Err(e) = result {
                     log::warn!("Failed to write InstrumentAny: {e}");
                 }
             }
             // Silently ignore unsupported message types.
-        });
-
-        // Subscribe to all messages using wildcard pattern
-        subscribe_any(
-            MStr::pattern("*"),
-            handler.clone(),
-            None, // No priority
-        );
-
-        Ok(handler)
+        })
     }
 
     /// Unsubscribes from the message bus.

--- a/crates/persistence/src/backend/feather.rs
+++ b/crates/persistence/src/backend/feather.rs
@@ -33,7 +33,19 @@ use jiff::{
 use nautilus_common::{
     cache::fifo::FifoCache,
     clock::Clock,
-    msgbus::{mstr::MStr, subscribe_any, typed_handler::ShareableMessageHandler, unsubscribe_any},
+    msgbus::{
+        mstr::MStr,
+        subscribe_account_state, subscribe_any, subscribe_bars, subscribe_book_deltas,
+        subscribe_book_depth10, subscribe_funding_rates, subscribe_index_prices,
+        subscribe_instruments, subscribe_mark_prices, subscribe_option_greeks,
+        subscribe_order_events, subscribe_position_events, subscribe_quotes, subscribe_trades,
+        typed_handler::{ShareableMessageHandler, TypedHandler},
+        unsubscribe_account_state, unsubscribe_any, unsubscribe_bars, unsubscribe_book_deltas,
+        unsubscribe_book_depth10, unsubscribe_funding_rates, unsubscribe_index_prices,
+        unsubscribe_instruments, unsubscribe_mark_prices, unsubscribe_option_greeks,
+        unsubscribe_order_events, unsubscribe_position_events, unsubscribe_quotes,
+        unsubscribe_trades,
+    },
 };
 use nautilus_core::{UUID4, UnixNanos, datetime::NANOSECONDS_IN_SECOND};
 use nautilus_model::{
@@ -45,10 +57,10 @@ use nautilus_model::{
     },
     events::{
         AccountState, OrderAccepted, OrderCancelRejected, OrderCanceled, OrderDenied,
-        OrderEmulated, OrderExpired, OrderFillVoided, OrderFilled, OrderInitialized,
+        OrderEmulated, OrderEventAny, OrderExpired, OrderFillVoided, OrderFilled, OrderInitialized,
         OrderModifyRejected, OrderPendingCancel, OrderPendingUpdate, OrderRejected, OrderReleased,
         OrderSnapshot, OrderSubmitted, OrderTriggered, OrderUpdated, PositionAdjusted,
-        PositionChanged, PositionClosed, PositionOpened, PositionSnapshot,
+        PositionChanged, PositionClosed, PositionEvent, PositionOpened, PositionSnapshot,
     },
     instruments::InstrumentAny,
     reports::{ExecutionMassStatus, FillReport, OrderStatusReport, PositionStatusReport},
@@ -206,6 +218,35 @@ pub struct FeatherWriter {
     last_flush_ns: UnixNanos,
     /// Bounded cache of recently seen event IDs for deduplication.
     seen_event_ids: Box<FifoCache<UUID4, 10_000>>,
+}
+
+/// A message-bus subscription owned by a [`FeatherWriter`].
+pub struct FeatherWriterSubscription {
+    any_handler: Option<ShareableMessageHandler>,
+    typed_unsubscribers: Vec<Box<dyn FnOnce()>>,
+}
+
+impl FeatherWriterSubscription {
+    fn unsubscribe_inner(&mut self) {
+        if let Some(handler) = self.any_handler.take() {
+            unsubscribe_any(MStr::pattern("*"), &handler);
+        }
+
+        for unsubscribe in std::mem::take(&mut self.typed_unsubscribers) {
+            unsubscribe();
+        }
+    }
+
+    /// Removes all writer handlers from the current thread's message bus.
+    pub fn unsubscribe(mut self) {
+        self.unsubscribe_inner();
+    }
+}
+
+impl Drop for FeatherWriterSubscription {
+    fn drop(&mut self) {
+        self.unsubscribe_inner();
+    }
 }
 
 impl FeatherWriter {
@@ -858,7 +899,8 @@ impl FeatherWriter {
     ///
     /// The writer must be wrapped in `Rc<RefCell<>>` to be shareable with the message bus handler.
     ///
-    /// The handler blocks each write to completion using the shared Nautilus runtime.
+    /// The handler blocks each write to completion using the shared Nautilus runtime. Use
+    /// [`Self::subscribe_to_all_message_bus_routes`] to also subscribe to native typed routes.
     ///
     /// # Errors
     ///
@@ -869,6 +911,220 @@ impl FeatherWriter {
         let handler = Self::create_any_message_handler(writer);
         subscribe_any(MStr::pattern("*"), handler.clone(), None);
         Ok(handler)
+    }
+
+    /// Subscribes to all supported messages on the message bus.
+    ///
+    /// Both the runtime-typed wildcard route and the native typed market-data routes are
+    /// registered. This is required because live data producers publish quotes, trades, deltas,
+    /// and instruments through typed routers rather than `publish_any`.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The explicit route list is exhaustive"
+    )]
+    #[expect(
+        clippy::await_holding_refcell_ref,
+        reason = "The synchronous bus bridge blocks each write to completion"
+    )]
+    pub fn subscribe_to_all_message_bus_routes(
+        writer: &Rc<RefCell<Self>>,
+    ) -> FeatherWriterSubscription {
+        let runtime = writer.borrow().runtime.clone();
+        let handler = Self::create_any_message_handler(Rc::clone(writer));
+        subscribe_any(MStr::pattern("*"), handler.clone(), None);
+
+        let mut typed_unsubscribers: Vec<Box<dyn FnOnce()>> = Vec::new();
+
+        macro_rules! subscribe_typed {
+            (
+                $subscribe:path,
+                $unsubscribe:path,
+                $type:ty,
+                $writer_ident:ident,
+                $message_ident:ident,
+                $write:expr,
+                $name:literal
+            ) => {{
+                let pattern = MStr::pattern("*");
+                let typed_writer = Rc::clone(writer);
+                let typed_runtime = runtime.clone();
+                let typed_handler = TypedHandler::from(move |$message_ident: &$type| {
+                    let result = super::block_on(&typed_runtime, async {
+                        let mut $writer_ident = typed_writer.borrow_mut();
+                        $write
+                    });
+
+                    if let Err(e) = result {
+                        log::warn!("Failed to write {}: {e}", $name);
+                    }
+                });
+
+                $subscribe(pattern, typed_handler.clone(), None);
+                typed_unsubscribers.push(Box::new(move || {
+                    $unsubscribe(pattern, &typed_handler);
+                }));
+            }};
+        }
+
+        subscribe_typed!(
+            subscribe_instruments,
+            unsubscribe_instruments,
+            InstrumentAny,
+            writer,
+            message,
+            writer.write_instrument(message.clone()).await,
+            "InstrumentAny"
+        );
+        subscribe_typed!(
+            subscribe_book_deltas,
+            unsubscribe_book_deltas,
+            OrderBookDeltas,
+            writer,
+            message,
+            writer.write_batch(message.deltas.clone()).await,
+            "OrderBookDeltas"
+        );
+        subscribe_typed!(
+            subscribe_book_depth10,
+            unsubscribe_book_depth10,
+            OrderBookDepth10,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "OrderBookDepth10"
+        );
+        subscribe_typed!(
+            subscribe_quotes,
+            unsubscribe_quotes,
+            QuoteTick,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "QuoteTick"
+        );
+        subscribe_typed!(
+            subscribe_trades,
+            unsubscribe_trades,
+            TradeTick,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "TradeTick"
+        );
+        subscribe_typed!(
+            subscribe_bars,
+            unsubscribe_bars,
+            Bar,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "Bar"
+        );
+        subscribe_typed!(
+            subscribe_mark_prices,
+            unsubscribe_mark_prices,
+            MarkPriceUpdate,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "MarkPriceUpdate"
+        );
+        subscribe_typed!(
+            subscribe_index_prices,
+            unsubscribe_index_prices,
+            IndexPriceUpdate,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "IndexPriceUpdate"
+        );
+        subscribe_typed!(
+            subscribe_funding_rates,
+            unsubscribe_funding_rates,
+            FundingRateUpdate,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "FundingRateUpdate"
+        );
+        subscribe_typed!(
+            subscribe_option_greeks,
+            unsubscribe_option_greeks,
+            OptionGreeks,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "OptionGreeks"
+        );
+        subscribe_typed!(
+            subscribe_account_state,
+            unsubscribe_account_state,
+            AccountState,
+            writer,
+            message,
+            writer.write(message.clone()).await,
+            "AccountState"
+        );
+        subscribe_typed!(
+            subscribe_order_events,
+            unsubscribe_order_events,
+            OrderEventAny,
+            writer,
+            message,
+            writer.write_order_event(message.clone()).await,
+            "OrderEventAny"
+        );
+        subscribe_typed!(
+            subscribe_position_events,
+            unsubscribe_position_events,
+            PositionEvent,
+            writer,
+            message,
+            writer.write_position_event(message.clone()).await,
+            "PositionEvent"
+        );
+
+        FeatherWriterSubscription {
+            any_handler: Some(handler),
+            typed_unsubscribers,
+        }
+    }
+
+    async fn write_order_event(
+        &mut self,
+        event: OrderEventAny,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match event {
+            OrderEventAny::Initialized(event) => self.write(event).await,
+            OrderEventAny::Denied(event) => self.write(event).await,
+            OrderEventAny::Emulated(event) => self.write(event).await,
+            OrderEventAny::Released(event) => self.write(event).await,
+            OrderEventAny::Submitted(event) => self.write(event).await,
+            OrderEventAny::Accepted(event) => self.write(event).await,
+            OrderEventAny::Rejected(event) => self.write(event).await,
+            OrderEventAny::Canceled(event) => self.write(event).await,
+            OrderEventAny::Expired(event) => self.write(event).await,
+            OrderEventAny::Triggered(event) => self.write(event).await,
+            OrderEventAny::PendingUpdate(event) => self.write(event).await,
+            OrderEventAny::PendingCancel(event) => self.write(event).await,
+            OrderEventAny::ModifyRejected(event) => self.write(event).await,
+            OrderEventAny::CancelRejected(event) => self.write(event).await,
+            OrderEventAny::Updated(event) => self.write(event).await,
+            OrderEventAny::Filled(event) => self.write(event).await,
+            OrderEventAny::FillVoided(event) => self.write(event).await,
+        }
+    }
+
+    async fn write_position_event(
+        &mut self,
+        event: PositionEvent,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match event {
+            PositionEvent::PositionOpened(event) => self.write(event).await,
+            PositionEvent::PositionChanged(event) => self.write(event).await,
+            PositionEvent::PositionClosed(event) => self.write(event).await,
+            PositionEvent::PositionAdjusted(event) => self.write(event).await,
+        }
     }
 
     #[expect(

--- a/crates/persistence/src/python/feather.rs
+++ b/crates/persistence/src/python/feather.rs
@@ -24,7 +24,6 @@ use std::{
 
 use nautilus_common::{
     live::get_runtime,
-    msgbus::typed_handler::ShareableMessageHandler,
     python::{cache::PyCache, clock::PyClock},
 };
 use nautilus_core::{UnixNanos, datetime::get_timezone};
@@ -48,7 +47,7 @@ use object_store::ObjectStoreExt;
 use pyo3::{exceptions::PyIOError, prelude::*};
 
 use crate::{
-    backend::feather::{FeatherWriter, RotationConfig},
+    backend::feather::{FeatherWriter, FeatherWriterSubscription, RotationConfig},
     parquet::{ObjectStoreLocationKind, create_object_store_location_from_path},
 };
 
@@ -71,7 +70,7 @@ where
 #[pyo3_stub_gen::derive::gen_stub_pyclass(module = "nautilus_trader.persistence")]
 pub struct PyStreamingFeatherWriter {
     writer: Rc<RefCell<FeatherWriter>>,
-    handler: Option<ShareableMessageHandler>,
+    handler: Option<FeatherWriterSubscription>,
 }
 
 #[pymethods]
@@ -208,6 +207,9 @@ impl PyStreamingFeatherWriter {
         per_instrument_types.insert("bars".to_string());
         per_instrument_types.insert("funding_rate_update".to_string());
         per_instrument_types.insert("index_prices".to_string());
+        per_instrument_types.insert("instrument_closes".to_string());
+        per_instrument_types.insert("instrument_status".to_string());
+        per_instrument_types.insert("instruments".to_string());
         per_instrument_types.insert("mark_prices".to_string());
         per_instrument_types.insert("order_book_deltas".to_string());
         per_instrument_types.insert("order_book_depths".to_string());
@@ -239,18 +241,16 @@ impl PyStreamingFeatherWriter {
         })
     }
 
-    /// Subscribes to all messages on the message bus (pattern "*").
+    /// Subscribes to supported messages on the message bus.
     ///
-    /// This matches the behavior of Python's `StreamingFeatherWriter` when subscribed
-    /// via `trader.subscribe("*", writer.write)`.
+    /// This registers the runtime-typed wildcard route and the native typed market-data routes.
     pub fn subscribe(&mut self) -> PyResult<()> {
         if self.handler.is_some() {
             // Already subscribed
             return Ok(());
         }
 
-        let handler = FeatherWriter::subscribe_to_message_bus(self.writer.clone())
-            .map_err(|e| PyIOError::new_err(format!("Failed to subscribe to message bus: {e}")))?;
+        let handler = FeatherWriter::subscribe_to_all_message_bus_routes(&self.writer);
 
         self.handler = Some(handler);
         Ok(())
@@ -259,7 +259,7 @@ impl PyStreamingFeatherWriter {
     /// Unsubscribes from the message bus.
     pub fn unsubscribe(&mut self) -> PyResult<()> {
         if let Some(handler) = self.handler.take() {
-            FeatherWriter::unsubscribe_from_message_bus(&handler);
+            handler.unsubscribe();
         }
         Ok(())
     }
@@ -409,7 +409,11 @@ impl PyStreamingFeatherWriter {
     /// Closes all writers by flushing and removing them.
     ///
     /// After calling this, no further writes should be performed.
-    pub fn close(&self) -> PyResult<()> {
+    pub fn close(&mut self) -> PyResult<()> {
+        if let Some(handler) = self.handler.take() {
+            handler.unsubscribe();
+        }
+
         let mut writer = self.writer.borrow_mut();
 
         block_on_python_future(async { writer.close().await })

--- a/crates/persistence/src/python/feather.rs
+++ b/crates/persistence/src/python/feather.rs
@@ -18,6 +18,7 @@
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
+    future::Future,
     rc::Rc,
 };
 
@@ -50,6 +51,13 @@ use crate::{
     backend::feather::{FeatherWriter, RotationConfig},
     parquet::{ObjectStoreLocationKind, create_object_store_location_from_path},
 };
+
+fn block_on_python_future<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    crate::backend::block_on(get_runtime().handle(), future)
+}
 
 /// Python binding for the Rust `FeatherWriter`.
 ///
@@ -137,7 +145,6 @@ impl PyStreamingFeatherWriter {
 
         // Handle replace parameter - delete existing files if requested
         if replace {
-            let runtime = get_runtime();
             let store_ref = object_store.clone();
             let prefix = if base_path.is_empty() {
                 if !is_local_store {
@@ -149,25 +156,22 @@ impl PyStreamingFeatherWriter {
             } else {
                 Some(object_store::path::Path::from(base_path.clone()))
             };
-            runtime
-                .block_on(async {
-                    let mut stream = store_ref.list(prefix.as_ref());
-                    let mut to_delete = Vec::new();
+            block_on_python_future(async {
+                let mut stream = store_ref.list(prefix.as_ref());
+                let mut to_delete = Vec::new();
 
-                    while let Some(result) = futures::StreamExt::next(&mut stream).await {
-                        if let Ok(meta) = result {
-                            to_delete.push(meta.location);
-                        }
+                while let Some(result) = futures::StreamExt::next(&mut stream).await {
+                    if let Ok(meta) = result {
+                        to_delete.push(meta.location);
                     }
+                }
 
-                    for path in to_delete {
-                        let _ = store_ref.delete(&path).await;
-                    }
-                    Ok::<(), anyhow::Error>(())
-                })
-                .map_err(|e| {
-                    PyIOError::new_err(format!("Failed to replace existing files: {e}"))
-                })?;
+                for path in to_delete {
+                    let _ = store_ref.delete(&path).await;
+                }
+                Ok::<(), anyhow::Error>(())
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to replace existing files: {e}")))?;
         }
 
         // Convert rotation mode to RotationConfig
@@ -276,12 +280,9 @@ impl PyStreamingFeatherWriter {
             ($type:ty, $name:literal) => {
                 if let Ok(value) = data.extract::<$type>(py) {
                     let mut writer = self.writer.borrow_mut();
-                    let runtime = get_runtime();
-                    return runtime
-                        .block_on(async { writer.write(value).await })
-                        .map_err(|e| {
-                            PyIOError::new_err(format!("Failed to write {}: {e}", $name))
-                        });
+                    return block_on_python_future(async { writer.write(value).await }).map_err(
+                        |e| PyIOError::new_err(format!("Failed to write {}: {e}", $name)),
+                    );
                 }
             };
         }
@@ -289,74 +290,66 @@ impl PyStreamingFeatherWriter {
         // Try to convert from common pyo3 data types
         if let Ok(quote) = data.extract::<QuoteTick>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Quote(quote)).await })
+            return block_on_python_future(async { writer.write_data(Data::Quote(quote)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write QuoteTick: {e}")));
         }
 
         if let Ok(trade) = data.extract::<TradeTick>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Trade(trade)).await })
+            return block_on_python_future(async { writer.write_data(Data::Trade(trade)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write TradeTick: {e}")));
         }
 
         if let Ok(bar) = data.extract::<Bar>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Bar(bar)).await })
+            return block_on_python_future(async { writer.write_data(Data::Bar(bar)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write Bar: {e}")));
         }
 
         if let Ok(delta) = data.extract::<OrderBookDelta>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Delta(delta)).await })
+            return block_on_python_future(async { writer.write_data(Data::Delta(delta)).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write OrderBookDelta: {e}")));
         }
 
         if let Ok(depth) = data.extract::<OrderBookDepth10>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::Depth10(Box::new(depth))).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write OrderBookDepth10: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::Depth10(Box::new(depth))).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write OrderBookDepth10: {e}")));
         }
 
         if let Ok(price) = data.extract::<IndexPriceUpdate>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::IndexPrice(price)).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write IndexPriceUpdate: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::IndexPrice(price)).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write IndexPriceUpdate: {e}")));
         }
 
         if let Ok(price) = data.extract::<MarkPriceUpdate>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::MarkPrice(price)).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write MarkPriceUpdate: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::MarkPrice(price)).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write MarkPriceUpdate: {e}")));
         }
 
         if let Ok(greeks) = data.extract::<OptionGreeks>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::OptionGreeks(greeks)).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write OptionGreeks: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::OptionGreeks(greeks)).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write OptionGreeks: {e}")));
         }
 
         if let Ok(close) = data.extract::<InstrumentClose>(py) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_data(Data::InstrumentClose(close)).await })
-                .map_err(|e| PyIOError::new_err(format!("Failed to write InstrumentClose: {e}")));
+            return block_on_python_future(async {
+                writer.write_data(Data::InstrumentClose(close)).await
+            })
+            .map_err(|e| PyIOError::new_err(format!("Failed to write InstrumentClose: {e}")));
         }
 
         try_write!(FundingRateUpdate, "FundingRateUpdate");
@@ -393,9 +386,7 @@ impl PyStreamingFeatherWriter {
         // Try instrument types (uses type_str attribute for dispatch)
         if let Ok(instrument) = pyobject_to_instrument_any(py, data.clone_ref(py)) {
             let mut writer = self.writer.borrow_mut();
-            let runtime = get_runtime();
-            return runtime
-                .block_on(async { writer.write_instrument(instrument).await })
+            return block_on_python_future(async { writer.write_instrument(instrument).await })
                 .map_err(|e| PyIOError::new_err(format!("Failed to write instrument: {e}")));
         }
 
@@ -410,10 +401,8 @@ impl PyStreamingFeatherWriter {
     /// be called manually by the client.
     pub fn flush(&self) -> PyResult<()> {
         let mut writer = self.writer.borrow_mut();
-        let runtime = get_runtime();
 
-        runtime
-            .block_on(async { writer.flush().await })
+        block_on_python_future(async { writer.flush().await })
             .map_err(|e| PyIOError::new_err(format!("Failed to flush: {e}")))
     }
 
@@ -422,10 +411,8 @@ impl PyStreamingFeatherWriter {
     /// After calling this, no further writes should be performed.
     pub fn close(&self) -> PyResult<()> {
         let mut writer = self.writer.borrow_mut();
-        let runtime = get_runtime();
 
-        runtime
-            .block_on(async { writer.close().await })
+        block_on_python_future(async { writer.close().await })
             .map_err(|e| PyIOError::new_err(format!("Failed to close: {e}")))
     }
 

--- a/crates/persistence/tests/test_catalog.rs
+++ b/crates/persistence/tests/test_catalog.rs
@@ -32,13 +32,13 @@ use nautilus_model::{
     identifiers::{AccountId, InstrumentId, Symbol, TradeId},
     instruments::{
         CryptoPerpetual, CurrencyPair, Instrument, InstrumentAny,
-        stubs::{audusd_sim, equity_aapl},
+        stubs::{audusd_sim, binary_option, equity_aapl},
     },
     types::{AccountBalance, Currency, MarginBalance, Money, Price, Quantity},
 };
 use nautilus_persistence::{
     backend::{
-        catalog::ParquetDataCatalog,
+        catalog::{ParquetDataCatalog, urisafe_instrument_id},
         session::{DataBackendSession, QueryResult},
     },
     test_data::{
@@ -46,7 +46,10 @@ use nautilus_persistence::{
         RustTestHashMapCustomData, RustTestParamsCustomData, RustTestPriceMapCustomData,
     },
 };
-use nautilus_serialization::{arrow::ArrowSchemaProvider, ensure_custom_data_registered};
+use nautilus_serialization::{
+    arrow::{ArrowSchemaProvider, EncodeToRecordBatch},
+    ensure_custom_data_registered,
+};
 use nautilus_testkit::common::get_nautilus_test_data_file_path;
 use object_store::local::LocalFileSystem;
 use rstest::rstest;
@@ -4613,6 +4616,43 @@ fn test_convert_stream_to_data_unknown_type_with_files_errors() {
             .contains("Unknown data class"),
         "Should error once unknown stream files are present",
     );
+}
+
+#[rstest]
+fn test_convert_stream_to_data_writes_queryable_binary_option_instrument() {
+    use arrow::ipc::writer::StreamWriter;
+
+    let (temp_dir, mut catalog) = create_temp_catalog();
+    let mut binary = binary_option();
+    binary.id = InstrumentId::from("BINARY-OPTION.POLYMARKET");
+    let instrument = InstrumentAny::BinaryOption(binary);
+    let instrument_id = instrument.id().to_string();
+    let safe_instrument_id = urisafe_instrument_id(&instrument_id);
+    let feather_dir = temp_dir
+        .path()
+        .join("live")
+        .join("test_instance")
+        .join("instruments")
+        .join(&safe_instrument_id);
+    fs::create_dir_all(&feather_dir).unwrap();
+
+    let metadata = InstrumentAny::metadata(&instrument);
+    let schema = InstrumentAny::get_schema(Some(metadata.clone()));
+    let batch = InstrumentAny::encode_batch(&metadata, std::slice::from_ref(&instrument)).unwrap();
+    let feather_path = feather_dir.join(format!("{safe_instrument_id}_0.feather"));
+    let mut feather_file = fs::File::create(feather_path).unwrap();
+    let mut writer = StreamWriter::try_new(&mut feather_file, &schema).unwrap();
+    writer.write(&batch).unwrap();
+    writer.finish().unwrap();
+
+    catalog
+        .convert_stream_to_data("test_instance", "instruments", Some("live"), None, false)
+        .unwrap();
+
+    let decoded = catalog
+        .query_instruments(Some(std::slice::from_ref(&instrument_id)))
+        .unwrap();
+    assert_eq!(decoded, vec![instrument]);
 }
 
 #[rstest]

--- a/crates/persistence/tests/test_feather.rs
+++ b/crates/persistence/tests/test_feather.rs
@@ -16,7 +16,10 @@
 use std::{cell::RefCell, collections::HashSet, fs::File, rc::Rc, sync::Arc};
 
 use datafusion::arrow::ipc::reader::StreamReader;
-use nautilus_common::clock::{Clock, TestClock};
+use nautilus_common::{
+    clock::{Clock, TestClock},
+    msgbus::{self, MessageBus, typed_handler::ShareableMessageHandler},
+};
 use nautilus_core::UnixNanos;
 use nautilus_model::{
     data::{
@@ -30,6 +33,92 @@ use nautilus_persistence::backend::feather::{FeatherWriter, RotationConfig};
 use object_store::{ObjectStore, local::LocalFileSystem};
 use rstest::rstest;
 use tempfile::TempDir;
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_direct_writer_lifecycle_inside_multi_thread_runtime() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_path = temp_dir.path().to_str().unwrap().to_string();
+    let local_fs = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(local_fs);
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let mut writer = FeatherWriter::new(
+        base_path,
+        store,
+        clock,
+        RotationConfig::NoRotation,
+        Some(HashSet::from(["quotes".to_string()])),
+        None,
+        None,
+    );
+    let quote = QuoteTick::new(
+        InstrumentId::from("AUD/USD.SIM"),
+        Price::from("1.00001"),
+        Price::from("1.00002"),
+        Quantity::from("1000"),
+        Quantity::from("1001"),
+        UnixNanos::from(1_000),
+        UnixNanos::from(1_000),
+    );
+
+    writer.write(quote).await.unwrap();
+    writer.flush().await.unwrap();
+    writer.close().await.unwrap();
+
+    assert!(writer.is_closed());
+    assert_eq!(collect_feather_files(temp_dir.path()).len(), 1);
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[expect(
+    clippy::await_holding_refcell_ref,
+    reason = "The message-bus writer is single-threaded and the test awaits its final close before reading files"
+)]
+async fn test_legacy_message_bus_subscription_persists_any_route_and_unsubscribes() {
+    let _bus = MessageBus::default().register_message_bus();
+    let temp_dir = TempDir::new().unwrap();
+    let base_path = temp_dir.path().to_str().unwrap().to_string();
+    let local_fs = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(local_fs);
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let writer = Rc::new(RefCell::new(FeatherWriter::new(
+        base_path,
+        store,
+        clock,
+        RotationConfig::NoRotation,
+        Some(HashSet::from(["quotes".to_string()])),
+        None,
+        None,
+    )));
+    let quote = QuoteTick::new(
+        InstrumentId::from("AUD/USD.SIM"),
+        Price::from("1.00001"),
+        Price::from("1.00002"),
+        Quantity::from("1000"),
+        Quantity::from("1001"),
+        UnixNanos::from(1_000),
+        UnixNanos::from(1_000),
+    );
+
+    let handler: ShareableMessageHandler =
+        FeatherWriter::subscribe_to_message_bus(Rc::clone(&writer)).unwrap();
+    msgbus::publish_any("data.quotes.AUD/USD.SIM".into(), &quote);
+    FeatherWriter::unsubscribe_from_message_bus(&handler);
+    msgbus::publish_any("data.quotes.AUD/USD.SIM".into(), &quote);
+    writer.borrow_mut().close().await.unwrap();
+
+    let files = collect_feather_files(temp_dir.path());
+    assert_eq!(files.len(), 1);
+    let row_count: usize = StreamReader::try_new(File::open(&files[0]).unwrap(), None)
+        .unwrap()
+        .map(|batch| batch.unwrap().num_rows())
+        .sum();
+    assert_eq!(
+        row_count, 1,
+        "legacy unsubscribe must prevent the second write"
+    );
+}
 
 #[rstest]
 #[tokio::test]

--- a/crates/persistence/tests/test_feather.rs
+++ b/crates/persistence/tests/test_feather.rs
@@ -20,16 +20,31 @@ use nautilus_common::{
     clock::{Clock, TestClock},
     msgbus::{self, MessageBus, typed_handler::ShareableMessageHandler},
 };
-use nautilus_core::UnixNanos;
+use nautilus_core::{UUID4, UnixNanos};
 use nautilus_model::{
     data::{
-        BookOrder, Data, FundingRateUpdate, OrderBookDelta, OrderBookDeltas, QuoteTick, TradeTick,
+        BookOrder, Data, FundingRateUpdate, InstrumentClose, InstrumentStatus, OrderBookDelta,
+        OrderBookDeltas, QuoteTick, TradeTick,
     },
-    enums::{AggressorSide, BookAction, OrderSide},
-    identifiers::{InstrumentId, TradeId},
-    types::{Price, Quantity},
+    enums::{
+        AccountType, AggressorSide, BookAction, InstrumentCloseType, MarketStatusAction, OrderSide,
+        PositionSide,
+    },
+    events::{
+        AccountState, OrderEventAny, PositionEvent, PositionOpened, order::spec::OrderFilledSpec,
+    },
+    identifiers::{
+        AccountId, ClientOrderId, InstrumentId, PositionId, StrategyId, TradeId, TraderId,
+        VenueOrderId,
+    },
+    instruments::{Instrument, InstrumentAny, stubs::binary_option},
+    types::{Currency, Money, Price, Quantity},
 };
-use nautilus_persistence::backend::feather::{FeatherWriter, RotationConfig};
+use nautilus_persistence::backend::{
+    catalog::ParquetDataCatalog,
+    feather::{FeatherWriter, RotationConfig},
+};
+use nautilus_serialization::arrow::instrument::decode_instrument_any_batch;
 use object_store::{ObjectStore, local::LocalFileSystem};
 use rstest::rstest;
 use tempfile::TempDir;
@@ -117,6 +132,252 @@ async fn test_legacy_message_bus_subscription_persists_any_route_and_unsubscribe
     assert_eq!(
         row_count, 1,
         "legacy unsubscribe must prevent the second write"
+    );
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[expect(
+    clippy::await_holding_refcell_ref,
+    reason = "The message-bus writer is single-threaded and the test awaits its final close before reading files"
+)]
+async fn test_all_routes_subscription_persists_and_converts_typed_publications() {
+    let _bus = MessageBus::default().register_message_bus();
+    let temp_dir = TempDir::new().unwrap();
+    let local_fs = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(local_fs);
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let writer = Rc::new(RefCell::new(FeatherWriter::new(
+        "live/test_instance".to_string(),
+        store,
+        clock,
+        RotationConfig::NoRotation,
+        Some(HashSet::from([
+            "instrument_closes".to_string(),
+            "instrument_status".to_string(),
+            "instruments".to_string(),
+            "account_state".to_string(),
+            "order_book_deltas".to_string(),
+            "order_filled".to_string(),
+            "position_opened".to_string(),
+            "quotes".to_string(),
+            "trades".to_string(),
+        ])),
+        Some(HashSet::from([
+            "instrument_closes".to_string(),
+            "instrument_status".to_string(),
+            "instruments".to_string(),
+        ])),
+        None,
+    )));
+
+    let subscription = FeatherWriter::subscribe_to_all_message_bus_routes(&writer);
+    let mut binary = binary_option();
+    binary.id = InstrumentId::from("BINARY-OPTION.POLYMARKET");
+    let instrument = InstrumentAny::BinaryOption(binary);
+    let instrument_id = instrument.id();
+    let quote = QuoteTick::new(
+        instrument_id,
+        Price::from("1.00001"),
+        Price::from("1.00002"),
+        Quantity::from("1000"),
+        Quantity::from("1001"),
+        UnixNanos::from(1_000),
+        UnixNanos::from(1_000),
+    );
+    let trade = TradeTick::new(
+        instrument_id,
+        Price::from("1.00001"),
+        Quantity::from("1000"),
+        AggressorSide::Buy,
+        TradeId::from("1"),
+        UnixNanos::from(2_000),
+        UnixNanos::from(2_000),
+    );
+    let deltas = OrderBookDeltas::new(
+        instrument_id,
+        vec![OrderBookDelta::clear(
+            instrument_id,
+            0,
+            UnixNanos::from(3_000),
+            UnixNanos::from(3_000),
+        )],
+    );
+    let status = InstrumentStatus::new(
+        instrument_id,
+        MarketStatusAction::Trading,
+        UnixNanos::from(4_000),
+        UnixNanos::from(4_000),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let close = InstrumentClose::new(
+        instrument_id,
+        Price::from("1.00001"),
+        InstrumentCloseType::EndOfSession,
+        UnixNanos::from(5_000),
+        UnixNanos::from(5_000),
+    );
+    let account_state = AccountState::new(
+        AccountId::from("SIM-001"),
+        AccountType::Cash,
+        Vec::new(),
+        Vec::new(),
+        true,
+        UUID4::new(),
+        UnixNanos::from(6_000),
+        UnixNanos::from(6_000),
+        Some(Currency::USD()),
+    );
+    let order_event = OrderEventAny::Filled(
+        OrderFilledSpec::builder()
+            .trader_id(TraderId::from("TRADER-001"))
+            .strategy_id(StrategyId::from("STRATEGY-001"))
+            .instrument_id(instrument_id)
+            .client_order_id(ClientOrderId::from("O-001"))
+            .venue_order_id(VenueOrderId::from("V-001"))
+            .account_id(AccountId::from("SIM-001"))
+            .trade_id(TradeId::from("T-001"))
+            .last_qty(Quantity::from("1"))
+            .last_px(Price::from("1.00001"))
+            .currency(Currency::USD())
+            .commission(Money::new(0.0, Currency::USD()))
+            .ts_event(UnixNanos::from(7_000))
+            .ts_init(UnixNanos::from(7_000))
+            .build(),
+    );
+    let position_event = PositionEvent::PositionOpened(PositionOpened {
+        trader_id: TraderId::from("TRADER-001"),
+        strategy_id: StrategyId::from("STRATEGY-001"),
+        instrument_id,
+        position_id: PositionId::from("P-001"),
+        account_id: AccountId::from("SIM-001"),
+        opening_order_id: ClientOrderId::from("O-001"),
+        entry: OrderSide::Buy,
+        side: PositionSide::Long,
+        signed_qty: 1.0,
+        quantity: Quantity::from("1"),
+        last_qty: Quantity::from("1"),
+        last_px: Price::from("1.00001"),
+        currency: Currency::USD(),
+        avg_px_open: 1.00001,
+        realized_pnl: None,
+        event_id: UUID4::new(),
+        ts_event: UnixNanos::from(8_000),
+        ts_init: UnixNanos::from(8_000),
+    });
+
+    msgbus::publish_instrument("data.instrument.AUD/USD.SIM".into(), &instrument);
+    msgbus::publish_deltas("data.book.deltas.AUD/USD.SIM".into(), &deltas);
+    msgbus::publish_quote("data.quotes.AUD/USD.SIM".into(), &quote);
+    msgbus::publish_trade("data.trades.AUD/USD.SIM".into(), &trade);
+    msgbus::publish_any("data.status.AUD/USD.SIM".into(), &status);
+    msgbus::publish_any("data.close.AUD/USD.SIM".into(), &close);
+    msgbus::publish_account_state("events.account.SIM-001".into(), &account_state);
+    msgbus::publish_order_event("events.order.TRADER-001".into(), &order_event);
+    msgbus::publish_position_event("events.position.STRATEGY-001".into(), &position_event);
+    subscription.unsubscribe();
+    msgbus::publish_instrument("data.instrument.AUD/USD.SIM".into(), &instrument);
+    msgbus::publish_deltas("data.book.deltas.AUD/USD.SIM".into(), &deltas);
+    msgbus::publish_quote("data.quotes.AUD/USD.SIM".into(), &quote);
+    msgbus::publish_trade("data.trades.AUD/USD.SIM".into(), &trade);
+    msgbus::publish_any("data.status.AUD/USD.SIM".into(), &status);
+    msgbus::publish_any("data.close.AUD/USD.SIM".into(), &close);
+    msgbus::publish_account_state("events.account.SIM-001".into(), &account_state);
+    msgbus::publish_order_event("events.order.TRADER-001".into(), &order_event);
+    msgbus::publish_position_event("events.position.STRATEGY-001".into(), &position_event);
+    writer.borrow_mut().close().await.unwrap();
+
+    let files = collect_feather_files(temp_dir.path());
+    assert_eq!(files.len(), 9, "expected one file per data type");
+    let instrument_file = files
+        .iter()
+        .find(|path| {
+            path.components()
+                .any(|component| component.as_os_str() == "instruments")
+        })
+        .expect("missing per-instrument definition file");
+    let mut instrument_reader =
+        StreamReader::try_new(File::open(instrument_file).unwrap(), None).unwrap();
+    let metadata = instrument_reader.schema().metadata().clone();
+    let instrument_batch = instrument_reader.next().unwrap().unwrap();
+    let decoded = decode_instrument_any_batch(&metadata, &instrument_batch).unwrap();
+    assert_eq!(decoded, vec![instrument.clone()]);
+
+    let row_count: usize = files
+        .iter()
+        .map(|path| {
+            StreamReader::try_new(File::open(path).unwrap(), None)
+                .unwrap()
+                .map(|batch| batch.unwrap().num_rows())
+                .sum::<usize>()
+        })
+        .sum();
+    assert_eq!(row_count, 9, "unsubscribe must remove every route");
+
+    let mut catalog = ParquetDataCatalog::new(temp_dir.path(), None, None, None, None);
+    catalog
+        .convert_stream_to_data("test_instance", "instruments", Some("live"), None, false)
+        .unwrap();
+    let instrument_id = instrument_id.to_string();
+    assert_eq!(
+        catalog
+            .query_instruments(Some(std::slice::from_ref(&instrument_id)))
+            .unwrap(),
+        vec![instrument],
+    );
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[expect(
+    clippy::await_holding_refcell_ref,
+    reason = "The message-bus writer is single-threaded and the test awaits its final close before reading files"
+)]
+async fn test_all_routes_subscription_unsubscribes_on_drop() {
+    let _bus = MessageBus::default().register_message_bus();
+    let temp_dir = TempDir::new().unwrap();
+    let local_fs = LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(local_fs);
+    let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+    let writer = Rc::new(RefCell::new(FeatherWriter::new(
+        "live/test_instance".to_string(),
+        store,
+        clock,
+        RotationConfig::NoRotation,
+        Some(HashSet::from(["quotes".to_string()])),
+        None,
+        None,
+    )));
+    let quote = QuoteTick::new(
+        InstrumentId::from("AUD/USD.SIM"),
+        Price::from("1.00001"),
+        Price::from("1.00002"),
+        Quantity::from("1000"),
+        Quantity::from("1001"),
+        UnixNanos::from(1_000),
+        UnixNanos::from(1_000),
+    );
+
+    {
+        let _subscription = FeatherWriter::subscribe_to_all_message_bus_routes(&writer);
+        msgbus::publish_quote("data.quotes.AUD/USD.SIM".into(), &quote);
+    }
+    msgbus::publish_quote("data.quotes.AUD/USD.SIM".into(), &quote);
+    writer.borrow_mut().close().await.unwrap();
+
+    let files = collect_feather_files(temp_dir.path());
+    assert_eq!(files.len(), 1);
+    let row_count: usize = StreamReader::try_new(File::open(&files[0]).unwrap(), None)
+        .unwrap()
+        .map(|batch| batch.unwrap().num_rows())
+        .sum();
+    assert_eq!(
+        row_count, 1,
+        "dropping the subscription must unsubscribe every route"
     );
 }
 

--- a/python/tests/unit/persistence/test_persistence.py
+++ b/python/tests/unit/persistence/test_persistence.py
@@ -34,7 +34,11 @@ from nautilus_trader.model import BookOrder
 from nautilus_trader.model import CurrencyPair
 from nautilus_trader.model import FundingRateUpdate
 from nautilus_trader.model import IndexPriceUpdate
+from nautilus_trader.model import InstrumentClose
+from nautilus_trader.model import InstrumentCloseType
 from nautilus_trader.model import InstrumentId
+from nautilus_trader.model import InstrumentStatus
+from nautilus_trader.model import MarketStatusAction
 from nautilus_trader.model import MarkPriceUpdate
 from nautilus_trader.model import OrderBookDelta
 from nautilus_trader.model import OrderBookDepth10
@@ -669,6 +673,57 @@ def test_streaming_feather_writer_uses_per_instrument_paths(
     assert table.schema.metadata[b"instrument_id"] == str(instrument_id).encode()
     for key, value in expected_metadata.items():
         assert table.schema.metadata[key] == value
+
+
+@pytest.mark.parametrize(
+    ("data_name", "event"),
+    [
+        (
+            "instrument_status",
+            InstrumentStatus(AUDUSD_SIM, MarketStatusAction.TRADING, 1_000, 1_001),
+        ),
+        (
+            "instrument_closes",
+            InstrumentClose(
+                AUDUSD_SIM,
+                Price.from_str("1.00001"),
+                InstrumentCloseType.END_OF_SESSION,
+                2_000,
+                2_001,
+            ),
+        ),
+    ],
+)
+def test_streaming_feather_writer_status_and_close_catalog_round_trip(
+    tmp_path,
+    data_name,
+    event,
+):
+    instance_id = "test_instance"
+    stream_path = tmp_path / "live" / instance_id
+    stream_path.mkdir(parents=True)
+    writer = StreamingFeatherWriter(
+        path=str(stream_path),
+        cache=Cache(),
+        clock=Clock.new_test(),
+        include_types=[data_name],
+        flush_interval_ms=0,
+    )
+
+    writer.write(event)
+    writer.close()
+
+    files = list((stream_path / data_name).glob("*/*.feather"))
+    assert len(files) == 1
+    with files[0].open("rb") as stream:
+        table = pa.ipc.open_stream(stream).read_all()
+    assert table.schema.metadata is not None
+    assert table.schema.metadata[b"instrument_id"] == str(AUDUSD_SIM).encode()
+
+    catalog = ParquetDataCatalog(str(tmp_path))
+    catalog.convert_stream_to_data(instance_id, data_name, subdirectory="live")
+
+    assert catalog.query(data_name, identifiers=[str(AUDUSD_SIM)]) == [event]
 
 
 def test_streaming_feather_writer_replace_removes_local_files(tmp_path):


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed
- [x] I ran all relevant tests locally
- [x] I have not modified `RELEASES.md`

## Summary

This adds a separate all-routes subscription for `StreamingFeatherWriter`.

It records live market, account, order, and position data from message-bus routes that the old wildcard handler does not receive. Stopping or dropping the subscription removes every handler. The existing Rust subscription API is unchanged.

## Related issues/PRs

Closes #4845.

This is a stacked PR. It targets `fix/feather-runtime-safety`.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Ran focused Rust Feather and catalog tests, plus Python persistence tests.

The tests confirm that typed live messages are written to Feather, convert to queryable Parquet, and stop writing after unsubscribe or drop. `cargo check`, Clippy, `make format`, and `make pre-commit` also passed.