### PR TITLE
Stop two task lifecycle tests spinning on a stalled timer

### DIFF
--- a/crates/live/src/task.rs
+++ b/crates/live/src/task.rs
@@ -1330,6 +1330,15 @@ mod tests {
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(1);
 
+    /// Interval a test waits on while letting an in-flight `finish_*` future make progress.
+    ///
+    /// Sleeping rather than yielding is deliberate. A `yield_now` arm keeps the remaining
+    /// worker runnable and can delay it servicing the timer driver, so a zero-duration
+    /// `time::timeout` inside the raced future may not fire promptly and the loop spins
+    /// waiting for it. Sleeping lets the runtime park and service the timer before the
+    /// next poll.
+    const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
     #[rstest]
     fn task_group_guard_closes_all_groups_and_runs_rollback_until_disarmed() {
         let first = Arc::new(TaskGroup::new());
@@ -2114,7 +2123,7 @@ mod tests {
                 tokio::select! {
                     biased;
                     outcome = &mut finish => panic!("finish completed unexpectedly: {outcome:?}"),
-                    () = task::yield_now() => {}
+                    () = time::sleep(POLL_INTERVAL) => {}
                 }
             }
 
@@ -3011,7 +3020,7 @@ mod tests {
                 tokio::select! {
                     biased;
                     outcome = &mut finish => panic!("finish completed unexpectedly: {outcome:?}"),
-                    () = task::yield_now() => {}
+                    () = time::sleep(POLL_INTERVAL) => {}
                 }
             }
         }

--- a/crates/live/src/task.rs
+++ b/crates/live/src/task.rs
@@ -1332,11 +1332,11 @@ mod tests {
 
     /// Interval a test waits on while letting an in-flight `finish_*` future make progress.
     ///
-    /// Sleeping rather than yielding is deliberate. A `yield_now` arm keeps the remaining
-    /// worker runnable and can delay it servicing the timer driver, so a zero-duration
-    /// `time::timeout` inside the raced future may not fire promptly and the loop spins
-    /// waiting for it. Sleeping lets the runtime park and service the timer before the
-    /// next poll.
+    /// Sleeping rather than yielding is deliberate. A `yield_now` arm leaves the polling task
+    /// immediately runnable again, so the loop can re-poll without the runtime servicing its
+    /// timer driver, and a zero-duration `time::timeout` inside the raced future may then not
+    /// fire promptly. Sleeping yields to the timer driver before the next poll.
+    #[cfg(not(all(feature = "simulation", madsim)))]
     const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
     #[rstest]


### PR DESCRIPTION
A follow-up to the task-lifecycle standardization in 4c18691277.

## Two task tests spin against a timer that cannot advance

`canceled_singular_abort_wait_preserves_abort_classification` and `canceled_finish_preserves_forced_abort_classification` each loop over a `finish_*` future with a zero-duration graceful timeout, racing it against `task::yield_now()` in a `select!`.

The zero-duration `time::timeout` inside the raced future is a timer, and the `yield_now` arm keeps the task runnable, so the remaining worker can be delayed in servicing the timer driver. Neither loop can make progress until it does, because the exit conditions - `slot.abort_requested` and `generation.force.is_cancelled()` - are both set only after that timeout fires. Both tests run on a two-worker runtime whose other worker is parked in a deliberately blocking `recv()`, which leaves nothing else to drive the timer.

Measured on an idle machine, with an iteration counter added to the loops:

- `canceled_singular_abort_wait_preserves_abort_classification`: 15,917,237 iterations, 6.26s in the loop, 6.47s wall. Repeat runs of the same binary took 0.89s, 4.32s and 6.47s.
- `canceled_finish_preserves_forced_abort_classification`: 31,673 iterations, 0.12s wall.

The second spins too. Wall time alone hides it, which is why the iteration count is the measurement that matters here.

## The fix

Both `yield_now` arms become `time::sleep(POLL_INTERVAL)`, a shared 10ms constant. Sleeping makes the task non-runnable, so the runtime parks, services the timer, and the raced timeout fires on the next poll. The loops, the assertions and the blocking task are unchanged.

After: the first test runs 1 iteration, 11.09ms in the loop, 0.28s wall; the second stays at 0.12s.

## Testing

No test was added; these are the tests. Inverting the `abort_requested` condition in `TaskSlot::complete` fails `canceled_singular_abort_wait_preserves_abort_classification` on its `TaskJoinOutcome::Aborted` assertion, so the faster loop still pins the classification it exists to pin.

Both were reached through `cargo test -p nautilus-live`, and the crate is green.
