### PR TITLE
Publish Binance Spot dispatch readiness at task admission

### DIFF
--- a/crates/adapters/binance/src/spot/execution.rs
+++ b/crates/adapters/binance/src/spot/execution.rs
@@ -47,7 +47,7 @@ use nautilus_core::{
 };
 use nautilus_live::{
     ExecutionClientCore, ExecutionEventEmitter, SocketControlFactory,
-    task::{TaskGroup, TaskGroupGuard, TaskSpawner},
+    task::{TaskGroup, TaskGroupGuard, TaskSpawnError, TaskSpawner},
 };
 use nautilus_model::{
     accounts::AccountAny,
@@ -656,10 +656,7 @@ impl BinanceSpotExecutionClient {
             .spawner()
             .context("Binance Spot session task admission is closed")?;
 
-        if let Err(e) = self.session_tasks.spawn(async move {
-            dispatch_active.store(true, Ordering::Release);
-            let _active = DispatchActiveGuard(dispatch_active);
-
+        if let Err(e) = spawn_dispatch_task(&self.session_tasks, &dispatch_active, async move {
             while let Some(message) = ws_clone.recv().await {
                 if matches!(&message, BinanceSpotWsTradingMessage::Reconnected) {
                     ws_clone.mark_user_data_active();
@@ -913,9 +910,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                         .spawner()
                         .context("Binance Spot session task admission is closed")?;
 
-                    self.session_tasks.spawn(async move {
-                        dispatch_active.store(true, Ordering::Release);
-                        let _active = DispatchActiveGuard(dispatch_active);
+                    spawn_dispatch_task(&self.session_tasks, &dispatch_active, async move {
                         let mut resubscribing = false;
 
                         loop {
@@ -2067,6 +2062,39 @@ impl Drop for DispatchActiveGuard {
     fn drop(&mut self) {
         self.0.store(false, Ordering::Release);
     }
+}
+
+/// Marks `dispatch_active` before spawning `dispatch`, and clears it when the task ends.
+///
+/// The flag says a dispatch consumer has been admitted, which submission readiness reads
+/// through `ws_user_data_active`. Marking it here rather than inside `dispatch` is what orders
+/// it against admission: a store in the task body carries no happens-before edge from a
+/// successful spawn to the flag being visible, so a caller can observe `false` after admission
+/// has already succeeded.
+///
+/// The guard is constructed here and moved into the task, so ownership clears the flag on
+/// every path: [`TaskGroup::spawn`] drops a rejected future, the group's wrapper can drop the
+/// future without polling it when cancellation wins, and the task dropping it covers a normal
+/// exit or a panic.
+///
+/// # Errors
+///
+/// Returns an error if task admission is closed, having left the flag clear.
+fn spawn_dispatch_task<F>(
+    session_tasks: &TaskGroup,
+    dispatch_active: &Arc<AtomicBool>,
+    dispatch: F,
+) -> Result<(), TaskSpawnError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    dispatch_active.store(true, Ordering::Release);
+    let active = DispatchActiveGuard(Arc::clone(dispatch_active));
+
+    session_tasks.spawn(async move {
+        let _active = active;
+        dispatch.await;
+    })
 }
 
 fn max_trade_id(reports: &[FillReport]) -> anyhow::Result<i64> {
@@ -3331,6 +3359,20 @@ mod tests {
             ),
             expected
         );
+    }
+
+    #[rstest]
+    fn test_spawn_dispatch_task_clears_active_when_admission_closed() {
+        let tasks = TaskGroup::new();
+        tasks.begin_shutdown();
+        let dispatch_active = Arc::new(AtomicBool::new(false));
+
+        spawn_dispatch_task(&tasks, &dispatch_active, std::future::pending())
+            .expect_err("closed task group must reject the dispatch task");
+
+        // The rejected future is dropped with the guard it owns, so the flag cannot
+        // stay true for a dispatch loop that never ran.
+        assert!(!dispatch_active.load(Ordering::Acquire));
     }
 
     #[rstest]


### PR DESCRIPTION
A follow-up to the task-lifecycle standardization in 4c18691277.

## The dispatch-active flag is published from inside the task it describes

`BinanceSpotExecutionClient::submit_order` and `submit_order_list` reject a command with "Binance Spot user data stream is not active" unless `ws_user_data_active()` holds, and that predicate ands the client's user-data state with a `dispatch_running` flag. Both dispatch flags were stored by the first statement *inside* the spawned dispatch task.

`TaskGroup::spawn` returns once the task is admitted; the body runs when the runtime first polls it. There is no happens-before edge from a successful spawn to that store becoming visible, so a caller can observe `false` after admission has already succeeded.

On the Binance US path that window survives `connect()`. The dispatch task is spawned, `mark_user_data_active()` then runs synchronously, and `connect()` returns without awaiting anything the dispatch task produces - so an order submitted immediately after a successful connect can be rejected for a stream that is connected and subscribed. The non-US path is protected by its own handshake today, because `connect()` waits for the `UserDataSubscribed` notification that the dispatch task itself emits.

Before 4c18691277 the same conjunct read `ws_user_data_handle.as_ref().is_some_and(|handle| !handle.is_finished())`, which was true the moment `spawn` returned. Replacing the handle with an atomic moved the observable transition from admission time to first-poll time.

`ws_order_transport_active()` reads the same predicate, so during the window the submit, cancel, modify, and cancel-all paths silently select HTTP rather than the WS order transport.

## The fix

Both sites now go through `spawn_dispatch_task`, which stores the flag, constructs `DispatchActiveGuard`, and moves the guard into the spawned future. Readiness is therefore published before `spawn` returns, restoring the pre-refactor ordering, and ownership clears the flag on every path: `TaskGroup::spawn` drops a rejected future, the group's wrapper can drop the future without polling it when cancellation wins, and a normal exit or panic drops it as before. Publishing before admission is what makes that last part load-bearing - a flag set before the task exists has to be cleared by a task that may never run.

## Testing

`test_spawn_dispatch_task_clears_active_when_admission_closed` spawns into a closed group and asserts the flag is clear on return, covering the obligation the new ordering introduces.

There is no deterministic regression test for the window itself. `TaskGroup` spawns onto the process-global multi-threaded runtime, so nothing a test can do from outside will hold a successfully admitted future unpolled: saturating workers is scheduler pressure rather than synchronization, and `NAUTILUS_WORKER_THREADS` is read once per process behind a `OnceLock`. A test that merely tends to fail against the old code would be exactly the scheduler-sensitive flake this area has been removing. The evidence the window is real is a full-workspace test run in which `test_binance_us_submit_order_uses_http_transport` failed at its `submit_order` call with this error under parallel load, and passed in 1.84s run alone; it synchronizes on the socket-state event, which says nothing about the dispatch task having been polled.
