### PR TITLE
Stream backtest data lazily across multiple data configs

### DIFF
--- a/crates/backtest/src/node.rs
+++ b/crates/backtest/src/node.rs
@@ -421,11 +421,14 @@ fn run_streaming(
             .map(|item| item.map_err(anyhow::Error::from))
             .peekable();
 
-        if stream.peek().is_none() {
-            log::warn!("No data found for config: {:?}", data_config.data_type());
-            continue;
+        match stream.peek() {
+            Some(Ok(_)) => streams.push(stream),
+            // Surface a failed query in config order, before opening later ones
+            Some(Err(_)) => {
+                stream.next().transpose()?;
+            }
+            None => log::warn!("No data found for config: {:?}", data_config.data_type()),
         }
-        streams.push(stream);
     }
 
     stream_chunks(

--- a/crates/backtest/src/node.rs
+++ b/crates/backtest/src/node.rs
@@ -407,26 +407,60 @@ fn run_streaming(
 ) -> anyhow::Result<()> {
     let data_configs = config.data();
 
-    if data_configs.len() == 1 {
-        // Single config: stream directly from catalog iterator without
-        // materializing the full dataset, bounded by chunk_size
-        let data_config = &data_configs[0];
-        let mut catalog = create_catalog(data_config)?;
-        let result = dispatch_query(&mut catalog, data_config, config.start(), config.end())?;
-        let data = result.map(|item| item.map_err(anyhow::Error::from));
-        stream_chunks(engine, config, data.peekable(), chunk_size)?;
-    } else {
-        // Multiple configs require loading all data to merge-sort across types
-        let all_data = load_and_merge_data(config)?;
-        stream_chunks(
-            engine,
-            config,
-            all_data.into_iter().map(Ok).peekable(),
-            chunk_size,
-        )?;
+    // Stream directly from the catalog iterators without materializing the full
+    // dataset, so memory stays bounded by chunk_size for any number of configs
+    let mut catalogs = data_configs
+        .iter()
+        .map(create_catalog)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let mut streams = Vec::with_capacity(catalogs.len());
+
+    for (catalog, data_config) in catalogs.iter_mut().zip(data_configs) {
+        let result = dispatch_query(catalog, data_config, config.start(), config.end())?;
+        let mut stream = result
+            .map(|item| item.map_err(anyhow::Error::from))
+            .peekable();
+
+        if stream.peek().is_none() {
+            log::warn!("No data found for config: {:?}", data_config.data_type());
+            continue;
+        }
+        streams.push(stream);
     }
 
-    Ok(())
+    stream_chunks(
+        engine,
+        config,
+        merge_streams(streams).peekable(),
+        chunk_size,
+    )
+}
+
+// Merges the data streams of every config in ascending `ts_init` order, taking one
+// item at a time so the merge holds only a single item per config. Ties keep config
+// order, matching the stable sort the eager path applies.
+fn merge_streams<I: Iterator<Item = anyhow::Result<Data>>>(
+    mut streams: Vec<Peekable<I>>,
+) -> impl Iterator<Item = anyhow::Result<Data>> {
+    std::iter::from_fn(move || {
+        let mut next: Option<(usize, UnixNanos)> = None;
+
+        for (i, stream) in streams.iter_mut().enumerate() {
+            match stream.peek() {
+                Some(Ok(data)) => {
+                    let ts_init = data.ts_init();
+                    if next.is_none_or(|(_, ts)| ts_init < ts) {
+                        next = Some((i, ts_init));
+                    }
+                }
+                // A failed stream ends the merge rather than reading as exhaustion
+                Some(Err(_)) => return stream.next(),
+                None => {}
+            }
+        }
+
+        streams[next?.0].next()
+    })
 }
 
 // Feeds data from an iterator to the engine in timestamp-aligned chunks.
@@ -501,21 +535,6 @@ fn take_aligned_chunk<I: Iterator<Item = anyhow::Result<Data>>>(
     }
 
     Ok(chunk)
-}
-
-fn load_and_merge_data(config: &BacktestRunConfig) -> anyhow::Result<Vec<Data>> {
-    let mut all_data = Vec::new();
-
-    for data_config in config.data() {
-        let data = load_data(data_config, config.start(), config.end())?;
-        if data.is_empty() {
-            log::warn!("No data found for config: {:?}", data_config.data_type());
-            continue;
-        }
-        all_data.extend(data);
-    }
-    all_data.sort_by_key(HasTsInit::ts_init);
-    Ok(all_data)
 }
 
 fn create_catalog(config: &BacktestDataConfig) -> anyhow::Result<ParquetDataCatalog> {
@@ -614,7 +633,8 @@ mod tests {
     #[cfg(feature = "python")]
     use nautilus_model::enums::{AccountType, OmsType};
     use nautilus_model::{
-        identifiers::InstrumentId,
+        enums::AggressorSide,
+        identifiers::{InstrumentId, TradeId},
         types::{Price, Quantity},
     };
     #[cfg(feature = "python")]
@@ -641,8 +661,82 @@ mod tests {
         ))
     }
 
+    fn trade(ts_init: u64) -> Data {
+        Data::Trade(TradeTick::new(
+            InstrumentId::from("EUR/USD.SIM"),
+            Price::from("1.0001"),
+            Quantity::from("100"),
+            AggressorSide::Buy,
+            TradeId::from("T-1"),
+            UnixNanos::from(ts_init),
+            UnixNanos::from(ts_init),
+        ))
+    }
+
     fn stream_failure() -> anyhow::Error {
         anyhow::anyhow!("injected stream failure")
+    }
+
+    #[rstest]
+    fn merge_streams_orders_items_across_streams_by_ts_init() {
+        let streams = vec![
+            vec![Ok(quote(1)), Ok(quote(3)), Ok(quote(3))]
+                .into_iter()
+                .peekable(),
+            vec![Ok(trade(2)), Ok(trade(3))].into_iter().peekable(),
+            vec![].into_iter().peekable(),
+        ];
+
+        let merged: Vec<(u64, bool)> = merge_streams(streams)
+            .map(|item| item.expect("the merged stream must not fail"))
+            .map(|data| (data.ts_init().as_u64(), matches!(data, Data::Trade(_))))
+            .collect();
+
+        assert_eq!(
+            merged,
+            vec![(1, false), (2, true), (3, false), (3, false), (3, true)]
+        );
+    }
+
+    #[rstest]
+    fn merge_streams_leaves_its_streams_undrained() {
+        // Unbounded streams, so a merge that materialized its input would never return
+        let ok_quote: fn(u64) -> anyhow::Result<Data> = |ts_init| Ok(quote(ts_init));
+        let evens = (0u64..).step_by(2).map(ok_quote);
+        let odds = (1u64..).step_by(2).map(ok_quote);
+
+        let merged: Vec<u64> = merge_streams(vec![evens.peekable(), odds.peekable()])
+            .take(4)
+            .map(|item| item.expect("the merged stream must not fail").ts_init())
+            .map(|ts_init| ts_init.as_u64())
+            .collect();
+
+        assert_eq!(merged, vec![0, 1, 2, 3]);
+    }
+
+    #[rstest]
+    fn merge_streams_reports_a_stream_failure() {
+        let streams = vec![
+            vec![Ok(quote(1)), Err(stream_failure())]
+                .into_iter()
+                .peekable(),
+            vec![Ok(quote(2))].into_iter().peekable(),
+        ];
+        let mut merged = merge_streams(streams);
+
+        let first = merged.next().expect("the first item must be present");
+        let second = merged.next().expect("the failure must be yielded");
+
+        assert_eq!(
+            first.expect("the first item must not fail").ts_init(),
+            UnixNanos::from(1)
+        );
+        assert_eq!(
+            second
+                .expect_err("a failed stream must not read as exhaustion")
+                .to_string(),
+            "injected stream failure"
+        );
     }
 
     #[rstest]

--- a/crates/backtest/tests/backtest_node.rs
+++ b/crates/backtest/tests/backtest_node.rs
@@ -20,7 +20,7 @@
 //! Tests that arm shutdown-on-error use global logging state. Run with cargo-nextest for process
 //! isolation, or use --test-threads=1.
 
-use std::{fmt::Debug, str::FromStr};
+use std::{cell::RefCell, fmt::Debug, rc::Rc, str::FromStr};
 
 use nautilus_backtest::{
     config::{
@@ -374,6 +374,53 @@ impl DataActor for ShutdownOnTick {
         if self.tick_count == self.shutdown_after {
             self.shutdown_system(Some("shutdown on tick".to_string()));
         }
+        Ok(())
+    }
+}
+
+struct RecordingStrategy {
+    core: StrategyCore,
+    instrument_id: InstrumentId,
+    timestamps: Rc<RefCell<Vec<UnixNanos>>>,
+}
+
+impl RecordingStrategy {
+    fn new(instrument_id: InstrumentId, timestamps: Rc<RefCell<Vec<UnixNanos>>>) -> Self {
+        let config = StrategyConfig {
+            strategy_id: Some(StrategyId::from("RECORDING-001")),
+            order_id_tag: Some("001".to_string()),
+            ..Default::default()
+        };
+        Self {
+            core: StrategyCore::new(config),
+            instrument_id,
+            timestamps,
+        }
+    }
+}
+
+nautilus_strategy!(RecordingStrategy);
+
+impl Debug for RecordingStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(stringify!(RecordingStrategy)).finish()
+    }
+}
+
+impl DataActor for RecordingStrategy {
+    fn on_start(&mut self) -> anyhow::Result<()> {
+        self.subscribe_quotes(self.instrument_id, None, None);
+        self.subscribe_trades(self.instrument_id, None, None);
+        Ok(())
+    }
+
+    fn on_quote(&mut self, quote: &QuoteTick) -> anyhow::Result<()> {
+        self.timestamps.borrow_mut().push(quote.ts_init);
+        Ok(())
+    }
+
+    fn on_trade(&mut self, trade: &TradeTick) -> anyhow::Result<()> {
+        self.timestamps.borrow_mut().push(trade.ts_init);
         Ok(())
     }
 }
@@ -1165,6 +1212,61 @@ fn test_multiple_data_configs_mixed_types(crypto_perpetual_ethusdt: CryptoPerpet
     // Should process both quotes and trades (10 + 10 = 20)
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].iterations, 20);
+}
+
+#[rstest]
+fn test_run_streaming_multiple_data_configs(crypto_perpetual_ethusdt: CryptoPerpetual) {
+    let instrument = InstrumentAny::CryptoPerpetual(crypto_perpetual_ethusdt);
+    let base_ts = 1_000_000_000u64;
+    let (_temp_dir, catalog_path) =
+        create_catalog_with_quotes_and_trades(&instrument, 10, 10, base_ts);
+
+    let quote_data = BacktestDataConfig::builder()
+        .data_type(NautilusDataType::QuoteTick)
+        .catalog_path(catalog_path.clone())
+        .instrument_id(instrument.id())
+        .build()
+        .unwrap();
+    let trade_data = BacktestDataConfig::builder()
+        .data_type(NautilusDataType::TradeTick)
+        .catalog_path(catalog_path)
+        .instrument_id(instrument.id())
+        .build()
+        .unwrap();
+
+    // chunk_size=3 spans the 20 events over several chunks
+    let config = BacktestRunConfig::builder()
+        .venues(vec![binance_venue_config()])
+        .data(vec![quote_data, trade_data])
+        .chunk_size(3)
+        .build()
+        .unwrap();
+    let config_id = config.id().to_string();
+
+    let timestamps = Rc::new(RefCell::new(Vec::new()));
+    let mut node = BacktestNode::new(vec![config]).unwrap();
+    node.build().unwrap();
+    node.get_engine_mut(&config_id)
+        .unwrap()
+        .add_strategy(RecordingStrategy::new(
+            instrument.id(),
+            Rc::clone(&timestamps),
+        ))
+        .unwrap();
+
+    let results = node.run().unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].iterations, 20);
+
+    // Trades sit 500ms after each quote, so both configs must arrive interleaved
+    let expected: Vec<UnixNanos> = (0..10u64)
+        .flat_map(|i| {
+            let ts = base_ts + i * 1_000_000_000;
+            [UnixNanos::from(ts), UnixNanos::from(ts + 500_000_000)]
+        })
+        .collect();
+    assert_eq!(*timestamps.borrow(), expected);
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

`run_streaming` only streamed lazily when exactly one `BacktestDataConfig` was present. With two or
more it fell through to `load_and_merge_data`, which collected every record into a single
`Vec<Data>` and sorted by `ts_init` — so `chunk_size` still appeared to apply while the memory bound
it promises was silently gone.

This builds one `QueryResult` per data config and k-way merges them by `ts_init`, feeding
`stream_chunks` exactly as the single-config branch already did. The single-config case becomes k=1
of that same path, so the two can no longer drift, and `load_and_merge_data` is deleted. `load_data`
and `run_oneshot` keep loading eagerly — oneshot needs the whole `Vec<Data>` for
`add_data`/`sort_data`, and `load_data_config` is public API.

The merge holds one peeked item per config and breaks `ts_init` ties by config order, matching the
stable `sort_by_key` the eager path applied. A peeked `Err` is returned immediately so a failed
stream cannot read as exhaustion, the same contract as `QueryResult::next`.

One behavior change: the single-config path now emits the existing `"No data found for config"`
warning it previously skipped. Log-only.

Closes #4832

## On not reusing KMerge

`KMerge<I, T, C>` requires `I: Iterator<Item = std::vec::IntoIter<T>>` — a stream of batches — and
yields a bare `T`, not a `Result`. Reusing it would mean wrapping each item in a one-element `Vec`,
defeating `ElementBatchIter`, plus a `Compare` impl and a second `ErrorSlot` inside
`nautilus-persistence` to satisfy the orphan rule. That is a public API change to another crate to
serve a merge over k = data configs, typically 2-5, so this stays in `node.rs` and leaves
`nautilus-persistence` untouched. Happy to switch if you'd rather it used the shared machinery.

## Testing

Unit, in `node.rs`: ordering across streams including a three-way `ts_init` tie; a merge over two
*unbounded* streams taking four items, which would not terminate if the merge materialized its
input; and a failure surfacing as the next item rather than as exhaustion.

Integration: `test_run_streaming_multiple_data_configs` runs a real catalog with quote and trade
configs at `chunk_size=3` over 20 events and asserts the exact interleaved sequence the strategy
receives, proving ordering holds across chunk boundaries, not just within one.

- `cargo test -p nautilus-backtest --lib --features streaming` — 155 passed
- `cargo test -p nautilus-backtest --test backtest_node --features streaming` — 48 passed
- `cargo clippy --no-deps -p nautilus-backtest --lib --tests --features "python,high-precision,streaming" -- -D warnings` — clean
- `cargo +nightly fmt` — no changes

`arrow`/`ffi` are not features of this crate. `--no-deps` avoids pre-existing `doc_markdown` errors
in `crates/persistence/src/parquet.rs:656`, present on an untouched tree. `canonical_backtest_workloads`
fails locally on Windows but fails identically on clean `develop` with a byte-identical
`result_digest`, so this change is result-neutral there.
