### PR TITLE
Implement Serializable for OrderBookDeltas

### DIFF
--- a/crates/model/src/data/deltas.rs
+++ b/crates/model/src/data/deltas.rs
@@ -23,6 +23,7 @@ use std::{
 use nautilus_core::{
     UnixNanos,
     correctness::{FAILED, check_predicate_true},
+    serialization::Serializable,
 };
 use serde::{Deserialize, Serialize};
 
@@ -136,10 +137,6 @@ impl Hash for OrderBookDeltas {
     }
 }
 
-// TODO: Implement
-// impl Serializable for OrderBookDeltas {}
-
-// TODO: Exact format for Debug and Display TBD
 impl Display for OrderBookDeltas {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -155,6 +152,8 @@ impl Display for OrderBookDeltas {
     }
 }
 
+impl Serializable for OrderBookDeltas {}
+
 impl HasTsInit for OrderBookDeltas {
     fn ts_init(&self) -> UnixNanos {
         self.ts_init
@@ -168,6 +167,10 @@ mod tests {
         hash::{Hash, Hasher},
     };
 
+    use nautilus_core::serialization::{
+        Serializable,
+        msgpack::{FromMsgPack, ToMsgPack},
+    };
     use rstest::rstest;
     use serde_json;
 
@@ -289,6 +292,16 @@ mod tests {
         ];
 
         OrderBookDeltas::new(instrument_id, deltas)
+    }
+
+    /// Asserts all fields match, as `PartialEq` only compares `instrument_id` and `sequence`.
+    fn assert_deltas_eq(left: &OrderBookDeltas, right: &OrderBookDeltas) {
+        assert_eq!(left.instrument_id, right.instrument_id);
+        assert_eq!(left.deltas, right.deltas);
+        assert_eq!(left.flags, right.flags);
+        assert_eq!(left.sequence, right.sequence);
+        assert_eq!(left.ts_event, right.ts_event);
+        assert_eq!(left.ts_init, right.ts_init);
     }
 
     #[rstest]
@@ -531,6 +544,24 @@ mod tests {
         assert_eq!(deltas.sequence, deserialized.sequence);
         assert_eq!(deltas.ts_event, deserialized.ts_event);
         assert_eq!(deltas.ts_init, deserialized.ts_init);
+    }
+
+    #[rstest]
+    fn test_json_serialization(stub_deltas: OrderBookDeltas) {
+        let deltas = stub_deltas;
+        let serialized = deltas.to_json_bytes().unwrap();
+        let deserialized = OrderBookDeltas::from_json_bytes(serialized.as_ref()).unwrap();
+
+        assert_deltas_eq(&deserialized, &deltas);
+    }
+
+    #[rstest]
+    fn test_msgpack_serialization(stub_deltas: OrderBookDeltas) {
+        let deltas = stub_deltas;
+        let serialized = deltas.to_msgpack_bytes().unwrap();
+        let deserialized = OrderBookDeltas::from_msgpack_bytes(serialized.as_ref()).unwrap();
+
+        assert_deltas_eq(&deserialized, &deltas);
     }
 
     #[rstest]

--- a/crates/model/src/data/deltas.rs
+++ b/crates/model/src/data/deltas.rs
@@ -294,14 +294,36 @@ mod tests {
         OrderBookDeltas::new(instrument_id, deltas)
     }
 
-    /// Asserts all fields match, as `PartialEq` only compares `instrument_id` and `sequence`.
-    fn assert_deltas_eq(left: &OrderBookDeltas, right: &OrderBookDeltas) {
-        assert_eq!(left.instrument_id, right.instrument_id);
-        assert_eq!(left.deltas, right.deltas);
-        assert_eq!(left.flags, right.flags);
-        assert_eq!(left.sequence, right.sequence);
-        assert_eq!(left.ts_event, right.ts_event);
-        assert_eq!(left.ts_init, right.ts_init);
+    // Compared field by field, as `PartialEq` covers only `instrument_id` and `sequence` here,
+    // and only `order_id` on the nested `BookOrder`.
+    fn assert_book_order_fields(expected: &BookOrder, actual: &BookOrder) {
+        assert_eq!(expected.side, actual.side);
+        assert_eq!(expected.price, actual.price);
+        assert_eq!(expected.size, actual.size);
+        assert_eq!(expected.order_id, actual.order_id);
+    }
+
+    fn assert_order_book_delta_fields(expected: &OrderBookDelta, actual: &OrderBookDelta) {
+        assert_eq!(expected.instrument_id, actual.instrument_id);
+        assert_eq!(expected.action, actual.action);
+        assert_book_order_fields(&expected.order, &actual.order);
+        assert_eq!(expected.flags, actual.flags);
+        assert_eq!(expected.sequence, actual.sequence);
+        assert_eq!(expected.ts_event, actual.ts_event);
+        assert_eq!(expected.ts_init, actual.ts_init);
+    }
+
+    fn assert_order_book_deltas_fields(expected: &OrderBookDeltas, actual: &OrderBookDeltas) {
+        assert_eq!(expected.instrument_id, actual.instrument_id);
+        assert_eq!(expected.flags, actual.flags);
+        assert_eq!(expected.sequence, actual.sequence);
+        assert_eq!(expected.ts_event, actual.ts_event);
+        assert_eq!(expected.ts_init, actual.ts_init);
+        assert_eq!(expected.deltas.len(), actual.deltas.len());
+
+        for (expected_delta, actual_delta) in expected.deltas.iter().zip(&actual.deltas) {
+            assert_order_book_delta_fields(expected_delta, actual_delta);
+        }
     }
 
     #[rstest]
@@ -552,16 +574,16 @@ mod tests {
         let serialized = deltas.to_json_bytes().unwrap();
         let deserialized = OrderBookDeltas::from_json_bytes(serialized.as_ref()).unwrap();
 
-        assert_deltas_eq(&deserialized, &deltas);
+        assert_order_book_deltas_fields(&deltas, &deserialized);
     }
 
     #[rstest]
-    fn test_msgpack_serialization(stub_deltas: OrderBookDeltas) {
-        let deltas = stub_deltas;
+    fn test_msgpack_serialization() {
+        let deltas = create_test_deltas_multiple();
         let serialized = deltas.to_msgpack_bytes().unwrap();
         let deserialized = OrderBookDeltas::from_msgpack_bytes(serialized.as_ref()).unwrap();
 
-        assert_deltas_eq(&deserialized, &deltas);
+        assert_order_book_deltas_fields(&deltas, &deserialized);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

`OrderBookDeltas` was the only type in `crates/model/src/data` without a `Serializable` impl, so it
had no canonical JSON/MsgPack path for persistence, IPC and replay. `Serializable` is a marker trait
over `Serialize + Deserialize` with default bodies, and the blanket impls in
`nautilus_core::serialization::msgpack` derive `FromMsgPack`/`ToMsgPack` from it, so this is one line
plus tests. No behavior changes for existing callers.

It also deletes both TODO comments the issue cites. The first is replaced by the impl. The second,
`// TODO: Exact format for Debug and Display TBD`, is stale: `Display` and `Debug` are already
implemented, and `test_order_book_deltas_display_format` and `test_display_with_stub` already assert
the exact string `AAPL.XNAS,len=7,flags=32,sequence=0,ts_event=1,ts_init=2`. The format was settled,
so I removed the comment rather than act on it. I kept `flags` decimal; the issue suggests hex
`flags=0x3`, which would break existing consumers.

Closes #4821

## Noted, not changed

`depth.rs` carries the same stale comment above `impl Display for OrderBookDepth10`. I left it to
keep this focused, happy to include it.

## Testing

Added `test_json_serialization` and `test_msgpack_serialization`, following `delta.rs`. Both compare
every field through a helper rather than `assert_eq!`, since `PartialEq` for `OrderBookDeltas`
compares only `instrument_id` and `sequence` — a plain `assert_eq!` passes even if `deltas` comes
back empty.

- `cargo test -p nautilus-model --lib --features "arrow,ffi,python,high-precision"` — 3276 passed
- `cargo clippy -p nautilus-model --lib --tests --features "arrow,ffi,python,high-precision" -- -D warnings` — clean
- `cargo +nightly fmt` — clean
- `prek run --files crates/model/src/data/deltas.rs` — convention hooks pass

The `cargo fmt`, `cargo clippy` and `cargo machete` hooks fail locally, but fail identically on a
clean `develop` with nothing applied, so they are unrelated to this change. The clippy one is
`doc_markdown` on `crates/persistence/src/parquet.rs:656`, in a Windows-only path Linux CI does not
compile.
