### PR TITLE
Fix IBKR restored-order cancel routing

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -1617,6 +1617,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         let client = self.ib_client.as_ref().context("IB client not connected")?;
 
         let order_id_map = Arc::clone(&self.order_id_map);
+        let venue_order_id_map = Arc::clone(&self.venue_order_id_map);
         let instrument_id_map = Arc::clone(&self.instrument_id_map);
         let trader_id_map = Arc::clone(&self.trader_id_map);
         let strategy_id_map = Arc::clone(&self.strategy_id_map);
@@ -1632,6 +1633,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                 &cmd,
                 &client_clone,
                 &order_id_map,
+                &venue_order_id_map,
                 &instrument_id_map,
                 &trader_id_map,
                 &strategy_id_map,
@@ -2056,6 +2058,7 @@ impl InteractiveBrokersExecutionClient {
         cmd: &CancelOrder,
         client: &Arc<Client>,
         order_id_map: &Arc<Mutex<AHashMap<ClientOrderId, i32>>>,
+        venue_order_id_map: &Arc<Mutex<AHashMap<i32, ClientOrderId>>>,
         instrument_id_map: &Arc<Mutex<AHashMap<i32, InstrumentId>>>,
         trader_id_map: &Arc<Mutex<AHashMap<i32, TraderId>>>,
         strategy_id_map: &Arc<Mutex<AHashMap<i32, StrategyId>>>,
@@ -2079,6 +2082,15 @@ impl InteractiveBrokersExecutionClient {
         let ib_order_id =
             Self::resolve_ib_order_id(client, order_selector, account_id, request_timeout_secs)
                 .await?;
+        Self::cache_cancel_order_tracking(
+            ib_order_id,
+            cmd,
+            order_id_map,
+            venue_order_id_map,
+            instrument_id_map,
+            trader_id_map,
+            strategy_id_map,
+        )?;
 
         if let Err(e) = client.cancel_order(ib_order_id, "").await {
             tracing::error!(

--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -1615,6 +1615,26 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         }
 
         let client = self.ib_client.as_ref().context("IB client not connected")?;
+        let exec_sender = get_exec_event_sender();
+        let clock = get_atomic_clock_realtime();
+        let account_id = self.core.account_id;
+        let target_order = match self.core.get_order(&cmd.client_order_id).and_then(|order| {
+            Self::validate_cancel_order_target(&cmd, &order)?;
+            Ok(order)
+        }) {
+            Ok(order) => Arc::new(order),
+            Err(e) => {
+                let reason = format!("Failed to resolve cancel order target: {e:#}");
+                Self::send_order_cancel_rejected(
+                    &cmd,
+                    &reason,
+                    &exec_sender,
+                    clock.get_time_ns(),
+                    account_id,
+                )?;
+                return Ok(());
+            }
+        };
 
         let order_id_map = Arc::clone(&self.order_id_map);
         let venue_order_id_map = Arc::clone(&self.venue_order_id_map);
@@ -1622,15 +1642,13 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         let trader_id_map = Arc::clone(&self.trader_id_map);
         let strategy_id_map = Arc::clone(&self.strategy_id_map);
         let pending_cancel_orders = Arc::clone(&self.pending_cancel_orders);
-        let exec_sender = get_exec_event_sender();
-        let clock = get_atomic_clock_realtime();
-        let account_id = self.core.account_id;
         let client_clone = client.as_arc().clone();
         let request_timeout_secs = self.config.request_timeout;
 
         let handle = get_runtime().spawn(async move {
             if let Err(e) = Self::handle_cancel_order_async(
                 &cmd,
+                &target_order,
                 &client_clone,
                 &order_id_map,
                 &venue_order_id_map,
@@ -2049,13 +2067,44 @@ impl InteractiveBrokersExecutionClient {
         );
     }
 
-    /// Handles cancel all orders asynchronously.
+    fn validate_cancel_order_target(
+        cmd: &CancelOrder,
+        target_order: &OrderAny,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            cmd.client_order_id == target_order.client_order_id(),
+            "command client order ID {} does not match cached order {}",
+            cmd.client_order_id,
+            target_order.client_order_id()
+        );
+        anyhow::ensure!(
+            cmd.instrument_id == target_order.instrument_id(),
+            "command instrument ID {} does not match cached order {}",
+            cmd.instrument_id,
+            target_order.instrument_id()
+        );
+
+        // Command actor IDs identify the requester and are not ownership evidence.
+        if let (Some(command_venue_order_id), Some(target_venue_order_id)) =
+            (cmd.venue_order_id.as_ref(), target_order.venue_order_id())
+        {
+            anyhow::ensure!(
+                command_venue_order_id == &target_venue_order_id,
+                "command venue order ID {command_venue_order_id} does not match cached order {target_venue_order_id}"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Handles cancel order asynchronously.
     ///
     /// # Errors
     ///
-    /// Returns an error if the global cancel request fails.
+    /// Returns an error if broker order resolution or identity caching fails.
     async fn handle_cancel_order_async(
         cmd: &CancelOrder,
+        target_order: &OrderAny,
         client: &Arc<Client>,
         order_id_map: &Arc<Mutex<AHashMap<ClientOrderId, i32>>>,
         venue_order_id_map: &Arc<Mutex<AHashMap<i32, ClientOrderId>>>,
@@ -2085,6 +2134,7 @@ impl InteractiveBrokersExecutionClient {
         Self::cache_cancel_order_tracking(
             ib_order_id,
             cmd,
+            target_order,
             order_id_map,
             venue_order_id_map,
             instrument_id_map,

--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -1603,38 +1603,35 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
     }
 
     fn cancel_order(&self, cmd: CancelOrder) -> anyhow::Result<()> {
+        let target_order = Arc::new(self.core.get_order(&cmd.client_order_id)?);
+        let exec_sender = get_exec_event_sender();
+        let clock = get_atomic_clock_realtime();
+        let account_id = self.core.account_id;
+
+        if let Err(e) = Self::validate_cancel_order_target(&cmd, &target_order) {
+            let reason = format!("Failed to resolve cancel order target: {e:#}");
+            Self::send_order_cancel_rejected(
+                &target_order,
+                &reason,
+                &exec_sender,
+                clock.get_time_ns(),
+                account_id,
+            )?;
+            return Ok(());
+        }
+
         if let Err(reason) = self.ensure_client_ready_for_order_request("cancel order") {
             Self::send_order_cancel_rejected(
-                &cmd,
+                &target_order,
                 &reason,
-                &get_exec_event_sender(),
-                get_atomic_clock_realtime().get_time_ns(),
-                self.core.account_id,
+                &exec_sender,
+                clock.get_time_ns(),
+                account_id,
             )?;
             return Ok(());
         }
 
         let client = self.ib_client.as_ref().context("IB client not connected")?;
-        let exec_sender = get_exec_event_sender();
-        let clock = get_atomic_clock_realtime();
-        let account_id = self.core.account_id;
-        let target_order = match self.core.get_order(&cmd.client_order_id).and_then(|order| {
-            Self::validate_cancel_order_target(&cmd, &order)?;
-            Ok(order)
-        }) {
-            Ok(order) => Arc::new(order),
-            Err(e) => {
-                let reason = format!("Failed to resolve cancel order target: {e:#}");
-                Self::send_order_cancel_rejected(
-                    &cmd,
-                    &reason,
-                    &exec_sender,
-                    clock.get_time_ns(),
-                    account_id,
-                )?;
-                return Ok(());
-            }
-        };
 
         let order_id_map = Arc::clone(&self.order_id_map);
         let venue_order_id_map = Arc::clone(&self.venue_order_id_map);
@@ -1666,7 +1663,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                 let reason = format!("Failed to route cancel order to IB: {e:#}");
 
                 if let Err(send_error) = Self::send_order_cancel_rejected(
-                    &cmd,
+                    &target_order,
                     &reason,
                     &exec_sender,
                     clock.get_time_ns(),
@@ -1723,30 +1720,32 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
                 .collect();
 
             if orders_to_cancel.is_empty() {
-                let instrument_id_map = self
-                    .instrument_id_map
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("Failed to lock instrument ID map"))?;
+                let ib_order_ids: Vec<i32> = {
+                    let instrument_id_map = self
+                        .instrument_id_map
+                        .lock()
+                        .map_err(|_| anyhow::anyhow!("Failed to lock instrument ID map"))?;
+                    instrument_id_map
+                        .iter()
+                        .filter_map(|(order_id, instrument_id)| {
+                            (*instrument_id == cmd.instrument_id).then_some(*order_id)
+                        })
+                        .collect()
+                };
 
                 let venue_map = self
                     .venue_order_id_map
                     .lock()
                     .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?;
 
-                orders_to_cancel.extend(instrument_id_map.iter().filter_map(
-                    |(order_id, instrument_id)| {
-                        (*instrument_id == cmd.instrument_id)
-                            .then_some(*order_id)
-                            .and_then(|ib_order_id| {
-                                venue_map.get(&ib_order_id).copied().map(|client_order_id| {
-                                    (
-                                        client_order_id,
-                                        Some(VenueOrderId::from(ib_order_id.to_string())),
-                                    )
-                                })
-                            })
-                    },
-                ));
+                orders_to_cancel.extend(ib_order_ids.into_iter().filter_map(|ib_order_id| {
+                    venue_map.get(&ib_order_id).copied().map(|client_order_id| {
+                        (
+                            client_order_id,
+                            Some(VenueOrderId::from(ib_order_id.to_string())),
+                        )
+                    })
+                }));
             }
 
             orders_to_cancel.sort_by_key(|(client_order_id, _)| client_order_id.to_string());
@@ -1920,23 +1919,23 @@ impl InteractiveBrokersExecutionClient {
     }
 
     fn send_order_cancel_rejected(
-        cmd: &CancelOrder,
+        target_order: &OrderAny,
         reason: &str,
         exec_sender: &tokio::sync::mpsc::UnboundedSender<ExecutionEvent>,
         ts_event: UnixNanos,
         account_id: AccountId,
     ) -> anyhow::Result<()> {
         let event = OrderCancelRejected::new(
-            cmd.trader_id,
-            cmd.strategy_id,
-            cmd.instrument_id,
-            cmd.client_order_id,
+            target_order.trader_id(),
+            target_order.strategy_id(),
+            target_order.instrument_id(),
+            target_order.client_order_id(),
             Ustr::from(reason),
             UUID4::new(),
             ts_event,
             ts_event,
             false,
-            cmd.venue_order_id,
+            target_order.venue_order_id(),
             Some(account_id),
         );
         exec_sender
@@ -2084,7 +2083,7 @@ impl InteractiveBrokersExecutionClient {
             target_order.instrument_id()
         );
 
-        // Command actor IDs identify the requester and are not ownership evidence.
+        // Command actor IDs identify the requester and are not ownership evidence
         if let (Some(command_venue_order_id), Some(target_venue_order_id)) =
             (cmd.venue_order_id.as_ref(), target_order.venue_order_id())
         {
@@ -2150,9 +2149,13 @@ impl InteractiveBrokersExecutionClient {
             return Ok(());
         }
 
+        let venue_order_id = target_order
+            .venue_order_id()
+            .unwrap_or_else(|| VenueOrderId::from(ib_order_id.to_string()));
         if let Err(e) = Self::emit_order_pending_cancel(
             ib_order_id,
             cmd.client_order_id,
+            venue_order_id,
             instrument_id_map,
             trader_id_map,
             strategy_id_map,
@@ -2260,7 +2263,7 @@ impl InteractiveBrokersExecutionClient {
         orders_to_cancel: Vec<(ClientOrderId, Option<VenueOrderId>)>,
     ) -> anyhow::Result<()> {
         // Get all IB order selectors first, then drop the guard before awaiting
-        let order_selectors: Vec<(ClientOrderId, IbOrderSelector)> = {
+        let order_selectors: Vec<(ClientOrderId, IbOrderSelector, Option<VenueOrderId>)> = {
             let order_id_map_guard = order_id_map
                 .lock()
                 .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?;
@@ -2270,7 +2273,9 @@ impl InteractiveBrokersExecutionClient {
                 .filter_map(|(client_order_id, venue_order_id)| {
                     if let Some(venue_order_id) = venue_order_id {
                         match IbOrderSelector::from_venue_order_id(&venue_order_id) {
-                            Ok(order_selector) => return Some((client_order_id, order_selector)),
+                            Ok(order_selector) => {
+                                return Some((client_order_id, order_selector, Some(venue_order_id)));
+                            }
                             Err(e) => {
                                 tracing::error!(
                                     "Failed resolve cancel-all order {} from venue order ID {}: {e}",
@@ -2285,13 +2290,19 @@ impl InteractiveBrokersExecutionClient {
                     order_id_map_guard
                         .get(&client_order_id)
                         .copied()
-                        .map(|ib_order_id| (client_order_id, IbOrderSelector::OrderId(ib_order_id)))
+                        .map(|ib_order_id| {
+                            (
+                                client_order_id,
+                                IbOrderSelector::OrderId(ib_order_id),
+                                None,
+                            )
+                        })
                 })
                 .collect()
         };
 
         // Now cancel each order (guard is dropped, so we can await)
-        for (client_order_id, order_selector) in order_selectors {
+        for (client_order_id, order_selector, venue_order_id) in order_selectors {
             let ib_order_id = match Self::resolve_ib_order_id(
                 client,
                 order_selector,
@@ -2306,6 +2317,8 @@ impl InteractiveBrokersExecutionClient {
                     continue;
                 }
             };
+            let venue_order_id =
+                venue_order_id.unwrap_or_else(|| VenueOrderId::from(ib_order_id.to_string()));
 
             if let Err(e) = client.cancel_order(ib_order_id, "").await {
                 tracing::error!(
@@ -2317,6 +2330,7 @@ impl InteractiveBrokersExecutionClient {
                 if let Err(e) = Self::emit_order_pending_cancel(
                     ib_order_id,
                     client_order_id,
+                    venue_order_id,
                     instrument_id_map,
                     trader_id_map,
                     strategy_id_map,
@@ -2348,6 +2362,7 @@ impl InteractiveBrokersExecutionClient {
     fn emit_order_pending_cancel(
         order_id: i32,
         client_order_id: ClientOrderId,
+        venue_order_id: VenueOrderId,
         instrument_id_map: &Arc<Mutex<AHashMap<i32, InstrumentId>>>,
         trader_id_map: &Arc<Mutex<AHashMap<i32, TraderId>>>,
         strategy_id_map: &Arc<Mutex<AHashMap<i32, StrategyId>>>,
@@ -2379,7 +2394,7 @@ impl InteractiveBrokersExecutionClient {
             ts_init,
             ts_init,
             false,
-            Some(VenueOrderId::from(order_id.to_string())),
+            Some(venue_order_id),
         );
 
         exec_sender

--- a/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
@@ -234,6 +234,17 @@ impl InteractiveBrokersExecutionClient {
         trader_id_map: &Arc<Mutex<AHashMap<i32, TraderId>>>,
         strategy_id_map: &Arc<Mutex<AHashMap<i32, StrategyId>>>,
     ) -> anyhow::Result<()> {
+        let mut venue_map = venue_order_id_map
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?;
+        if let Some(existing_client_order_id) = venue_map.get(&ib_order_id) {
+            anyhow::ensure!(
+                *existing_client_order_id == cmd.client_order_id,
+                "IB order ID {ib_order_id} is already mapped to client order {existing_client_order_id}"
+            );
+        }
+        venue_map.remove(&ib_order_id);
+
         order_id_map
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?
@@ -250,10 +261,7 @@ impl InteractiveBrokersExecutionClient {
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock strategy ID map"))?
             .insert(ib_order_id, target_order.strategy_id());
-        venue_order_id_map
-            .lock()
-            .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?
-            .insert(ib_order_id, cmd.client_order_id);
+        venue_map.insert(ib_order_id, cmd.client_order_id);
 
         Ok(())
     }

--- a/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
@@ -227,6 +227,7 @@ impl InteractiveBrokersExecutionClient {
     pub(super) fn cache_cancel_order_tracking(
         ib_order_id: i32,
         cmd: &CancelOrder,
+        target_order: &OrderAny,
         order_id_map: &Arc<Mutex<AHashMap<ClientOrderId, i32>>>,
         venue_order_id_map: &Arc<Mutex<AHashMap<i32, ClientOrderId>>>,
         instrument_id_map: &Arc<Mutex<AHashMap<i32, InstrumentId>>>,
@@ -240,15 +241,15 @@ impl InteractiveBrokersExecutionClient {
         instrument_id_map
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock instrument ID map"))?
-            .insert(ib_order_id, cmd.instrument_id);
+            .insert(ib_order_id, target_order.instrument_id());
         trader_id_map
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock trader ID map"))?
-            .insert(ib_order_id, cmd.trader_id);
+            .insert(ib_order_id, target_order.trader_id());
         strategy_id_map
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock strategy ID map"))?
-            .insert(ib_order_id, cmd.strategy_id);
+            .insert(ib_order_id, target_order.strategy_id());
         venue_order_id_map
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?

--- a/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
@@ -234,6 +234,9 @@ impl InteractiveBrokersExecutionClient {
         trader_id_map: &Arc<Mutex<AHashMap<i32, TraderId>>>,
         strategy_id_map: &Arc<Mutex<AHashMap<i32, StrategyId>>>,
     ) -> anyhow::Result<()> {
+        // Order-status callbacks first map the IB order ID to a client order ID, then read
+        // its instrument, trader, and strategy IDs. Hold this lock while updating all maps
+        // so a callback sees either the complete identity or no route at all.
         let mut venue_map = venue_order_id_map
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?;

--- a/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
@@ -223,6 +223,40 @@ impl InteractiveBrokersExecutionClient {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn cache_cancel_order_tracking(
+        ib_order_id: i32,
+        cmd: &CancelOrder,
+        order_id_map: &Arc<Mutex<AHashMap<ClientOrderId, i32>>>,
+        venue_order_id_map: &Arc<Mutex<AHashMap<i32, ClientOrderId>>>,
+        instrument_id_map: &Arc<Mutex<AHashMap<i32, InstrumentId>>>,
+        trader_id_map: &Arc<Mutex<AHashMap<i32, TraderId>>>,
+        strategy_id_map: &Arc<Mutex<AHashMap<i32, StrategyId>>>,
+    ) -> anyhow::Result<()> {
+        order_id_map
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?
+            .insert(cmd.client_order_id, ib_order_id);
+        venue_order_id_map
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?
+            .insert(ib_order_id, cmd.client_order_id);
+        instrument_id_map
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock instrument ID map"))?
+            .insert(ib_order_id, cmd.instrument_id);
+        trader_id_map
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock trader ID map"))?
+            .insert(ib_order_id, cmd.trader_id);
+        strategy_id_map
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock strategy ID map"))?
+            .insert(ib_order_id, cmd.strategy_id);
+
+        Ok(())
+    }
+
     pub(super) fn get_tracked_order_context(
         ib_order_id: i32,
         active_order_contexts: &Arc<Mutex<AHashMap<i32, TrackedOrderContext>>>,

--- a/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_helpers.rs
@@ -237,10 +237,6 @@ impl InteractiveBrokersExecutionClient {
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock order ID map"))?
             .insert(cmd.client_order_id, ib_order_id);
-        venue_order_id_map
-            .lock()
-            .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?
-            .insert(ib_order_id, cmd.client_order_id);
         instrument_id_map
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock instrument ID map"))?
@@ -253,6 +249,10 @@ impl InteractiveBrokersExecutionClient {
             .lock()
             .map_err(|_| anyhow::anyhow!("Failed to lock strategy ID map"))?
             .insert(ib_order_id, cmd.strategy_id);
+        venue_order_id_map
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Failed to lock venue order ID map"))?
+            .insert(ib_order_id, cmd.client_order_id);
 
         Ok(())
     }

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -1996,6 +1996,7 @@ async fn test_cancel_order_recovery_tracks_resolved_order_identity() {
         None,
         None,
     );
+    // Raw order ID returned after resolving PERM-456.
     let resolved_order_id = 7001;
 
     InteractiveBrokersExecutionClient::cache_cancel_order_tracking(

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -898,15 +898,31 @@ fn modify_order_rejects_when_client_not_ready() {
 
 #[rstest]
 fn cancel_order_rejects_when_client_not_ready() {
-    let (client, mut rx, _) = create_test_execution_client();
-    let order = create_test_limit_order(ClientOrderId::from("O-IB-001"));
+    let (client, mut rx, cache) = create_test_execution_client();
+    let target_trader_id = TraderId::from("TRADER-TARGET");
+    let target_strategy_id = StrategyId::from("STRATEGY-TARGET");
+    let instrument_id = create_test_stock_instrument();
+    let client_order_id = ClientOrderId::from("O-IB-001");
+    let venue_order_id = VenueOrderId::from("1001");
+    let order = create_test_accepted_limit_order(
+        target_trader_id,
+        target_strategy_id,
+        instrument_id,
+        client_order_id,
+        venue_order_id,
+        client.core.account_id,
+    );
+    cache
+        .borrow_mut()
+        .add_order(order, None, Some(*IB_CLIENT_ID), false)
+        .unwrap();
     let cmd = CancelOrder::new(
-        client.core.trader_id,
+        TraderId::from("TRADER-REQUESTER"),
         Some(client.core.client_id),
-        order.strategy_id(),
-        order.instrument_id(),
-        order.client_order_id(),
-        Some(VenueOrderId::from("1001")),
+        StrategyId::from("STRATEGY-REQUESTER"),
+        instrument_id,
+        client_order_id,
+        Some(venue_order_id),
         UUID4::new(),
         UnixNanos::default(),
         None,
@@ -917,11 +933,11 @@ fn cancel_order_rejects_when_client_not_ready() {
 
     match next_order_event(&mut rx) {
         OrderEventAny::CancelRejected(event) => {
-            assert_eq!(event.trader_id, client.core.trader_id);
-            assert_eq!(event.client_order_id, order.client_order_id());
-            assert_eq!(event.instrument_id, order.instrument_id());
-            assert_eq!(event.strategy_id, order.strategy_id());
-            assert_eq!(event.venue_order_id, Some(VenueOrderId::from("1001")));
+            assert_eq!(event.trader_id, target_trader_id);
+            assert_eq!(event.client_order_id, client_order_id);
+            assert_eq!(event.instrument_id, instrument_id);
+            assert_eq!(event.strategy_id, target_strategy_id);
+            assert_eq!(event.venue_order_id, Some(venue_order_id));
             assert_eq!(event.account_id, Some(client.core.account_id));
             assert_eq!(event.ts_init, event.ts_event);
             assert!(!event.reconciliation);
@@ -1953,6 +1969,7 @@ fn test_emit_order_pending_cancel_is_idempotent() {
     InteractiveBrokersExecutionClient::emit_order_pending_cancel(
         order_id,
         client_order_id,
+        VenueOrderId::from("PERM-456"),
         &instrument_id_map,
         &trader_id_map,
         &strategy_id_map,
@@ -1965,6 +1982,7 @@ fn test_emit_order_pending_cancel_is_idempotent() {
     InteractiveBrokersExecutionClient::emit_order_pending_cancel(
         order_id,
         client_order_id,
+        VenueOrderId::from("PERM-456"),
         &instrument_id_map,
         &trader_id_map,
         &strategy_id_map,
@@ -1975,11 +1993,12 @@ fn test_emit_order_pending_cancel_is_idempotent() {
     )
     .unwrap();
 
-    let first = exec_receiver.try_recv().unwrap();
-    assert!(matches!(
-        first,
-        ExecutionEvent::Order(OrderEventAny::PendingCancel(_))
-    ));
+    match exec_receiver.try_recv().unwrap() {
+        ExecutionEvent::Order(OrderEventAny::PendingCancel(event)) => {
+            assert_eq!(event.venue_order_id, Some(VenueOrderId::from("PERM-456")));
+        }
+        event => panic!("Expected OrderPendingCancel, was {event:?}"),
+    }
     assert!(exec_receiver.try_recv().is_err());
     assert!(
         pending_cancel_orders
@@ -2036,6 +2055,85 @@ fn cancel_order_target_validation_rejects_identity_conflicts() {
 }
 
 #[rstest]
+fn cancel_tracking_blocks_preexisting_route_until_identity_complete() {
+    let order_id = 7001;
+    let trader_id = TraderId::from("TRADER-TARGET");
+    let strategy_id = StrategyId::from("STRATEGY-TARGET");
+    let instrument_id = create_test_stock_instrument();
+    let client_order_id = ClientOrderId::from("O-TARGET-001");
+    let venue_order_id = VenueOrderId::from("PERM-456");
+    let target_order = create_test_accepted_limit_order(
+        trader_id,
+        strategy_id,
+        instrument_id,
+        client_order_id,
+        venue_order_id,
+        AccountId::from("IB-001"),
+    );
+    let cmd = CancelOrder::new(
+        trader_id,
+        Some(*IB_CLIENT_ID),
+        strategy_id,
+        instrument_id,
+        client_order_id,
+        Some(venue_order_id),
+        UUID4::new(),
+        UnixNanos::new(1),
+        None,
+        None,
+    );
+    let order_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let venue_order_id_map = Arc::new(Mutex::new(AHashMap::from_iter([(
+        order_id,
+        client_order_id,
+    )])));
+    let instrument_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let trader_id_map = Arc::new(Mutex::new(AHashMap::new()));
+    let strategy_id_map = Arc::new(Mutex::new(AHashMap::new()));
+
+    let writer_order_id_map = Arc::clone(&order_id_map);
+    let writer_venue_order_id_map = Arc::clone(&venue_order_id_map);
+    let writer_instrument_id_map = Arc::clone(&instrument_id_map);
+    let writer_trader_id_map = Arc::clone(&trader_id_map);
+    let writer_strategy_id_map = Arc::clone(&strategy_id_map);
+    let strategy_guard = strategy_id_map.lock().unwrap();
+
+    let writer = std::thread::spawn(move || {
+        InteractiveBrokersExecutionClient::cache_cancel_order_tracking(
+            order_id,
+            &cmd,
+            &target_order,
+            &writer_order_id_map,
+            &writer_venue_order_id_map,
+            &writer_instrument_id_map,
+            &writer_trader_id_map,
+            &writer_strategy_id_map,
+        )
+    });
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+
+    while !trader_id_map.lock().unwrap().contains_key(&order_id) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "tracking writer stalled"
+        );
+        std::thread::yield_now();
+    }
+    assert!(matches!(
+        venue_order_id_map.try_lock(),
+        Err(std::sync::TryLockError::WouldBlock)
+    ));
+
+    drop(strategy_guard);
+    writer.join().unwrap().unwrap();
+    assert_eq!(
+        venue_order_id_map.lock().unwrap().get(&order_id),
+        Some(&client_order_id)
+    );
+}
+
+#[rstest]
 #[case("TRADER-RESTORED", "STRATEGY-RESTORED")]
 #[case("TRADER-OPERATOR", "OPERATOR-001")]
 #[tokio::test]
@@ -2087,7 +2185,7 @@ async fn test_cancel_order_recovery_tracks_resolved_order_identity(
         None,
     );
     InteractiveBrokersExecutionClient::validate_cancel_order_target(&cmd, &target_order).unwrap();
-    // Raw order ID returned after resolving PERM-456.
+    // Raw order ID returned after resolving PERM-456
     let resolved_order_id = 7001;
 
     InteractiveBrokersExecutionClient::cache_cancel_order_tracking(
@@ -2134,6 +2232,7 @@ async fn test_cancel_order_recovery_tracks_resolved_order_identity(
             assert_eq!(event.strategy_id, target_strategy_id);
             assert_eq!(event.instrument_id, instrument_id);
             assert_eq!(event.client_order_id, client_order_id);
+            assert_eq!(event.venue_order_id, Some(venue_order_id));
         }
         other => panic!("unexpected event: {other:?}"),
     }

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -1967,6 +1967,139 @@ fn test_emit_order_pending_cancel_is_idempotent() {
 }
 
 #[tokio::test]
+async fn test_cancel_order_recovery_tracks_resolved_order_identity() {
+    let (client, mut exec_receiver, _) = create_test_execution_client();
+    let spread = create_test_option_spread();
+    let instrument_id = spread.id;
+    client
+        .instrument_provider
+        .insert_test_instrument(InstrumentAny::from(spread), 54321, 1);
+
+    assert!(client.order_id_map.lock().unwrap().is_empty());
+    assert!(client.venue_order_id_map.lock().unwrap().is_empty());
+    assert!(client.instrument_id_map.lock().unwrap().is_empty());
+    assert!(client.trader_id_map.lock().unwrap().is_empty());
+    assert!(client.strategy_id_map.lock().unwrap().is_empty());
+
+    let trader_id = TraderId::from("TRADER-RESTORED");
+    let strategy_id = StrategyId::from("STRATEGY-RESTORED");
+    let client_order_id = ClientOrderId::from("O-RESTORED-001");
+    let cmd = CancelOrder::new(
+        trader_id,
+        Some(*IB_CLIENT_ID),
+        strategy_id,
+        instrument_id,
+        client_order_id,
+        Some(VenueOrderId::from("PERM-456")),
+        UUID4::new(),
+        UnixNanos::new(1),
+        None,
+        None,
+    );
+    let resolved_order_id = 7001;
+
+    InteractiveBrokersExecutionClient::cache_cancel_order_tracking(
+        resolved_order_id,
+        &cmd,
+        &client.order_id_map,
+        &client.venue_order_id_map,
+        &client.instrument_id_map,
+        &client.trader_id_map,
+        &client.strategy_id_map,
+    )
+    .unwrap();
+
+    let mut pending_status = create_test_order_status(resolved_order_id, "PendingCancel");
+    pending_status.perm_id = 456;
+    let exec_sender = get_exec_event_sender();
+    InteractiveBrokersExecutionClient::handle_order_status(
+        &pending_status,
+        &client.order_id_map,
+        &client.venue_order_id_map,
+        &client.instrument_provider,
+        &exec_sender,
+        UnixNanos::new(2),
+        client.core.account_id,
+        &client.instrument_id_map,
+        &client.trader_id_map,
+        &client.strategy_id_map,
+        &client.active_order_contexts,
+        &client.terminal_order_contexts,
+        &client.order_avg_prices,
+        &client.pending_combo_fills,
+        &client.pending_combo_fill_avgs,
+        &client.order_fill_progress,
+        &client.pending_cancel_orders,
+        &client.spread_fill_tracking,
+    )
+    .await
+    .unwrap();
+
+    match exec_receiver.try_recv().unwrap() {
+        ExecutionEvent::Order(OrderEventAny::PendingCancel(event)) => {
+            assert_eq!(event.trader_id, trader_id);
+            assert_eq!(event.strategy_id, strategy_id);
+            assert_eq!(event.instrument_id, instrument_id);
+            assert_eq!(event.client_order_id, client_order_id);
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+    assert!(
+        client
+            .pending_cancel_orders
+            .lock()
+            .unwrap()
+            .contains(&client_order_id)
+    );
+
+    let mut canceled_status = create_test_order_status(resolved_order_id, "Cancelled");
+    canceled_status.perm_id = 456;
+    InteractiveBrokersExecutionClient::handle_order_status(
+        &canceled_status,
+        &client.order_id_map,
+        &client.venue_order_id_map,
+        &client.instrument_provider,
+        &exec_sender,
+        UnixNanos::new(3),
+        client.core.account_id,
+        &client.instrument_id_map,
+        &client.trader_id_map,
+        &client.strategy_id_map,
+        &client.active_order_contexts,
+        &client.terminal_order_contexts,
+        &client.order_avg_prices,
+        &client.pending_combo_fills,
+        &client.pending_combo_fill_avgs,
+        &client.order_fill_progress,
+        &client.pending_cancel_orders,
+        &client.spread_fill_tracking,
+    )
+    .await
+    .unwrap();
+
+    match exec_receiver.try_recv().unwrap() {
+        ExecutionEvent::Order(OrderEventAny::Canceled(event)) => {
+            assert_eq!(event.trader_id, trader_id);
+            assert_eq!(event.strategy_id, strategy_id);
+            assert_eq!(event.instrument_id, instrument_id);
+            assert_eq!(event.client_order_id, client_order_id);
+            assert_eq!(event.venue_order_id, Some(VenueOrderId::from("PERM-456")));
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+
+    assert!(exec_receiver.try_recv().is_err());
+    assert!(client.order_id_map.lock().unwrap().is_empty());
+    assert!(client.venue_order_id_map.lock().unwrap().is_empty());
+    assert!(client.instrument_id_map.lock().unwrap().is_empty());
+    assert!(client.trader_id_map.lock().unwrap().is_empty());
+    assert!(client.strategy_id_map.lock().unwrap().is_empty());
+    assert!(client.pending_cancel_orders.lock().unwrap().is_empty());
+    assert!(client.active_order_contexts.lock().unwrap().is_empty());
+    assert!(client.terminal_order_contexts.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn test_handle_order_status_canceled_emits_canceled_event() {
     let instrument_provider = create_test_instrument_provider();
     let spread = create_test_option_spread();

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -31,7 +31,7 @@ use nautilus_model::{
         Venue, VenueOrderId,
     },
     instruments::{InstrumentAny, OptionSpread, stubs::equity_aapl},
-    orders::{OrderList, builder::OrderTestBuilder},
+    orders::{OrderList, builder::OrderTestBuilder, stubs::TestOrderEventStubs},
     types::{Currency, Money, Price, Quantity},
 };
 use rstest::rstest;
@@ -101,6 +101,29 @@ fn create_test_limit_order(client_order_id: ClientOrderId) -> OrderAny {
         .quantity(Quantity::from(1))
         .submit(true)
         .build()
+}
+
+fn create_test_accepted_limit_order(
+    trader_id: TraderId,
+    strategy_id: StrategyId,
+    instrument_id: InstrumentId,
+    client_order_id: ClientOrderId,
+    venue_order_id: VenueOrderId,
+    account_id: AccountId,
+) -> OrderAny {
+    let mut order = OrderTestBuilder::new(OrderType::Limit)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument_id)
+        .client_order_id(client_order_id)
+        .side(OrderSide::Buy)
+        .price(Price::from("100.00"))
+        .quantity(Quantity::from(1))
+        .submit(true)
+        .build();
+    let accepted = TestOrderEventStubs::accepted(&order, account_id, venue_order_id);
+    order.apply(accepted).unwrap();
+    order
 }
 
 fn create_tracked_order_context(
@@ -1966,9 +1989,61 @@ fn test_emit_order_pending_cancel_is_idempotent() {
     );
 }
 
+#[rstest]
+fn cancel_order_target_validation_rejects_identity_conflicts() {
+    let trader_id = TraderId::from("TRADER-TARGET");
+    let target_strategy_id = StrategyId::from("STRATEGY-TARGET");
+    let client_order_id = ClientOrderId::from("O-TARGET-001");
+    let instrument_id = create_test_stock_instrument();
+    let venue_order_id = VenueOrderId::from("PERM-456");
+    let target_order = create_test_accepted_limit_order(
+        trader_id,
+        target_strategy_id,
+        instrument_id,
+        client_order_id,
+        venue_order_id,
+        AccountId::from("IB-001"),
+    );
+
+    let command = |instrument_id, venue_order_id| {
+        CancelOrder::new(
+            trader_id,
+            Some(*IB_CLIENT_ID),
+            StrategyId::from("OPERATOR-001"),
+            instrument_id,
+            client_order_id,
+            Some(venue_order_id),
+            UUID4::new(),
+            UnixNanos::new(1),
+            None,
+            None,
+        )
+    };
+
+    let error = InteractiveBrokersExecutionClient::validate_cancel_order_target(
+        &command(create_test_leg_instrument(), venue_order_id),
+        &target_order,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("command instrument ID"));
+
+    let error = InteractiveBrokersExecutionClient::validate_cancel_order_target(
+        &command(instrument_id, VenueOrderId::from("PERM-999")),
+        &target_order,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("command venue order ID"));
+}
+
+#[rstest]
+#[case("TRADER-RESTORED", "STRATEGY-RESTORED")]
+#[case("TRADER-OPERATOR", "OPERATOR-001")]
 #[tokio::test]
-async fn test_cancel_order_recovery_tracks_resolved_order_identity() {
-    let (client, mut exec_receiver, _) = create_test_execution_client();
+async fn test_cancel_order_recovery_tracks_resolved_order_identity(
+    #[case] requesting_trader_id: &str,
+    #[case] requesting_strategy_id: &str,
+) {
+    let (client, mut exec_receiver, cache) = create_test_execution_client();
     let spread = create_test_option_spread();
     let instrument_id = spread.id;
     client
@@ -1982,26 +2057,43 @@ async fn test_cancel_order_recovery_tracks_resolved_order_identity() {
     assert!(client.strategy_id_map.lock().unwrap().is_empty());
 
     let trader_id = TraderId::from("TRADER-RESTORED");
-    let strategy_id = StrategyId::from("STRATEGY-RESTORED");
+    let target_strategy_id = StrategyId::from("STRATEGY-RESTORED");
     let client_order_id = ClientOrderId::from("O-RESTORED-001");
-    let cmd = CancelOrder::new(
+    let venue_order_id = VenueOrderId::from("PERM-456");
+    let target_order = create_test_accepted_limit_order(
         trader_id,
-        Some(*IB_CLIENT_ID),
-        strategy_id,
+        target_strategy_id,
         instrument_id,
         client_order_id,
-        Some(VenueOrderId::from("PERM-456")),
+        venue_order_id,
+        client.core.account_id,
+    );
+    cache
+        .borrow_mut()
+        .add_order(target_order, None, Some(*IB_CLIENT_ID), false)
+        .unwrap();
+    let target_order = client.core.get_order(&client_order_id).unwrap();
+
+    let cmd = CancelOrder::new(
+        TraderId::from(requesting_trader_id),
+        Some(*IB_CLIENT_ID),
+        StrategyId::from(requesting_strategy_id),
+        instrument_id,
+        client_order_id,
+        Some(venue_order_id),
         UUID4::new(),
         UnixNanos::new(1),
         None,
         None,
     );
+    InteractiveBrokersExecutionClient::validate_cancel_order_target(&cmd, &target_order).unwrap();
     // Raw order ID returned after resolving PERM-456.
     let resolved_order_id = 7001;
 
     InteractiveBrokersExecutionClient::cache_cancel_order_tracking(
         resolved_order_id,
         &cmd,
+        &target_order,
         &client.order_id_map,
         &client.venue_order_id_map,
         &client.instrument_id_map,
@@ -2039,7 +2131,7 @@ async fn test_cancel_order_recovery_tracks_resolved_order_identity() {
     match exec_receiver.try_recv().unwrap() {
         ExecutionEvent::Order(OrderEventAny::PendingCancel(event)) => {
             assert_eq!(event.trader_id, trader_id);
-            assert_eq!(event.strategy_id, strategy_id);
+            assert_eq!(event.strategy_id, target_strategy_id);
             assert_eq!(event.instrument_id, instrument_id);
             assert_eq!(event.client_order_id, client_order_id);
         }
@@ -2081,7 +2173,7 @@ async fn test_cancel_order_recovery_tracks_resolved_order_identity() {
     match exec_receiver.try_recv().unwrap() {
         ExecutionEvent::Order(OrderEventAny::Canceled(event)) => {
             assert_eq!(event.trader_id, trader_id);
-            assert_eq!(event.strategy_id, strategy_id);
+            assert_eq!(event.strategy_id, target_strategy_id);
             assert_eq!(event.instrument_id, instrument_id);
             assert_eq!(event.client_order_id, client_order_id);
             assert_eq!(event.venue_order_id, Some(VenueOrderId::from("PERM-456")));

--- a/crates/adapters/interactive_brokers/src/execution/core_updates.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_updates.rs
@@ -627,6 +627,7 @@ impl InteractiveBrokersExecutionClient {
                 Self::emit_order_pending_cancel(
                     status.order_id,
                     client_order_id,
+                    venue_order_id,
                     instrument_id_map,
                     trader_id_map,
                     strategy_id_map,


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Canceling an IBKR order restored with a `PERM-*` venue ID resolves the current raw IB order ID, but
the adapter did not rebuild the tracking maps used by status callbacks. Because `CancelOrder` actor
IDs identify the requester and can differ from the target order owner, this change resolves and
validates the cached target before spawning, then caches its trader, strategy, and instrument
identity before sending the cancel. The command client and venue IDs still drive broker resolution,
and the raw-to-client route is published last so `PendingCancel` and `Cancelled` callbacks see
complete target identity.

## Related issues/PRs

Related to #4564.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation change is required because this corrects internal adapter routing and changes no
public API.

## Testing

**New or changed logic must be covered by tests.** Select all that apply:

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Local validation completed:

- `make format`
- `make pre-commit`
- `cargo test -p nautilus-interactive-brokers`

The adapter suite passed 414 unit tests, one connection test, and doc tests. Regression coverage
includes same-strategy and cross-strategy requesters, target trader and strategy routing,
instrument and venue identity conflicts, `PendingCancel` and `Cancelled` callbacks, and terminal
tracking cleanup.
