### PR TITLE
Fix broken OMS type link in live trading config doc

### DIFF
--- a/docs/how_to/configure_live_trading.md
+++ b/docs/how_to/configure_live_trading.md
@@ -415,7 +415,7 @@ For a complete parameter list see the `StrategyConfig`
 
 | Setting                     | Default | Description                                                                               |
 | --------------------------- | ------- | ----------------------------------------------------------------------------------------- |
-| `oms_type`                  | None    | [OMS type](../concepts/execution#oms-configuration) for position ID and order processing. |
+| `oms_type`                  | None    | [OMS type](../concepts/execution.md#oms-configuration) for position ID and order processing. |
 | `use_uuid_client_order_ids` | False   | Use UUID4 values for client order IDs.                                                    |
 | `external_order_claims`     | None    | Instrument IDs whose external orders and reconciliation activity this strategy claims.    |
 | `manage_contingent_orders`  | False   | Automatically manage OTO, OCO, and OUO contingent orders.                                 |


### PR DESCRIPTION
## What
Fixed a broken internal doc link in docs/how_to/configure_live_trading.md that was missing the .md extension on a link to docs/concepts/execution.md#oms-configuration

## Why
A small, objectively-verifiable improvement (broken-link) found during a
daily open-source maintenance pass (2026-08-27).

## How verified
Confirmed line 418 used '../concepts/execution#oms-configuration' (no .md) while every other internal link in the same file and repo uses the 'path.md#anchor' form; verified the target file and heading '### OMS configuration' exist via grep
Automated gates: 2 changed lines across 1 files (within limits); cargo check: not needed.

---
Prepared with Claude Code assistance and reviewed by Aarush's
automation gates (diff-size, file-scope, deletion, and build checks)
before opening.