### PR TITLE
Add an account registration wait to the live node handle

### DIFF
--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -411,6 +411,7 @@ impl LiveNode {
 
         self.kernel.reset_shutdown_flag();
         self.kernel.start_async().await;
+        self.seed_registered_accounts();
 
         if self.kernel.is_event_store_replay() {
             log::info!(
@@ -1051,6 +1052,7 @@ impl LiveNode {
         self.handle.set_starting();
         self.kernel.reset_shutdown_flag();
         self.kernel.start_async().await;
+        self.seed_registered_accounts();
 
         if self.kernel.is_event_store_replay() {
             log::info!(
@@ -1929,7 +1931,6 @@ impl LiveNode {
 
         let cache = self.kernel.cache();
         if !cache.borrow().has_backing() {
-            self.seed_registered_accounts();
             return Ok(());
         }
 
@@ -1940,7 +1941,6 @@ impl LiveNode {
             .is_some_and(|config| config.flush_on_start)
         {
             cache.borrow_mut().flush_db();
-            self.seed_registered_accounts();
             return Ok(());
         }
 
@@ -1953,7 +1953,12 @@ impl LiveNode {
                 .context("Failed to load persistent cache")?;
         }
 
-        self.seed_registered_accounts();
+        // Deliberately no tracker seeding here: `prepare_cache` runs before
+        // `set_starting` bumps the lifecycle generation, so a seed taken now
+        // would tag database-loaded accounts with the PREVIOUS lifecycle and
+        // wrongly release a waiter from it. The unconditional seed after
+        // `kernel.start_async` covers every account loaded here, at the
+        // started generation.
         Ok(())
     }
 
@@ -2149,9 +2154,14 @@ impl LiveNode {
 
     async fn connect_exec_clients(&mut self, deadline: dst::time::Instant) -> anyhow::Result<()> {
         let remaining = deadline.saturating_duration_since(dst::time::Instant::now());
-        dst::time::timeout(remaining, self.kernel.connect_exec_clients())
+        let result = dst::time::timeout(remaining, self.kernel.connect_exec_clients())
             .await
-            .map_err(|_| anyhow::anyhow!("exec-connect timeout"))
+            .map_err(|_| anyhow::anyhow!("exec-connect timeout"));
+        // Seed on the timeout path too: clients connect concurrently, so an
+        // aggregate timeout can leave an already-connected client's account
+        // cached with no later observation point before the tracker closes.
+        self.seed_registered_accounts();
+        result
     }
 
     /// Connects execution clients and checks all engines are connected.
@@ -4085,6 +4095,7 @@ mod tests {
             Arc,
             atomic::{AtomicBool, Ordering},
         },
+        task::{Context, Poll, Waker},
     };
 
     use bytes::Bytes;
@@ -4179,6 +4190,79 @@ mod tests {
         venue: Venue,
         outcome: FillReportClientOutcome,
         commands: Rc<RefCell<Vec<GenerateFillReports>>>,
+    }
+
+    #[derive(Debug)]
+    struct DirectAccountClient {
+        account_state: AccountState,
+        connected: Cell<bool>,
+        // When set, `connect` parks until the test releases it, so a test can
+        // prove an already-parked waiter is woken by the post-connect seed
+        // rather than satisfied by the fast path.
+        gate: Option<Arc<tokio::sync::Notify>>,
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl ExecutionClient for DirectAccountClient {
+        fn is_connected(&self) -> bool {
+            self.connected.get()
+        }
+
+        fn client_id(&self) -> ClientId {
+            ClientId::from(self.account_state.account_id.inner().as_str())
+        }
+
+        fn account_id(&self) -> AccountId {
+            self.account_state.account_id
+        }
+
+        fn venue(&self) -> Venue {
+            Venue::from(self.account_state.account_id.inner().as_str())
+        }
+
+        fn oms_type(&self) -> OmsType {
+            OmsType::Netting
+        }
+
+        fn get_account(&self) -> Option<AccountAny> {
+            None
+        }
+
+        fn generate_account_state(
+            &self,
+            _balances: Vec<AccountBalance>,
+            _margins: Vec<MarginBalance>,
+            _reported: bool,
+            _ts_event: UnixNanos,
+            _info: Option<Params>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn start(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn stop(&mut self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn connect(&mut self) -> anyhow::Result<()> {
+            if let Some(gate) = &self.gate {
+                gate.notified().await;
+            }
+            msgbus::send_account_state(
+                MessagingSwitchboard::portfolio_update_account(),
+                &self.account_state,
+            );
+            self.connected.set(true);
+            Ok(())
+        }
+
+        async fn disconnect(&mut self) -> anyhow::Result<()> {
+            self.connected.set(false);
+            Ok(())
+        }
     }
 
     #[async_trait::async_trait(?Send)]
@@ -5885,16 +5969,30 @@ mod tests {
     #[derive(Debug)]
     struct ReplayKernelEventStore {
         fail_restore: bool,
+        account_state: Option<AccountState>,
+        restore_after: u32,
+        restore_count: Rc<Cell<u32>>,
     }
 
     impl KernelEventStore for ReplayKernelEventStore {
         fn restore_parent_cache(
             &mut self,
             _instance_id: UUID4,
-            _cache: &mut Cache,
+            cache: &mut Cache,
         ) -> anyhow::Result<()> {
             if self.fail_restore {
                 anyhow::bail!("replay restore failed");
+            }
+
+            let restore_count = self.restore_count.get() + 1;
+            self.restore_count.set(restore_count);
+            if restore_count >= self.restore_after
+                && let Some(account_state) = &self.account_state
+            {
+                cache.add_account(AccountAny::Margin(MarginAccount::new(
+                    account_state.clone(),
+                    true,
+                )))?;
             }
 
             Ok(())
@@ -5965,10 +6063,97 @@ mod tests {
             .with_load_state(true)
             .with_name("TestKernel")
             .with_event_store(move |_instance_id: UUID4, _clock: Rc<RefCell<dyn Clock>>| {
-                Ok(Box::new(ReplayKernelEventStore { fail_restore }) as Box<dyn KernelEventStore>)
+                Ok(Box::new(ReplayKernelEventStore {
+                    fail_restore,
+                    account_state: None,
+                    restore_after: 1,
+                    restore_count: Rc::new(Cell::new(0)),
+                }) as Box<dyn KernelEventStore>)
             });
 
         builder.build().unwrap()
+    }
+
+    fn live_node_with_replay_account(account_id: AccountId) -> LiveNode {
+        LiveNodeBuilder::new(TraderId::default(), Environment::Live)
+            .unwrap()
+            .with_exec_engine_config(crate::config::LiveExecutionEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            })
+            .with_load_state(true)
+            .with_name("ReplayAccountNode")
+            .with_event_store(move |_instance_id, _clock| {
+                Ok(Box::new(ReplayKernelEventStore {
+                    fail_restore: false,
+                    account_state: Some(registration_account_state(account_id)),
+                    restore_after: 1,
+                    restore_count: Rc::new(Cell::new(0)),
+                }) as Box<dyn KernelEventStore>)
+            })
+            .build()
+            .unwrap()
+    }
+
+    fn live_node_with_account_restored_on_second_start(account_id: AccountId) -> LiveNode {
+        LiveNodeBuilder::new(TraderId::default(), Environment::Live)
+            .unwrap()
+            .with_exec_engine_config(crate::config::LiveExecutionEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            })
+            .with_load_state(true)
+            .with_name("LifecycleReplayAccountNode")
+            .with_event_store(move |_instance_id, _clock| {
+                Ok(Box::new(ReplayKernelEventStore {
+                    fail_restore: false,
+                    account_state: Some(registration_account_state(account_id)),
+                    restore_after: 2,
+                    restore_count: Rc::new(Cell::new(0)),
+                }) as Box<dyn KernelEventStore>)
+            })
+            .build()
+            .unwrap()
+    }
+
+    fn add_direct_account_client(
+        node: &mut LiveNode,
+        account_id: AccountId,
+        gate: Option<Arc<tokio::sync::Notify>>,
+    ) {
+        let client = LiveExecutionClient::new(Box::new(DirectAccountClient {
+            account_state: registration_account_state(account_id),
+            connected: Cell::new(false),
+            gate,
+        }));
+        node.kernel
+            .exec_engine()
+            .borrow_mut()
+            .register_client(Box::new(client.clone()))
+            .unwrap();
+        node.exec_clients.push(client);
+    }
+
+    fn assert_waiter_pending<F: Future>(future: Pin<&mut F>) {
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        assert!(matches!(future.poll(&mut context), Poll::Pending));
+    }
+
+    fn account_registration_node_config() -> LiveNodeConfig {
+        LiveNodeConfig {
+            exec_engine: crate::config::LiveExecutionEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            timeout_connection: Duration::from_secs(1),
+            timeout_reconciliation: Duration::ZERO,
+            timeout_portfolio: Duration::ZERO,
+            timeout_disconnection: Duration::ZERO,
+            delay_post_stop: Duration::ZERO,
+            timeout_shutdown: Duration::ZERO,
+            ..Default::default()
+        }
     }
 
     #[rstest]
@@ -7400,6 +7585,222 @@ mod tests {
 
         assert_eq!(handle.state(), NodeState::Stopped);
         assert!(handle.should_stop());
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_waiter_released_after_event_store_restores_account() {
+        let account_id = AccountId::from("REGISTER-REPLAY-001");
+        let mut node = live_node_with_replay_account(account_id);
+        let handle = node.handle();
+        let wait_handle = handle.clone();
+        let cache = node.kernel.cache();
+
+        let (start_result, wait_result) = tokio::join!(node.start(), async move {
+            while wait_handle.state() == NodeState::Idle {
+                tokio::task::yield_now().await;
+            }
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                wait_handle.await_account_registered(account_id),
+            )
+            .await
+        });
+
+        start_result.unwrap();
+        wait_result
+            .expect("restored account registration should arrive before timeout")
+            .unwrap();
+        assert!(cache.borrow().account(&account_id).is_some());
+        node.stop().await.unwrap();
+        node.dispose();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_waiter_released_after_direct_connect_insertion() {
+        let account_id = AccountId::from("REGISTER-DIRECT-001");
+        let mut node = LiveNode::build(
+            "DirectAccountNode".to_string(),
+            Some(account_registration_node_config()),
+        )
+        .unwrap();
+        let gate = Arc::new(tokio::sync::Notify::new());
+        add_direct_account_client(&mut node, account_id, Some(Arc::clone(&gate)));
+        let handle = node.handle();
+        let wait_handle = handle.clone();
+        let cache = node.kernel.cache();
+
+        // The gated client holds `connect` open until the waiter is provably
+        // parked, so the release below is what wakes it - the fast path
+        // cannot have satisfied it.
+        let (start_result, wait_result) = tokio::join!(node.start(), async move {
+            while wait_handle.state() == NodeState::Idle {
+                tokio::task::yield_now().await;
+            }
+            let mut waiter = Box::pin(wait_handle.await_account_registered(account_id));
+            assert_waiter_pending(waiter.as_mut());
+            gate.notify_one();
+            tokio::time::timeout(Duration::from_secs(1), waiter).await
+        });
+
+        start_result.unwrap();
+        wait_result
+            .expect("direct account registration should arrive before timeout")
+            .unwrap();
+        assert!(cache.borrow().account(&account_id).is_some());
+        node.stop().await.unwrap();
+        node.dispose();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_waiter_released_when_exec_connect_times_out() {
+        // Clients connect concurrently: one inserts its account and completes,
+        // the other holds the aggregate connect past the deadline. The seed on
+        // the timeout path is what releases the waiter; without it the account
+        // is cached but the tracker closes with the waiter still parked.
+        let account_id = AccountId::from("REGISTER-TIMEOUT-001");
+        let mut node = LiveNode::build(
+            "TimeoutAccountNode".to_string(),
+            Some(account_registration_node_config()),
+        )
+        .unwrap();
+        add_direct_account_client(&mut node, account_id, None);
+        let never = Arc::new(tokio::sync::Notify::new());
+        add_direct_account_client(
+            &mut node,
+            AccountId::from("REGISTER-TIMEOUT-HELD-001"),
+            Some(never),
+        );
+        let handle = node.handle();
+        let wait_handle = handle.clone();
+        let cache = node.kernel.cache();
+
+        let (start_result, wait_result) = tokio::join!(node.start(), async move {
+            while wait_handle.state() == NodeState::Idle {
+                tokio::task::yield_now().await;
+            }
+            tokio::time::timeout(
+                Duration::from_secs(5),
+                wait_handle.await_account_registered(account_id),
+            )
+            .await
+        });
+
+        start_result.expect_err("held client should time out the aggregate connect");
+        wait_result
+            .expect("connected client's account should release the waiter before timeout")
+            .unwrap();
+        assert!(cache.borrow().account(&account_id).is_some());
+        node.dispose();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_waiter_released_after_replay_run_restores_account() {
+        // Same restoration mechanism as the start() test, through the
+        // run_with_mode replay branch, which returns before the select loop
+        // and carries its own post-start seed.
+        let account_id = AccountId::from("REGISTER-REPLAY-RUN-001");
+        let mut node = live_node_with_replay_account(account_id);
+        let handle = node.handle();
+        let wait_handle = handle.clone();
+        let cache = node.kernel.cache();
+
+        let (run_result, wait_result) = tokio::join!(node.run(), async move {
+            while wait_handle.state() == NodeState::Idle {
+                tokio::task::yield_now().await;
+            }
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                wait_handle.await_account_registered(account_id),
+            )
+            .await
+        });
+
+        run_result.unwrap();
+        wait_result
+            .expect("restored account registration should arrive before timeout")
+            .unwrap();
+        assert!(cache.borrow().account(&account_id).is_some());
+        node.stop().await.unwrap();
+        node.dispose();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_waiter_rejects_later_lifecycle_replay_registration() {
+        let account_id = AccountId::from("REGISTER-LIFECYCLE-001");
+        let mut node = live_node_with_account_restored_on_second_start(account_id);
+        let handle = node.handle();
+
+        node.start().await.unwrap();
+        let mut waiter = Box::pin(handle.await_account_registered(account_id));
+        assert_waiter_pending(waiter.as_mut());
+
+        node.stop().await.unwrap();
+        node.start().await.unwrap();
+
+        let error = waiter.await.unwrap_err();
+        assert!(error.to_string().contains("Node stopped before account"));
+        assert!(node.kernel.cache().borrow().account(&account_id).is_some());
+        node.stop().await.unwrap();
+        node.dispose();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_waiter_succeeds_for_event_drained_before_tracker_close() {
+        let mut node = LiveNode::build(
+            "DrainedAccountNode".to_string(),
+            Some(account_registration_node_config()),
+        )
+        .unwrap();
+        let handle = node.handle();
+        let account_id = AccountId::from("REGISTER-DRAIN-001");
+
+        node.start().await.unwrap();
+        let mut waiter = Box::pin(handle.await_account_registered(account_id));
+        assert_waiter_pending(waiter.as_mut());
+        get_exec_event_sender()
+            .send(registration_account_event(account_id))
+            .unwrap();
+
+        node.stop().await.unwrap();
+
+        waiter.await.unwrap();
+        assert!(node.kernel.cache().borrow().account(&account_id).is_some());
+        node.dispose();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_wait_fast_path_succeeds_after_normal_stop() {
+        let mut node = LiveNode::build(
+            "StoppedAccountNode".to_string(),
+            Some(account_registration_node_config()),
+        )
+        .unwrap();
+        let handle = node.handle();
+        let account_id = AccountId::from("REGISTER-STOPPED-001");
+        node.kernel
+            .cache()
+            .borrow_mut()
+            .add_account(AccountAny::Margin(MarginAccount::new(
+                registration_account_state(account_id),
+                true,
+            )))
+            .unwrap();
+
+        node.start().await.unwrap();
+        node.stop().await.unwrap();
+
+        tokio::time::timeout(Duration::ZERO, handle.await_account_registered(account_id))
+            .await
+            .expect("cached account wait should be immediately ready after stop")
+            .unwrap();
+        node.dispose();
     }
 
     #[rstest]

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -77,13 +77,16 @@
 //! maintenance below 100ms (defaults are seconds to minutes). Cadence drifts
 //! by at most one body duration per fire.
 
-use std::{any::Any, fmt::Debug, future::Future, pin::Pin, time::Duration};
+use std::{any::Any, cell::RefCell, fmt::Debug, future::Future, pin::Pin, rc::Rc, time::Duration};
 
 use anyhow::Context;
 use indexmap::{IndexMap, IndexSet};
 use nautilus_common::{
     actor::{Actor, DataActor, DataActorNative},
-    cache::database::{CacheDatabaseAdapter, CacheDatabaseFactory},
+    cache::{
+        Cache,
+        database::{CacheDatabaseAdapter, CacheDatabaseFactory},
+    },
     clients::ExecutionClient,
     component::Component,
     enums::{Environment, LogColor},
@@ -109,7 +112,7 @@ use nautilus_core::{
 use nautilus_model::reports::OrderStatusReport;
 use nautilus_model::{
     events::OrderEventAny,
-    identifiers::{ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId},
+    identifiers::{AccountId, ClientId, ClientOrderId, InstrumentId, StrategyId, TraderId},
     orders::Order,
     reports::{FillReport, PositionStatusReport},
 };
@@ -153,7 +156,7 @@ use config::{LiveNodeConfig, PluginConfig, validate_live_environment};
 pub use metrics::{RunnerChannelMetricsSnapshot, RunnerMetricsDelta, RunnerMetricsSnapshot};
 use metrics::{RunnerChannelQueueDepths, RunnerMetrics};
 use queue::{QueueMonitor, QueueStateTransition};
-use state::{EngineConnectionStatus, RunningTransition};
+use state::{EngineConnectionStatus, RegistrationTracker, RunningTransition};
 pub use state::{LiveNodeHandle, NodeRunMode, NodeState};
 
 /// Dispatches the run loop performs before yielding to the executor.
@@ -217,7 +220,7 @@ impl LiveNode {
             kernel,
             runner: Some(runner),
             config,
-            handle: LiveNodeHandle::new(),
+            handle: LiveNodeHandle::attached(),
             exec_manager,
             exec_clients,
             socket_registry,
@@ -292,7 +295,7 @@ impl LiveNode {
             kernel,
             runner: Some(runner),
             config,
-            handle: LiveNodeHandle::new(),
+            handle: LiveNodeHandle::attached(),
             exec_manager,
             exec_clients: Vec::new(),
             socket_registry: SocketReconnectRegistry::default(),
@@ -561,8 +564,11 @@ impl LiveNode {
     /// Disposes the live node kernel and releases resources.
     pub fn dispose(&mut self) {
         self.close_external_ingress();
-        self.kernel.dispose();
+        // The tracker is invalidated before the kernel clears the cache, so a
+        // cross-thread waiter cannot resolve against a row disposal removes.
         self.handle.set_stopped();
+        self.handle.dispose_registration_tracker();
+        self.kernel.dispose();
     }
 
     async fn process_runner_for(&mut self, duration: Duration) -> usize {
@@ -598,11 +604,13 @@ impl LiveNode {
 
     fn drain_runner_pending(&mut self) -> usize {
         let Some(mut runner) = self.runner.take() else {
+            self.handle.close_registration_tracker();
             return 0;
         };
 
         let processed = runner.poll_pending(|event| self.process_runner_event(event));
         self.runner = Some(runner);
+        self.handle.close_registration_tracker();
         processed
     }
 
@@ -1065,9 +1073,9 @@ impl LiveNode {
             Ok(rx) => rx,
             Err(e) => {
                 let result = self
-                    .abort_startup("External message bus ingress failed to start")
+                    .abort_startup_before_drain("External message bus ingress failed to start")
                     .await;
-                Self::drain_channels(
+                self.drain_channels(
                     &mut time_evt_rx,
                     &mut system_evt_rx,
                     &mut system_cmd_rx,
@@ -1093,6 +1101,8 @@ impl LiveNode {
         let mut startup_system_events = Vec::new();
         let mut startup_system_commands = Vec::new();
         let connection_deadline = dst::time::Instant::now() + self.config.timeout_connection;
+        let cache = self.kernel.cache();
+        let registration_tracker = self.handle.registration_tracker();
 
         // Startup phase 1: Connect data clients and drain instrument events into cache.
         // This ensures the cache is populated before execution clients connect.
@@ -1106,6 +1116,8 @@ impl LiveNode {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            &cache,
+            &registration_tracker,
         )
         .await;
 
@@ -1119,11 +1131,13 @@ impl LiveNode {
                 &mut exec_cmd_rx,
                 &mut data_evt_rx,
                 &mut data_cmd_rx,
+                &cache,
+                &registration_tracker,
             );
             let result = self
-                .abort_startup_with_error("Data client connection timed out", e)
+                .abort_startup_with_error_before_drain("Data client connection timed out", e)
                 .await;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1158,6 +1172,8 @@ impl LiveNode {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            &cache,
+            &registration_tracker,
         )
         .await;
 
@@ -1171,6 +1187,8 @@ impl LiveNode {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            &cache,
+            &registration_tracker,
         );
         startup_system_events.extend(pending.take_system_events());
         startup_system_commands.extend(pending.take_system_commands());
@@ -1183,9 +1201,12 @@ impl LiveNode {
             Ok(status) => status,
             Err(e) => {
                 let result = self
-                    .abort_startup_with_error("Execution client connection timed out", e)
+                    .abort_startup_with_error_before_drain(
+                        "Execution client connection timed out",
+                        e,
+                    )
                     .await;
-                Self::drain_channels(
+                self.drain_channels(
                     &mut time_evt_rx,
                     &mut system_evt_rx,
                     &mut system_cmd_rx,
@@ -1201,12 +1222,12 @@ impl LiveNode {
 
         if engine_connection_status == EngineConnectionStatus::TimedOut {
             let result = self
-                .abort_startup_with_error(
+                .abort_startup_with_error_before_drain(
                     "Engine readiness timed out",
                     anyhow::anyhow!("readiness timeout while waiting for engine connections"),
                 )
                 .await;
-            Self::drain_channels(
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1223,8 +1244,8 @@ impl LiveNode {
             .abort_reason()
             .or_else(|| self.startup_abort_reason())
         {
-            self.abort_startup(reason).await?;
-            Self::drain_channels(
+            let result = self.abort_startup_before_drain(reason).await;
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1234,15 +1255,17 @@ impl LiveNode {
                 &mut data_cmd_rx,
             );
             log::info!("Event loop stopped");
-            return Ok(());
+            return result;
         }
 
         debug_assert_eq!(engine_connection_status, EngineConnectionStatus::Connected);
 
         // Run reconciliation now that instruments are in cache and start trader
         if let Err(e) = self.perform_startup_reconciliation().await {
-            let result = self.abort_startup("Startup reconciliation failed").await;
-            Self::drain_channels(
+            let result = self
+                .abort_startup_before_drain("Startup reconciliation failed")
+                .await;
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1263,8 +1286,8 @@ impl LiveNode {
         }
 
         if let Some(reason) = self.startup_abort_reason() {
-            let result = self.abort_startup(reason).await;
-            Self::drain_channels(
+            let result = self.abort_startup_before_drain(reason).await;
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1278,8 +1301,8 @@ impl LiveNode {
         }
 
         if let Err(e) = self.kernel.start_trader() {
-            let result = self.abort_after_trader_start_failure(e).await;
-            Self::drain_channels(
+            let result = self.abort_after_trader_start_failure_before_drain(e).await;
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1293,8 +1316,8 @@ impl LiveNode {
         }
         #[cfg(feature = "plugin")]
         if let Err(e) = self.plugins.start_controllers() {
-            let result = self.abort_after_trader_start_failure(e).await;
-            Self::drain_channels(
+            let result = self.abort_after_trader_start_failure_before_drain(e).await;
+            self.drain_channels(
                 &mut time_evt_rx,
                 &mut system_evt_rx,
                 &mut system_cmd_rx,
@@ -1861,7 +1884,7 @@ impl LiveNode {
         let stop_result = self.finalize_stop().await;
 
         // Handle events that arrived during finalize_stop
-        Self::drain_channels(
+        self.drain_channels(
             &mut time_evt_rx,
             &mut system_evt_rx,
             &mut system_cmd_rx,
@@ -1906,6 +1929,7 @@ impl LiveNode {
 
         let cache = self.kernel.cache();
         if !cache.borrow().has_backing() {
+            self.seed_registered_accounts();
             return Ok(());
         }
 
@@ -1916,6 +1940,7 @@ impl LiveNode {
             .is_some_and(|config| config.flush_on_start)
         {
             cache.borrow_mut().flush_db();
+            self.seed_registered_accounts();
             return Ok(());
         }
 
@@ -1928,7 +1953,19 @@ impl LiveNode {
                 .context("Failed to load persistent cache")?;
         }
 
+        self.seed_registered_accounts();
         Ok(())
+    }
+
+    fn seed_registered_accounts(&self) {
+        let account_ids = self
+            .kernel
+            .cache()
+            .borrow()
+            .accounts_all_owned()
+            .into_iter()
+            .map(|account| account.id());
+        self.handle.registration_tracker().seed(account_ids);
     }
 
     /// Returns whether a cache database backing is configured but not yet installed.
@@ -2079,8 +2116,19 @@ impl LiveNode {
             ExecutionEvent::Order(OrderEventAny::Filled(fill)) => Some(fill.clone()),
             _ => None,
         };
-
+        let account_id = match &evt {
+            ExecutionEvent::Account(account) => Some(account.account_id),
+            _ => None,
+        };
         AsyncRunner::handle_exec_event(evt);
+
+        if let Some(account_id) = account_id {
+            mark_account_registered_if_cached(
+                &self.kernel.cache(),
+                &self.handle.registration_tracker(),
+                account_id,
+            );
+        }
 
         if let Some(fill) = &recent_fill_candidate {
             self.exec_manager.commit_recent_fill_if_applied(fill);
@@ -2183,6 +2231,14 @@ impl LiveNode {
     async fn abort_startup(&mut self, reason: &str) -> anyhow::Result<()> {
         log::info!("{reason}, aborting startup");
         self.handle.set_shutting_down();
+        let result = self.finalize_stop().await;
+        self.handle.close_registration_tracker();
+        result
+    }
+
+    async fn abort_startup_before_drain(&mut self, reason: &str) -> anyhow::Result<()> {
+        log::info!("{reason}, aborting startup");
+        self.handle.set_shutting_down();
         self.finalize_stop().await
     }
 
@@ -2192,6 +2248,19 @@ impl LiveNode {
         startup_err: anyhow::Error,
     ) -> anyhow::Result<()> {
         match self.abort_startup(reason).await {
+            Ok(()) => Err(startup_err),
+            Err(finalize_err) => {
+                anyhow::bail!("{startup_err}; failed to finalize startup abort: {finalize_err}")
+            }
+        }
+    }
+
+    async fn abort_startup_with_error_before_drain(
+        &mut self,
+        reason: &str,
+        startup_err: anyhow::Error,
+    ) -> anyhow::Result<()> {
+        match self.abort_startup_before_drain(reason).await {
             Ok(()) => Err(startup_err),
             Err(finalize_err) => {
                 anyhow::bail!("{startup_err}; failed to finalize startup abort: {finalize_err}")
@@ -2228,7 +2297,7 @@ impl LiveNode {
         let finalize_result = self.finalize_stop().await;
 
         if let Some(receivers) = receivers {
-            Self::drain_channels(
+            self.drain_channels(
                 receivers.time_evt,
                 receivers.system_evt,
                 receivers.system_cmd,
@@ -2316,6 +2385,17 @@ impl LiveNode {
         &mut self,
         start_err: anyhow::Error,
     ) -> anyhow::Result<()> {
+        let result = self
+            .abort_after_trader_start_failure_before_drain(start_err)
+            .await;
+        self.handle.close_registration_tracker();
+        result
+    }
+
+    async fn abort_after_trader_start_failure_before_drain(
+        &mut self,
+        start_err: anyhow::Error,
+    ) -> anyhow::Result<()> {
         log::info!("Trader startup failed, aborting startup");
         self.handle.set_shutting_down();
         let stop_result = self.kernel.stop_trader_after_start_failure();
@@ -2393,7 +2473,12 @@ impl LiveNode {
         }
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "all runner receivers are drained together"
+    )]
     fn drain_channels(
+        &self,
         time_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TimeEventMessage>,
         system_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemEvent>,
         system_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SystemCommand>,
@@ -2428,7 +2513,19 @@ impl LiveNode {
         }
 
         while let Ok(evt) = exec_evt_rx.try_recv() {
+            let account_id = match &evt {
+                ExecutionEvent::Account(account) => Some(account.account_id),
+                _ => None,
+            };
             AsyncRunner::handle_exec_event(evt);
+
+            if let Some(account_id) = account_id {
+                mark_account_registered_if_cached(
+                    &self.kernel.cache(),
+                    &self.handle.registration_tracker(),
+                    account_id,
+                );
+            }
             drained += 1;
         }
 
@@ -2440,6 +2537,8 @@ impl LiveNode {
         if drained > 0 {
             log::info!("Drained {drained} remaining events during shutdown");
         }
+
+        self.handle.close_registration_tracker();
     }
 
     fn observe_exec_event_before_dispatch(
@@ -3678,6 +3777,16 @@ fn flush_pending_data(
     }
 }
 
+fn mark_account_registered_if_cached(
+    cache: &Rc<RefCell<Cache>>,
+    registration_tracker: &RegistrationTracker,
+    account_id: AccountId,
+) {
+    if cache.borrow().account(&account_id).is_some() {
+        registration_tracker.mark_registered(account_id);
+    }
+}
+
 /// Flushes all channel receivers into `pending`, then drains everything.
 ///
 /// Unlike [`flush_pending_data`] this is a single pass, not a drain-until-quiet
@@ -3696,6 +3805,8 @@ fn flush_all_pending(
     exec_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TradingCommandMessage>,
     data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
     data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
+    cache: &Rc<RefCell<Cache>>,
+    registration_tracker: &RegistrationTracker,
 ) {
     // Flush channel receivers into pending
     while let Ok(handler) = time_evt_rx.try_recv() {
@@ -3720,8 +3831,10 @@ fn flush_all_pending(
 
     while let Ok(evt) = exec_evt_rx.try_recv() {
         match evt {
-            ExecutionEvent::Account(_) => {
+            ExecutionEvent::Account(ref account) => {
+                let account_id = account.account_id;
                 AsyncRunner::handle_exec_event(evt);
+                mark_account_registered_if_cached(cache, registration_tracker, account_id);
             }
             ExecutionEvent::Report(report) => {
                 pending.exec_reports.push(report);
@@ -3772,6 +3885,8 @@ async fn drive_with_event_buffering<F: std::future::Future>(
     exec_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<TradingCommandMessage>,
     data_evt_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataEvent>,
     data_cmd_rx: &mut tokio::sync::mpsc::UnboundedReceiver<DataCommand>,
+    cache: &Rc<RefCell<Cache>>,
+    registration_tracker: &RegistrationTracker,
 ) -> F::Output {
     tokio::pin!(future);
 
@@ -3796,8 +3911,14 @@ async fn drive_with_event_buffering<F: std::future::Future>(
                 // Order events need ExecEngine borrow_mut which may conflict
                 // with the borrow held by the driven future.
                 match evt {
-                    ExecutionEvent::Account(_) => {
+                    ExecutionEvent::Account(ref account) => {
+                        let account_id = account.account_id;
                         AsyncRunner::handle_exec_event(evt);
+                        mark_account_registered_if_cached(
+                            cache,
+                            registration_tracker,
+                            account_id,
+                        );
                     }
                     ExecutionEvent::Report(report) => {
                         pending.exec_reports.push(report);
@@ -7282,6 +7403,216 @@ mod tests {
     }
 
     #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_waiter_released_after_running_loop_caches_account() {
+        let config = LiveNodeConfig {
+            exec_engine: crate::config::LiveExecutionEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            timeout_connection: Duration::ZERO,
+            timeout_reconciliation: Duration::ZERO,
+            timeout_portfolio: Duration::ZERO,
+            timeout_disconnection: Duration::ZERO,
+            delay_post_stop: Duration::ZERO,
+            timeout_shutdown: Duration::ZERO,
+            ..Default::default()
+        };
+        let mut node =
+            LiveNode::build("AccountRegistrationNode".to_string(), Some(config)).unwrap();
+        let handle = node.handle();
+        let drive_handle = handle.clone();
+        let cache = node.kernel.cache();
+        let account_id = AccountId::from("REGISTER-001");
+        let event = registration_account_event(account_id);
+
+        let result = tokio::time::timeout(Duration::from_secs(5), async {
+            let run = node.run();
+            tokio::pin!(run);
+
+            let drive = async move {
+                while !drive_handle.is_running() {
+                    tokio::task::yield_now().await;
+                }
+
+                get_exec_event_sender().send(event).unwrap();
+                tokio::time::timeout(
+                    Duration::from_secs(1),
+                    drive_handle.await_account_registered(account_id),
+                )
+                .await
+                .expect("account registration should arrive before timeout")
+                .unwrap();
+                assert!(cache.borrow().account(&account_id).is_some());
+                drive_handle.stop();
+            };
+
+            let (run_result, ()) = tokio::join!(run, drive);
+            run_result
+        })
+        .await;
+
+        assert!(result.is_ok(), "node should stop before timeout");
+        assert!(result.unwrap().is_ok(), "run() should succeed");
+        node.dispose();
+        msgbus::get_message_bus().borrow_mut().dispose();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_wait_resolves_immediately_when_already_registered() {
+        let handle = LiveNodeHandle::attached();
+        let account_id = AccountId::from("REGISTER-002");
+        handle.registration_tracker().mark_registered(account_id);
+
+        tokio::time::timeout(Duration::ZERO, handle.await_account_registered(account_id))
+            .await
+            .expect("registered account wait should be immediately ready")
+            .unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_wait_returns_error_when_node_stops() {
+        let handle = LiveNodeHandle::attached();
+        handle.set_starting();
+        let stop_handle = handle.clone();
+        let account_id = AccountId::from("REGISTER-003");
+
+        let (result, ()) = tokio::join!(
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                handle.await_account_registered(account_id),
+            ),
+            async move {
+                tokio::task::yield_now().await;
+                stop_handle.set_stopped();
+                stop_handle.close_registration_tracker();
+            },
+        );
+        let error = result
+            .expect("stopped account wait should resolve before timeout")
+            .unwrap_err();
+
+        assert!(error.to_string().contains("Node stopped before account"));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_wait_returns_success_when_mark_precedes_tracker_close() {
+        let handle = LiveNodeHandle::attached();
+        handle.set_starting();
+        let tracker = handle.registration_tracker();
+        let account_id = AccountId::from("REGISTER-006");
+
+        let (result, ()) = tokio::join!(handle.await_account_registered(account_id), async move {
+            tokio::task::yield_now().await;
+            tracker.mark_registered(account_id);
+            tracker.set_stopped();
+        },);
+
+        result.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_wait_from_previous_lifecycle_errors_after_restart() {
+        let handle = LiveNodeHandle::attached();
+        handle.set_starting();
+        let tracker = handle.registration_tracker();
+        let account_id = AccountId::from("REGISTER-007");
+
+        let (result, ()) = tokio::join!(handle.await_account_registered(account_id), async move {
+            tokio::task::yield_now().await;
+            tracker.set_stopped();
+            tracker.set_starting();
+        },);
+        let error = result.unwrap_err();
+
+        assert!(error.to_string().contains("Node stopped before account"));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_wait_errors_after_dispose_clears_registration() {
+        let handle = LiveNodeHandle::attached();
+        handle.set_starting();
+        let tracker = handle.registration_tracker();
+        let account_id = AccountId::from("REGISTER-009");
+        tracker.mark_registered(account_id);
+        handle.set_stopped();
+        handle.dispose_registration_tracker();
+
+        let error = handle
+            .await_account_registered(account_id)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("node is not running"));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_wait_errors_when_attached_node_is_idle() {
+        let error = LiveNodeHandle::attached()
+            .await_account_registered(AccountId::from("REGISTER-008"))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("node is not running"));
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_prepare_cache_seeds_existing_account_registration() {
+        let config = LiveNodeConfig {
+            exec_engine: crate::config::LiveExecutionEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            timeout_connection: Duration::ZERO,
+            timeout_reconciliation: Duration::ZERO,
+            timeout_portfolio: Duration::ZERO,
+            timeout_disconnection: Duration::ZERO,
+            delay_post_stop: Duration::ZERO,
+            timeout_shutdown: Duration::ZERO,
+            ..Default::default()
+        };
+        let mut node = LiveNode::build("SeededAccountNode".to_string(), Some(config)).unwrap();
+        let account_id = AccountId::from("REGISTER-004");
+        let account = AccountAny::Margin(MarginAccount::new(
+            registration_account_state(account_id),
+            true,
+        ));
+        node.kernel
+            .cache()
+            .borrow_mut()
+            .add_account(account)
+            .unwrap();
+        let handle = node.handle();
+
+        node.start().await.unwrap();
+
+        tokio::time::timeout(Duration::ZERO, handle.await_account_registered(account_id))
+            .await
+            .expect("seeded account wait should be immediately ready")
+            .unwrap();
+        node.stop().await.unwrap();
+        node.dispose();
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_account_wait_errors_for_unattached_handle() {
+        let error = LiveNodeHandle::new()
+            .await_account_registered(AccountId::from("REGISTER-005"))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("unattached node handle"));
+    }
+
+    #[rstest]
     fn test_builder_creation() {
         let result = LiveNode::builder(TraderId::from("TRADER-001"), Environment::Sandbox);
 
@@ -8114,6 +8445,8 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            &Rc::new(RefCell::new(Cache::default())),
+            &LiveNodeHandle::attached().registration_tracker(),
         );
 
         let system_events = pending.take_system_events();
@@ -8140,6 +8473,28 @@ mod tests {
         ExecutionEvent::Order(OrderEventAny::Submitted(
             OrderSubmittedSpec::builder().build(),
         ))
+    }
+
+    fn registration_account_state(account_id: AccountId) -> AccountState {
+        AccountState::new(
+            account_id,
+            AccountType::Margin,
+            vec![AccountBalance::new(
+                Money::from("1000000 USDT"),
+                Money::from("0 USDT"),
+                Money::from("1000000 USDT"),
+            )],
+            Vec::new(),
+            true,
+            UUID4::new(),
+            UnixNanos::default(),
+            UnixNanos::default(),
+            Some(Currency::USDT()),
+        )
+    }
+
+    fn registration_account_event(account_id: AccountId) -> ExecutionEvent {
+        ExecutionEvent::Account(registration_account_state(account_id))
     }
 
     fn stub_account_event() -> ExecutionEvent {
@@ -8189,6 +8544,8 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            &Rc::new(RefCell::new(Cache::default())),
+            &LiveNodeHandle::attached().registration_tracker(),
         );
 
         // Both order and report events are drained by pending.drain()
@@ -8224,6 +8581,8 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            &Rc::new(RefCell::new(Cache::default())),
+            &LiveNodeHandle::attached().registration_tracker(),
         );
 
         // Account events are forwarded immediately, never buffered in pending
@@ -8399,6 +8758,8 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            &Rc::new(RefCell::new(Cache::default())),
+            &LiveNodeHandle::attached().registration_tracker(),
         );
 
         // Batch should be unpacked into individual Submitted events then drained
@@ -8433,6 +8794,8 @@ mod tests {
             &mut exec_cmd_rx,
             &mut data_evt_rx,
             &mut data_cmd_rx,
+            &Rc::new(RefCell::new(Cache::default())),
+            &LiveNodeHandle::attached().registration_tracker(),
         );
 
         // Batch should be unpacked into individual Canceled events then drained

--- a/crates/live/src/node/state.rs
+++ b/crates/live/src/node/state.rs
@@ -13,10 +13,15 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicU8, Ordering},
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU8, Ordering},
+    },
 };
+
+use nautilus_model::identifiers::AccountId;
 
 use super::metrics::{RunnerMetrics, RunnerMetricsSnapshot};
 
@@ -109,6 +114,82 @@ pub(super) enum RunningTransition {
     Invalid(u8),
 }
 
+#[derive(Debug)]
+struct RegistrationState {
+    registered: HashSet<AccountId>,
+    lifecycle_generation: u64,
+    stopped: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct RegistrationTracker {
+    state: Mutex<RegistrationState>,
+    changed: tokio::sync::watch::Sender<u64>,
+}
+
+impl RegistrationTracker {
+    fn new() -> Self {
+        let (changed, _) = tokio::sync::watch::channel(0);
+        Self {
+            state: Mutex::new(RegistrationState {
+                registered: HashSet::new(),
+                lifecycle_generation: 0,
+                stopped: false,
+            }),
+            changed,
+        }
+    }
+
+    pub(super) fn seed(&self, account_ids: impl IntoIterator<Item = AccountId>) {
+        let mut state = self.state.lock().expect("registration tracker poisoned");
+        let previous_len = state.registered.len();
+        state.registered.extend(account_ids);
+        if state.registered.len() != previous_len {
+            self.notify();
+        }
+    }
+
+    pub(super) fn mark_registered(&self, account_id: AccountId) {
+        let mut state = self.state.lock().expect("registration tracker poisoned");
+        if state.registered.insert(account_id) {
+            self.notify();
+        }
+    }
+
+    pub(super) fn set_starting(&self) {
+        let mut state = self.state.lock().expect("registration tracker poisoned");
+        state.lifecycle_generation = state
+            .lifecycle_generation
+            .checked_add(1)
+            .expect("registration lifecycle generation overflowed");
+        state.stopped = false;
+        self.notify();
+    }
+
+    pub(super) fn set_stopped(&self) {
+        let mut state = self.state.lock().expect("registration tracker poisoned");
+        state.stopped = true;
+        self.notify();
+    }
+
+    // Disposal invalidates the cache's account rows, so the registered
+    // predicate is cleared with the stop rather than retained across it.
+    pub(super) fn set_disposed(&self) {
+        let mut state = self.state.lock().expect("registration tracker poisoned");
+        state.registered.clear();
+        state.stopped = true;
+        self.notify();
+    }
+
+    fn notify(&self) {
+        self.changed.send_modify(|generation| {
+            *generation = generation
+                .checked_add(1)
+                .expect("registration change generation overflowed");
+        });
+    }
+}
+
 /// A thread-safe handle to control a `LiveNode` from other threads.
 ///
 /// This allows stopping and querying the node's state without requiring the
@@ -117,6 +198,7 @@ pub(super) enum RunningTransition {
 pub struct LiveNodeHandle {
     control: Arc<AtomicU8>,
     pub(crate) metrics: Arc<RunnerMetrics>,
+    registration: Option<Arc<RegistrationTracker>>,
 }
 
 impl Default for LiveNodeHandle {
@@ -132,10 +214,29 @@ impl LiveNodeHandle {
         Self {
             control: Arc::new(AtomicU8::new(NodeState::Idle.as_u8())),
             metrics: Arc::new(RunnerMetrics::default()),
+            registration: None,
         }
     }
 
+    pub(crate) fn attached() -> Self {
+        Self {
+            registration: Some(Arc::new(RegistrationTracker::new())),
+            ..Self::new()
+        }
+    }
+
+    pub(super) fn registration_tracker(&self) -> Arc<RegistrationTracker> {
+        Arc::clone(
+            self.registration
+                .as_ref()
+                .expect("live node handle must be attached"),
+        )
+    }
+
     pub(crate) fn set_starting(&self) {
+        if let Some(registration) = &self.registration {
+            registration.set_starting();
+        }
         self.set_state(NodeState::Starting);
     }
 
@@ -145,6 +246,18 @@ impl LiveNodeHandle {
 
     pub(crate) fn set_stopped(&self) {
         self.set_state(NodeState::Stopped);
+    }
+
+    pub(crate) fn close_registration_tracker(&self) {
+        if let Some(registration) = &self.registration {
+            registration.set_stopped();
+        }
+    }
+
+    pub(crate) fn dispose_registration_tracker(&self) {
+        if let Some(registration) = &self.registration {
+            registration.set_disposed();
+        }
     }
 
     pub(super) fn try_set_running(&self) -> RunningTransition {
@@ -192,6 +305,66 @@ impl LiveNodeHandle {
     #[must_use]
     pub fn metrics_snapshot(&self) -> RunnerMetricsSnapshot {
         self.metrics.snapshot()
+    }
+
+    /// Waits until the account is registered in the node cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the handle is unattached or the node stops before registration.
+    pub async fn await_account_registered(&self, account_id: AccountId) -> anyhow::Result<()> {
+        let Some(registration) = &self.registration else {
+            anyhow::bail!("Cannot await account registration with an unattached node handle");
+        };
+        let mut changed = registration.changed.subscribe();
+        let lifecycle_generation = {
+            let state = registration
+                .state
+                .lock()
+                .map_err(|_| anyhow::anyhow!("Account registration tracker is unavailable"))?;
+
+            if state.registered.contains(&account_id) {
+                return Ok(());
+            }
+
+            if matches!(self.state(), NodeState::Idle | NodeState::Stopped) {
+                anyhow::bail!("Cannot await account registration while node is not running");
+            }
+
+            if state.stopped {
+                anyhow::bail!(
+                    "Node stopped before account {account_id} was registered in lifecycle {}",
+                    state.lifecycle_generation,
+                );
+            }
+
+            state.lifecycle_generation
+        };
+
+        loop {
+            changed.changed().await.map_err(|_| {
+                anyhow::anyhow!(
+                    "Account registration tracker closed before {account_id} registered"
+                )
+            })?;
+
+            {
+                let state = registration
+                    .state
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("Account registration tracker is unavailable"))?;
+
+                if state.registered.contains(&account_id) {
+                    return Ok(());
+                }
+
+                if state.stopped || state.lifecycle_generation != lifecycle_generation {
+                    anyhow::bail!(
+                        "Node stopped before account {account_id} was registered in lifecycle {lifecycle_generation}",
+                    );
+                }
+            }
+        }
     }
 
     /// Signals the node to stop.

--- a/crates/live/src/node/state.rs
+++ b/crates/live/src/node/state.rs
@@ -14,7 +14,7 @@
 // -------------------------------------------------------------------------------------------------
 
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     sync::{
         Arc, Mutex,
         atomic::{AtomicU8, Ordering},
@@ -116,7 +116,7 @@ pub(super) enum RunningTransition {
 
 #[derive(Debug)]
 struct RegistrationState {
-    registered: HashSet<AccountId>,
+    registered: HashMap<AccountId, u64>,
     lifecycle_generation: u64,
     stopped: bool,
 }
@@ -132,7 +132,7 @@ impl RegistrationTracker {
         let (changed, _) = tokio::sync::watch::channel(0);
         Self {
             state: Mutex::new(RegistrationState {
-                registered: HashSet::new(),
+                registered: HashMap::new(),
                 lifecycle_generation: 0,
                 stopped: false,
             }),
@@ -143,7 +143,14 @@ impl RegistrationTracker {
     pub(super) fn seed(&self, account_ids: impl IntoIterator<Item = AccountId>) {
         let mut state = self.state.lock().expect("registration tracker poisoned");
         let previous_len = state.registered.len();
-        state.registered.extend(account_ids);
+        let lifecycle_generation = state.lifecycle_generation;
+        for account_id in account_ids {
+            state
+                .registered
+                .entry(account_id)
+                .or_insert(lifecycle_generation);
+        }
+
         if state.registered.len() != previous_len {
             self.notify();
         }
@@ -151,7 +158,14 @@ impl RegistrationTracker {
 
     pub(super) fn mark_registered(&self, account_id: AccountId) {
         let mut state = self.state.lock().expect("registration tracker poisoned");
-        if state.registered.insert(account_id) {
+        let previous_len = state.registered.len();
+        let lifecycle_generation = state.lifecycle_generation;
+        state
+            .registered
+            .entry(account_id)
+            .or_insert(lifecycle_generation);
+
+        if state.registered.len() != previous_len {
             self.notify();
         }
     }
@@ -311,7 +325,8 @@ impl LiveNodeHandle {
     ///
     /// # Errors
     ///
-    /// Returns an error if the handle is unattached or the node stops before registration.
+    /// Returns an error if the handle is unattached, the account is absent while the node is
+    /// `Idle` or `Stopped`, or the node stops before registration.
     pub async fn await_account_registered(&self, account_id: AccountId) -> anyhow::Result<()> {
         let Some(registration) = &self.registration else {
             anyhow::bail!("Cannot await account registration with an unattached node handle");
@@ -323,7 +338,12 @@ impl LiveNodeHandle {
                 .lock()
                 .map_err(|_| anyhow::anyhow!("Account registration tracker is unavailable"))?;
 
-            if state.registered.contains(&account_id) {
+            let lifecycle_generation = state.lifecycle_generation;
+            if state
+                .registered
+                .get(&account_id)
+                .is_some_and(|generation| *generation <= lifecycle_generation)
+            {
                 return Ok(());
             }
 
@@ -338,7 +358,7 @@ impl LiveNodeHandle {
                 );
             }
 
-            state.lifecycle_generation
+            lifecycle_generation
         };
 
         loop {
@@ -354,7 +374,11 @@ impl LiveNodeHandle {
                     .lock()
                     .map_err(|_| anyhow::anyhow!("Account registration tracker is unavailable"))?;
 
-                if state.registered.contains(&account_id) {
+                if state
+                    .registered
+                    .get(&account_id)
+                    .is_some_and(|generation| *generation <= lifecycle_generation)
+                {
                     return Ok(());
                 }
 


### PR DESCRIPTION
Add an account registration wait to the live node handle

## No signal exists at the account cache insertion boundary

A live host that registers an execution client cannot await the account row existing in the cache: `Cache::add_account` returns without notifying, and the live route is fire-and-forget end to end - the adapter emits `ExecutionEvent::Account`, the runner forwards it to the portfolio's msgbus endpoint, and the portfolio inserts. A deployed consumer polls the cache every 10 ms under a wall bound to know when its account is usable; an adapter-side latch cannot substitute, because the adapter forwarding the event only queues it.

`LiveNodeHandle` gains `await_account_registered(account_id)`. The node marks an account registered after dispatching each `ExecutionEvent::Account` and confirming the row is in the cache - msgbus dispatch is synchronous on the runner thread, so the mark is at-or-after the insertion, and the cache re-check means a failed portfolio insertion (logged and swallowed today) is not reported as registration. All four node-owned dispatch paths are hooked, including the startup buffering phases and the shutdown drain; the standalone `AsyncRunner` is untouched, as are `Cache`, the portfolio, and every adapter. Accounts restored from storage during cache preparation are seeded, since they never arrive as events.

The carrier is a registered-set plus generation watch shared between the node and its handles, with waits subscribing before the first predicate check so no insertion can fall between check and sleep. A wait on an already-registered account resolves immediately; an unattached or not-running handle errors. The tracker closes only after each terminal path's final event drain, so an account inserted by the shutdown drain releases its waiter with success rather than a stop error; a waiter stranded across a stop-and-restart terminates with a lifecycle error instead of silently surviving; and `dispose()` invalidates the tracker before the kernel clears the cache, so a retained handle cannot resolve against a row disposal removes.

## Testing

`test_account_waiter_released_after_running_loop_caches_account` drives `run()` to the main loop, sends an account event, and asserts the waiter resolves with the row present; with the mark's cache predicate inverted, it fails by timeout. Sibling tests pin immediate resolution for an already-registered account, seeding from a pre-populated cache through `start()`, the not-running and unattached errors, mark-before-close ordering (a drain-inserted account wins over the stop error), termination of a waiter whose stop and restart coalesce before it wakes, and the post-dispose error for a previously registered account. All on current-thread runtimes with bounded waits, no wall-clock sleeps.
