### PR TITLE
Bound WMA and HMA periods to their buffer capacity

### DIFF
--- a/crates/indicators/src/average/hma.rs
+++ b/crates/indicators/src/average/hma.rs
@@ -21,7 +21,7 @@ use nautilus_model::{
 };
 
 use crate::{
-    average::wma::WeightedMovingAverage,
+    average::wma::{MAX_PERIOD, WeightedMovingAverage},
     indicator::{Indicator, MovingAverage},
 };
 
@@ -107,12 +107,18 @@ impl HullMovingAverage {
     ///
     /// # Panics
     ///
-    /// Panics if `period` is not a positive integer (> 0).
+    /// Panics if `period` is not a positive integer (> 0), or exceeds `MAX_PERIOD`.
     #[must_use]
     pub fn new(period: usize, price_type: Option<PriceType>) -> Self {
         assert!(
             period > 0,
             "HullMovingAverage: period must be > 0 (received {period})"
+        );
+        // `ma2` below is a `WeightedMovingAverage` over the full `period`, so this
+        // indicator cannot support a period its inner averages cannot buffer.
+        assert!(
+            period <= MAX_PERIOD,
+            "HullMovingAverage: period {period} exceeds MAX_PERIOD ({MAX_PERIOD})"
         );
 
         let half = usize::max(1, period / 2);
@@ -176,7 +182,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        average::hma::HullMovingAverage,
+        average::{hma::HullMovingAverage, wma::MAX_PERIOD},
         indicator::{Indicator, MovingAverage},
         stubs::*,
         testing::assert_approx_equal,
@@ -279,10 +285,16 @@ mod tests {
     }
 
     #[rstest]
+    #[should_panic(expected = "exceeds MAX_PERIOD")]
+    fn test_new_with_period_above_max_panics() {
+        let _ = HullMovingAverage::new(MAX_PERIOD + 1, None);
+    }
+
+    #[rstest]
     #[case(1)]
     #[case(5)]
     #[case(128)]
-    #[case(10_000)]
+    #[case(MAX_PERIOD)]
     fn test_new_with_positive_period_constructs(#[case] period: usize) {
         let hma = HullMovingAverage::new(period, None);
         assert_eq!(hma.period, period);

--- a/crates/indicators/src/average/hma.rs
+++ b/crates/indicators/src/average/hma.rs
@@ -15,6 +15,7 @@
 
 use std::fmt::Display;
 
+use nautilus_core::correctness::{FAILED, check_predicate_true};
 use nautilus_model::{
     data::{Bar, QuoteTick, TradeTick},
     enums::PriceType,
@@ -110,16 +111,27 @@ impl HullMovingAverage {
     /// Panics if `period` is not a positive integer (> 0), or exceeds `MAX_PERIOD`.
     #[must_use]
     pub fn new(period: usize, price_type: Option<PriceType>) -> Self {
-        assert!(
+        Self::new_checked(period, price_type).expect(FAILED)
+    }
+
+    /// Creates a new [`HullMovingAverage`] instance with the given period.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - `period` is not a positive integer (> 0).
+    /// - `period` exceeds `MAX_PERIOD`.
+    pub fn new_checked(period: usize, price_type: Option<PriceType>) -> anyhow::Result<Self> {
+        check_predicate_true(
             period > 0,
-            "HullMovingAverage: period must be > 0 (received {period})"
-        );
+            &format!("HullMovingAverage: period must be > 0 (received {period})"),
+        )?;
         // `ma2` below is a `WeightedMovingAverage` over the full `period`, so this
         // indicator cannot support a period its inner averages cannot buffer.
-        assert!(
+        check_predicate_true(
             period <= MAX_PERIOD,
-            "HullMovingAverage: period {period} exceeds MAX_PERIOD ({MAX_PERIOD})"
-        );
+            &format!("HullMovingAverage: period {period} exceeds MAX_PERIOD ({MAX_PERIOD})"),
+        )?;
 
         let half = usize::max(1, period / 2);
         let root = usize::max(1, (period as f64).sqrt() as usize);
@@ -130,7 +142,7 @@ impl HullMovingAverage {
         let ma2 = WeightedMovingAverage::new(period, get_weights(period), Some(pt));
         let ma3 = WeightedMovingAverage::new(root, get_weights(root), Some(pt));
 
-        Self {
+        Ok(Self {
             period,
             price_type: pt,
             value: 0.0,
@@ -140,7 +152,7 @@ impl HullMovingAverage {
             ma1,
             ma2,
             ma3,
-        }
+        })
     }
 }
 
@@ -288,6 +300,18 @@ mod tests {
     #[should_panic(expected = "exceeds MAX_PERIOD")]
     fn test_new_with_period_above_max_panics() {
         let _ = HullMovingAverage::new(MAX_PERIOD + 1, None);
+    }
+
+    #[rstest]
+    fn test_new_checked_with_period_above_max_errors() {
+        // The Python binding constructs through `new_checked`, so this is the path
+        // that has to return rather than panic.
+        assert!(HullMovingAverage::new_checked(MAX_PERIOD + 1, None).is_err());
+    }
+
+    #[rstest]
+    fn test_new_checked_with_zero_period_errors() {
+        assert!(HullMovingAverage::new_checked(0, None).is_err());
     }
 
     #[rstest]

--- a/crates/indicators/src/average/wma.rs
+++ b/crates/indicators/src/average/wma.rs
@@ -25,7 +25,7 @@ use nautilus_model::{
 use crate::indicator::{Indicator, MovingAverage};
 
 /// Maximum supported rolling window period (bounded by the fixed-capacity input buffer).
-pub const MAX_PERIOD: usize = 8_192;
+pub(crate) const MAX_PERIOD: usize = 8_192;
 
 /// An indicator which calculates a weighted moving average across a rolling window.
 #[repr(C)]

--- a/crates/indicators/src/average/wma.rs
+++ b/crates/indicators/src/average/wma.rs
@@ -24,7 +24,8 @@ use nautilus_model::{
 
 use crate::indicator::{Indicator, MovingAverage};
 
-const MAX_PERIOD: usize = 8_192;
+/// Maximum supported rolling window period (bounded by the fixed-capacity input buffer).
+pub const MAX_PERIOD: usize = 8_192;
 
 /// An indicator which calculates a weighted moving average across a rolling window.
 #[repr(C)]
@@ -65,6 +66,7 @@ impl WeightedMovingAverage {
     ///
     /// This function panics if:
     /// - `period` is zero.
+    /// - `period` exceeds `MAX_PERIOD`.
     /// - `weights.len()` does not equal `period`.
     /// - `weights` sum is effectively zero.
     #[must_use]
@@ -78,6 +80,7 @@ impl WeightedMovingAverage {
     ///
     /// Returns an error if **any** of the validation rules fails:
     /// - `period` must be **positive**.
+    /// - `period` must not exceed `MAX_PERIOD`.
     /// - `weights` must be **exactly** `period` elements long.
     /// - `weights` must contain at least one non-zero value (∑wᵢ > ε).
     pub fn new_checked(
@@ -88,6 +91,8 @@ impl WeightedMovingAverage {
         const EPS: f64 = f64::EPSILON;
 
         check_predicate_true(period > 0, "`period` must be positive")?;
+
+        check_predicate_true(period <= MAX_PERIOD, "`period` must not exceed MAX_PERIOD")?;
 
         check_predicate_true(
             period == weights.len(),
@@ -185,7 +190,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        average::wma::WeightedMovingAverage,
+        average::wma::{MAX_PERIOD, WeightedMovingAverage},
         indicator::{Indicator, MovingAverage},
         stubs::*,
         testing::assert_approx_equal,
@@ -582,5 +587,31 @@ mod tests {
         wma.update_raw(20.0);
         let expected = 20.0f64.mul_add(1.0, 10.0 * 1.0) / 2.0;
         assert_eq!(wma.value(), expected);
+    }
+
+    #[rstest]
+    #[should_panic]
+    fn new_period_exceeds_max_panics() {
+        let period = MAX_PERIOD + 1;
+        let _ = WeightedMovingAverage::new(period, vec![1.0; period], None);
+    }
+
+    #[rstest]
+    fn new_checked_period_exceeds_max_errors() {
+        let period = MAX_PERIOD + 1;
+        assert!(WeightedMovingAverage::new_checked(period, vec![1.0; period], None).is_err());
+    }
+
+    #[rstest]
+    fn new_period_at_max_initializes() {
+        // The boundary itself stays valid: the buffer holds exactly `period`
+        // inputs, so the indicator can still reach `initialized`.
+        let period = MAX_PERIOD;
+        let mut wma = WeightedMovingAverage::new(period, vec![1.0; period], None);
+        for i in 0..period {
+            wma.update_raw(i as f64);
+        }
+        assert_eq!(wma.count(), period);
+        assert!(wma.initialized());
     }
 }

--- a/crates/indicators/src/average/wma.rs
+++ b/crates/indicators/src/average/wma.rs
@@ -92,7 +92,10 @@ impl WeightedMovingAverage {
 
         check_predicate_true(period > 0, "`period` must be positive")?;
 
-        check_predicate_true(period <= MAX_PERIOD, "`period` must not exceed MAX_PERIOD")?;
+        check_predicate_true(
+            period <= MAX_PERIOD,
+            &format!("WeightedMovingAverage: period {period} exceeds MAX_PERIOD ({MAX_PERIOD})"),
+        )?;
 
         check_predicate_true(
             period == weights.len(),
@@ -599,7 +602,13 @@ mod tests {
     #[rstest]
     fn new_checked_period_exceeds_max_errors() {
         let period = MAX_PERIOD + 1;
-        assert!(WeightedMovingAverage::new_checked(period, vec![1.0; period], None).is_err());
+        let err = WeightedMovingAverage::new_checked(period, vec![1.0; period], None)
+            .expect_err("period above MAX_PERIOD must be rejected");
+        // `MAX_PERIOD` is not reachable from Python, so the message has to carry
+        // both the offending period and the bound it exceeded.
+        let msg = err.to_string();
+        assert!(msg.contains(&period.to_string()), "{msg}");
+        assert!(msg.contains(&MAX_PERIOD.to_string()), "{msg}");
     }
 
     #[rstest]

--- a/crates/indicators/src/python/average/hma.rs
+++ b/crates/indicators/src/python/average/hma.rs
@@ -33,8 +33,8 @@ impl HullMovingAverage {
     /// moving average.
     #[new]
     #[pyo3(signature = (period, price_type=None))]
-    fn py_new(period: usize, price_type: Option<PriceType>) -> Self {
-        Self::new(period, price_type)
+    fn py_new(period: usize, price_type: Option<PriceType>) -> PyResult<Self> {
+        Self::new_checked(period, price_type).map_err(to_pyvalue_err)
     }
 
     fn __repr__(&self) -> String {

--- a/python/tests/unit/indicators/test_hma.py
+++ b/python/tests/unit/indicators/test_hma.py
@@ -220,3 +220,40 @@ def test_reset_successfully_returns_indicator_to_fresh_state(hma: HullMovingAver
     # Assert
     assert not hma.initialized
     assert hma.value == 0
+
+
+# The inner `WeightedMovingAverage` buffers into a fixed-capacity `ArrayDeque`
+# sized by `MAX_PERIOD` in `crates/indicators/src/average/wma.rs`.
+MAX_PERIOD = 8192
+
+
+def test_new_at_max_period_constructs() -> None:
+    """
+    Test construction at the period upper bound succeeds.
+    """
+    # Act
+    hma = HullMovingAverage(MAX_PERIOD)
+
+    # Assert
+    assert hma.period == MAX_PERIOD
+
+
+def test_new_above_max_period_raises_value_error() -> None:
+    """
+    Test construction above the period upper bound raises rather than aborts.
+
+    Release wheels compile with `panic = "abort"`, so this has to come back
+    through the checked constructor as a `ValueError` instead of unwinding.
+    """
+    # Act, Assert
+    with pytest.raises(ValueError, match="exceeds MAX_PERIOD"):
+        HullMovingAverage(MAX_PERIOD + 1)
+
+
+def test_new_with_zero_period_raises_value_error() -> None:
+    """
+    Test construction with a zero period raises rather than aborts.
+    """
+    # Act, Assert
+    with pytest.raises(ValueError, match="period must be > 0"):
+        HullMovingAverage(0)

--- a/python/tests/unit/indicators/test_hma.py
+++ b/python/tests/unit/indicators/test_hma.py
@@ -244,6 +244,7 @@ def test_new_above_max_period_raises_value_error() -> None:
 
     Release wheels compile with `panic = "abort"`, so this has to come back
     through the checked constructor as a `ValueError` instead of unwinding.
+
     """
     # Act, Assert
     with pytest.raises(ValueError, match="exceeds MAX_PERIOD"):


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed CONTRIBUTING.md and, if I used AI, AI_POLICY.md
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below — **`make format` ran; `make pre-commit` did not complete, see Testing**
- [x] I ran all relevant tests locally
- [x] I have not modified `RELEASES.md`

## Summary

`WeightedMovingAverage` buffers inputs in an `ArrayDeque` with a fixed `MAX_PERIOD` capacity of 8192 but never validated `period` against it, so a larger period was accepted and then silently degraded. `HullMovingAverage` forwards its `period` straight into a `WeightedMovingAverage` and only checked `period > 0`, inheriting the problem in a worse form. Both now validate against `MAX_PERIOD`.

### WMA: never initializes

`initialized` compares `count()` against the unclamped `period`, so it can never become true once `period` exceeds capacity, while `weighted_average` keeps returning a value built from the last 8192 weights:

```
period            = 8193
inputs buffered   = 8192
initialized()     = false   <- after 8293 updates
value             = 4196.5
```

### HMA: reports ready on a short window

HMA tracks its own count rather than its inner averages', so it does report ready while `ma2` is short of inputs:

```
hma.period        = 10000
hma.count         = 10500
hma.initialized() = true    <- inner WMA(10000) holds at most 8192
hma.value()       = 10281.690433849888
```

That second figure is the configuration `hma`'s own `test_new_with_positive_period_constructs` pinned as `case(10_000)`, so that case asserted successful construction of an indicator that cannot work. It now pins `MAX_PERIOD`, with a separate case covering rejection above it. That is the one existing expectation this changes.

`SimpleMovingAverage`, `LinearRegression`, `CommodityChannelIndex`, `BollingerBands` and `Stochastics` all already reject a period above their capacity, so this brings two outliers into line rather than introducing a new convention.

**Alternative, if you prefer:** raise `MAX_PERIOD`, or move `WeightedMovingAverage` to a heap-allocated buffer, so a 10,000 period genuinely works instead of being rejected. That keeps `case(10_000)` valid but changes allocation behaviour, so it seemed like your call rather than mine. Happy to redo it that way.

## Related issues/PRs

None. I checked open issues and pull requests for existing work on these indicators.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Breaking change (impacts existing behavior)

## Breaking change details

Constructing `WeightedMovingAverage` or `HullMovingAverage` with `period > 8192` now fails instead of returning a silently broken indicator. Both validate in `new_checked`, and both Python bindings raise `ValueError`.

The moving average factory is an in-tree caller on this path. `MovingAverageFactory::create` calls `HullMovingAverage::new` directly, and the factory-backed indicators forward a user period without a cap of their own, so `RelativeStrengthIndex(10_000, ma_type=MovingAverageType.Hull)` constructed before this change and now reaches `expect(FAILED)`. Those bindings take `py_new(...) -> Self` rather than `PyResult<Self>`, so a release wheel aborts rather than raising. RSI, CMO, MACD, ATR, KC, RVI, DM, KVO, PSL and Pressure all share that route.

This is not a new failure mode for the factory: `SimpleMovingAverage::new` already asserts against its own 1024 cap on exactly that path. Widening the factory to checked constructors is out of scope for this PR and is being tracked separately.

Error messages carry both the offending period and the bound, matching `sma.rs`, `roc.rs` and `swings.rs`: `WeightedMovingAverage: period 8193 exceeds MAX_PERIOD (8192)`. `MAX_PERIOD` is `pub(crate)` and is not exported to Python, so the value has to be in the message for a caller to act on it.

## Documentation

- [x] Doc comments on both constructors updated to list the new bound
- [x] `make py-stubs` not needed. I ran `generate_stubs.py`: `PyResult<Self>` produces the same `__new__` signature for `HullMovingAverage` as `Self` did

## Testing

- [x] I added/updated tests to cover new or changed logic

Rust: three WMA tests (panic above max, `new_checked` errors above max and the message carries both numbers, boundary at `MAX_PERIOD` still reaches `initialized`) and one HMA test (panic above max).

Python: three HMA tests covering construction at the bound, `ValueError` above it, and `ValueError` at zero.

Reverting only the guards and keeping the tests fails them. The boundary test passes either way, so the fix does not over-reject. Reverting only the interpolation in the WMA message fails `new_checked_period_exceeds_max_errors` and nothing else.

Ran locally:

- `cargo test -p nautilus-indicators` — 573 passed, 0 failed (plus 2 doc-tests)
- `cargo clippy -p nautilus-indicators --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt --check` — clean
- `maturin develop --profile nextest`, then `pytest python/tests/unit/indicators/` — 151 passed, which includes the three new HMA cases:

```
tests/unit/indicators/test_hma.py::test_new_at_max_period_constructs PASSED
tests/unit/indicators/test_hma.py::test_new_above_max_period_raises_value_error PASSED
tests/unit/indicators/test_hma.py::test_new_with_zero_period_raises_value_error PASSED
```

**Limitation:** `make pre-commit` did not complete locally. `prek` was still provisioning environments for the 70 configured hooks when it exhausted disk on my machine. I checked the hooks that apply to the changed files by hand instead: no trailing whitespace, no CRLF, no tabs, files end with a newline, and `cargo +nightly fmt --check` is clean.
