### PR TITLE
Consolidate WebSocket initial-connect retry into the client

### DIFF
--- a/crates/adapters/architect_ax/src/websocket/data/client.rs
+++ b/crates/adapters/architect_ax/src/websocket/data/client.rs
@@ -17,6 +17,7 @@
 
 use std::{
     fmt::Debug,
+    num::NonZeroU32,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicI64, AtomicU8, Ordering},
@@ -30,14 +31,14 @@ use nautilus_common::live::get_runtime;
 use nautilus_core::{AtomicMap, consts::NAUTILUS_USER_AGENT};
 use nautilus_live::SocketControl;
 use nautilus_network::{
-    backoff::ExponentialBackoff,
     http::USER_AGENT,
     mode::ConnectionMode,
     websocket::{
-        PingHandler, ReconnectHeaders, SubscriptionState, TransportBackend, WebSocketClient,
-        WebSocketConfig, channel_message_handler,
+        InitialConnectRetryPolicy, PingHandler, ReconnectHeaders, SubscriptionState,
+        TransportBackend, WebSocketClient, WebSocketConfig, channel_message_handler,
     },
 };
+use tokio_util::sync::CancellationToken;
 use ustr::Ustr;
 
 use super::{
@@ -136,6 +137,7 @@ pub struct AxMdWebSocketClient {
     cmd_tx: Arc<tokio::sync::RwLock<tokio::sync::mpsc::UnboundedSender<HandlerCommand>>>,
     out_rx: Option<Arc<tokio::sync::mpsc::UnboundedReceiver<AxDataWsMessage>>>,
     signal: Arc<AtomicBool>,
+    cancellation_token: Arc<ArcSwap<CancellationToken>>,
     task_handle: Option<tokio::task::JoinHandle<()>>,
     subscriptions: SubscriptionState,
     request_id_counter: Arc<AtomicI64>,
@@ -168,6 +170,7 @@ impl Clone for AxMdWebSocketClient {
             cmd_tx: Arc::clone(&self.cmd_tx),
             out_rx: None,
             signal: Arc::clone(&self.signal),
+            cancellation_token: Arc::clone(&self.cancellation_token),
             task_handle: None,
             subscriptions: self.subscriptions.clone(),
             subscribe_lock: Arc::clone(&self.subscribe_lock),
@@ -182,6 +185,16 @@ impl Clone for AxMdWebSocketClient {
 }
 
 impl AxMdWebSocketClient {
+    fn initial_connect_retry_policy() -> InitialConnectRetryPolicy {
+        InitialConnectRetryPolicy {
+            max_attempts: NonZeroU32::new(5).expect("initial connect attempts must be non-zero"),
+            delay_initial: Duration::from_millis(500),
+            delay_max: Duration::from_secs(5),
+            backoff_factor: 2.0,
+            jitter_ms: 250,
+        }
+    }
+
     /// Creates a new Ax market data WebSocket client.
     ///
     /// The `auth_token` is a Bearer token obtained from the HTTP `/api/authenticate` endpoint.
@@ -207,6 +220,7 @@ impl AxMdWebSocketClient {
             cmd_tx: Arc::new(tokio::sync::RwLock::new(cmd_tx)),
             out_rx: None,
             signal: Arc::new(AtomicBool::new(false)),
+            cancellation_token: Arc::new(ArcSwap::from_pointee(CancellationToken::new())),
             task_handle: None,
             subscriptions: SubscriptionState::new(AX_TOPIC_DELIMITER),
             request_id_counter: Arc::new(AtomicI64::new(1)),
@@ -243,6 +257,7 @@ impl AxMdWebSocketClient {
             cmd_tx: Arc::new(tokio::sync::RwLock::new(cmd_tx)),
             out_rx: None,
             signal: Arc::new(AtomicBool::new(false)),
+            cancellation_token: Arc::new(ArcSwap::from_pointee(CancellationToken::new())),
             task_handle: None,
             subscriptions: SubscriptionState::new(AX_TOPIC_DELIMITER),
             request_id_counter: Arc::new(AtomicI64::new(1)),
@@ -354,10 +369,10 @@ impl AxMdWebSocketClient {
     /// # Errors
     ///
     pub async fn connect(&mut self) -> AxWsResult<()> {
-        const MAX_RETRIES: u32 = 5;
-        const CONNECTION_TIMEOUT_SECS: u64 = 10;
-
         self.signal.store(false, Ordering::Release);
+        let cancellation_token = CancellationToken::new();
+        self.cancellation_token
+            .store(Arc::new(cancellation_token.clone()));
 
         let (raw_handler, raw_rx) = channel_message_handler();
 
@@ -393,74 +408,18 @@ impl AxMdWebSocketClient {
             proxy_url: self.proxy_url.clone(),
         };
 
-        // Retry initial connection with exponential backoff
-        let mut backoff = ExponentialBackoff::new(
-            Duration::from_millis(500),
-            Duration::from_millis(5000),
-            2.0,
-            250,
-            false,
-        )
-        .map_err(|e| AxWsClientError::Transport(e.to_string()))?;
-
-        let mut last_error: String;
-        let mut attempt = 0;
-
-        let client = loop {
-            attempt += 1;
-
-            match tokio::time::timeout(
-                Duration::from_secs(CONNECTION_TIMEOUT_SECS),
-                WebSocketClient::builder()
-                    .config(config.clone())
-                    .message_handler(raw_handler.clone())
-                    .ping_handler(ping_handler.clone())
-                    .maybe_state_sink(self.socket_control.as_ref().map(SocketControl::sink))
-                    .connect(),
-            )
+        let client = WebSocketClient::builder()
+            .config(config.clone())
+            .message_handler(raw_handler.clone())
+            .ping_handler(ping_handler.clone())
+            .initial_connect_retry_policy(Self::initial_connect_retry_policy())
+            .cancellation_token(cancellation_token)
+            .maybe_state_sink(self.socket_control.as_ref().map(SocketControl::sink))
+            .connect()
             .await
-            {
-                Ok(Ok(client)) => {
-                    if attempt > 1 {
-                        log::debug!("WebSocket connection established after {attempt} attempts");
-                    }
-                    break client;
-                }
-                Ok(Err(e)) => {
-                    last_error = e.to_string();
-                    log::warn!(
-                        "WebSocket connection attempt failed: attempt={attempt}/{MAX_RETRIES}, url={}, error={last_error}",
-                        self.url
-                    );
-                }
-                Err(_) => {
-                    last_error = format!("Connection timeout after {CONNECTION_TIMEOUT_SECS}s");
-                    log::warn!(
-                        "WebSocket connection attempt timed out: attempt={attempt}/{MAX_RETRIES}, url={}",
-                        self.url
-                    );
-                }
-            }
-
-            if attempt >= MAX_RETRIES {
-                return Err(AxWsClientError::Transport(format!(
-                    "Failed to connect to {} after {MAX_RETRIES} attempts: {}",
-                    self.url,
-                    if last_error.is_empty() {
-                        "unknown error"
-                    } else {
-                        &last_error
-                    }
-                )));
-            }
-
-            let delay = backoff.next_duration();
-            log::debug!(
-                "Retrying in {delay:?} (attempt {}/{MAX_RETRIES})",
-                attempt + 1
-            );
-            tokio::time::sleep(delay).await;
-        };
+            .map_err(|e| {
+                AxWsClientError::Transport(format!("Failed to connect to {}: {e}", self.url))
+            })?;
 
         self.connection_mode.store(client.connection_mode_atomic());
         let reconnect_handle = client.reconnect_handle();
@@ -1056,6 +1015,7 @@ impl AxMdWebSocketClient {
         log::debug!("Closing WebSocket client");
 
         // Send disconnect first to allow graceful cleanup before signal
+        self.cancellation_token.load().cancel();
         let _ = self.send_cmd(HandlerCommand::Disconnect).await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         self.signal.store(true, Ordering::Release);

--- a/crates/adapters/architect_ax/src/websocket/orders/client.rs
+++ b/crates/adapters/architect_ax/src/websocket/orders/client.rs
@@ -17,6 +17,7 @@
 
 use std::{
     fmt::Debug,
+    num::NonZeroU32,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicI64, AtomicU8, Ordering},
@@ -41,14 +42,14 @@ use nautilus_model::{
     types::{Price, Quantity},
 };
 use nautilus_network::{
-    backoff::ExponentialBackoff,
     http::USER_AGENT,
     mode::ConnectionMode,
     websocket::{
-        AuthTracker, PingHandler, ReconnectHeaders, TransportBackend, WebSocketClient,
-        WebSocketConfig, channel_message_handler,
+        AuthTracker, InitialConnectRetryPolicy, PingHandler, ReconnectHeaders, TransportBackend,
+        WebSocketClient, WebSocketConfig, channel_message_handler,
     },
 };
+use tokio_util::sync::CancellationToken;
 use ustr::Ustr;
 
 use super::handler::{AxOrdersWsFeedHandler, HandlerCommand, WsOrderInfo};
@@ -130,6 +131,7 @@ pub struct AxOrdersWebSocketClient {
     cmd_tx: Arc<tokio::sync::RwLock<tokio::sync::mpsc::UnboundedSender<HandlerCommand>>>,
     out_rx: Option<Arc<tokio::sync::mpsc::UnboundedReceiver<AxOrdersWsMessage>>>,
     signal: Arc<AtomicBool>,
+    cancellation_token: Arc<ArcSwap<CancellationToken>>,
     task_handle: Option<tokio::task::JoinHandle<()>>,
     auth_tracker: AuthTracker,
     instruments_cache: Arc<AtomicMap<Ustr, InstrumentAny>>,
@@ -163,6 +165,7 @@ impl Clone for AxOrdersWebSocketClient {
             cmd_tx: Arc::clone(&self.cmd_tx),
             out_rx: None, // Each clone gets its own receiver
             signal: Arc::clone(&self.signal),
+            cancellation_token: Arc::clone(&self.cancellation_token),
             task_handle: None,
             auth_tracker: self.auth_tracker.clone(),
             instruments_cache: Arc::clone(&self.instruments_cache),
@@ -178,6 +181,16 @@ impl Clone for AxOrdersWebSocketClient {
 }
 
 impl AxOrdersWebSocketClient {
+    fn initial_connect_retry_policy() -> InitialConnectRetryPolicy {
+        InitialConnectRetryPolicy {
+            max_attempts: NonZeroU32::new(5).expect("initial connect attempts must be non-zero"),
+            delay_initial: Duration::from_millis(500),
+            delay_max: Duration::from_secs(5),
+            backoff_factor: 2.0,
+            jitter_ms: 250,
+        }
+    }
+
     /// Creates a new Ax orders WebSocket client.
     #[must_use]
     pub fn new(
@@ -202,6 +215,7 @@ impl AxOrdersWebSocketClient {
             cmd_tx: Arc::new(tokio::sync::RwLock::new(cmd_tx)),
             out_rx: None,
             signal: Arc::new(AtomicBool::new(false)),
+            cancellation_token: Arc::new(ArcSwap::from_pointee(CancellationToken::new())),
             task_handle: None,
             auth_tracker: AuthTracker::default(),
             instruments_cache: Arc::new(AtomicMap::new()),
@@ -396,10 +410,10 @@ impl AxOrdersWebSocketClient {
     ///
     /// Returns an error if the connection cannot be established.
     pub async fn connect(&mut self, bearer_token: &str) -> AxOrdersWsResult<()> {
-        const MAX_RETRIES: u32 = 5;
-        const CONNECTION_TIMEOUT_SECS: u64 = 10;
-
         self.signal.store(false, Ordering::Release);
+        let cancellation_token = CancellationToken::new();
+        self.cancellation_token
+            .store(Arc::new(cancellation_token.clone()));
 
         let (raw_handler, raw_rx) = channel_message_handler();
 
@@ -431,74 +445,18 @@ impl AxOrdersWebSocketClient {
             proxy_url: self.proxy_url.clone(),
         };
 
-        // Retry initial connection with exponential backoff
-        let mut backoff = ExponentialBackoff::new(
-            Duration::from_millis(500),
-            Duration::from_millis(5000),
-            2.0,
-            250,
-            false,
-        )
-        .map_err(|e| AxOrdersWsClientError::Transport(e.to_string()))?;
-
-        let mut last_error: String;
-        let mut attempt = 0;
-
-        let client = loop {
-            attempt += 1;
-
-            match tokio::time::timeout(
-                Duration::from_secs(CONNECTION_TIMEOUT_SECS),
-                WebSocketClient::builder()
-                    .config(config.clone())
-                    .message_handler(raw_handler.clone())
-                    .ping_handler(ping_handler.clone())
-                    .maybe_state_sink(self.socket_control.as_ref().map(SocketControl::sink))
-                    .connect(),
-            )
+        let client = WebSocketClient::builder()
+            .config(config.clone())
+            .message_handler(raw_handler.clone())
+            .ping_handler(ping_handler.clone())
+            .initial_connect_retry_policy(Self::initial_connect_retry_policy())
+            .cancellation_token(cancellation_token)
+            .maybe_state_sink(self.socket_control.as_ref().map(SocketControl::sink))
+            .connect()
             .await
-            {
-                Ok(Ok(client)) => {
-                    if attempt > 1 {
-                        log::debug!("WebSocket connection established after {attempt} attempts");
-                    }
-                    break client;
-                }
-                Ok(Err(e)) => {
-                    last_error = e.to_string();
-                    log::warn!(
-                        "WebSocket connection attempt failed: attempt={attempt}, max_retries={MAX_RETRIES}, url={}, error={last_error}",
-                        self.url
-                    );
-                }
-                Err(_) => {
-                    last_error = format!("Connection timeout after {CONNECTION_TIMEOUT_SECS}s");
-                    log::warn!(
-                        "WebSocket connection attempt timed out: attempt={attempt}, max_retries={MAX_RETRIES}, url={}",
-                        self.url
-                    );
-                }
-            }
-
-            if attempt >= MAX_RETRIES {
-                return Err(AxOrdersWsClientError::Transport(format!(
-                    "Failed to connect to {} after {MAX_RETRIES} attempts: {}",
-                    self.url,
-                    if last_error.is_empty() {
-                        "unknown error"
-                    } else {
-                        &last_error
-                    }
-                )));
-            }
-
-            let delay = backoff.next_duration();
-            log::debug!(
-                "Retrying in {delay:?} (attempt {}/{MAX_RETRIES})",
-                attempt + 1
-            );
-            tokio::time::sleep(delay).await;
-        };
+            .map_err(|e| {
+                AxOrdersWsClientError::Transport(format!("Failed to connect to {}: {e}", self.url))
+            })?;
 
         self.connection_mode.store(client.connection_mode_atomic());
         let reconnect_handle = client.reconnect_handle();
@@ -726,6 +684,7 @@ impl AxOrdersWebSocketClient {
         log::debug!("Closing WebSocket client");
 
         // Send disconnect first to allow graceful cleanup before signal
+        self.cancellation_token.load().cancel();
         let _ = self.send_cmd(HandlerCommand::Disconnect).await;
         tokio::time::sleep(Duration::from_millis(50)).await;
         self.signal.store(true, Ordering::Release);

--- a/crates/adapters/architect_ax/tests/websocket.rs
+++ b/crates/adapters/architect_ax/tests/websocket.rs
@@ -250,10 +250,8 @@ async fn test_md_connection_failure_to_invalid_url() {
 
     assert!(matches!(err, AxWsClientError::Transport(_)));
     assert!(
-        message.starts_with(&format!(
-            "Transport error: Failed to connect to {url} after 5 attempts: "
-        )),
-        "expected the retry ladder to run to exhaustion, was: {message}"
+        message.starts_with(&format!("Transport error: Failed to connect to {url}: ")),
+        "expected the failure to name the endpoint, was: {message}"
     );
     assert!(
         !message.contains("Connection timeout"),
@@ -1299,10 +1297,8 @@ async fn test_orders_connection_failure_to_invalid_url() {
 
     assert!(matches!(err, AxOrdersWsClientError::Transport(_)));
     assert!(
-        message.starts_with(&format!(
-            "Transport error: Failed to connect to {url} after 5 attempts: "
-        )),
-        "expected the retry ladder to run to exhaustion, was: {message}"
+        message.starts_with(&format!("Transport error: Failed to connect to {url}: ")),
+        "expected the failure to name the endpoint, was: {message}"
     );
     assert!(
         !message.contains("Connection timeout"),

--- a/crates/adapters/bybit/src/websocket/client.rs
+++ b/crates/adapters/bybit/src/websocket/client.rs
@@ -20,6 +20,7 @@
 use std::{
     collections::HashSet,
     fmt::Debug,
+    num::NonZeroU32,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
@@ -40,13 +41,12 @@ use nautilus_model::{
     types::{Price, Quantity},
 };
 use nautilus_network::{
-    backoff::ExponentialBackoff,
     http::USER_AGENT,
     mode::ConnectionMode,
     ratelimiter::{RateLimiter, clock::MonotonicClock},
     websocket::{
-        AuthTracker, SubscriptionState, TransportBackend, WebSocketClient, WebSocketConfig,
-        channel_message_handler,
+        AuthTracker, InitialConnectRetryPolicy, SubscriptionState, TransportBackend,
+        WebSocketClient, WebSocketConfig, channel_message_handler,
     },
 };
 use serde_json::Value;
@@ -135,7 +135,7 @@ pub struct BybitWebSocketClient {
     bars_timestamp_on_close: Arc<AtomicBool>,
     pending_py_requests: Arc<DashMap<String, Vec<PendingPyRequest>>>,
     transport_backend: TransportBackend,
-    cancellation_token: CancellationToken,
+    cancellation_token: Arc<ArcSwap<CancellationToken>>,
     proxy_url: Option<String>,
     socket_control: Option<SocketControl>,
 }
@@ -182,7 +182,7 @@ impl Clone for BybitWebSocketClient {
             bars_timestamp_on_close: Arc::clone(&self.bars_timestamp_on_close),
             pending_py_requests: Arc::clone(&self.pending_py_requests),
             transport_backend: self.transport_backend,
-            cancellation_token: self.cancellation_token.clone(),
+            cancellation_token: Arc::clone(&self.cancellation_token),
             proxy_url: self.proxy_url.clone(),
             socket_control: self.socket_control.clone(),
         }
@@ -190,6 +190,16 @@ impl Clone for BybitWebSocketClient {
 }
 
 impl BybitWebSocketClient {
+    fn initial_connect_retry_policy() -> InitialConnectRetryPolicy {
+        InitialConnectRetryPolicy {
+            max_attempts: NonZeroU32::new(5).expect("initial connect attempts must be non-zero"),
+            delay_initial: Duration::from_millis(500),
+            delay_max: Duration::from_secs(5),
+            backoff_factor: 2.0,
+            jitter_ms: 250,
+        }
+    }
+
     /// Creates a new Bybit public WebSocket client.
     #[must_use]
     pub fn new_public(url: Option<String>, heartbeat: u64) -> Self {
@@ -259,7 +269,7 @@ impl BybitWebSocketClient {
             account_id: None,
             mm_level: Arc::new(AtomicU8::new(0)),
             transport_backend,
-            cancellation_token: CancellationToken::new(),
+            cancellation_token: Arc::new(ArcSwap::from_pointee(CancellationToken::new())),
             proxy_url,
             socket_control: None,
         }
@@ -329,7 +339,7 @@ impl BybitWebSocketClient {
             account_id: None,
             mm_level: Arc::new(AtomicU8::new(0)),
             transport_backend,
-            cancellation_token: CancellationToken::new(),
+            cancellation_token: Arc::new(ArcSwap::from_pointee(CancellationToken::new())),
             proxy_url,
             socket_control: None,
         }
@@ -392,7 +402,7 @@ impl BybitWebSocketClient {
             account_id: None,
             mm_level: Arc::new(AtomicU8::new(0)),
             transport_backend,
-            cancellation_token: CancellationToken::new(),
+            cancellation_token: Arc::new(ArcSwap::from_pointee(CancellationToken::new())),
             proxy_url,
             socket_control: None,
         }
@@ -405,9 +415,10 @@ impl BybitWebSocketClient {
     /// Returns an error if the underlying WebSocket connection cannot be established,
     /// after retrying multiple times with exponential backoff.
     pub async fn connect(&mut self) -> BybitWsResult<()> {
-        const MAX_RETRIES: u32 = 5;
-
         self.signal.store(false, Ordering::Relaxed);
+        let cancellation_token = CancellationToken::new();
+        self.cancellation_token
+            .store(Arc::new(cancellation_token.clone()));
 
         let (raw_handler, raw_rx) = channel_message_handler();
 
@@ -437,19 +448,6 @@ impl BybitWebSocketClient {
             proxy_url: self.proxy_url.clone(),
         };
 
-        // Retry initial connection with exponential backoff to handle transient DNS/network issues
-        let mut backoff = ExponentialBackoff::new(
-            Duration::from_millis(500),
-            Duration::from_millis(5000),
-            2.0,
-            250,
-            false,
-        )
-        .map_err(|e| BybitWsError::ClientError(e.to_string()))?;
-
-        #[allow(unused_assignments)]
-        let mut last_error = String::new();
-        let mut attempt = 0;
         let message_rate_limiter = Arc::new(RateLimiter::<Ustr, MonotonicClock>::new_with_quota(
             None,
             vec![],
@@ -457,54 +455,24 @@ impl BybitWebSocketClient {
         let connection_rate_limiter =
             websocket_connection_limiter(&self.url, self.proxy_url.as_deref());
         let connection_rate_keys: Arc<[Ustr]> = Arc::from([websocket_connection_key()]);
-        let client = loop {
-            attempt += 1;
-
-            match WebSocketClient::builder()
-                .config(config.clone())
-                .message_handler(raw_handler.clone())
-                .rate_limiter(Arc::clone(&message_rate_limiter))
-                .connection_rate_limiter(Arc::clone(&connection_rate_limiter))
-                .connection_rate_keys(Arc::clone(&connection_rate_keys))
-                .maybe_state_sink(self.socket_control.as_ref().map(SocketControl::sink))
-                .connect()
-                .await
-            {
-                Ok(client) => {
-                    if attempt > 1 {
-                        log::info!("WebSocket connection established after {attempt} attempts");
-                    }
-                    break client;
-                }
-                Err(e) => {
-                    last_error = e.to_string();
-                    log::warn!(
-                        "WebSocket connection attempt failed: attempt={attempt}, max_retries={MAX_RETRIES}, url={}, error={last_error}",
-                        self.url
-                    );
-                }
-            }
-
-            if attempt >= MAX_RETRIES {
-                return Err(BybitWsError::Transport(format!(
-                    "Failed to connect to {} after {MAX_RETRIES} attempts: {}. \
+        let client = WebSocketClient::builder()
+            .config(config.clone())
+            .message_handler(raw_handler.clone())
+            .rate_limiter(Arc::clone(&message_rate_limiter))
+            .connection_rate_limiter(Arc::clone(&connection_rate_limiter))
+            .connection_rate_keys(Arc::clone(&connection_rate_keys))
+            .initial_connect_retry_policy(Self::initial_connect_retry_policy())
+            .cancellation_token(cancellation_token)
+            .maybe_state_sink(self.socket_control.as_ref().map(SocketControl::sink))
+            .connect()
+            .await
+            .map_err(|e| {
+                BybitWsError::Transport(format!(
+                    "Failed to connect to {}: {e}. \
                     If this is a DNS error, check your network configuration and DNS settings.",
                     self.url,
-                    if last_error.is_empty() {
-                        "unknown error"
-                    } else {
-                        &last_error
-                    }
-                )));
-            }
-
-            let delay = backoff.next_duration();
-            log::debug!(
-                "Retrying in {delay:?} (attempt {}/{MAX_RETRIES})",
-                attempt + 1
-            );
-            tokio::time::sleep(delay).await;
-        };
+                ))
+            })?;
 
         self.connection_mode.store(client.connection_mode_atomic());
         let reconnect_handle = client.reconnect_handle();
@@ -700,6 +668,7 @@ impl BybitWebSocketClient {
         log::debug!("Starting close process");
 
         self.signal.store(true, Ordering::Relaxed);
+        self.cancellation_token.load().cancel();
 
         let cmd = HandlerCommand::Disconnect;
         if let Err(e) = self.cmd_tx.read().await.send(cmd) {

--- a/crates/network/src/transport/error.rs
+++ b/crates/network/src/transport/error.rs
@@ -35,6 +35,14 @@ pub enum TransportError {
     #[error("handshake failed: {0}")]
     Handshake(String),
 
+    /// Server rejected the WebSocket HTTP upgrade.
+    #[error("WebSocket upgrade rejected with status {0}")]
+    UpgradeRejected(u16),
+
+    /// Proxy rejected the HTTP CONNECT request.
+    #[error("proxy CONNECT rejected with status {0}")]
+    ProxyConnectRejected(u16),
+
     /// URL was invalid or unsupported.
     #[error("invalid URL: {0}")]
     InvalidUrl(String),
@@ -159,6 +167,8 @@ mod tests {
             TransportError::InvalidUtf8,
             TransportError::Tls("bad".into()),
             TransportError::Handshake("bad".into()),
+            TransportError::UpgradeRejected(429),
+            TransportError::ProxyConnectRejected(503),
         ] {
             assert!(err.is_fatal(), "expected fatal: {err:?}");
             assert!(!err.is_closed(), "expected not closed: {err:?}");

--- a/crates/network/src/transport/sockudo.rs
+++ b/crates/network/src/transport/sockudo.rs
@@ -76,7 +76,7 @@ pub(crate) async fn client_handshake_with_headers<S>(
     path: &str,
     protocol: Option<&str>,
     extra_headers: &[(String, String)],
-) -> Result<HandshakeResult, SockudoError>
+) -> Result<HandshakeResult, TransportError>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -85,26 +85,33 @@ where
     let key = handshake::generate_key();
     let request = build_request_with_headers(host, path, &key, protocol, None, extra_headers);
 
-    stream.write_all(&request).await?;
-    stream.flush().await?;
+    stream
+        .write_all(&request)
+        .await
+        .map_err(TransportError::from)?;
+    stream.flush().await.map_err(TransportError::from)?;
 
     let mut buf = BytesMut::with_capacity(4096);
 
     loop {
         if buf.len() > MAX_HTTP_HEADER_SIZE {
-            return Err(SockudoError::InvalidHttp("response too large"));
+            return Err(SockudoError::InvalidHttp("response too large").into());
         }
 
-        let n = stream.read_buf(&mut buf).await?;
+        let n = stream
+            .read_buf(&mut buf)
+            .await
+            .map_err(TransportError::from)?;
         if n == 0 {
-            return Err(SockudoError::ConnectionClosed);
+            return Err(TransportError::ConnectionClosed);
         }
 
         let parsed = match handshake::parse_response(&buf) {
             Ok(parsed) => parsed,
             Err(e) => {
                 log_handshake_response(&e, &buf);
-                return Err(e);
+                return Err(rejected_upgrade_status(&e, &buf)
+                    .map_or_else(|| TransportError::from(e), TransportError::UpgradeRejected));
             }
         };
 
@@ -112,13 +119,13 @@ where
             let accept = res.accept.ok_or_else(|| {
                 let e = SockudoError::HandshakeFailed("missing Sec-WebSocket-Accept");
                 log_handshake_response(&e, &buf);
-                e
+                TransportError::from(e)
             })?;
 
             if !handshake::validate_accept_key(&key, accept) {
                 let e = SockudoError::HandshakeFailed("invalid Sec-WebSocket-Accept");
                 log_handshake_response(&e, &buf);
-                return Err(e);
+                return Err(e.into());
             }
 
             let res_protocol = res.protocol.map(String::from);
@@ -137,6 +144,29 @@ where
             });
         }
     }
+}
+
+// Gated on the error variant rather than its message. `HandshakeFailed` means the response parsed
+// as HTTP but failed handshake validation, which is the only case where a rejection status is
+// recoverable; `InvalidHttp` stays permanent. Matching the diagnostic text would put an upstream
+// string into transport semantics, and recovering after any error would let a plausible status
+// line with malformed headers pass as a rejection.
+fn rejected_upgrade_status(err: &SockudoError, buf: &[u8]) -> Option<u16> {
+    if !matches!(err, SockudoError::HandshakeFailed(_)) {
+        return None;
+    }
+
+    let status_line_end = buf.windows(2).position(|window| window == b"\r\n")?;
+    let status_line = std::str::from_utf8(&buf[..status_line_end]).ok()?;
+    let mut parts = status_line.split_whitespace();
+    let version = parts.next()?;
+    let status = parts.next()?;
+    if !version.starts_with("HTTP/1.") || status.len() != 3 {
+        return None;
+    }
+
+    // A 101 that still failed validation is a protocol fault, not a rejection.
+    status.parse().ok().filter(|status| *status != 101)
 }
 
 fn log_handshake_response(err: &SockudoError, buf: &BytesMut) {
@@ -605,8 +635,26 @@ mod tests {
 
         assert!(matches!(
             err,
-            SockudoError::HandshakeFailed("missing Sec-WebSocket-Accept")
+            TransportError::Handshake(ref msg) if msg == "missing Sec-WebSocket-Accept"
         ));
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "turmoil"))]
+    async fn client_handshake_with_headers_preserves_rejected_status() {
+        let (mut client, mut server) = duplex(4096);
+
+        let server_task = tokio::spawn(async move {
+            let _request = read_http_request(&mut server).await;
+            server.write_all(b"HTTP/1.1 429\r\n\r\n").await.unwrap();
+        });
+
+        let err = client_handshake_with_headers(&mut client, "example.com", "/ws", None, &[])
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, TransportError::UpgradeRejected(429)));
         server_task.await.unwrap();
     }
 

--- a/crates/network/src/transport/tungstenite.rs
+++ b/crates/network/src/transport/tungstenite.rs
@@ -123,9 +123,7 @@ impl From<tungstenite::Error> for TransportError {
             tungstenite::Error::Protocol(e) => Self::Protocol(e.to_string()),
             tungstenite::Error::Utf8(_) => Self::InvalidUtf8,
             tungstenite::Error::Url(e) => Self::InvalidUrl(e.to_string()),
-            tungstenite::Error::Http(resp) => {
-                Self::Handshake(format!("HTTP status {}", resp.status()))
-            }
+            tungstenite::Error::Http(resp) => Self::UpgradeRejected(resp.status().as_u16()),
             tungstenite::Error::HttpFormat(e) => Self::Handshake(e.to_string()),
             other => Self::Other(other.to_string()),
         }

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -2638,7 +2638,7 @@ impl WebSocketClient {
     ///
     /// `cancellation_token` aborts the initial connection only, and is observed during the
     /// connection rate-limit wait, the dial itself, and each backoff delay. It has no effect once
-    /// this function returns a client: use [`Self::close`] to stop an established one, whose
+    /// this function returns a client: use [`WebSocketClient::disconnect`] to stop an established one, whose
     /// reconnect loop the token does not govern.
     ///
     /// The message handler is required:

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -81,13 +81,14 @@ use tokio_tungstenite::connect_async_with_config;
 use tokio_tungstenite::tungstenite::{
     client::IntoClientRequest, handshake::client::Request, http::HeaderValue,
 };
+use tokio_util::sync::CancellationToken;
 use ustr::Ustr;
 
 #[cfg(not(feature = "turmoil"))]
 use super::proxy::{ProxyKind, WsTarget, tunnel_via_proxy};
 use super::{
     auth::{AuthState, AuthTracker},
-    config::{TransportBackend, WebSocketConfig},
+    config::{InitialConnectRetryPolicy, TransportBackend, WebSocketConfig},
     consts::{
         CONNECTION_STATE_CHECK_INTERVAL_MS, GRACEFUL_SHUTDOWN_DELAY_MS,
         GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
@@ -182,6 +183,12 @@ pub struct WebSocketClientInner {
 struct ConnectionRateLimit {
     limiter: Arc<RateLimiter<Ustr, MonotonicClock>>,
     keys: Arc<[Ustr]>,
+}
+
+#[derive(Default)]
+struct InitialConnectOptions {
+    retry_policy: Option<InitialConnectRetryPolicy>,
+    cancellation_token: Option<CancellationToken>,
 }
 
 impl WebSocketClientInner {
@@ -322,6 +329,7 @@ impl WebSocketClientInner {
             ping_handler.map(IncomingPingHandler::Ping),
             None,
             None,
+            InitialConnectOptions::default(),
         )
         .await
     }
@@ -332,6 +340,7 @@ impl WebSocketClientInner {
         ping_handler: Option<IncomingPingHandler>,
         state_sink: Option<SocketStateSink>,
         connection_rate_limit: Option<ConnectionRateLimit>,
+        initial_connect_options: InitialConnectOptions,
     ) -> Result<Self, TransportError> {
         install_cryptographic_provider();
 
@@ -375,33 +384,97 @@ impl WebSocketClientInner {
 
         let reconnect_headers = ReconnectHeaders::new(config.headers.clone());
 
-        if let Some(rate_limit) = &connection_rate_limit {
-            rate_limit
-                .limiter
-                .await_keys_ready(Some(&rate_limit.keys))
-                .await;
-        }
+        let cancellation_token = initial_connect_options
+            .cancellation_token
+            .unwrap_or_default();
+        let max_attempts = initial_connect_options
+            .retry_policy
+            .as_ref()
+            .map_or(1, |policy| policy.max_attempts.get());
+        let mut initial_connect_backoff = initial_connect_options
+            .retry_policy
+            .as_ref()
+            .map(|policy| {
+                ExponentialBackoff::new(
+                    policy.delay_initial,
+                    policy.delay_max,
+                    policy.backoff_factor,
+                    policy.jitter_ms,
+                    false,
+                )
+            })
+            .transpose()
+            .map_err(|e| {
+                TransportError::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+            })?;
 
-        // Bound the connection attempt: a server that accepts TCP but never upgrades must not hang the caller
-        let (writer, reader) = dst::time::timeout(
-            connect_timeout,
-            Box::pin(Self::connect_with_server(
-                &config.url,
-                config.headers.clone(),
-                config.backend,
-                config.proxy_url.as_deref(),
-            )),
-        )
-        .await
-        .map_err(|_| {
-            TransportError::Io(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                format!(
-                    "connection timed out after {}s",
-                    connect_timeout.as_secs_f64()
-                ),
-            ))
-        })??;
+        let mut attempt = 0;
+        let (writer, reader) = loop {
+            attempt += 1;
+
+            if let Some(rate_limit) = &connection_rate_limit {
+                tokio::select! {
+                    biased;
+                    () = cancellation_token.cancelled() => return Err(initial_connect_cancelled()),
+                    () = rate_limit.limiter.await_keys_ready(Some(&rate_limit.keys)) => {}
+                }
+            }
+
+            // Bound the connection attempt: a server that accepts TCP but never upgrades must not hang the caller.
+            let result = tokio::select! {
+                biased;
+                () = cancellation_token.cancelled() => return Err(initial_connect_cancelled()),
+                result = dst::time::timeout(
+                    connect_timeout,
+                    Box::pin(Self::connect_with_server(
+                        &config.url,
+                        config.headers.clone(),
+                        config.backend,
+                        config.proxy_url.as_deref(),
+                    )),
+                ) => result.unwrap_or_else(|_| {
+                    // A timed-out attempt is transient and must reach the retry
+                    // classification below rather than aborting the ladder.
+                    Err(TransportError::Io(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!(
+                            "connection timed out after {}s",
+                            connect_timeout.as_secs_f64()
+                        ),
+                    )))
+                }),
+            };
+
+            match result {
+                Ok(transport) => {
+                    if attempt > 1 {
+                        log::info!("WebSocket connection established after {attempt} attempts");
+                    }
+                    break transport;
+                }
+                Err(e) if attempt < max_attempts && is_retryable_initial_connect_error(&e) => {
+                    log::warn!(
+                        "WebSocket connection attempt {attempt}/{max_attempts} to {} failed: {e}",
+                        config.url,
+                    );
+                }
+                Err(e) => return Err(e),
+            }
+
+            let delay = initial_connect_backoff
+                .as_mut()
+                .expect("multiple attempts require a retry policy")
+                .next_duration();
+            log::debug!(
+                "Retrying in {delay:?} (attempt {}/{max_attempts})",
+                attempt + 1,
+            );
+            tokio::select! {
+                biased;
+                () = cancellation_token.cancelled() => return Err(initial_connect_cancelled()),
+                () = dst::time::sleep(delay) => {}
+            }
+        };
 
         let connection_mode = Arc::new(AtomicU8::new(ConnectionMode::Reconnect.as_u8()));
         let connection_epoch = Arc::new(AtomicU64::new(0));
@@ -838,6 +911,36 @@ fn tungstenite_request(
 
 fn is_connection_drop_transport_error(err: &TransportError) -> bool {
     err.is_closed() || matches!(err, TransportError::Io(e) if is_connection_drop_io_error(e))
+}
+
+fn is_retryable_initial_connect_error(err: &TransportError) -> bool {
+    match err {
+        TransportError::ConnectionClosed
+        | TransportError::ConnectionReset
+        | TransportError::ClosedByPeer(_) => true,
+        TransportError::Io(error) => !matches!(
+            error.kind(),
+            std::io::ErrorKind::InvalidInput
+                | std::io::ErrorKind::InvalidData
+                | std::io::ErrorKind::Unsupported
+                | std::io::ErrorKind::PermissionDenied
+        ),
+        TransportError::InvalidUrl(_)
+        | TransportError::Handshake(_)
+        | TransportError::Tls(_)
+        | TransportError::Protocol(_)
+        | TransportError::MessageTooLarge
+        | TransportError::FrameTooLarge
+        | TransportError::InvalidUtf8
+        | TransportError::Other(_) => false,
+    }
+}
+
+fn initial_connect_cancelled() -> TransportError {
+    TransportError::Io(std::io::Error::new(
+        std::io::ErrorKind::Interrupted,
+        "initial WebSocket connection cancelled",
+    ))
 }
 
 // Debug when we asked to disconnect (Disconnect/Closed), else Warn for a peer close
@@ -2513,6 +2616,8 @@ impl WebSocketClient {
         state_sink: Option<SocketStateSink>,
         connection_rate_limiter: Option<Arc<RateLimiter<Ustr, MonotonicClock>>>,
         #[builder(default)] connection_rate_keys: Arc<[Ustr]>,
+        initial_connect_retry_policy: Option<InitialConnectRetryPolicy>,
+        cancellation_token: Option<CancellationToken>,
     ) -> Result<Self, TransportError> {
         let rate_limiter = Self::resolve_rate_limiter(default_quota, keyed_quotas, rate_limiter)?;
         let connection_rate_limit =
@@ -2524,6 +2629,10 @@ impl WebSocketClient {
             rate_limiter,
             state_sink,
             connection_rate_limit,
+            InitialConnectOptions {
+                retry_policy: initial_connect_retry_policy,
+                cancellation_token,
+            },
         )
         .await
     }
@@ -2567,6 +2676,8 @@ impl WebSocketClient {
         state_sink: Option<SocketStateSink>,
         connection_rate_limiter: Option<Arc<RateLimiter<Ustr, MonotonicClock>>>,
         #[builder(default)] connection_rate_keys: Arc<[Ustr]>,
+        initial_connect_retry_policy: Option<InitialConnectRetryPolicy>,
+        cancellation_token: Option<CancellationToken>,
     ) -> Result<Self, TransportError> {
         let ping_handler = match (ping_handler, epoch_ping_handler) {
             (Some(_), Some(_)) => {
@@ -2589,6 +2700,10 @@ impl WebSocketClient {
             rate_limiter,
             state_sink,
             connection_rate_limit,
+            InitialConnectOptions {
+                retry_policy: initial_connect_retry_policy,
+                cancellation_token,
+            },
         )
         .await
     }
@@ -2646,6 +2761,7 @@ impl WebSocketClient {
         rate_limiter: Arc<RateLimiter<Ustr, MonotonicClock>>,
         state_sink: Option<SocketStateSink>,
         connection_rate_limit: Option<ConnectionRateLimit>,
+        initial_connect_options: InitialConnectOptions,
     ) -> Result<Self, TransportError> {
         log::debug!("Connecting");
         let inner = WebSocketClientInner::connect_url_with_handler(
@@ -2654,6 +2770,7 @@ impl WebSocketClient {
             ping_handler,
             state_sink,
             connection_rate_limit,
+            initial_connect_options,
         )
         .await?;
         let connection_mode = inner.connection_mode.clone();
@@ -4601,6 +4718,143 @@ mod rust_tests {
         }
     }
 
+    fn initial_connect_test_policy() -> InitialConnectRetryPolicy {
+        InitialConnectRetryPolicy {
+            max_attempts: std::num::NonZeroU32::new(5).unwrap(),
+            delay_initial: Duration::from_secs(30),
+            delay_max: Duration::from_secs(30),
+            backoff_factor: 2.0,
+            jitter_ms: 0,
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn initial_connect_cancellation_interrupts_in_flight_handshake() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+
+        let server = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            let _ = accepted_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        let token = CancellationToken::new();
+        let (handler, _rx) = channel_message_handler();
+        let mut config = reconnect_test_config(port);
+        config.connect_timeout_ms = Some(10_000);
+        let connect = WebSocketClient::builder()
+            .config(config)
+            .message_handler(handler)
+            .initial_connect_retry_policy(initial_connect_test_policy())
+            .cancellation_token(token.clone())
+            .connect();
+        tokio::pin!(connect);
+
+        tokio::select! {
+            biased;
+            result = &mut connect => panic!("connect completed before cancellation: {result:?}"),
+            result = accepted_rx => result.unwrap(),
+        }
+        token.cancel();
+
+        let err = tokio::time::timeout(Duration::from_millis(250), connect)
+            .await
+            .expect("cancellation should interrupt the handshake")
+            .expect_err("cancelled connect should fail");
+        assert!(
+            matches!(err, TransportError::Io(ref e) if e.kind() == std::io::ErrorKind::Interrupted)
+        );
+        server.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn timed_out_initial_connect_attempt_is_retried() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accepted = Arc::new(AtomicU64::new(0));
+        let accepted_server = Arc::clone(&accepted);
+
+        // Accept the TCP connection but never complete the upgrade, so every attempt
+        // reaches the connect timeout rather than failing fast.
+        let server = tokio::spawn(async move {
+            let mut held = Vec::new();
+
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                accepted_server.fetch_add(1, Ordering::SeqCst);
+                held.push(stream);
+            }
+        });
+
+        let (handler, _rx) = channel_message_handler();
+        let mut config = reconnect_test_config(port);
+        config.connect_timeout_ms = Some(50);
+        let policy = InitialConnectRetryPolicy {
+            max_attempts: std::num::NonZeroU32::new(3).unwrap(),
+            delay_initial: Duration::from_millis(1),
+            delay_max: Duration::from_millis(1),
+            backoff_factor: 1.0,
+            jitter_ms: 0,
+        };
+
+        let err = WebSocketClient::builder()
+            .config(config)
+            .message_handler(handler)
+            .initial_connect_retry_policy(policy)
+            .connect()
+            .await
+            .expect_err("every attempt times out");
+
+        assert!(
+            matches!(err, TransportError::Io(ref e) if e.kind() == std::io::ErrorKind::TimedOut)
+        );
+
+        // The ladder must exhaust its attempts: a timeout is transient, so returning after
+        // the first one leaves this at 1. Wait for the count rather than sampling it, since
+        // the final connection can complete through the listen backlog before the accepting
+        // task is scheduled to record it.
+        let counted = tokio::time::timeout(Duration::from_secs(1), async {
+            while accepted.load(Ordering::SeqCst) < 3 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+        assert!(
+            counted.is_ok(),
+            "expected 3 connection attempts, observed {}",
+            accepted.load(Ordering::SeqCst)
+        );
+        // Exactly three: the wait above resolves the scheduling race, but the ladder must
+        // also stop at its configured maximum rather than exceeding it.
+        assert_eq!(accepted.load(Ordering::SeqCst), 3);
+        server.abort();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn permanent_initial_connect_error_does_not_wait_for_retry_ladder() {
+        let (handler, _rx) = channel_message_handler();
+        let mut config = reconnect_test_config(1);
+        config.url = "not a websocket URL".to_string();
+        let connect = WebSocketClient::builder()
+            .config(config)
+            .message_handler(handler)
+            .initial_connect_retry_policy(initial_connect_test_policy())
+            .connect();
+
+        let err = tokio::time::timeout(Duration::from_millis(250), connect)
+            .await
+            .expect("permanent error should not enter retry backoff")
+            .expect_err("invalid URL should fail");
+        assert!(matches!(
+            err,
+            TransportError::InvalidUrl(_) | TransportError::Handshake(_)
+        ));
+    }
+
     #[rstest]
     #[tokio::test(start_paused = true)]
     async fn connection_rate_limit_gates_initial_connect_and_reconnect() {
@@ -4632,6 +4886,7 @@ mod rust_tests {
             None,
             None,
             Some(rate_limit),
+            InitialConnectOptions::default(),
         );
         tokio::pin!(initial);
         assert!(futures_util::poll!(&mut initial).is_pending());
@@ -4730,6 +4985,7 @@ mod rust_tests {
             None,
             None,
             None,
+            InitialConnectOptions::default(),
         )
         .await
         .unwrap();

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -60,6 +60,7 @@ use std::{
 
 use futures_util::{SinkExt, StreamExt};
 use http::HeaderName;
+use nautilus_core::string::secret::REDACTED;
 use nautilus_cryptography::providers::install_cryptographic_provider;
 #[cfg(any(feature = "turmoil", feature = "transport-sockudo"))]
 use rustls::ClientConfig;
@@ -453,9 +454,10 @@ impl WebSocketClientInner {
                     break transport;
                 }
                 Err(e) if attempt < max_attempts && is_retryable_initial_connect_error(&e) => {
+                    // The URL is redacted for the same reason `WebSocketConfig::Debug` redacts it:
+                    // it can carry credentials, tokens, or signed query parameters.
                     log::warn!(
-                        "WebSocket connection attempt {attempt}/{max_attempts} to {} failed: {e}",
-                        config.url,
+                        "WebSocket connection attempt {attempt}/{max_attempts} to {REDACTED} failed: {e}"
                     );
                 }
                 Err(e) => return Err(e),
@@ -2630,6 +2632,15 @@ impl WebSocketClient {
     /// creates one from `default_quota` and `keyed_quotas`. `connection_rate_limiter` gates the
     /// initial connection and reconnects using `connection_rate_keys`.
     ///
+    /// Without `initial_connect_retry_policy` the builder makes exactly one connection attempt.
+    /// With one, failures classified as retryable are retried up to its `max_attempts`; see
+    /// [`InitialConnectRetryPolicy`] for which failures return before that bound is reached.
+    ///
+    /// `cancellation_token` aborts the initial connection only, and is observed during the
+    /// connection rate-limit wait, the dial itself, and each backoff delay. It has no effect once
+    /// this function returns a client: use [`Self::close`] to stop an established one, whose
+    /// reconnect loop the token does not govern.
+    ///
     /// The message handler is required:
     ///
     /// ```compile_fail
@@ -2682,7 +2693,7 @@ impl WebSocketClient {
     /// The initial connection has epoch `0`. Each replacement connection increments the epoch,
     /// and both its incoming messages and `RECONNECTED` notification carry that new value. Use
     /// [`Self::send_text_on_connection`] to bind an outgoing message to one of those epochs.
-    /// Rate-limit and state options match [`Self::builder`].
+    /// Rate-limit, state, initial-connect retry, and cancellation options match [`Self::builder`].
     /// Set either `ping_handler` or `epoch_ping_handler` when custom ping handling is required.
     ///
     /// The epoch handler is required:
@@ -3609,8 +3620,10 @@ mod tests {
     use futures_util::{SinkExt, StreamExt};
     use log::{Level, LevelFilter, Log, Metadata, Record};
     use nautilus_common::testing::wait_until_async;
+    use nautilus_core::string::secret::REDACTED;
     use rstest::rstest;
     use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
         sync::{mpsc, oneshot},
         task::{self, JoinHandle},
@@ -3630,7 +3643,10 @@ mod tests {
         http::{HttpClient, Method},
         mode::ConnectionMode,
         ratelimiter::quota::Quota,
-        websocket::{TransportBackend, WebSocketClient, WebSocketConfig},
+        transport::TransportError,
+        websocket::{
+            InitialConnectRetryPolicy, TransportBackend, WebSocketClient, WebSocketConfig,
+        },
     };
 
     const SECRET_MARKER: &str = "OUTBOUND_SECRET_MARKER";
@@ -3686,7 +3702,7 @@ mod tests {
 
     impl Log for NetworkLogCapture {
         fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            metadata.level() == Level::Trace
+            matches!(metadata.level(), Level::Trace | Level::Warn)
                 && matches!(
                     metadata.target(),
                     "nautilus_network::http::client" | "nautilus_network::websocket::client"
@@ -3699,6 +3715,7 @@ mod tests {
                 if message.starts_with("Sending ")
                     || message.starts_with("Received ")
                     || message.starts_with("Replaced ")
+                    || message.starts_with("WebSocket connection attempt ")
                 {
                     self.messages.lock().unwrap().push(message);
                 }
@@ -3935,8 +3952,72 @@ mod tests {
             .await
             .unwrap();
 
+        // The initial-connect retry warning names the endpoint, which can carry credentials or
+        // signed query data, so it must report the redaction placeholder rather than the URL.
+        let rejecting = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let rejecting_port = rejecting.local_addr().unwrap().port();
+
+        let rejecting_server = task::spawn(async move {
+            loop {
+                let (mut stream, _) = rejecting.accept().await.unwrap();
+                let mut request = [0; 1024];
+                let _ = stream.read(&mut request).await.unwrap();
+                stream
+                    .write_all(b"HTTP/1.1 503 Service Unavailable\r\n\r\n")
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let retry_config = WebSocketConfig {
+            url: format!("ws://127.0.0.1:{rejecting_port}/?token={SECRET_MARKER}"),
+            headers: vec![],
+            heartbeat_interval_secs: None,
+            heartbeat_payload: None,
+            connect_timeout_ms: Some(5_000),
+            reconnect_delay_initial_ms: None,
+            reconnect_backoff_factor: None,
+            reconnect_delay_max_ms: None,
+            reconnect_jitter_ms: None,
+            reconnect_max_attempts: None,
+            heartbeat_timeout_secs: None,
+            idle_timeout_ms: None,
+            backend: TransportBackend::Tungstenite,
+            proxy_url: None,
+        };
+        let retry_error = WebSocketClient::builder()
+            .config(retry_config)
+            .message_handler(Arc::new(|_| {}))
+            .initial_connect_retry_policy(InitialConnectRetryPolicy {
+                max_attempts: NonZeroU32::new(2).unwrap(),
+                delay_initial: Duration::from_millis(1),
+                delay_max: Duration::from_millis(1),
+                backoff_factor: 1.0,
+                jitter_ms: 0,
+            })
+            .connect()
+            .await
+            .expect_err("server always rejects the upgrade");
+        rejecting_server.abort();
+
+        assert!(
+            matches!(retry_error, TransportError::UpgradeRejected(503)),
+            "expected a 503 upgrade rejection, was: {retry_error:?}"
+        );
+
         let messages = NETWORK_LOG_CAPTURE.messages();
         let invalid_header_message = invalid_header_error.to_string();
+
+        // Asserted positively so the blanket secret assertion below cannot pass vacuously by
+        // capturing no warning at all.
+        let retry_warning = messages
+            .iter()
+            .find(|message| message.starts_with("WebSocket connection attempt 1/2 "))
+            .expect("initial-connect retry warning was not captured");
+        assert!(
+            retry_warning.contains(REDACTED),
+            "retry warning omitted the redaction placeholder: {retry_warning}"
+        );
 
         assert!(
             messages.iter().all(|message| {
@@ -4665,8 +4746,9 @@ mod rust_tests {
     #[cfg(feature = "transport-sockudo")]
     use sockudo_ws::handshake as sockudo_handshake;
     #[cfg(feature = "transport-sockudo")]
-    use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncRead;
     use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
         task::{self, JoinHandle},
         time::{Duration, sleep},

--- a/crates/network/src/websocket/client.rs
+++ b/crates/network/src/websocket/client.rs
@@ -876,8 +876,7 @@ impl WebSocketClientInner {
             None,
             headers,
         )
-        .await
-        .map_err(TransportError::from)?;
+        .await?;
 
         // Reading the HTTP 101 may also read the first WebSocket frame prefix;
         // replay it only when present so the ordinary path stays unwrapped.
@@ -925,6 +924,9 @@ fn is_retryable_initial_connect_error(err: &TransportError) -> bool {
                 | std::io::ErrorKind::Unsupported
                 | std::io::ErrorKind::PermissionDenied
         ),
+        TransportError::UpgradeRejected(status) | TransportError::ProxyConnectRejected(status) => {
+            retryable_status(*status)
+        }
         TransportError::InvalidUrl(_)
         | TransportError::Handshake(_)
         | TransportError::Tls(_)
@@ -934,6 +936,10 @@ fn is_retryable_initial_connect_error(err: &TransportError) -> bool {
         | TransportError::InvalidUtf8
         | TransportError::Other(_) => false,
     }
+}
+
+const fn retryable_status(status: u16) -> bool {
+    matches!(status, 408 | 425 | 429 | 500..=599)
 }
 
 fn initial_connect_cancelled() -> TransportError {
@@ -994,6 +1000,40 @@ mod connection_error_tests {
         #[case] expected: bool,
     ) {
         assert_eq!(is_connection_drop_transport_error(&err), expected);
+    }
+
+    #[rstest]
+    #[case(408, true)]
+    #[case(425, true)]
+    #[case(429, true)]
+    #[case(500, true)]
+    #[case(503, true)]
+    #[case(599, true)]
+    #[case(400, false)]
+    #[case(401, false)]
+    #[case(403, false)]
+    #[case(404, false)]
+    #[case(407, false)]
+    #[case(409, false)]
+    #[case(426, false)]
+    #[case(499, false)]
+    #[case(600, false)]
+    #[case(101, false)]
+    #[case(200, false)]
+    fn initial_connect_retryable_status_policy(#[case] status: u16, #[case] expected: bool) {
+        assert_eq!(retryable_status(status), expected);
+    }
+
+    #[rstest]
+    #[case(TransportError::UpgradeRejected(429), true)]
+    #[case(TransportError::UpgradeRejected(503), true)]
+    #[case(TransportError::UpgradeRejected(404), false)]
+    #[case(TransportError::ProxyConnectRejected(429), true)]
+    #[case(TransportError::ProxyConnectRejected(407), false)]
+    #[case(TransportError::ConnectionClosed, true)]
+    #[case(TransportError::Handshake("malformed".into()), false)]
+    fn initial_connect_error_classification(#[case] err: TransportError, #[case] expected: bool) {
+        assert_eq!(is_retryable_initial_connect_error(&err), expected);
     }
 }
 
@@ -4728,6 +4768,99 @@ mod rust_tests {
         }
     }
 
+    async fn rejected_upgrade_attempts(status: u16, backend: TransportBackend) -> u64 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accepted = Arc::new(AtomicU64::new(0));
+        let accepted_server = Arc::clone(&accepted);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                accepted_server.fetch_add(1, Ordering::SeqCst);
+                let mut request = Vec::new();
+
+                loop {
+                    let mut chunk = [0; 1024];
+                    let n = stream.read(&mut chunk).await.unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&chunk[..n]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                stream
+                    .write_all(format!("HTTP/1.1 {status}\r\n\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let (handler, _rx) = channel_message_handler();
+        let mut config = reconnect_test_config(port);
+        config.backend = backend;
+        let policy = InitialConnectRetryPolicy {
+            max_attempts: std::num::NonZeroU32::new(3).unwrap(),
+            delay_initial: Duration::from_millis(1),
+            delay_max: Duration::from_millis(1),
+            backoff_factor: 1.0,
+            jitter_ms: 0,
+        };
+
+        WebSocketClient::builder()
+            .config(config)
+            .message_handler(handler)
+            .initial_connect_retry_policy(policy)
+            .connect()
+            .await
+            .expect_err("server always rejects the upgrade");
+
+        let attempts = accepted.load(Ordering::SeqCst);
+        server.abort();
+        attempts
+    }
+
+    async fn closed_proxy_attempts() -> u64 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        let accepted = Arc::new(AtomicU64::new(0));
+        let accepted_server = Arc::clone(&accepted);
+
+        let server = tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                accepted_server.fetch_add(1, Ordering::SeqCst);
+                let mut request = [0; 1024];
+                let _ = stream.read(&mut request).await.unwrap();
+            }
+        });
+
+        let (handler, _rx) = channel_message_handler();
+        let mut config = reconnect_test_config(9);
+        config.proxy_url = Some(format!("http://{proxy_addr}"));
+        let policy = InitialConnectRetryPolicy {
+            max_attempts: std::num::NonZeroU32::new(3).unwrap(),
+            delay_initial: Duration::from_millis(1),
+            delay_max: Duration::from_millis(1),
+            backoff_factor: 1.0,
+            jitter_ms: 0,
+        };
+
+        WebSocketClient::builder()
+            .config(config)
+            .message_handler(handler)
+            .initial_connect_retry_policy(policy)
+            .connect()
+            .await
+            .expect_err("proxy always closes before its CONNECT response");
+
+        let attempts = accepted.load(Ordering::SeqCst);
+        server.abort();
+        attempts
+    }
+
     #[rstest]
     #[tokio::test]
     async fn initial_connect_cancellation_interrupts_in_flight_handshake() {
@@ -4831,6 +4964,42 @@ mod rust_tests {
         // also stop at its configured maximum rather than exceeding it.
         assert_eq!(accepted.load(Ordering::SeqCst), 3);
         server.abort();
+    }
+
+    #[rstest]
+    #[case::too_many_requests(429)]
+    #[case::server_error(503)]
+    #[tokio::test]
+    async fn transient_upgrade_rejection_is_retried(#[case] status: u16) {
+        assert_eq!(
+            rejected_upgrade_attempts(status, TransportBackend::Tungstenite).await,
+            3
+        );
+    }
+
+    #[cfg(feature = "transport-sockudo")]
+    #[rstest]
+    #[tokio::test]
+    async fn sockudo_too_many_requests_upgrade_rejection_is_retried() {
+        assert_eq!(
+            rejected_upgrade_attempts(429, TransportBackend::Sockudo).await,
+            3
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn permanent_upgrade_rejection_is_not_retried() {
+        assert_eq!(
+            rejected_upgrade_attempts(404, TransportBackend::Tungstenite).await,
+            1
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn proxy_close_before_connect_response_is_retried() {
+        assert_eq!(closed_proxy_attempts().await, 3);
     }
 
     #[rstest]

--- a/crates/network/src/websocket/config.rs
+++ b/crates/network/src/websocket/config.rs
@@ -359,9 +359,23 @@ impl WebSocketConfig {
 ///
 /// This does not affect automatic reconnection after a connection has been established; that is
 /// configured by the `reconnect_*` fields of [`WebSocketConfig`].
+///
+/// An attempt is retried only after `ConnectionClosed`, `ConnectionReset`, or `ClosedByPeer`; an
+/// I/O error of any kind except `InvalidInput`, `InvalidData`, `Unsupported`, and
+/// `PermissionDenied`; or an HTTP upgrade or proxy `CONNECT` rejection carrying status 408, 425,
+/// 429, or 500 through 599. Every other transport error and rejection status returns immediately
+/// without waiting for a backoff delay, however many attempts remain.
+///
+/// The classification is by error variant, not by cause, and the backends do not map causes to
+/// variants uniformly - a TLS failure is permanent as `Tls` but follows the I/O rule where a
+/// backend reports it as `Io`. A permanent failure on the first attempt is indistinguishable from
+/// an exhausted ladder by the returned error alone.
 #[derive(Clone, Debug)]
 pub struct InitialConnectRetryPolicy {
     /// Maximum number of connection attempts, including the first attempt.
+    ///
+    /// This is an upper bound rather than a promise: a failure classified as permanent returns
+    /// before the bound is reached.
     pub max_attempts: NonZeroU32,
     /// Delay before the second connection attempt.
     pub delay_initial: Duration,

--- a/crates/network/src/websocket/config.rs
+++ b/crates/network/src/websocket/config.rs
@@ -28,7 +28,7 @@
 //! seconds resets its attempt count and backoff delay; shorter-lived connections continue the
 //! current cycle.
 
-use std::fmt::Debug;
+use std::{fmt::Debug, num::NonZeroU32, time::Duration};
 
 use nautilus_core::string::secret::REDACTED;
 use serde::{Deserialize, Serialize};
@@ -349,6 +349,28 @@ impl WebSocketConfig {
             self.heartbeat_interval_secs,
         )
     }
+}
+
+/// Retry policy for establishing the initial handler-mode connection.
+///
+/// Supplied to the client builder rather than held in [`WebSocketConfig`], because it governs a
+/// single invocation of `connect` and has no meaning once a client exists. Without a policy the
+/// builder makes exactly one attempt.
+///
+/// This does not affect automatic reconnection after a connection has been established; that is
+/// configured by the `reconnect_*` fields of [`WebSocketConfig`].
+#[derive(Clone, Debug)]
+pub struct InitialConnectRetryPolicy {
+    /// Maximum number of connection attempts, including the first attempt.
+    pub max_attempts: NonZeroU32,
+    /// Delay before the second connection attempt.
+    pub delay_initial: Duration,
+    /// Maximum delay between connection attempts.
+    pub delay_max: Duration,
+    /// Multiplier applied to the delay after each failed attempt.
+    pub backoff_factor: f64,
+    /// Maximum random jitter added to each delay, in milliseconds.
+    pub jitter_ms: u64,
 }
 
 #[cfg(test)]

--- a/crates/network/src/websocket/mod.rs
+++ b/crates/network/src/websocket/mod.rs
@@ -82,7 +82,7 @@ pub use auth::AuthTracker;
 pub use client::{
     ReconnectHeaders, WebSocketClient, WebSocketClientInner, WebSocketReconnectHandle,
 };
-pub use config::{TransportBackend, WebSocketConfig};
+pub use config::{InitialConnectRetryPolicy, TransportBackend, WebSocketConfig};
 pub use consts::{AUTHENTICATION_TIMEOUT_SECS, TEXT_PING, TEXT_PONG};
 pub use subscription::{SubscriptionSnapshot, SubscriptionState, split_topic};
 pub use types::{

--- a/crates/network/src/websocket/proxy.rs
+++ b/crates/network/src/websocket/proxy.rs
@@ -377,7 +377,7 @@ fn decode_userinfo(value: &str) -> String {
 /// - The TLS layer to the proxy or upstream cannot be established
 ///   ([`TransportError::Tls`]).
 /// - The proxy returns a non-success status, malformed headers, or closes the
-///   stream before completing the response ([`TransportError::Handshake`]).
+///   stream before completing the response.
 pub async fn tunnel_via_proxy(
     target: &WsTarget,
     proxy: &ProxyTarget,
@@ -463,9 +463,7 @@ where
     loop {
         let n = stream.read(&mut byte).await.map_err(TransportError::Io)?;
         if n == 0 {
-            return Err(TransportError::Handshake(
-                "proxy closed connection before sending CONNECT response".to_string(),
-            ));
+            return Err(TransportError::ConnectionClosed);
         }
 
         buf.push(byte[0]);
@@ -491,9 +489,22 @@ where
 
     // Expect: `HTTP/1.1 200 Connection established` (or any 2xx).
     let mut parts = status_line.splitn(3, ' ');
-    let _version = parts.next().ok_or_else(|| {
+    let version = parts.next().ok_or_else(|| {
         TransportError::Handshake("proxy CONNECT response has a malformed status line".to_string())
     })?;
+
+    // The version gates the status branch below: without this check a malformed line such as
+    // `NOT-HTTP 503 ...` would yield a retryable `ProxyConnectRejected` rather than staying a
+    // permanent handshake failure.
+    if !matches!(version, "HTTP/1.0" | "HTTP/1.1") {
+        return Err(TransportError::Handshake(
+            "proxy CONNECT response has a malformed status line".to_string(),
+        ));
+    }
+
+    // Parsed as a `StatusCode` rather than a bare `u16` for the same reason the version is
+    // validated above: the number now selects retry behavior, and `u16` parsing accepts tokens
+    // HTTP does not, normalizing `0503` to `503`.
     let status_code = parts
         .next()
         .ok_or_else(|| {
@@ -501,17 +512,16 @@ where
                 "proxy CONNECT response has a malformed status line".to_string(),
             )
         })?
-        .parse::<u16>()
+        .parse::<http::StatusCode>()
         .map_err(|_| {
             TransportError::Handshake(
-                "proxy CONNECT response has a non-numeric status code".to_string(),
+                "proxy CONNECT response has a invalid status code".to_string(),
             )
-        })?;
+        })?
+        .as_u16();
 
     if !(200..300).contains(&status_code) {
-        return Err(TransportError::Handshake(format!(
-            "proxy refused CONNECT with status {status_code}"
-        )));
+        return Err(TransportError::ProxyConnectRejected(status_code));
     }
 
     Ok(())
@@ -798,10 +808,7 @@ mod tests {
             .unwrap();
         stream.flush().await.unwrap();
         let err = read_connect_response(&mut stream).await.unwrap_err();
-        let TransportError::Handshake(msg) = err else {
-            panic!("expected Handshake error");
-        };
-        assert_eq!(msg, "proxy refused CONNECT with status 403");
+        assert!(matches!(err, TransportError::ProxyConnectRejected(403)));
     }
 
     /// 300 sits on the upper boundary of the accepted `200..300` range; if
@@ -809,16 +816,22 @@ mod tests {
     /// classic "Proxy Authentication Required" response. Non-numeric status
     /// probes the parse path.
     #[rstest]
-    #[case::status_300(&b"HTTP/1.1 300 Multiple Choices\r\n\r\n"[..], "300")]
+    #[case::status_300(&b"HTTP/1.1 300 Multiple Choices\r\n\r\n"[..], Some(300), None)]
     #[case::status_407(
         &b"HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic\r\n\r\n"[..],
-        "407",
+        Some(407),
+        None,
     )]
-    #[case::malformed_status(&b"HTTP/1.1 abc Boom\r\n\r\n"[..], "non-numeric status code")]
+    #[case::malformed_status(
+        &b"HTTP/1.1 abc Boom\r\n\r\n"[..],
+        None,
+        Some("invalid status code"),
+    )]
     #[tokio::test]
     async fn read_connect_response_rejects_non_2xx(
         #[case] response: &'static [u8],
-        #[case] expected_msg_substring: &'static str,
+        #[case] expected_status: Option<u16>,
+        #[case] expected_msg_substring: Option<&'static str>,
     ) {
         let addr = spawn_fake_proxy(response).await;
         let mut stream = TcpStream::connect(addr).await.unwrap();
@@ -828,13 +841,24 @@ mod tests {
             .unwrap();
         stream.flush().await.unwrap();
         let err = read_connect_response(&mut stream).await.unwrap_err();
-        let TransportError::Handshake(msg) = err else {
-            panic!("expected Handshake error, was {err:?}");
-        };
-        assert!(
-            msg.contains(expected_msg_substring),
-            "expected error message to contain {expected_msg_substring:?}, was {msg:?}"
-        );
+
+        match (expected_status, expected_msg_substring) {
+            (Some(status), None) => {
+                assert!(
+                    matches!(err, TransportError::ProxyConnectRejected(actual) if actual == status)
+                );
+            }
+            (None, Some(expected_msg_substring)) => {
+                let TransportError::Handshake(msg) = err else {
+                    panic!("expected Handshake error, was {err:?}");
+                };
+                assert!(
+                    msg.contains(expected_msg_substring),
+                    "expected error message to contain {expected_msg_substring:?}, was {msg:?}"
+                );
+            }
+            _ => unreachable!(),
+        }
     }
 
     #[tokio::test]
@@ -852,10 +876,7 @@ mod tests {
 
         let err = read_connect_response(&mut stream).await.unwrap_err();
 
-        assert_eq!(
-            err.to_string(),
-            "handshake failed: proxy refused CONNECT with status 407"
-        );
+        assert_eq!(err.to_string(), "proxy CONNECT rejected with status 407");
         assert!(!err.to_string().contains(SECRET));
     }
 
@@ -872,13 +893,45 @@ mod tests {
             .unwrap();
         stream.flush().await.unwrap();
         let err = read_connect_response(&mut stream).await.unwrap_err();
+        assert!(matches!(err, TransportError::ConnectionClosed));
+    }
+
+    /// A malformed version with an otherwise retryable status must stay a permanent
+    /// `Handshake` failure. The status is 503 deliberately: were the version left
+    /// unvalidated, this would parse as `ProxyConnectRejected(503)` and be retried.
+    #[tokio::test]
+    async fn read_connect_response_rejects_malformed_version_with_retryable_status() {
+        let addr = spawn_fake_proxy(b"NOT-HTTP 503 Service Unavailable\r\n\r\n").await;
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(b"CONNECT host:443 HTTP/1.1\r\nHost: host:443\r\n\r\n")
+            .await
+            .unwrap();
+        stream.flush().await.unwrap();
+        let err = read_connect_response(&mut stream).await.unwrap_err();
         let TransportError::Handshake(msg) = err else {
             panic!("expected Handshake error, was {err:?}");
         };
-        assert!(
-            msg.contains("closed connection"),
-            "unexpected handshake error: {msg}"
-        );
+        assert!(msg.contains("malformed status line"), "was {msg}");
+    }
+
+    /// `0503` is not a valid status token but parses as `503` under bare `u16`
+    /// parsing, which would make a malformed line retryable. 503 is used because
+    /// a permanent status would pass whether or not the token is validated.
+    #[tokio::test]
+    async fn read_connect_response_rejects_malformed_status_token_with_retryable_value() {
+        let addr = spawn_fake_proxy(b"HTTP/1.1 0503 Service Unavailable\r\n\r\n").await;
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(b"CONNECT host:443 HTTP/1.1\r\nHost: host:443\r\n\r\n")
+            .await
+            .unwrap();
+        stream.flush().await.unwrap();
+        let err = read_connect_response(&mut stream).await.unwrap_err();
+        let TransportError::Handshake(msg) = err else {
+            panic!("expected Handshake error, was {err:?}");
+        };
+        assert!(msg.contains("invalid status code"), "was {msg}");
     }
 
     /// A proxy that streams headers without ever emitting `\r\n\r\n` should


### PR DESCRIPTION
Bybit and both Architect AX WebSocket clients each carry a copy of the same hand-rolled initial-connect retry ladder, because `WebSocketClient::connect` does not retry.

This is a suggested implementation rather than a question: it picks an answer, says which one below, and I am happy to reshape it if you would rather the policy lived elsewhere.

## The copied ladder

`WebSocketClient::connect` bounds its attempt with `connect_timeout_ms` and returns on failure; its `ExponentialBackoff` drives the reconnect loop only. So the three adapters wrap it in a `const MAX_RETRIES: u32 = 5` loop with their own `ExponentialBackoff`, at `bybit/src/websocket/client.rs:439`, `architect_ax/src/websocket/data/client.rs:397` and `.../orders/client.rs:435`.

Each copy has the same three problems. It never reads the client's own cancellation state, so a `close()` arriving during the ladder is observed only after it finishes, up to roughly 33 seconds later. It retries every error, so a malformed URL or a rejected handshake consumes all five attempts. And its parameters are unreachable: the attempt count is a local `const` and the backoff values are literals sitting ten lines below the `reconnect_backoff_factor` the same function sets from configuration.

The raw socket transport already solves this. `SocketConfig::connection_max_retries` drives an initial-connect ladder in `SocketClient::connect` with identical backoff values, so this is an asymmetry between two transports rather than a missing design.

## The policy is a builder input, not a config field

`WebSocketClient::builder()` and `epoch_builder()` gain an optional `InitialConnectRetryPolicy` and an optional `CancellationToken`. With no policy the builder makes exactly one attempt, so every existing caller is unchanged; the three adapters opt in to their current values. `stream_builder` is untouched, since stream mode promises a single bounded connection.

The policy is a builder input rather than a `WebSocketConfig` field because it governs one invocation of `connect` and means nothing once a client exists, which is the same reason `rate_limiter` and `state_sink` are builder inputs. It also avoids a source break: `WebSocketConfig` is constructed by literal in roughly 85 places, and a new field would require every one to change.

The builder does not return a client until the initial dial succeeds, so `WebSocketClient::close()` cannot interrupt the ladder and the token has to reach the builder instead. The adapters hold the token in an `ArcSwap` shared across clones: `connect` installs a fresh one, `close` cancels the current one, and the next `connect` replaces it, so a connect-close-connect sequence is not poisoned by a spent token. The loop selects cancellation against all three blocking phases - the connection rate-limit wait, the dial, and the backoff sleep - since checking only at attempt boundaries would still leave `close()` waiting out a full connection timeout.

## What counts as retryable

`is_retryable_initial_connect_error` retries connection timeouts, the connection-loss variants, and network-shaped `Io` errors, and refuses `InvalidUrl`, `Handshake`, `Tls`, `Protocol`, the size and encoding errors, and `Other`.

The polarity of the `Io` arm is deliberate. Resolver failures commonly surface as `ErrorKind::Other`, so an allowlist of retryable kinds would stop retrying the DNS case these ladders exist for. It therefore names the kinds that are clearly permanent - `InvalidInput`, `InvalidData`, `Unsupported`, `PermissionDenied` - and treats the rest of connection-time `Io` as transient.

Every `Handshake` error is permanent, so an HTTP 429 or 5xx upgrade response no longer retries. Distinguishing those needs the status preserved structurally in `TransportError::Handshake` rather than in its string payload.

The adapters now report `Failed to connect to {url}: {e}`, keeping Bybit's DNS hint. They no longer claim an attempt count, which they cannot know from a `TransportError`: the same error is returned for a permanent failure rejected on the first attempt and for an exhausted ladder.

A structured exhausted-ladder error carrying the real count would fix that and is a reasonable follow-up if you want it.

## Testing

`timed_out_initial_connect_attempt_is_retried` stands up a listener that accepts TCP but never upgrades, so every attempt reaches the connect timeout, and asserts the server saw exactly three connections against a three-attempt policy. It fails at one against three on the previous behaviour, where a timed-out attempt returned instead of retrying. `initial_connect_cancellation_interrupts_in_flight_handshake` cancels after the server has accepted and asserts `Interrupted`; `permanent_initial_connect_error_does_not_wait_for_retry_ladder` proves an invalid URL returns without entering a 30 second backoff. Both fail against the unfixed code by timing out.

The two Architect AX connection-failure tests previously asserted the message named the URL and the attempt count. They now assert only that it names the endpoint, because the attempt count is no longer claimed; the exhaustion property they were standing in for is pinned directly by the network test above, which counts attempts rather than reading a string.
