### PR TITLE
Allow external order claim changes while the live node runs

### DIFF
--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -5485,7 +5485,10 @@ fn test_reconnect_socket_enqueues_typed_command(
     drop(actor);
 
     let SystemCommand::ReconnectSocket(command) =
-        system_rx.try_recv().expect("reconnect command queued");
+        system_rx.try_recv().expect("reconnect command queued")
+    else {
+        panic!("expected reconnect command");
+    };
 
     assert_eq!(command.trader_id, trader_id);
     assert_eq!(command.client_id, ClientId::from("POLYMARKET"));

--- a/crates/common/src/messages/mod.rs
+++ b/crates/common/src/messages/mod.rs
@@ -62,7 +62,9 @@ pub enum DataEvent {
 #[derive(Debug, Display)]
 pub enum SystemCommand {
     ReconnectSocket(system::ReconnectSocket),
+    #[cfg(feature = "live")]
     RegisterExternalOrderClaims(system::RegisterExternalOrderClaims),
+    #[cfg(feature = "live")]
     DeregisterExternalOrderClaims(system::DeregisterExternalOrderClaims),
 }
 

--- a/crates/common/src/messages/mod.rs
+++ b/crates/common/src/messages/mod.rs
@@ -59,9 +59,11 @@ pub enum DataEvent {
 }
 
 /// System command variants routed to a live node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+#[derive(Debug, Display)]
 pub enum SystemCommand {
     ReconnectSocket(system::ReconnectSocket),
+    RegisterExternalOrderClaims(system::RegisterExternalOrderClaims),
+    DeregisterExternalOrderClaims(system::DeregisterExternalOrderClaims),
 }
 
 /// System event variants routed to a live node.

--- a/crates/common/src/messages/system/claims.rs
+++ b/crates/common/src/messages/system/claims.rs
@@ -13,19 +13,19 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod claims;
-pub mod component;
-pub mod queue;
-pub mod shutdown;
-pub mod socket;
-pub mod trading;
+use nautilus_model::identifiers::{InstrumentId, StrategyId};
 
-// Re-exports
-pub use claims::{DeregisterExternalOrderClaims, RegisterExternalOrderClaims};
-pub use component::ComponentStateChanged;
-pub use queue::{QueueCondition, QueueState, QueueStateChanged};
-pub use shutdown::ShutdownSystem;
-#[cfg(feature = "live")]
-pub(crate) use socket::socket_endpoint;
-pub use socket::{ReconnectSocket, SocketState, SocketStateChange, SocketStateChanged};
-pub use trading::TradingStateChanged;
+/// Command requesting registration of external order claims on a running live node.
+#[derive(Debug)]
+pub struct RegisterExternalOrderClaims {
+    pub strategy_id: StrategyId,
+    pub claims: Vec<InstrumentId>,
+    pub response: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+}
+
+/// Command requesting deregistration of external order claims on a running live node.
+#[derive(Debug)]
+pub struct DeregisterExternalOrderClaims {
+    pub strategy_id: StrategyId,
+    pub response: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+}

--- a/crates/common/src/messages/system/mod.rs
+++ b/crates/common/src/messages/system/mod.rs
@@ -13,14 +13,17 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod claims;
 pub mod component;
 pub mod queue;
 pub mod shutdown;
 pub mod socket;
 pub mod trading;
 
+#[cfg(feature = "live")]
+pub mod claims;
+
 // Re-exports
+#[cfg(feature = "live")]
 pub use claims::{DeregisterExternalOrderClaims, RegisterExternalOrderClaims};
 pub use component::ComponentStateChanged;
 pub use queue::{QueueCondition, QueueState, QueueStateChanged};

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -3811,7 +3811,9 @@ class CapturingActor:
         let command = system_rx
             .try_recv()
             .expect("reconnect command should be queued");
-        let SystemCommand::ReconnectSocket(command) = command;
+        let SystemCommand::ReconnectSocket(command) = command else {
+            panic!("expected reconnect command");
+        };
 
         assert_eq!(command.trader_id, trader_id);
         assert_eq!(command.client_id, ClientId::from("POLYMARKET"));

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -96,7 +96,10 @@ use nautilus_common::{
             GenerateFillReports, GenerateOrderStatusReports, GeneratePositionStatusReports,
             TradingCommand,
         },
-        system::{QueueStateChanged, ReconnectSocket, SocketStateChange, SocketStateChanged},
+        system::{
+            DeregisterExternalOrderClaims, QueueStateChanged, ReconnectSocket,
+            RegisterExternalOrderClaims, SocketStateChange, SocketStateChanged,
+        },
     },
     msgbus::{self, BusMessage, MessagingSwitchboard},
     runner::{SystemChannel, TimeEventMessage, TradingCommandMessage},
@@ -203,11 +206,12 @@ impl LiveNode {
         cache_database_factory: Option<Box<dyn CacheDatabaseFactory>>,
         external_msgbus: Option<ExternalMessageBusIngress>,
     ) -> Self {
+        let handle = LiveNodeHandle::with_system_command_sender(runner.system_command_sender());
         Self {
             kernel,
             runner: Some(runner),
             config,
-            handle: LiveNodeHandle::new(),
+            handle,
             exec_manager,
             exec_clients,
             socket_registry,
@@ -277,11 +281,12 @@ impl LiveNode {
             exec_manager_config,
         )?;
 
+        let handle = LiveNodeHandle::with_system_command_sender(runner.system_command_sender());
         let node = Self {
             kernel,
             runner: Some(runner),
             config,
-            handle: LiveNodeHandle::new(),
+            handle,
             exec_manager,
             exec_clients: Vec::new(),
             socket_registry: SocketReconnectRegistry::default(),
@@ -588,16 +593,33 @@ impl LiveNode {
         }
     }
 
-    fn process_system_commands(&self, commands: Vec<SystemCommand>) {
+    fn process_system_commands(&mut self, commands: Vec<SystemCommand>) {
         for command in commands {
             self.process_system_command(command);
         }
     }
 
-    fn process_system_command(&self, command: SystemCommand) {
+    fn process_system_command(&mut self, command: SystemCommand) {
         match command {
             SystemCommand::ReconnectSocket(command) => {
                 self.process_socket_reconnect(command);
+            }
+            SystemCommand::RegisterExternalOrderClaims(command) => {
+                let RegisterExternalOrderClaims {
+                    strategy_id,
+                    claims,
+                    response,
+                } = command;
+                let result = self.register_external_order_claims_inner(strategy_id, &claims);
+                let _ = response.send(result);
+            }
+            SystemCommand::DeregisterExternalOrderClaims(command) => {
+                let DeregisterExternalOrderClaims {
+                    strategy_id,
+                    response,
+                } = command;
+                let result = self.deregister_external_order_claims_inner(strategy_id);
+                let _ = response.send(result);
             }
         }
     }
@@ -2690,7 +2712,8 @@ impl LiveNode {
     ///
     /// The operation is synchronous and atomic across the reconciliation manager and execution
     /// engine. It can be called while the node is idle, after manual [`start`](Self::start)
-    /// returns, or after the node stops. It cannot be called while [`run`](Self::run) or
+    /// returns, or after the node stops. Use
+    /// [`LiveNodeHandle::register_external_order_claims`] while [`run`](Self::run) or
     /// [`run_with_mode`](Self::run_with_mode) owns the node.
     ///
     /// # Errors
@@ -2698,6 +2721,14 @@ impl LiveNode {
     /// Returns an error without changing either tier if the execution engine is already borrowed,
     /// the request repeats an instrument, or either tier already contains any requested claim.
     pub fn register_external_order_claims(
+        &mut self,
+        strategy_id: StrategyId,
+        claims: &[InstrumentId],
+    ) -> anyhow::Result<()> {
+        self.register_external_order_claims_inner(strategy_id, claims)
+    }
+
+    fn register_external_order_claims_inner(
         &mut self,
         strategy_id: StrategyId,
         claims: &[InstrumentId],
@@ -2758,14 +2789,22 @@ impl LiveNode {
     ///
     /// Remove the strategy through the trader or controller first, then call this method before
     /// registering a successor. The operation is synchronous and can be called while the node is
-    /// idle, after manual [`start`](Self::start) returns, or after the node stops. It cannot be
-    /// called while [`run`](Self::run) or [`run_with_mode`](Self::run_with_mode) owns the node.
+    /// idle, after manual [`start`](Self::start) returns, or after the node stops. Use
+    /// [`LiveNodeHandle::deregister_external_order_claims`] while [`run`](Self::run) or
+    /// [`run_with_mode`](Self::run_with_mode) owns the node.
     ///
     /// # Errors
     ///
     /// Returns an error without changing either tier if the execution engine is already borrowed
     /// or the two tiers do not contain identical claim sets for the strategy.
     pub fn deregister_external_order_claims(
+        &mut self,
+        strategy_id: StrategyId,
+    ) -> anyhow::Result<()> {
+        self.deregister_external_order_claims_inner(strategy_id)
+    }
+
+    fn deregister_external_order_claims_inner(
         &mut self,
         strategy_id: StrategyId,
     ) -> anyhow::Result<()> {
@@ -4368,7 +4407,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let node = LiveNode::build("SocketReconnectNode".to_string(), Some(config)).unwrap();
+        let mut node = LiveNode::build("SocketReconnectNode".to_string(), Some(config)).unwrap();
         let client_id = ClientId::from("TEST");
         let endpoint = Ustr::from("test-streams");
         let requests = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -5823,6 +5862,21 @@ mod tests {
         builder.build().unwrap()
     }
 
+    // Reaches the main select loop under `run()`; the replay-store fixture above
+    // returns from `run_with_mode` before the loop starts.
+    fn live_node_for_run_loop() -> LiveNode {
+        let config = LiveNodeConfig {
+            trader_id: TraderId::from("CLAIMS-RUN-001"),
+            exec_engine: crate::config::LiveExecutionEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            delay_post_stop: Duration::ZERO,
+            ..Default::default()
+        };
+        LiveNode::build("ClaimsRunNode".to_string(), Some(config)).unwrap()
+    }
+
     #[rstest]
     fn test_add_strategy_registers_external_order_claims_with_manager_and_engine() {
         let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
@@ -5906,6 +5960,127 @@ mod tests {
                 .get_external_order_claim(&instrument_id),
             Some(strategy_id)
         );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_register_external_order_claims_while_event_loop_runs() {
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let run = node.run();
+            tokio::pin!(run);
+
+            let drive = async {
+                wait_until_async(|| async { handle.is_running() }, Duration::from_secs(2)).await;
+                handle
+                    .register_external_order_claims(strategy_id, &[instrument_id])
+                    .await
+                    .unwrap();
+                handle.stop();
+            };
+
+            let (run_result, ()) = tokio::join!(run, drive);
+            run_result.unwrap();
+        })
+        .await
+        .expect("node should register claims and stop before timeout");
+
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_deregister_external_order_claims_while_event_loop_runs() {
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+        node.register_external_order_claims(strategy_id, &[instrument_id])
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let run = node.run();
+            tokio::pin!(run);
+
+            let drive = async {
+                wait_until_async(|| async { handle.is_running() }, Duration::from_secs(2)).await;
+                handle
+                    .deregister_external_order_claims(strategy_id)
+                    .await
+                    .unwrap();
+                handle.stop();
+            };
+
+            let (run_result, ()) = tokio::join!(run, drive);
+            run_result.unwrap();
+        })
+        .await
+        .expect("node should deregister claims and stop before timeout");
+
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&instrument_id),
+            None
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&instrument_id),
+            None
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_registration_returns_synchronous_preflight_error() {
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+        node.register_external_order_claims(strategy_id, &[instrument_id])
+            .unwrap();
+        let expected = node
+            .register_external_order_claims(strategy_id, &[instrument_id])
+            .unwrap_err()
+            .to_string();
+
+        let actual = tokio::time::timeout(Duration::from_secs(5), async {
+            let run = node.run();
+            tokio::pin!(run);
+
+            let drive = async {
+                wait_until_async(|| async { handle.is_running() }, Duration::from_secs(2)).await;
+                let result = handle
+                    .register_external_order_claims(strategy_id, &[instrument_id])
+                    .await;
+                handle.stop();
+                result
+            };
+
+            let (run_result, result) = tokio::join!(run, drive);
+            run_result.unwrap();
+            result
+        })
+        .await
+        .expect("node should return registration error and stop before timeout")
+        .unwrap_err()
+        .to_string();
+
+        assert_eq!(actual, expected);
     }
 
     #[rstest]
@@ -6121,6 +6296,50 @@ mod tests {
                 .get_external_order_claim(&engine_instrument),
             Some(strategy_id)
         );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_handle_deregistration_returns_synchronous_preflight_error() {
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let manager_instrument = InstrumentId::from("AUDUSD.SIM");
+        let engine_instrument = InstrumentId::from("EURUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+        node.exec_manager
+            .claim_external_orders(manager_instrument, strategy_id)
+            .unwrap();
+        node.kernel
+            .exec_engine
+            .borrow_mut()
+            .register_external_order_claims(strategy_id, &HashSet::from([engine_instrument]))
+            .unwrap();
+        let expected = node
+            .deregister_external_order_claims(strategy_id)
+            .unwrap_err()
+            .to_string();
+
+        let actual = tokio::time::timeout(Duration::from_secs(5), async {
+            let run = node.run();
+            tokio::pin!(run);
+
+            let drive = async {
+                wait_until_async(|| async { handle.is_running() }, Duration::from_secs(2)).await;
+                let result = handle.deregister_external_order_claims(strategy_id).await;
+                handle.stop();
+                result
+            };
+
+            let (run_result, result) = tokio::join!(run, drive);
+            run_result.unwrap();
+            result
+        })
+        .await
+        .expect("node should return deregistration error and stop before timeout")
+        .unwrap_err()
+        .to_string();
+
+        assert_eq!(actual, expected);
     }
 
     #[rstest]
@@ -7892,6 +8111,45 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test]
+    async fn test_shutdown_drain_drops_external_claim_response() {
+        let runner = AsyncRunner::new();
+        let system_cmd_tx = runner.system_command_sender();
+        let AsyncRunnerChannels {
+            mut time_evt_rx,
+            mut system_evt_rx,
+            mut system_cmd_rx,
+            mut exec_evt_rx,
+            mut exec_cmd_rx,
+            mut data_evt_rx,
+            mut data_cmd_rx,
+        } = runner.take_channels();
+        let (response, receiver) = tokio::sync::oneshot::channel();
+
+        system_cmd_tx
+            .send(SystemCommand::RegisterExternalOrderClaims(
+                RegisterExternalOrderClaims {
+                    strategy_id: StrategyId::from("CLAIMS-001"),
+                    claims: vec![InstrumentId::from("AUDUSD.SIM")],
+                    response,
+                },
+            ))
+            .unwrap();
+
+        LiveNode::drain_channels(
+            &mut time_evt_rx,
+            &mut system_evt_rx,
+            &mut system_cmd_rx,
+            &mut exec_evt_rx,
+            &mut exec_cmd_rx,
+            &mut data_evt_rx,
+            &mut data_cmd_rx,
+        );
+
+        assert!(receiver.await.is_err());
+    }
+
+    #[rstest]
     fn test_pending_drain_data_returns_false_when_empty() {
         let mut pending = PendingEvents::default();
 
@@ -8015,7 +8273,14 @@ mod tests {
         pending.system_commands.push(command);
         let system_commands = pending.take_system_commands();
 
-        assert_eq!(system_commands, vec![command]);
+        assert_eq!(system_commands.len(), 1);
+        let SystemCommand::ReconnectSocket(actual) = &system_commands[0] else {
+            panic!("expected reconnect command");
+        };
+        let SystemCommand::ReconnectSocket(expected) = stub_system_command() else {
+            panic!("expected reconnect command");
+        };
+        assert_eq!(actual, &expected);
         assert!(pending.is_empty());
     }
 
@@ -8136,7 +8401,14 @@ mod tests {
         let system_events = pending.take_system_events();
         let system_commands = pending.take_system_commands();
         assert_eq!(system_events, vec![SystemEvent::SocketState(change)]);
-        assert_eq!(system_commands, vec![stub_system_command()]);
+        assert_eq!(system_commands.len(), 1);
+        let SystemCommand::ReconnectSocket(actual) = &system_commands[0] else {
+            panic!("expected reconnect command");
+        };
+        let SystemCommand::ReconnectSocket(expected) = stub_system_command() else {
+            panic!("expected reconnect command");
+        };
+        assert_eq!(actual, &expected);
         assert!(pending.data_evts.is_empty());
         assert!(pending.data_cmds.is_empty());
         assert!(pending.exec_reports.is_empty());

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -1294,6 +1294,7 @@ impl LiveNode {
         self.process_system_events(startup_system_events);
         self.process_system_commands(startup_system_commands);
 
+        let _servicing_guard = self.handle.begin_event_loop_servicing();
         let finish_result = {
             let mut receivers = RunnerReceivers {
                 time_evt: &mut time_evt_rx,
@@ -5959,6 +5960,114 @@ mod tests {
                 .borrow()
                 .get_external_order_claim(&instrument_id),
             Some(strategy_id)
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_handle_register_external_order_claims_rejects_manual_start() {
+        // Full startup path: this fixture reaches `Running` through `finish_startup_trader`,
+        // which `start()` shares with `run_with_mode`. The replay-store fixture returns earlier
+        // and cannot observe a servicing flag set on that shared call.
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+
+        node.start().await.unwrap();
+        assert_eq!(node.state(), NodeState::Running);
+
+        let error = tokio::time::timeout(
+            Duration::from_millis(100),
+            handle.register_external_order_claims(strategy_id, &[instrument_id]),
+        )
+        .await
+        .expect("manual-start registration should return before timeout")
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Cannot register external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_handle_deregister_external_order_claims_rejects_manual_start() {
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let strategy_id = StrategyId::from("CLAIMS-001");
+
+        node.start().await.unwrap();
+        assert_eq!(node.state(), NodeState::Running);
+
+        let error = tokio::time::timeout(
+            Duration::from_millis(100),
+            handle.deregister_external_order_claims(strategy_id),
+        )
+        .await
+        .expect("manual-start deregistration should return before timeout")
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Cannot deregister external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_handle_register_external_order_claims_rejects_event_store_replay_start() {
+        // The replay branch reaches `Running` through `finish_startup_replay` and returns
+        // without entering the select loop, so it is unserviced for the same reason.
+        let mut node = live_node_with_replay_store(false);
+        let handle = node.handle();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+
+        node.start().await.unwrap();
+        assert_eq!(node.state(), NodeState::Running);
+
+        let error = tokio::time::timeout(
+            Duration::from_millis(100),
+            handle.register_external_order_claims(strategy_id, &[instrument_id]),
+        )
+        .await
+        .expect("replay-start registration should return before timeout")
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Cannot register external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_handle_register_external_order_claims_rejects_replay_run() {
+        // The replay branch inside `run_with_mode` takes the channels and then returns without
+        // entering the select loop. Reaching it through `run()` rather than `start()` is what
+        // detects a servicing flag set on the run path ahead of that branch: such a flag would
+        // let the call fall through to the send and report the channel-closed error instead.
+        let mut node = live_node_with_replay_store(false);
+        let handle = node.handle();
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        let strategy_id = StrategyId::from("CLAIMS-001");
+
+        node.run().await.unwrap();
+        assert_eq!(node.state(), NodeState::Running);
+
+        let error = tokio::time::timeout(
+            Duration::from_millis(100),
+            handle.register_external_order_claims(strategy_id, &[instrument_id]),
+        )
+        .await
+        .expect("replay-run registration should return before timeout")
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Cannot register external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
         );
     }
 

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -610,7 +610,7 @@ impl LiveNode {
                     claims,
                     response,
                 } = command;
-                let result = self.register_external_order_claims_inner(strategy_id, &claims);
+                let result = self.register_external_order_claims(strategy_id, &claims);
                 let _ = response.send(result);
             }
             SystemCommand::DeregisterExternalOrderClaims(command) => {
@@ -618,7 +618,7 @@ impl LiveNode {
                     strategy_id,
                     response,
                 } = command;
-                let result = self.deregister_external_order_claims_inner(strategy_id);
+                let result = self.deregister_external_order_claims(strategy_id);
                 let _ = response.send(result);
             }
         }
@@ -2726,14 +2726,6 @@ impl LiveNode {
         strategy_id: StrategyId,
         claims: &[InstrumentId],
     ) -> anyhow::Result<()> {
-        self.register_external_order_claims_inner(strategy_id, claims)
-    }
-
-    fn register_external_order_claims_inner(
-        &mut self,
-        strategy_id: StrategyId,
-        claims: &[InstrumentId],
-    ) -> anyhow::Result<()> {
         let mut exec_engine = self
             .kernel
             .exec_engine
@@ -2799,13 +2791,6 @@ impl LiveNode {
     /// Returns an error without changing either tier if the execution engine is already borrowed
     /// or the two tiers do not contain identical claim sets for the strategy.
     pub fn deregister_external_order_claims(
-        &mut self,
-        strategy_id: StrategyId,
-    ) -> anyhow::Result<()> {
-        self.deregister_external_order_claims_inner(strategy_id)
-    }
-
-    fn deregister_external_order_claims_inner(
         &mut self,
         strategy_id: StrategyId,
     ) -> anyhow::Result<()> {
@@ -5987,7 +5972,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "Cannot register external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+            "Cannot register external order claims: handle calls require an active event loop servicing the runner channels, and are unavailable after manual start or in event-store replay mode"
         );
     }
 
@@ -6011,7 +5996,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "Cannot deregister external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+            "Cannot deregister external order claims: handle calls require an active event loop servicing the runner channels, and are unavailable after manual start or in event-store replay mode"
         );
     }
 
@@ -6038,7 +6023,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "Cannot register external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+            "Cannot register external order claims: handle calls require an active event loop servicing the runner channels, and are unavailable after manual start or in event-store replay mode"
         );
     }
 
@@ -6067,7 +6052,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "Cannot register external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+            "Cannot register external order claims: handle calls require an active event loop servicing the runner channels, and are unavailable after manual start or in event-store replay mode"
         );
     }
 

--- a/crates/live/src/node/state.rs
+++ b/crates/live/src/node/state.rs
@@ -228,7 +228,8 @@ impl LiveNodeHandle {
     /// # Errors
     ///
     /// Returns an error if the handle is unattached, the node is not running, the node is running
-    /// without an active event loop servicing the runner channels (as after [`LiveNode::start`]),
+    /// without an active event loop servicing the runner channels (as after manual
+    /// [`LiveNode::start`] or in event-store replay mode),
     /// the command channel is closed before enqueue, the event loop exits before responding, or
     /// claim preflight fails.
     ///
@@ -248,7 +249,7 @@ impl LiveNodeHandle {
 
         if !self.event_loop_servicing.load(Ordering::Acquire) {
             anyhow::bail!(
-                "Cannot register external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+                "Cannot register external order claims: handle calls require an active event loop servicing the runner channels, and are unavailable after manual start or in event-store replay mode"
             );
         }
 
@@ -280,7 +281,8 @@ impl LiveNodeHandle {
     /// # Errors
     ///
     /// Returns an error if the handle is unattached, the node is not running, the node is running
-    /// without an active event loop servicing the runner channels (as after [`LiveNode::start`]),
+    /// without an active event loop servicing the runner channels (as after manual
+    /// [`LiveNode::start`] or in event-store replay mode),
     /// the command channel is closed before enqueue, the event loop exits before responding, or
     /// claim preflight fails.
     ///
@@ -299,7 +301,7 @@ impl LiveNodeHandle {
 
         if !self.event_loop_servicing.load(Ordering::Acquire) {
             anyhow::bail!(
-                "Cannot deregister external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+                "Cannot deregister external order claims: handle calls require an active event loop servicing the runner channels, and are unavailable after manual start or in event-store replay mode"
             );
         }
 

--- a/crates/live/src/node/state.rs
+++ b/crates/live/src/node/state.rs
@@ -15,7 +15,7 @@
 
 use std::sync::{
     Arc,
-    atomic::{AtomicU8, Ordering},
+    atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
 use nautilus_common::messages::{
@@ -122,6 +122,7 @@ pub(super) enum RunningTransition {
 #[derive(Clone, Debug)]
 pub struct LiveNodeHandle {
     control: Arc<AtomicU8>,
+    event_loop_servicing: Arc<AtomicBool>,
     pub(crate) metrics: Arc<RunnerMetrics>,
     system_cmd_tx: Option<tokio::sync::mpsc::UnboundedSender<SystemCommand>>,
 }
@@ -138,6 +139,7 @@ impl LiveNodeHandle {
     pub fn new() -> Self {
         Self {
             control: Arc::new(AtomicU8::new(NodeState::Idle.as_u8())),
+            event_loop_servicing: Arc::new(AtomicBool::new(false)),
             metrics: Arc::new(RunnerMetrics::default()),
             system_cmd_tx: None,
         }
@@ -211,12 +213,26 @@ impl LiveNodeHandle {
         self.metrics.snapshot()
     }
 
+    pub(super) fn begin_event_loop_servicing(&self) -> EventLoopServicingGuard {
+        self.event_loop_servicing.store(true, Ordering::Release);
+        EventLoopServicingGuard {
+            event_loop_servicing: self.event_loop_servicing.clone(),
+        }
+    }
+
     /// Registers external order claims on both execution tiers of a running node.
+    ///
+    /// Once enqueued, dropping or timing out this future does not cancel the command. The event
+    /// loop may still apply the mutation, so a timeout is not evidence that no state changed.
     ///
     /// # Errors
     ///
-    /// Returns an error if the handle is unattached, the node is not running, the command channel
-    /// is closed before enqueue, the event loop exits before responding, or claim preflight fails.
+    /// Returns an error if the handle is unattached, the node is not running, the node is running
+    /// without an active event loop servicing the runner channels (as after [`LiveNode::start`]),
+    /// the command channel is closed before enqueue, the event loop exits before responding, or
+    /// claim preflight fails.
+    ///
+    /// [`LiveNode::start`]: super::LiveNode::start
     pub async fn register_external_order_claims(
         &self,
         strategy_id: StrategyId,
@@ -228,6 +244,12 @@ impl LiveNodeHandle {
 
         if !self.is_running() {
             anyhow::bail!("Cannot register external order claims while node is not running");
+        }
+
+        if !self.event_loop_servicing.load(Ordering::Acquire) {
+            anyhow::bail!(
+                "Cannot register external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+            );
         }
 
         let (response, receiver) = tokio::sync::oneshot::channel();
@@ -252,10 +274,17 @@ impl LiveNodeHandle {
 
     /// Deregisters external order claims from both execution tiers of a running node.
     ///
+    /// Once enqueued, dropping or timing out this future does not cancel the command. The event
+    /// loop may still apply the mutation, so a timeout is not evidence that no state changed.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the handle is unattached, the node is not running, the command channel
-    /// is closed before enqueue, the event loop exits before responding, or claim preflight fails.
+    /// Returns an error if the handle is unattached, the node is not running, the node is running
+    /// without an active event loop servicing the runner channels (as after [`LiveNode::start`]),
+    /// the command channel is closed before enqueue, the event loop exits before responding, or
+    /// claim preflight fails.
+    ///
+    /// [`LiveNode::start`]: super::LiveNode::start
     pub async fn deregister_external_order_claims(
         &self,
         strategy_id: StrategyId,
@@ -266,6 +295,12 @@ impl LiveNodeHandle {
 
         if !self.is_running() {
             anyhow::bail!("Cannot deregister external order claims while node is not running");
+        }
+
+        if !self.event_loop_servicing.load(Ordering::Acquire) {
+            anyhow::bail!(
+                "Cannot deregister external order claims: node was started without an active event loop; use LiveNode::run or LiveNode::run_with_mode"
+            );
         }
 
         let (response, receiver) = tokio::sync::oneshot::channel();
@@ -290,6 +325,16 @@ impl LiveNodeHandle {
     /// Signals the node to stop.
     pub fn stop(&self) {
         self.control.fetch_or(STOP_REQUESTED, Ordering::AcqRel);
+    }
+}
+
+pub(super) struct EventLoopServicingGuard {
+    event_loop_servicing: Arc<AtomicBool>,
+}
+
+impl Drop for EventLoopServicingGuard {
+    fn drop(&mut self) {
+        self.event_loop_servicing.store(false, Ordering::Release);
     }
 }
 

--- a/crates/live/src/node/state.rs
+++ b/crates/live/src/node/state.rs
@@ -18,6 +18,12 @@ use std::sync::{
     atomic::{AtomicU8, Ordering},
 };
 
+use nautilus_common::messages::{
+    SystemCommand,
+    system::{DeregisterExternalOrderClaims, RegisterExternalOrderClaims},
+};
+use nautilus_model::identifiers::{InstrumentId, StrategyId};
+
 use super::metrics::{RunnerMetrics, RunnerMetricsSnapshot};
 
 const STOP_REQUESTED: u8 = 1 << 7;
@@ -117,6 +123,7 @@ pub(super) enum RunningTransition {
 pub struct LiveNodeHandle {
     control: Arc<AtomicU8>,
     pub(crate) metrics: Arc<RunnerMetrics>,
+    system_cmd_tx: Option<tokio::sync::mpsc::UnboundedSender<SystemCommand>>,
 }
 
 impl Default for LiveNodeHandle {
@@ -132,6 +139,16 @@ impl LiveNodeHandle {
         Self {
             control: Arc::new(AtomicU8::new(NodeState::Idle.as_u8())),
             metrics: Arc::new(RunnerMetrics::default()),
+            system_cmd_tx: None,
+        }
+    }
+
+    pub(crate) fn with_system_command_sender(
+        system_cmd_tx: tokio::sync::mpsc::UnboundedSender<SystemCommand>,
+    ) -> Self {
+        Self {
+            system_cmd_tx: Some(system_cmd_tx),
+            ..Self::new()
         }
     }
 
@@ -192,6 +209,82 @@ impl LiveNodeHandle {
     #[must_use]
     pub fn metrics_snapshot(&self) -> RunnerMetricsSnapshot {
         self.metrics.snapshot()
+    }
+
+    /// Registers external order claims on both execution tiers of a running node.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the handle is unattached, the node is not running, the command channel
+    /// is closed before enqueue, the event loop exits before responding, or claim preflight fails.
+    pub async fn register_external_order_claims(
+        &self,
+        strategy_id: StrategyId,
+        claims: &[InstrumentId],
+    ) -> anyhow::Result<()> {
+        let Some(system_cmd_tx) = &self.system_cmd_tx else {
+            anyhow::bail!("Cannot register external order claims with an unattached node handle");
+        };
+
+        if !self.is_running() {
+            anyhow::bail!("Cannot register external order claims while node is not running");
+        }
+
+        let (response, receiver) = tokio::sync::oneshot::channel();
+        system_cmd_tx
+            .send(SystemCommand::RegisterExternalOrderClaims(
+                RegisterExternalOrderClaims {
+                    strategy_id,
+                    claims: claims.to_vec(),
+                    response,
+                },
+            ))
+            .map_err(|_| {
+                anyhow::anyhow!("Cannot register external order claims: command channel closed")
+            })?;
+
+        receiver.await.map_err(|_| {
+            anyhow::anyhow!(
+                "Cannot register external order claims: event loop exited before dispatch"
+            )
+        })?
+    }
+
+    /// Deregisters external order claims from both execution tiers of a running node.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the handle is unattached, the node is not running, the command channel
+    /// is closed before enqueue, the event loop exits before responding, or claim preflight fails.
+    pub async fn deregister_external_order_claims(
+        &self,
+        strategy_id: StrategyId,
+    ) -> anyhow::Result<()> {
+        let Some(system_cmd_tx) = &self.system_cmd_tx else {
+            anyhow::bail!("Cannot deregister external order claims with an unattached node handle");
+        };
+
+        if !self.is_running() {
+            anyhow::bail!("Cannot deregister external order claims while node is not running");
+        }
+
+        let (response, receiver) = tokio::sync::oneshot::channel();
+        system_cmd_tx
+            .send(SystemCommand::DeregisterExternalOrderClaims(
+                DeregisterExternalOrderClaims {
+                    strategy_id,
+                    response,
+                },
+            ))
+            .map_err(|_| {
+                anyhow::anyhow!("Cannot deregister external order claims: command channel closed")
+            })?;
+
+        receiver.await.map_err(|_| {
+            anyhow::anyhow!(
+                "Cannot deregister external order claims: event loop exited before dispatch"
+            )
+        })?
     }
 
     /// Signals the node to stop.

--- a/crates/live/src/runner.rs
+++ b/crates/live/src/runner.rs
@@ -293,6 +293,13 @@ impl AsyncRunner {
         }
     }
 
+    #[must_use]
+    pub(crate) fn system_command_sender(
+        &self,
+    ) -> tokio::sync::mpsc::UnboundedSender<SystemCommand> {
+        self.system_cmd_tx.clone()
+    }
+
     /// Consumes the runner and returns the channel receivers for direct event loop driving.
     ///
     /// This is used when the event loop needs to run on the same thread as the msgbus
@@ -1925,10 +1932,15 @@ mod tests {
             get_system_command_sender()
                 .send(test_system_command())
                 .unwrap();
-            assert_eq!(
-                runner.channels.system_cmd_rx.try_recv().unwrap(),
-                test_system_command()
-            );
+            let SystemCommand::ReconnectSocket(actual) =
+                runner.channels.system_cmd_rx.try_recv().unwrap()
+            else {
+                panic!("expected reconnect command");
+            };
+            let SystemCommand::ReconnectSocket(expected) = test_system_command() else {
+                panic!("expected reconnect command");
+            };
+            assert_eq!(actual, expected);
 
             get_data_event_sender()
                 .send(DataEvent::Data(Data::Quote(test_quote())))
@@ -1991,7 +2003,14 @@ mod tests {
 
             let system_commands = runner.drain_pending_system_commands();
 
-            assert_eq!(system_commands, vec![system_command]);
+            assert_eq!(system_commands.len(), 1);
+            let SystemCommand::ReconnectSocket(actual) = &system_commands[0] else {
+                panic!("expected reconnect command");
+            };
+            let SystemCommand::ReconnectSocket(expected) = test_system_command() else {
+                panic!("expected reconnect command");
+            };
+            assert_eq!(actual, &expected);
             assert!(runner.channels.system_cmd_rx.try_recv().is_err());
             assert!(runner.channels.system_evt_rx.try_recv().is_ok());
         })

--- a/crates/trading/src/python/strategy.rs
+++ b/crates/trading/src/python/strategy.rs
@@ -4857,7 +4857,9 @@ class IndicatorEventStrategy:
             let command = system_rx
                 .try_recv()
                 .expect("reconnect command should be queued");
-            let SystemCommand::ReconnectSocket(command) = command;
+            let SystemCommand::ReconnectSocket(command) = command else {
+                panic!("expected reconnect command");
+            };
 
             assert_eq!(command.trader_id, TraderId::from("TRADER-001"));
             assert_eq!(command.client_id, ClientId::from("POLYMARKET"));


### PR DESCRIPTION
Allow external order claim changes while the live node runs

A follow-up to the external-order-claim registration work in #4620.

## Claim registration while the event loop owns the node

`LiveNode::register_external_order_claims` and `deregister_external_order_claims` take `&mut self`, and `run` / `run_with_mode` hold that borrow for the whole run, so as documented neither can be called while the event loop owns the node. A deployed consumer that adds and removes strategies at runtime cannot reach either from a running worker: `start()` releases the borrow but nothing then services the runner's channels, and `LiveNodeHandle` carries only control state and metrics. The consumer's remaining option is halting the account whenever a strategy change would leave claims it knows are wrong.

Two new `SystemCommand` variants, `RegisterExternalOrderClaims` and `DeregisterExternalOrderClaims`, carry the request plus a oneshot responder and ride the runner's existing command channel, dispatched by `process_system_command` inside the running loop (which becomes `&mut self`; every caller already held `&mut`). The synchronous method bodies moved into private helpers that both routes call, so preflight-before-mutation and the engine-then-manager commit order are shared rather than duplicated, and the responder receives the helper's exact `Result` after both commits - a dropped receiver cannot roll back a committed registration.

`LiveNodeHandle` gains async `register_external_order_claims` / `deregister_external_order_claims` backed by a clone of the channel sender, giving worker threads a `Send` route. `new()` and `Default` handles stay control-only, and the synchronous methods remain the idle / started / stopped route, with their rustdoc updated to name the handle route for the running case. Handle failure outcomes are explicit: unattached handle, node not running, channel closed before enqueue, event loop exit before dispatch, and the same preflight errors the synchronous API returns.

`SystemCommand`'s derives reduce from `Debug, Clone, Copy, PartialEq, Eq, Display` to `Debug, Display`: the responder is single-use, the claims payload owns a `Vec<InstrumentId>`, and no production path clones or compares commands - the channel moves them. The tests that relied on the old derives now match the variant and assert its fields.

## Testing

`test_handle_register_external_order_claims_while_event_loop_runs` and its deregistration sibling drive `run()` to the main loop from a task on the same runtime and assert the claim change reached both the execution engine and the reconciliation manager. `test_handle_registration_returns_synchronous_preflight_error` and its deregistration sibling pin that a duplicate claim and mismatched tiers come back through the responder with the same error text the synchronous API produces. `test_shutdown_drain_drops_external_claim_response` pins that a command drained at shutdown resolves the caller with an error rather than leaving it pending. The new node tests run on current-thread runtimes with bounded waits on the handle's own state, no wall-clock sleeps. With the register dispatch arm disarmed (reporting success without registering), the running-path test fails on the manager-tier state assertion.
