### PR TITLE
Share the execution event emitter sender across clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6409,6 +6409,7 @@ version = "0.63.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bon",
  "bytes",

--- a/crates/adapters/lighter/fuzz/pornin/Cargo.lock
+++ b/crates/adapters/lighter/fuzz/pornin/Cargo.lock
@@ -636,7 +636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -968,7 +968,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1444,6 +1444,7 @@ version = "0.63.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bon",
  "indexmap",
@@ -1727,7 +1728,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -1766,9 +1767,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2153,7 +2154,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3076,7 +3077,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/live/Cargo.toml
+++ b/crates/live/Cargo.toml
@@ -98,6 +98,7 @@ nautilus-trading = { workspace = true, optional = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
+arc-swap = { workspace = true }
 async-trait = { workspace = true }
 bon = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/live/src/execution/emitter.rs
+++ b/crates/live/src/execution/emitter.rs
@@ -23,12 +23,15 @@
 //!
 //! ```text
 //! Adapter
-//! ├── core: ExecutionClientCore    (identity + connection state)
-//! └── emitter: ExecutionEventEmitter   (event generation + async dispatch)
-//!     ├── factory: OrderEventFactory
-//!     └── sender: Option<Sender>   (set in start())
+//! |-- core: ExecutionClientCore    (identity + connection state)
+//! `-- emitter: ExecutionEventEmitter   (event generation + async dispatch)
+//!     |-- factory: OrderEventFactory
+//!     `-- sender: ArcSwapOption<Sender>   (set in start())
 //! ```
 
+use std::sync::Arc;
+
+use arc_swap::ArcSwapOption;
 use nautilus_common::{
     factories::OrderEventFactory,
     messages::{ExecutionEvent, ExecutionReport},
@@ -56,11 +59,12 @@ use nautilus_model::{
 /// generate and send events in a single call.
 ///
 /// The sender is set during the adapter's `start()` phase via [`set_sender`](Self::set_sender).
+/// Clones share the sender slot and observe later sender installations and replacements.
 #[derive(Debug, Clone)]
 pub struct ExecutionEventEmitter {
     clock: &'static AtomicTime,
     factory: OrderEventFactory,
-    sender: Option<tokio::sync::mpsc::UnboundedSender<ExecutionEvent>>,
+    sender: Arc<ArcSwapOption<tokio::sync::mpsc::UnboundedSender<ExecutionEvent>>>,
 }
 
 impl ExecutionEventEmitter {
@@ -78,7 +82,7 @@ impl ExecutionEventEmitter {
         Self {
             clock,
             factory: OrderEventFactory::new(trader_id, account_id, account_type, base_currency),
-            sender: None,
+            sender: Arc::new(ArcSwapOption::empty()),
         }
     }
 
@@ -86,15 +90,17 @@ impl ExecutionEventEmitter {
         self.clock.get_time_ns()
     }
 
-    /// Sets the sender. Call in adapter's `start()`.
+    /// Installs or replaces the sender for this emitter and all its clones.
+    ///
+    /// Call in the adapter's `start()` method.
     pub fn set_sender(&mut self, sender: tokio::sync::mpsc::UnboundedSender<ExecutionEvent>) {
-        self.sender = Some(sender);
+        self.sender.store(Some(Arc::new(sender)));
     }
 
-    /// Returns true if the sender is initialized.
+    /// Returns true if the sender is initialized for this emitter and its clones.
     #[must_use]
     pub fn is_initialized(&self) -> bool {
-        self.sender.is_some()
+        self.sender.load().is_some()
     }
 
     /// Returns the trader ID.
@@ -419,8 +425,8 @@ impl ExecutionEventEmitter {
     ///
     /// Returns an error if the sender is uninitialized or its receiver is closed.
     pub fn try_send_order_event(&self, event: OrderEventAny) -> anyhow::Result<()> {
-        let sender = self
-            .sender
+        let sender = self.sender.load();
+        let sender = sender
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Cannot send order event: sender not initialized"))?;
         sender
@@ -430,7 +436,8 @@ impl ExecutionEventEmitter {
 
     /// Emits a batch of order submitted events as a single channel message.
     pub fn send_order_submitted_batch(&self, batch: OrderSubmittedBatch) {
-        if let Some(sender) = &self.sender {
+        let sender = self.sender.load();
+        if let Some(sender) = sender.as_ref() {
             if let Err(e) = sender.send(ExecutionEvent::OrderSubmittedBatch(batch)) {
                 log::warn!("Failed to send order submitted batch: {e}");
             }
@@ -441,7 +448,8 @@ impl ExecutionEventEmitter {
 
     /// Emits a batch of order accepted events as a single channel message.
     pub fn send_order_accepted_batch(&self, batch: OrderAcceptedBatch) {
-        if let Some(sender) = &self.sender {
+        let sender = self.sender.load();
+        if let Some(sender) = sender.as_ref() {
             if let Err(e) = sender.send(ExecutionEvent::OrderAcceptedBatch(batch)) {
                 log::warn!("Failed to send order accepted batch: {e}");
             }
@@ -452,7 +460,8 @@ impl ExecutionEventEmitter {
 
     /// Emits a batch of order canceled events as a single channel message.
     pub fn send_order_canceled_batch(&self, batch: OrderCanceledBatch) {
-        if let Some(sender) = &self.sender {
+        let sender = self.sender.load();
+        if let Some(sender) = sender.as_ref() {
             if let Err(e) = sender.send(ExecutionEvent::OrderCanceledBatch(batch)) {
                 log::warn!("Failed to send order canceled batch: {e}");
             }
@@ -469,8 +478,8 @@ impl ExecutionEventEmitter {
     }
 
     fn try_send_account_state(&self, state: AccountState) -> anyhow::Result<()> {
-        let sender = self
-            .sender
+        let sender = self.sender.load();
+        let sender = sender
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Cannot send account state: sender not initialized"))?;
         sender
@@ -491,7 +500,8 @@ impl ExecutionEventEmitter {
     ///
     /// Returns an error if the sender is not initialized or the receiving channel is closed.
     pub fn try_send_execution_report(&self, report: ExecutionReport) -> anyhow::Result<()> {
-        let sender = self.sender.as_ref().ok_or_else(|| {
+        let sender = self.sender.load();
+        let sender = sender.as_ref().ok_or_else(|| {
             anyhow::anyhow!("Cannot send execution report: sender not initialized")
         })?;
         sender
@@ -517,5 +527,83 @@ impl ExecutionEventEmitter {
     /// Emits a position status report.
     pub fn send_position_report(&self, report: PositionStatusReport) {
         self.send_execution_report(ExecutionReport::Position(Box::new(report)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nautilus_core::time::get_atomic_clock_static;
+    use nautilus_model::events::order::spec::OrderSubmittedSpec;
+    use rstest::rstest;
+
+    use super::*;
+
+    fn create_emitter() -> ExecutionEventEmitter {
+        ExecutionEventEmitter::new(
+            get_atomic_clock_static(),
+            TraderId::from("TRADER-001"),
+            AccountId::from("SIM-001"),
+            AccountType::Cash,
+            None,
+        )
+    }
+
+    fn create_order_event() -> OrderEventAny {
+        OrderEventAny::Submitted(
+            OrderSubmittedSpec::builder()
+                .client_order_id(ClientOrderId::from("O-001"))
+                .build(),
+        )
+    }
+
+    #[rstest]
+    fn test_clone_before_set_sender_observes_sender() {
+        let mut emitter = create_emitter();
+        let cloned = emitter.clone();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        emitter.set_sender(tx);
+
+        assert!(cloned.is_initialized());
+        cloned.send_order_event(create_order_event());
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ExecutionEvent::Order(OrderEventAny::Submitted(_)))
+        ));
+    }
+
+    #[rstest]
+    fn test_set_sender_replaces_existing_sender() {
+        let mut emitter = create_emitter();
+        let (tx_a, mut rx_a) = tokio::sync::mpsc::unbounded_channel();
+        let (tx_b, mut rx_b) = tokio::sync::mpsc::unbounded_channel();
+
+        emitter.set_sender(tx_a);
+        emitter.set_sender(tx_b);
+        emitter.send_order_event(create_order_event());
+
+        assert!(matches!(
+            rx_a.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
+        assert!(matches!(
+            rx_b.try_recv(),
+            Ok(ExecutionEvent::Order(OrderEventAny::Submitted(_)))
+        ));
+    }
+
+    #[rstest]
+    fn test_never_initialized_sender_drops_or_errors() {
+        let emitter = create_emitter();
+
+        emitter.send_order_event(create_order_event());
+        let error = emitter
+            .try_send_order_event(create_order_event())
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Cannot send order event: sender not initialized"
+        );
     }
 }


### PR DESCRIPTION
Share the execution event emitter sender across clones

## A clone taken before `set_sender` is permanently senderless

`ExecutionEventEmitter` derives `Clone` over `sender: Option<UnboundedSender<ExecutionEvent>>` held by value, so a clone freezes the sender state of the instant it was taken: one taken before the adapter's `start()` installs the sender holds `None` for its lifetime, and `send_order_event` on it warns and drops the event. Every in-tree adapter installs the sender in `start()` and takes its emitter clones afterwards, so the ordering holds by convention rather than by construction - and a host that builds execution clients on one thread and connects them on another takes construction-time clones that stay senderless when the runner later installs the sender. The thread-local `EXEC_EVENT_SENDER` slot cannot heal such a clone from another thread.

The sender now lives in an `Arc<ArcSwapOption<UnboundedSender<ExecutionEvent>>>` shared through the derived `Clone`, so `set_sender` installs - or replaces, exactly as today - the sender for the emitter and all its clones, and `is_initialized` answers for the shared slot. Every send path takes one atomic `load()` snapshot for the whole operation; the added per-send cost is that lock-free load, with no mutex or rwlock. Public signatures are unchanged.

The alternative shape is to enforce the ordering instead - thread the sender through construction or make each adapter clone only after `start()` - but that touches every holder (~150 `emitter.clone()` sites and 68 `set_sender` calls across 18 execution clients) to establish a convention the representation can guarantee in one place. This diff changes only the emitter.

## Testing

`test_clone_before_set_sender_observes_sender` clones before installing, installs through the original, and asserts the clone reports initialized and delivers to the channel; with a freezing `Clone` substituted for the derived one (each clone getting a fresh empty cell), it fails at `is_initialized`. `test_set_sender_replaces_existing_sender` pins the existing overwrite semantics: the displaced channel disconnects and the new one receives. `test_never_initialized_sender_drops_or_errors` pins the warn-and-drop path and `try_send_order_event`'s error for an emitter never given a sender.
