### PR TITLE
Tighten Polymarket reconciliation regression coverage

### DIFF
--- a/crates/adapters/polymarket/src/execution/reconciliation.rs
+++ b/crates/adapters/polymarket/src/execution/reconciliation.rs
@@ -1325,32 +1325,6 @@ pub(crate) fn apply_fill_time_filters(
     reports
 }
 
-/// Builds position status reports from Data API positions, filtering dust.
-#[cfg(test)]
-pub(crate) fn build_position_reports(
-    positions: &[DataApiPosition],
-    account_id: AccountId,
-    ts: UnixNanos,
-) -> Vec<PositionStatusReport> {
-    positions
-        .iter()
-        .filter_map(|position| build_position_report(position, account_id, ts))
-        .collect()
-}
-
-#[cfg(test)]
-fn build_position_report(
-    position: &DataApiPosition,
-    account_id: AccountId,
-    ts: UnixNanos,
-) -> Option<PositionStatusReport> {
-    if position_is_dust(position) {
-        return None;
-    }
-
-    build_position_report_from_reportable_position(position, account_id, ts)
-}
-
 fn build_position_report_from_reportable_position(
     position: &DataApiPosition,
     account_id: AccountId,
@@ -1841,6 +1815,48 @@ mod tests {
     fn open_order() -> PolymarketOpenOrder {
         serde_json::from_str(include_str!("../../test_data/http_open_order.json"))
             .expect("valid open-order fixture")
+    }
+
+    fn data_api_positions() -> Vec<DataApiPosition> {
+        serde_json::from_str(include_str!(
+            "../../test_data/data_api_positions_response.json"
+        ))
+        .expect("valid Data API position fixture")
+    }
+
+    #[rstest]
+    #[case(0, Decimal::new(55, 2))]
+    #[case(2, Decimal::new(3, 1))]
+    fn test_build_position_report_carries_values(
+        #[case] position_index: usize,
+        #[case] expected_avg_price: Decimal,
+    ) {
+        let positions = data_api_positions();
+        let report = build_position_report_from_reportable_position(
+            &positions[position_index],
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect("fixture position is reportable");
+
+        assert!(report.is_long());
+        assert_eq!(report.avg_px_open, Some(expected_avg_price));
+        assert_eq!(report.quantity.precision, USDC_DECIMALS as u8);
+    }
+
+    #[rstest]
+    fn test_build_position_report_handles_missing_avg_price() {
+        let mut position = data_api_positions().remove(0);
+        position.avg_price = None;
+
+        let report = build_position_report_from_reportable_position(
+            &position,
+            AccountId::from("POLYMARKET-001"),
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .expect("fixture position is reportable");
+
+        assert_eq!(report.avg_px_open, None);
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/execution/responses.rs
+++ b/crates/adapters/polymarket/src/execution/responses.rs
@@ -1339,7 +1339,10 @@ mod tests {
         handle_fok_rest_status(&venue_order, venue_order_id, &ctx);
 
         assert!(receiver.try_recv().is_err());
-        assert!(order_identities.get(&venue_order_id).is_none());
+        assert!(
+            order_identities.mark_accepted(venue_order_id),
+            "handler must not have marked the order accepted"
+        );
     }
 
     #[rstest]

--- a/crates/adapters/polymarket/src/http/data_api.rs
+++ b/crates/adapters/polymarket/src/http/data_api.rs
@@ -601,19 +601,12 @@ fn parse_trade_ticks(
 
 #[cfg(test)]
 mod tests {
-    use nautilus_model::{
-        enums::AggressorSide,
-        identifiers::{AccountId, InstrumentId},
-    };
+    use nautilus_model::{enums::AggressorSide, identifiers::InstrumentId};
     use rstest::rstest;
     use rust_decimal_macros::dec;
 
     use super::*;
-    use crate::{
-        common::consts::USDC_DECIMALS,
-        execution::reconciliation::build_position_reports,
-        http::models::{DataApiPosition, DataApiTrade},
-    };
+    use crate::http::models::{DataApiPosition, DataApiTrade};
 
     fn load_positions() -> Vec<DataApiPosition> {
         let path = "test_data/data_api_positions_response.json";
@@ -639,64 +632,6 @@ mod tests {
             positions[0].condition_id,
             "0xc8f1cf5d4f26e0fd9c8fe89f2a7b3263b902cf14fde7bfccef525753bb492e47"
         );
-    }
-
-    #[rstest]
-    fn test_build_position_reports_filters_dust_and_zero() {
-        let positions = load_positions();
-        let account_id = AccountId::from("POLYMARKET-001");
-        let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
-
-        let reports = build_position_reports(&positions, account_id, ts_now);
-
-        // 4 positions: 150.5, 0.0, 42.0, 0.005 (dust)
-        // Only 150.5 and 42.0 pass the DUST_POSITION_THRESHOLD (0.01)
-        assert_eq!(reports.len(), 2);
-        assert!(reports[0].is_long());
-        assert!(reports[1].is_long());
-    }
-
-    #[rstest]
-    fn test_build_position_reports_carries_avg_price() {
-        let positions = load_positions();
-        let account_id = AccountId::from("POLYMARKET-001");
-        let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
-
-        let reports = build_position_reports(&positions, account_id, ts_now);
-
-        assert_eq!(reports.len(), 2);
-        assert_eq!(reports[0].avg_px_open, Some(dec!(0.55)));
-        assert_eq!(reports[1].avg_px_open, Some(dec!(0.3)));
-    }
-
-    #[rstest]
-    fn test_build_position_reports_uses_usdc_precision() {
-        let positions = load_positions();
-        let account_id = AccountId::from("POLYMARKET-001");
-        let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
-
-        let reports = build_position_reports(&positions, account_id, ts_now);
-
-        assert_eq!(reports.len(), 2);
-        assert_eq!(reports[0].quantity.precision, USDC_DECIMALS as u8);
-        assert_eq!(reports[1].quantity.precision, USDC_DECIMALS as u8);
-    }
-
-    #[rstest]
-    fn test_build_position_reports_handles_missing_avg_price() {
-        let positions = vec![DataApiPosition {
-            asset: "123".to_string(),
-            condition_id: "0xabc".to_string(),
-            size: dec!(10),
-            avg_price: None,
-        }];
-        let account_id = AccountId::from("POLYMARKET-001");
-        let ts_now = nautilus_core::UnixNanos::from(1_000_000_000u64);
-
-        let reports = build_position_reports(&positions, account_id, ts_now);
-
-        assert_eq!(reports.len(), 1);
-        assert_eq!(reports[0].avg_px_open, None);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

- Make the deferred-FOK contradiction regression assert the acceptance marker the handler can mutate
- Remove test-only position-report wrappers that duplicated dust filtering
- Exercise report construction through the private production constructor

## Context

Follow-up to #4831. The production reconciliation changes are already merged. This PR only tightens regression coverage and removes test-only duplicated authority; it does not change production behavior.

## Testing

- `cargo test -p nautilus-polymarket --lib execution::responses::tests::test_handle_fok_rest_status_rejects_contradictory_signed_quantity -- --exact`
- `cargo test -p nautilus-polymarket --lib execution::reconciliation::tests::test_build_position_report`
- `cargo test -p nautilus-polymarket --lib --quiet` (1,139 passed)
- `cargo test -p nautilus-polymarket --test exec_client --quiet` (405 passed)
- `make format`
- `make pre-commit`
