### PR TITLE
Refuse emulated order submission from execution algorithms

### DIFF
--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -568,6 +568,10 @@ pub trait ExecutionAlgorithm: DataActor {
     /// by the spawned quantity. If the spawned order is subsequently denied or
     /// rejected (before acceptance), the deducted quantity is automatically
     /// restored to the primary order.
+    ///
+    /// `_emulation_trigger` is accepted for signature parity and is not applied:
+    /// a `MARKET_TO_LIMIT` order is always initialized with `NoTrigger` and
+    /// cannot be emulated.
     #[expect(clippy::too_many_arguments)]
     fn spawn_market_to_limit(
         &mut self,
@@ -577,7 +581,7 @@ pub trait ExecutionAlgorithm: DataActor {
         expire_time: Option<UnixNanos>,
         reduce_only: bool,
         display_qty: Option<Quantity>,
-        emulation_trigger: Option<TriggerType>,
+        _emulation_trigger: Option<TriggerType>,
         tags: Option<Vec<Ustr>>,
         reduce_primary: bool,
     ) -> MarketToLimitOrder
@@ -596,7 +600,7 @@ pub trait ExecutionAlgorithm: DataActor {
                 .track_pending_spawn_reduction(client_order_id, quantity);
         }
 
-        let mut order = MarketToLimitOrder::new(
+        MarketToLimitOrder::new(
             primary.trader_id(),
             primary.strategy_id(),
             primary.instrument_id(),
@@ -619,13 +623,7 @@ pub trait ExecutionAlgorithm: DataActor {
             tags.or_else(|| primary.tags().map(<[Ustr]>::to_vec)),
             UUID4::new(),
             ts_init,
-        );
-
-        if emulation_trigger.is_some() {
-            order.set_emulation_trigger(emulation_trigger);
-        }
-
-        order
+        )
     }
 
     /// Reduces the primary order's quantity by the spawn quantity.
@@ -775,9 +773,11 @@ pub trait ExecutionAlgorithm: DataActor {
 
     /// Submits an order to the execution engine via the risk engine.
     ///
+    /// Execution algorithms cannot submit orders carrying a live emulation trigger.
+    ///
     /// # Errors
     ///
-    /// Returns an error if order submission fails.
+    /// Returns an error if the order carries a live emulation trigger or submission fails.
     fn submit_order(
         &mut self,
         order: OrderAny,
@@ -787,9 +787,21 @@ pub trait ExecutionAlgorithm: DataActor {
     where
         Self: ExecutionAlgorithmNative,
     {
-        let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+        let trader_id =
+            registered_trader_id(ExecutionAlgorithmNative::exec_algorithm_core_mut(self))?;
 
-        let trader_id = registered_trader_id(core)?;
+        if order
+            .emulation_trigger()
+            .is_some_and(|trigger| trigger != TriggerType::NoTrigger)
+        {
+            let client_order_id = order.client_order_id();
+            self.restore_primary_order_quantity(&order);
+            anyhow::bail!(
+                "Execution algorithm cannot submit order {client_order_id} with a live emulation trigger"
+            );
+        }
+
+        let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
         let ts_init = core.clock_mut().timestamp_ns();
 
         // For spawned orders, use the parent's strategy ID
@@ -2521,6 +2533,128 @@ mod tests {
 
         msgbus::unsubscribe_order_events(format!("events.order.{strategy_id}").into(), &handler);
         assert!(events.borrow().is_empty());
+    }
+
+    #[rstest]
+    fn test_algorithm_submit_order_refuses_emulated_limit_spawn() {
+        let mut algo = create_test_algorithm();
+        register_algorithm(&mut algo);
+
+        let strategy_id = StrategyId::from("STRAT-ALGO-EMULATED-LIMIT");
+        let order = OrderTestBuilder::new(OrderType::Market)
+            .strategy_id(strategy_id)
+            .instrument_id(InstrumentId::from("BTC/USDT.BINANCE"))
+            .client_order_id(ClientOrderId::from("O-ALGO-EMULATED-LIMIT"))
+            .quantity(Quantity::from("1.0"))
+            .build();
+        let mut primary = TestOrderStubs::make_accepted_order(&order);
+        {
+            let cache_rc = algo.core.cache_rc();
+            let mut cache = cache_rc.borrow_mut();
+            cache.add_order(primary.clone(), None, None, false).unwrap();
+        }
+        let (event_handler, events) = subscribe_order_topic(strategy_id);
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let (emulator_handler, emulator_messages): (
+            _,
+            TypedIntoMessageSavingHandler<TradingCommand>,
+        ) = get_typed_into_message_saving_handler(Some(Ustr::from("OrderEmulator.execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::order_emulator_execute(),
+            emulator_handler,
+        );
+
+        let spawned = algo.spawn_limit(
+            &mut primary,
+            Quantity::from("0.4"),
+            Price::from("50000.0"),
+            TimeInForce::Gtc,
+            None,
+            false,
+            false,
+            None,
+            Some(TriggerType::BidAsk),
+            None,
+            true,
+        );
+        let spawned = OrderAny::Limit(spawned);
+        let client_order_id = spawned.client_order_id();
+        let result = algo.submit_order(spawned, None, None);
+
+        msgbus::unsubscribe_order_events(
+            format!("events.order.{strategy_id}").into(),
+            &event_handler,
+        );
+        let cache = algo.core.cache_ref();
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("live emulation trigger"), "{error}");
+        assert!(error.contains(client_order_id.as_str()), "{error}");
+        assert!(risk_messages.get_messages().is_empty());
+        assert!(emulator_messages.get_messages().is_empty());
+        assert!(!cache.order_exists(&client_order_id));
+        assert!(!events.borrow().iter().any(|event| matches!(
+            event,
+            OrderEventAny::Initialized(initialized)
+                if initialized.client_order_id == client_order_id
+        )));
+        assert_eq!(
+            cache.order(&primary.client_order_id()).unwrap().quantity(),
+            Quantity::from("1.0"),
+        );
+        drop(cache);
+        assert!(
+            algo.core
+                .take_pending_spawn_reduction(&client_order_id)
+                .is_none()
+        );
+    }
+
+    #[rstest]
+    fn test_algorithm_submit_order_routes_unemulated_spawn_to_risk() {
+        let mut algo = create_test_algorithm();
+        register_algorithm(&mut algo);
+
+        let mut primary = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(InstrumentId::from("BTC/USDT.BINANCE"))
+            .client_order_id(ClientOrderId::from("O-ALGO-UNEMULATED"))
+            .quantity(Quantity::from("1.0"))
+            .build();
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+
+        let spawned = algo.spawn_limit(
+            &mut primary,
+            Quantity::from("0.4"),
+            Price::from("50000.0"),
+            TimeInForce::Gtc,
+            None,
+            false,
+            false,
+            None,
+            None,
+            None,
+            false,
+        );
+        let client_order_id = spawned.client_order_id;
+        algo.submit_order(OrderAny::Limit(spawned), None, None)
+            .unwrap();
+
+        let risk_messages = risk_messages.get_messages();
+        assert_eq!(risk_messages.len(), 1);
+        assert!(matches!(
+            risk_messages.first(),
+            Some(TradingCommand::SubmitOrder(command))
+                if command.client_order_id == client_order_id
+        ));
     }
 
     #[rstest]

--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -35,6 +35,8 @@
 //! 5. Spawned orders are submitted through the `RiskEngine`.
 //! 6. The algorithm receives fill events and manages remaining quantity.
 
+use std::fmt::Display;
+
 pub mod config;
 pub mod core;
 pub mod twap;
@@ -436,8 +438,8 @@ pub trait ExecutionAlgorithm: DataActor {
     ///
     /// If `reduce_primary` is true, the primary order's quantity will be reduced
     /// by the spawned quantity. If the spawned order is subsequently denied or
-    /// rejected (before acceptance), the deducted quantity is automatically
-    /// restored to the primary order.
+    /// rejected (before acceptance), or refused before submission, the deducted
+    /// quantity is automatically restored to the primary order.
     fn spawn_market(
         &mut self,
         primary: &mut OrderAny,
@@ -495,8 +497,8 @@ pub trait ExecutionAlgorithm: DataActor {
     ///
     /// If `reduce_primary` is true, the primary order's quantity will be reduced
     /// by the spawned quantity. If the spawned order is subsequently denied or
-    /// rejected (before acceptance), the deducted quantity is automatically
-    /// restored to the primary order.
+    /// rejected (before acceptance), or refused before submission, the deducted
+    /// quantity is automatically restored to the primary order.
     #[expect(clippy::too_many_arguments)]
     fn spawn_limit(
         &mut self,
@@ -566,8 +568,8 @@ pub trait ExecutionAlgorithm: DataActor {
     ///
     /// If `reduce_primary` is true, the primary order's quantity will be reduced
     /// by the spawned quantity. If the spawned order is subsequently denied or
-    /// rejected (before acceptance), the deducted quantity is automatically
-    /// restored to the primary order.
+    /// rejected (before acceptance), or refused before submission, the deducted
+    /// quantity is automatically restored to the primary order.
     ///
     /// `_emulation_trigger` is accepted for signature parity and is not applied:
     /// a `MARKET_TO_LIMIT` order is always initialized with `NoTrigger` and
@@ -681,12 +683,12 @@ pub trait ExecutionAlgorithm: DataActor {
         publish_order_event(&event);
     }
 
-    /// Restores the primary order quantity after a spawned order is denied or rejected.
+    /// Restores the primary order quantity after a spawned order fails before acceptance.
     ///
     /// This is called when a spawned order fails before acceptance. The quantity
     /// that was deducted from the primary order is restored (up to the spawned
     /// order's `leaves_qty` to handle partial fills).
-    fn restore_primary_order_quantity(&mut self, order: &OrderAny)
+    fn restore_primary_order_quantity(&mut self, order: &OrderAny, refused_before_submission: bool)
     where
         Self: ExecutionAlgorithmNative,
     {
@@ -763,8 +765,13 @@ pub trait ExecutionAlgorithm: DataActor {
 
         publish_order_event(&event);
 
+        let outcome = if refused_before_submission {
+            "refused before submission"
+        } else {
+            "denied/rejected"
+        };
         log::info!(
-            "Restored primary order {} quantity to {} after spawned order {} was denied/rejected",
+            "Restored primary order {} quantity to {} after spawned order {} was {outcome}",
             primary.client_order_id(),
             restored_qty,
             order.client_order_id()
@@ -773,7 +780,10 @@ pub trait ExecutionAlgorithm: DataActor {
 
     /// Submits an order to the execution engine via the risk engine.
     ///
-    /// Execution algorithms cannot submit orders carrying a live emulation trigger.
+    /// Orders carrying a live emulation trigger are refused before submission.
+    /// For spawned orders with a pending primary reduction, refusal restores the
+    /// primary order quantity, consumes the pending reduction, and publishes
+    /// `OrderUpdated`.
     ///
     /// # Errors
     ///
@@ -795,10 +805,8 @@ pub trait ExecutionAlgorithm: DataActor {
             .is_some_and(|trigger| trigger != TriggerType::NoTrigger)
         {
             let client_order_id = order.client_order_id();
-            self.restore_primary_order_quantity(&order);
-            anyhow::bail!(
-                "Execution algorithm cannot submit order {client_order_id} with a live emulation trigger"
-            );
+            self.restore_primary_order_quantity(&order, true);
+            return Err(EmulatedOrderSubmissionError { client_order_id }.into());
         }
 
         let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
@@ -1270,14 +1278,14 @@ pub trait ExecutionAlgorithm: DataActor {
         match &event {
             OrderEventAny::Initialized(e) => self.on_order_initialized(e.clone()),
             OrderEventAny::Denied(e) => {
-                self.restore_primary_order_quantity(&order);
+                self.restore_primary_order_quantity(&order, false);
                 self.on_order_denied(*e);
             }
             OrderEventAny::Emulated(e) => self.on_order_emulated(*e),
             OrderEventAny::Released(e) => self.on_order_released(*e),
             OrderEventAny::Submitted(e) => self.on_order_submitted(*e),
             OrderEventAny::Rejected(e) => {
-                self.restore_primary_order_quantity(&order);
+                self.restore_primary_order_quantity(&order, false);
                 self.on_order_rejected(*e);
             }
             OrderEventAny::Accepted(e) => {
@@ -1485,6 +1493,23 @@ pub trait ExecutionAlgorithm: DataActor {
     #[allow(unused_variables)]
     fn on_position_event(&mut self, event: PositionEvent) {}
 }
+
+#[derive(Debug)]
+pub(crate) struct EmulatedOrderSubmissionError {
+    client_order_id: ClientOrderId,
+}
+
+impl Display for EmulatedOrderSubmissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Execution algorithm cannot submit order {} with a live emulation trigger",
+            self.client_order_id
+        )
+    }
+}
+
+impl std::error::Error for EmulatedOrderSubmissionError {}
 
 fn publish_order_initialized(order: &OrderAny) {
     let event = OrderEventAny::Initialized(order.init_event().clone());
@@ -2591,7 +2616,13 @@ mod tests {
             &event_handler,
         );
         let cache = algo.core.cache_ref();
-        let error = result.unwrap_err().to_string();
+        let error = result.unwrap_err();
+        assert!(
+            error
+                .downcast_ref::<EmulatedOrderSubmissionError>()
+                .is_some()
+        );
+        let error = error.to_string();
         assert!(error.contains("live emulation trigger"), "{error}");
         assert!(error.contains(client_order_id.as_str()), "{error}");
         assert!(risk_messages.get_messages().is_empty());

--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -572,8 +572,8 @@ pub trait ExecutionAlgorithm: DataActor {
     /// quantity is automatically restored to the primary order.
     ///
     /// `_emulation_trigger` is accepted for signature parity and is not applied:
-    /// a `MARKET_TO_LIMIT` order is always initialized with `NoTrigger` and
-    /// cannot be emulated.
+    /// a `MARKET_TO_LIMIT` order is always initialized with no emulation trigger
+    /// and cannot be emulated.
     #[expect(clippy::too_many_arguments)]
     fn spawn_market_to_limit(
         &mut self,
@@ -800,10 +800,7 @@ pub trait ExecutionAlgorithm: DataActor {
         let trader_id =
             registered_trader_id(ExecutionAlgorithmNative::exec_algorithm_core_mut(self))?;
 
-        if order
-            .emulation_trigger()
-            .is_some_and(|trigger| trigger != TriggerType::NoTrigger)
-        {
+        if order.emulation_trigger().is_some() {
             let client_order_id = order.client_order_id();
             self.restore_primary_order_quantity(&order, true);
             return Err(EmulatedOrderSubmissionError { client_order_id }.into());

--- a/crates/trading/src/python/algorithm.rs
+++ b/crates/trading/src/python/algorithm.rs
@@ -55,8 +55,8 @@ use pyo3::{
 use ustr::Ustr;
 
 use crate::algorithm::{
-    ExecutionAlgorithm, ExecutionAlgorithmConfig, ExecutionAlgorithmCore, ExecutionAlgorithmNative,
-    ImportableExecutionAlgorithmConfig,
+    EmulatedOrderSubmissionError, ExecutionAlgorithm, ExecutionAlgorithmConfig,
+    ExecutionAlgorithmCore, ExecutionAlgorithmNative, ImportableExecutionAlgorithmConfig,
 };
 
 /// Inner state of `PyExecutionAlgorithm`, shared by the Python and Rust registries.
@@ -1100,8 +1100,13 @@ impl PyExecutionAlgorithm {
         client_id: Option<ClientId>,
     ) -> PyResult<()> {
         let order = pyobject_to_order_any(py, order)?;
-        ExecutionAlgorithm::submit_order(self, order, position_id, client_id)
-            .map_err(to_pyruntime_err)
+        ExecutionAlgorithm::submit_order(self, order, position_id, client_id).map_err(|e| {
+            if e.downcast_ref::<EmulatedOrderSubmissionError>().is_some() {
+                to_pyvalue_err(e)
+            } else {
+                to_pyruntime_err(e)
+            }
+        })
     }
 
     #[pyo3(name = "modify_order")]
@@ -1471,11 +1476,12 @@ mod tests {
     };
     use nautilus_core::{UUID4, UnixNanos};
     use nautilus_model::{
-        enums::OrderType,
+        enums::{OrderSide, OrderType, TriggerType},
         identifiers::{
             ClientId, ClientOrderId, InstrumentId, OrderListId, StrategyId, TraderId, Venue,
         },
         orders::OrderTestBuilder,
+        types::{Price, Quantity},
     };
     use pyo3::{
         ffi::c_str,
@@ -1485,6 +1491,53 @@ mod tests {
     use ustr::Ustr;
 
     use super::*;
+
+    #[rstest]
+    fn test_python_submit_order_maps_emulation_refusal_to_value_error() {
+        Python::initialize();
+
+        Python::attach(|py| {
+            *get_message_bus().borrow_mut() = MessageBus::default();
+
+            let mut algorithm = PyExecutionAlgorithm::new(None);
+            let clock: Rc<RefCell<dyn Clock>> = Rc::new(RefCell::new(TestClock::new()));
+            let cache = Rc::new(RefCell::new(Cache::default()));
+            Component::register(&mut algorithm, TraderId::from("TRADER-001"), clock, cache)
+                .unwrap();
+
+            let client_order_id = ClientOrderId::from("O-EMULATED-SUBMISSION");
+            let emulated_order = OrderTestBuilder::new(OrderType::Limit)
+                .instrument_id(InstrumentId::from("AUDUSD.SIM"))
+                .client_order_id(client_order_id)
+                .side(OrderSide::Buy)
+                .price(Price::from("1.00000"))
+                .quantity(Quantity::from("100"))
+                .emulation_trigger(TriggerType::BidAsk)
+                .build();
+            let emulated_order =
+                nautilus_model::python::orders::order_any_to_pyobject(py, emulated_order).unwrap();
+
+            let e = algorithm
+                .py_submit_order(py, emulated_order, None, None)
+                .unwrap_err();
+            assert!(e.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            let message = e.to_string();
+            assert!(message.contains(client_order_id.as_str()), "{message}");
+            assert!(message.contains("live emulation trigger"), "{message}");
+
+            let mut unregistered_algorithm = PyExecutionAlgorithm::new(None);
+            let order = OrderTestBuilder::new(OrderType::Market)
+                .instrument_id(InstrumentId::from("AUDUSD.SIM"))
+                .side(OrderSide::Buy)
+                .quantity(Quantity::from("100"))
+                .build();
+            let order = nautilus_model::python::orders::order_any_to_pyobject(py, order).unwrap();
+            let e = unregistered_algorithm
+                .py_submit_order(py, order, None, None)
+                .unwrap_err();
+            assert!(e.is_instance_of::<pyo3::exceptions::PyRuntimeError>(py));
+        });
+    }
 
     fn sample_queue_state_changed() -> QueueStateChanged {
         QueueStateChanged::new(


### PR DESCRIPTION
A follow-up to the execution algorithm command routing work in #4848, which fixed the modify half of this class and named the submission half.

## An execution algorithm can submit an emulated order that nothing owns

`ExecutionAlgorithm::submit_order` never reads the order's `emulation_trigger`. It caches the child, publishes `OrderInitialized`, and sends the `SubmitOrder` to the risk engine unconditionally. An algorithm can produce such a child through the crate's own API: `spawn_limit` takes an `emulation_trigger` and passes it to `LimitOrder::new`. `OrderEmulator` never learns the order exists, so nothing holds it local and nothing releases it when the trigger fires.

The fix refuses the submission before the order is cached or its initialization event published, and restores the primary order's deducted quantity on that path so a `reduce_primary` spawn does not strand it. This matches `ExecAlgorithm.submit_order` in the Python implementation, which raises `ValueError` on a live trigger under the stated rationale that emulated orders cannot be sent from execution algorithms.

Refusal rather than emulator routing, though `modify_order` and `cancel_order` in the same trait do route: `OrderEmulator::release` sends a released order carrying an `exec_algorithm_id` to `<algorithm-id>.execute`, and that endpoint dispatches a `SubmitOrder` to `on_order` rather than resuming the interrupted submission. A released child would re-enter the algorithm as fresh primary input and, for `TwapAlgorithm`, be scheduled and spawned again. Submission establishes ownership; modify and cancel act on an order whose owner is already established.

## A spawned MARKET_TO_LIMIT order stored a trigger it can never report

`spawn_market_to_limit` applied its `emulation_trigger` argument with `set_emulation_trigger` after construction, writing to `OrderCore` a value `MarketToLimitOrder::emulation_trigger` always reports as `None`. `MarketToLimitOrder` is initialized with `NO_TRIGGER` in both implementations and cannot be emulated, so the getter is right and the write was contradictory hidden state. The argument is now accepted and unapplied, as it is in the Python `spawn_market_to_limit`, and the rustdoc says so.

## Testing

`test_algorithm_submit_order_refuses_emulated_limit_spawn` spawns a child with a `BidAsk` trigger and `reduce_primary`, then asserts the error names the reason and the client order ID, that neither the risk endpoint nor the emulator endpoint received a command, that the child is absent from the cache with no `OrderInitialized` published for it, that the primary quantity is restored, and that the pending spawn reduction is consumed. Asserting both endpoints pins refusal rather than emulator routing. `test_algorithm_submit_order_routes_unemulated_spawn_to_risk` is the control.

Against the unfixed code the test fails on the error assertion; with that assertion removed it fails on the risk endpoint receiving the command, so the routing claim does not ride on the error.

## Reported rather than fixed

`restore_primary_order_quantity` consumes the `pending_spawn_reductions` entry before it looks up the primary, so a missing primary or a failed cache update discards the bookkeeping without restoring anything. That is pre-existing on the denied and rejected paths, and a repair needs a policy for whether such failures are retried at all.
