### PR TITLE
Add borrowed data dispatch

### DIFF
--- a/crates/backtest/src/engine.rs
+++ b/crates/backtest/src/engine.rs
@@ -52,7 +52,7 @@ use nautilus_data::client::DataClientAdapter;
 use nautilus_execution::models::fill::FillModelHandle;
 use nautilus_model::{
     accounts::{Account, AccountAny},
-    data::{Data, HasTsInit},
+    data::{Data, DataRef, HasTsInit},
     enums::{AccountType, AggregationSource, BookType},
     identifiers::{AccountId, ClientId, InstrumentId, StrategyId, TraderId, Venue},
     instruments::{Instrument, InstrumentAny},
@@ -848,7 +848,7 @@ impl BacktestEngine {
                 break;
             }
 
-            self.route_data_to_exchange(&d)?;
+            self.route_data_to_exchange(DataRef::from(&d))?;
             self.kernel.data_engine.borrow_mut().process_data(d);
 
             // Drain deferred commands, then process exchange queues
@@ -1426,15 +1426,18 @@ impl BacktestEngine {
         summary
     }
 
-    fn route_data_to_exchange(&mut self, data: &Data) -> anyhow::Result<()> {
+    fn route_data_to_exchange(&mut self, data: DataRef<'_>) -> anyhow::Result<()> {
         if matches!(
             data,
-            Data::MarkPrice(_) | Data::IndexPrice(_) | Data::OptionGreeks(_) | Data::Custom(_)
+            DataRef::MarkPrice(_)
+                | DataRef::IndexPrice(_)
+                | DataRef::OptionGreeks(_)
+                | DataRef::Custom(_)
         ) {
             return Ok(());
         }
         #[cfg(feature = "defi")]
-        if matches!(data, Data::Defi(_)) {
+        if matches!(data, DataRef::Defi(_)) {
             return Ok(());
         }
 
@@ -1444,31 +1447,38 @@ impl BacktestEngine {
             let mut processed_book_data = false;
 
             match data {
-                Data::Delta(delta) => {
+                DataRef::Delta(delta) => {
                     exchange_ref.process_order_book_delta(*delta)?;
                     processed_book_data = true;
                 }
-                Data::Deltas(deltas) => {
+                DataRef::Deltas(deltas) => {
                     exchange_ref.process_order_book_deltas(deltas)?;
                     processed_book_data = true;
                 }
-                Data::Depth10(depth) => {
+                DataRef::Depth10(depth) => {
                     exchange_ref.process_order_book_depth10(depth)?;
                     processed_book_data = true;
                 }
-                Data::Quote(quote) => exchange_ref.process_quote_tick(quote)?,
-                Data::Trade(trade) => exchange_ref.process_trade_tick(trade)?,
-                Data::Bar(bar) => exchange_ref.process_bar(*bar)?,
-                Data::InstrumentStatus(status) => {
+                DataRef::Quote(quote) => exchange_ref.process_quote_tick(quote)?,
+                DataRef::Trade(trade) => exchange_ref.process_trade_tick(trade)?,
+                DataRef::Bar(bar) => exchange_ref.process_bar(*bar)?,
+                DataRef::InstrumentStatus(status) => {
                     exchange_ref.process_instrument_status(*status)?;
                 }
-                Data::InstrumentClose(close) => exchange_ref.process_instrument_close(*close)?,
-                Data::FundingRate(funding) => {
+                DataRef::InstrumentClose(close) => {
+                    exchange_ref.process_instrument_close(*close)?;
+                }
+                DataRef::FundingRate(funding) => {
                     let settlement_ns =
                         exchange_ref.process_funding_rate_deferred(*funding, data.ts_init())?;
                     self.schedule_funding_settlement_if_required(venue, settlement_ns);
                 }
-                _ => {}
+                DataRef::MarkPrice(_)
+                | DataRef::IndexPrice(_)
+                | DataRef::OptionGreeks(_)
+                | DataRef::Custom(_) => unreachable!("filtered before exchange routing"),
+                #[cfg(feature = "defi")]
+                DataRef::Defi(_) => unreachable!("filtered before exchange routing"),
             }
 
             drop(exchange_ref);
@@ -3434,7 +3444,7 @@ mod tests {
         );
 
         engine
-            .route_data_to_exchange(&Data::InstrumentStatus(status))
+            .route_data_to_exchange(DataRef::InstrumentStatus(&status))
             .unwrap();
 
         let exchange = engine.venues.get(&instrument_id.venue).unwrap().borrow();

--- a/crates/data/src/engine/mod.rs
+++ b/crates/data/src/engine/mod.rs
@@ -99,9 +99,9 @@ use nautilus_core::{
 use nautilus_model::defi::DefiData;
 use nautilus_model::{
     data::{
-        Bar, BarType, CustomData, Data, DataType, FundingRateUpdate, HasTsInit, IndexPriceUpdate,
-        InstrumentClose, InstrumentStatus, MarkPriceUpdate, OrderBookDelta, OrderBookDeltas,
-        OrderBookDepth10, QuoteTick, TradeTick,
+        Bar, BarType, CustomData, Data, DataRef, DataType, FundingRateUpdate, HasTsInit,
+        IndexPriceUpdate, InstrumentClose, InstrumentStatus, MarkPriceUpdate, OrderBookDelta,
+        OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick,
         option_chain::{OptionGreeks, StrikeRange},
     },
     enums::{
@@ -1736,10 +1736,25 @@ impl DataEngine {
 
     /// Processes a `Data` enum instance, dispatching to live handlers.
     pub fn process_data(&mut self, data: Data) {
-        #[cfg(feature = "defi")]
-        let data = match data {
+        match data {
+            Data::Deltas(deltas) => {
+                self.data_count += 1;
+                self.handle_deltas(*deltas);
+            }
+            #[cfg(feature = "defi")]
             Data::Defi(defi) => {
                 self.process_defi_data(*defi);
+            }
+            data => self.process_data_ref(DataRef::from(&data)),
+        }
+    }
+
+    /// Processes a borrowed `Data` enum view, dispatching to live handlers.
+    pub fn process_data_ref(&mut self, data: DataRef<'_>) {
+        #[cfg(feature = "defi")]
+        let data = match data {
+            DataRef::Defi(defi) => {
+                self.process_defi_data(defi.clone());
                 return;
             }
             data => data,
@@ -1748,42 +1763,42 @@ impl DataEngine {
         self.data_count += 1;
 
         match data {
-            Data::Delta(delta) => self.handle_delta(delta),
-            Data::Deltas(deltas) => self.handle_deltas(*deltas),
-            Data::Depth10(depth) => self.handle_depth10(*depth),
-            Data::Quote(quote) => {
-                self.handle_quote(quote);
+            DataRef::Delta(delta) => self.handle_delta(*delta),
+            DataRef::Deltas(deltas) => self.handle_deltas(deltas.clone()),
+            DataRef::Depth10(depth) => self.handle_depth10(*depth),
+            DataRef::Quote(quote) => {
+                self.handle_quote(*quote);
                 self.drain_deferred_commands();
             }
-            Data::Trade(trade) => self.handle_trade(trade),
-            Data::Bar(bar) => self.handle_bar(bar),
-            Data::MarkPrice(mark_price) => {
-                self.handle_mark_price(mark_price);
+            DataRef::Trade(trade) => self.handle_trade(*trade),
+            DataRef::Bar(bar) => self.handle_bar(*bar),
+            DataRef::MarkPrice(mark_price) => {
+                self.handle_mark_price(*mark_price);
                 self.drain_deferred_commands();
             }
-            Data::IndexPrice(index_price) => {
-                self.handle_index_price(index_price);
+            DataRef::IndexPrice(index_price) => {
+                self.handle_index_price(*index_price);
                 self.drain_deferred_commands();
             }
-            Data::FundingRate(funding_rate) => {
-                self.handle_funding_rate(funding_rate);
+            DataRef::FundingRate(funding_rate) => {
+                self.handle_funding_rate(*funding_rate);
                 self.drain_deferred_commands();
             }
-            Data::OptionGreeks(greeks) => {
-                self.cache.borrow_mut().add_option_greeks(greeks);
-                self.feed_option_greeks_to_pre_bootstrap_chain(&greeks);
+            DataRef::OptionGreeks(greeks) => {
+                self.cache.borrow_mut().add_option_greeks(*greeks);
+                self.feed_option_greeks_to_pre_bootstrap_chain(greeks);
                 let topic = switchboard::get_option_greeks_topic(greeks.instrument_id);
-                msgbus::publish_option_greeks(topic, &greeks);
+                msgbus::publish_option_greeks(topic, greeks);
                 self.drain_deferred_commands();
             }
-            Data::InstrumentStatus(status) => {
-                self.handle_instrument_status(status);
+            DataRef::InstrumentStatus(status) => {
+                self.handle_instrument_status(*status);
                 self.drain_deferred_commands();
             }
-            Data::InstrumentClose(close) => self.handle_instrument_close(close),
-            Data::Custom(custom) => self.handle_custom_data(&custom),
+            DataRef::InstrumentClose(close) => self.handle_instrument_close(*close),
+            DataRef::Custom(custom) => self.handle_custom_data(custom),
             #[cfg(feature = "defi")]
-            Data::Defi(_) => unreachable!("handled before market data dispatch"),
+            DataRef::Defi(_) => unreachable!("handled before market data dispatch"),
         }
     }
 

--- a/crates/data/tests/engine.rs
+++ b/crates/data/tests/engine.rs
@@ -87,9 +87,9 @@ use nautilus_model::enums::CurrencyType;
 use nautilus_model::enums::{BookAction, OrderSide};
 use nautilus_model::{
     data::{
-        Bar, BarType, BookOrder, CustomData, DEPTH10_LEN, Data, DataType, FundingRateUpdate,
-        IndexPriceUpdate, InstrumentClose, InstrumentStatus, MarkPriceUpdate, OrderBookDelta,
-        OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick,
+        Bar, BarType, BookOrder, CustomData, DEPTH10_LEN, Data, DataRef, DataType,
+        FundingRateUpdate, IndexPriceUpdate, InstrumentClose, InstrumentStatus, MarkPriceUpdate,
+        OrderBookDelta, OrderBookDeltas, OrderBookDepth10, QuoteTick, TradeTick,
         greeks::OptionGreekValues,
         option_chain::{OptionChainSlice, OptionGreeks, StrikeRange},
         stubs::{
@@ -174,6 +174,18 @@ fn data_client(
 ) -> DataClientAdapter {
     let client = Box::new(MockDataClient::new(clock, cache, client_id, Some(venue)));
     DataClientAdapter::new(client_id, Some(venue), true, true, client)
+}
+
+fn dispatch_data(data_engine: &mut DataEngine, data: Data, borrowed: bool) {
+    let count = data_engine.data_count();
+
+    if borrowed {
+        data_engine.process_data_ref(DataRef::from(&data));
+    } else {
+        data_engine.process_data(data);
+    }
+
+    assert_eq!(data_engine.data_count(), count + 1);
 }
 
 // Test helper for registering a mock data client
@@ -8963,7 +8975,10 @@ fn test_process_instrument(
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_book_delta(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -8994,7 +9009,7 @@ fn test_process_book_delta(
     msgbus::subscribe_book_deltas(topic.into(), handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::Delta(delta));
+    dispatch_data(&mut data_engine, Data::Delta(delta), borrowed);
     let _cache = &data_engine.get_cache();
     let messages = saver.get_messages();
 
@@ -9100,7 +9115,10 @@ fn test_process_book_deltas_buffers_until_f_last(
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_book_deltas(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -9131,7 +9149,7 @@ fn test_process_book_deltas(
     msgbus::subscribe_book_deltas(topic.into(), handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::Deltas(deltas.clone()));
+    dispatch_data(&mut data_engine, Data::Deltas(deltas.clone()), borrowed);
     let _cache = &data_engine.get_cache();
     let messages = saver.get_messages();
 
@@ -9140,7 +9158,10 @@ fn test_process_book_deltas(
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_book_depth10(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -9171,7 +9192,7 @@ fn test_process_book_depth10(
     msgbus::subscribe_book_depth10(topic.into(), handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::from(depth));
+    dispatch_data(&mut data_engine, Data::from(depth), borrowed);
     let _cache = &data_engine.get_cache();
     let messages = saver.get_messages();
 
@@ -9180,7 +9201,10 @@ fn test_process_book_depth10(
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_quote_tick(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -9208,7 +9232,7 @@ fn test_process_quote_tick(
     msgbus::subscribe_quotes(topic.into(), handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::Quote(quote));
+    dispatch_data(&mut data_engine, Data::Quote(quote), borrowed);
     let cache = &data_engine.get_cache();
     let messages = saver.get_messages();
 
@@ -9218,7 +9242,10 @@ fn test_process_quote_tick(
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_trade_tick(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -9246,7 +9273,7 @@ fn test_process_trade_tick(
     msgbus::subscribe_trades(topic.into(), handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::Trade(trade));
+    dispatch_data(&mut data_engine, Data::Trade(trade), borrowed);
     let cache = &data_engine.get_cache();
     let messages = saver.get_messages();
 
@@ -9791,7 +9818,10 @@ fn test_reset_clears_synthetic_subscriptions(stub_msgbus: Rc<RefCell<MessageBus>
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_mark_price(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -9824,7 +9854,7 @@ fn test_process_mark_price(
     msgbus::subscribe_mark_prices(topic.into(), typed_handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::MarkPrice(mark_price));
+    dispatch_data(&mut data_engine, Data::MarkPrice(mark_price), borrowed);
     let cache = &data_engine.get_cache();
     let messages = saving_handler.get_messages();
 
@@ -9845,7 +9875,10 @@ fn test_process_mark_price(
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_index_price(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -9879,7 +9912,7 @@ fn test_process_index_price(
     msgbus::subscribe_index_prices(topic.into(), typed_handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::IndexPrice(index_price));
+    dispatch_data(&mut data_engine, Data::IndexPrice(index_price), borrowed);
     let cache = &data_engine.get_cache();
     let messages = saving_handler.get_messages();
 
@@ -9995,7 +10028,10 @@ fn test_process_funding_rate(
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_funding_rate_data_variant(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -10031,7 +10067,7 @@ fn test_process_funding_rate_data_variant(
     msgbus::subscribe_funding_rates(topic.into(), typed_handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::FundingRate(funding_rate));
+    dispatch_data(&mut data_engine, Data::FundingRate(funding_rate), borrowed);
     let cache = &data_engine.get_cache();
     let messages = saving_handler.get_messages();
 
@@ -10097,7 +10133,13 @@ fn test_process_funding_rate_updates_existing(
 }
 
 #[rstest]
-fn test_process_bar(data_engine: Rc<RefCell<DataEngine>>, data_client: DataClientAdapter) {
+#[case::owned(false)]
+#[case::borrowed(true)]
+fn test_process_bar(
+    #[case] borrowed: bool,
+    data_engine: Rc<RefCell<DataEngine>>,
+    data_client: DataClientAdapter,
+) {
     let client_id = data_client.client_id;
     let venue = data_client.venue;
     data_engine.borrow_mut().register_client(data_client, None);
@@ -10122,7 +10164,7 @@ fn test_process_bar(data_engine: Rc<RefCell<DataEngine>>, data_client: DataClien
     msgbus::subscribe_bars(topic.into(), handler, None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::Bar(bar));
+    dispatch_data(&mut data_engine, Data::Bar(bar), borrowed);
     let cache = &data_engine.get_cache();
     let messages = saver.get_messages();
 
@@ -10132,7 +10174,10 @@ fn test_process_bar(data_engine: Rc<RefCell<DataEngine>>, data_client: DataClien
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_instrument_status(
+    #[case] borrowed: bool,
     audusd_sim: CurrencyPair,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
@@ -10170,7 +10215,7 @@ fn test_process_instrument_status(
     msgbus::subscribe_any(topic.into(), handler.clone(), None);
 
     let mut data_engine = data_engine.borrow_mut();
-    data_engine.process_data(Data::InstrumentStatus(status));
+    dispatch_data(&mut data_engine, Data::InstrumentStatus(status), borrowed);
     let cache = data_engine.get_cache();
     let messages = msgbus::stubs::get_saved_messages::<InstrumentStatus>(&handler);
 
@@ -10181,6 +10226,34 @@ fn test_process_instrument_status(
         cache.instrument_statuses(&audusd_sim.id),
         Some(vec![status]),
     );
+}
+
+#[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
+fn test_process_instrument_close(
+    #[case] borrowed: bool,
+    audusd_sim: CurrencyPair,
+    data_engine: Rc<RefCell<DataEngine>>,
+) {
+    let close = InstrumentClose::new(
+        audusd_sim.id,
+        Price::from("0.8000"),
+        InstrumentCloseType::EndOfSession,
+        UnixNanos::from(1),
+        UnixNanos::from(2),
+    );
+    let (handler, saver) = get_any_saving_handler::<InstrumentClose>(None);
+    let topic = switchboard::get_instrument_close_topic(close.instrument_id);
+    msgbus::subscribe_any(topic.into(), handler, None);
+
+    dispatch_data(
+        &mut data_engine.borrow_mut(),
+        Data::InstrumentClose(close),
+        borrowed,
+    );
+
+    assert_eq!(saver.get_messages(), vec![close]);
 }
 
 #[rstest]
@@ -14133,11 +14206,19 @@ fn test_subscribe_option_chain_atm_relative_requests_forward_prices(
     );
 }
 
+#[derive(Clone, Copy)]
+enum OptionGreeksDispatch {
+    DataOwned,
+    TypedAny,
+    DataBorrowed,
+}
+
 #[rstest]
-#[case::data_enum(true)]
-#[case::typed_any(false)]
+#[case::data_owned(OptionGreeksDispatch::DataOwned)]
+#[case::typed_any(OptionGreeksDispatch::TypedAny)]
+#[case::data_borrowed(OptionGreeksDispatch::DataBorrowed)]
 fn test_option_chain_deferred_bootstrap_from_greeks_keeps_bootstrap_event(
-    #[case] use_data_enum: bool,
+    #[case] dispatch: OptionGreeksDispatch,
     clock: Rc<RefCell<TestClock>>,
     cache: Rc<RefCell<Cache>>,
 ) {
@@ -14230,12 +14311,14 @@ fn test_option_chain_deferred_bootstrap_from_greeks_keeps_bootstrap_event(
         ts_init: UnixNanos::from(1u64),
     };
 
-    if use_data_enum {
-        data_engine
+    match dispatch {
+        OptionGreeksDispatch::DataOwned => data_engine
             .borrow_mut()
-            .process_data(Data::OptionGreeks(greeks));
-    } else {
-        data_engine.borrow_mut().process(&greeks);
+            .process_data(Data::OptionGreeks(greeks)),
+        OptionGreeksDispatch::TypedAny => data_engine.borrow_mut().process(&greeks),
+        OptionGreeksDispatch::DataBorrowed => data_engine
+            .borrow_mut()
+            .process_data_ref(DataRef::OptionGreeks(&greeks)),
     }
 
     let recorded = recorder.borrow();
@@ -14862,7 +14945,10 @@ fn test_custom_data_response_does_not_publish_payload_to_custom_topic(
 }
 
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_custom_data_through_any_publishes_to_custom_topic(
+    #[case] borrowed: bool,
     _stub_msgbus: Rc<RefCell<MessageBus>>,
     data_engine: Rc<RefCell<DataEngine>>,
 ) {
@@ -14883,7 +14969,7 @@ fn test_process_custom_data_through_any_publishes_to_custom_topic(
     assert_eq!(saver.get_messages(), vec![custom.clone()]);
     assert_eq!(data_engine.data_count(), 1);
 
-    data_engine.process_data(Data::Custom(custom.clone()));
+    dispatch_data(&mut data_engine, Data::Custom(custom.clone()), borrowed);
 
     assert_eq!(saver.get_messages(), vec![custom.clone(), custom]);
     assert_eq!(data_engine.data_count(), 2);
@@ -14939,7 +15025,10 @@ fn test_execute_defi_command_counters(data_engine: Rc<RefCell<DataEngine>>) {
 
 #[cfg(feature = "defi")]
 #[rstest]
+#[case::owned(false)]
+#[case::borrowed(true)]
 fn test_process_defi_data_increments_data_count(
+    #[case] borrowed: bool,
     data_engine: Rc<RefCell<DataEngine>>,
     data_client: DataClientAdapter,
 ) {
@@ -14959,7 +15048,11 @@ fn test_process_defi_data_increments_data_count(
 
     let mut data_engine = data_engine.borrow_mut();
     assert_eq!(data_engine.data_count(), 0);
-    data_engine.process_defi_data(DefiData::Block(block));
+    dispatch_data(
+        &mut data_engine,
+        Data::Defi(Box::new(DefiData::Block(block))),
+        borrowed,
+    );
     assert_eq!(data_engine.data_count(), 1);
 }
 

--- a/crates/model/src/data/mod.rs
+++ b/crates/model/src/data/mod.rs
@@ -120,6 +120,48 @@ pub enum Data {
     Defi(Box<DefiData>), // This variant is significantly larger
 }
 
+/// A borrowed view of a built-in Nautilus data type.
+#[derive(Clone, Copy, Debug)]
+pub enum DataRef<'a> {
+    Delta(&'a OrderBookDelta),
+    Deltas(&'a OrderBookDeltas),
+    Depth10(&'a OrderBookDepth10),
+    Quote(&'a QuoteTick),
+    Trade(&'a TradeTick),
+    Bar(&'a Bar),
+    MarkPrice(&'a MarkPriceUpdate),
+    IndexPrice(&'a IndexPriceUpdate),
+    FundingRate(&'a FundingRateUpdate),
+    OptionGreeks(&'a OptionGreeks),
+    InstrumentStatus(&'a InstrumentStatus),
+    InstrumentClose(&'a InstrumentClose),
+    Custom(&'a CustomData),
+    #[cfg(feature = "defi")]
+    Defi(&'a DefiData),
+}
+
+impl<'a> From<&'a Data> for DataRef<'a> {
+    fn from(value: &'a Data) -> Self {
+        match value {
+            Data::Delta(delta) => Self::Delta(delta),
+            Data::Deltas(deltas) => Self::Deltas(deltas),
+            Data::Depth10(depth) => Self::Depth10(depth),
+            Data::Quote(quote) => Self::Quote(quote),
+            Data::Trade(trade) => Self::Trade(trade),
+            Data::Bar(bar) => Self::Bar(bar),
+            Data::MarkPrice(mark_price) => Self::MarkPrice(mark_price),
+            Data::IndexPrice(index_price) => Self::IndexPrice(index_price),
+            Data::FundingRate(funding_rate) => Self::FundingRate(funding_rate),
+            Data::OptionGreeks(greeks) => Self::OptionGreeks(greeks),
+            Data::InstrumentStatus(status) => Self::InstrumentStatus(status),
+            Data::InstrumentClose(close) => Self::InstrumentClose(close),
+            Data::Custom(custom) => Self::Custom(custom),
+            #[cfg(feature = "defi")]
+            Data::Defi(defi) => Self::Defi(defi),
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for Data {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -318,6 +360,20 @@ impl Data {
     /// Returns the instrument ID for the data.
     #[must_use]
     pub fn instrument_id(&self) -> InstrumentId {
+        DataRef::from(self).instrument_id()
+    }
+
+    /// Returns whether the data is a type of order book data.
+    #[must_use]
+    pub fn is_order_book_data(&self) -> bool {
+        matches!(self, Self::Delta(_) | Self::Deltas(_) | Self::Depth10(_))
+    }
+}
+
+impl DataRef<'_> {
+    /// Returns the instrument ID for the data.
+    #[must_use]
+    pub fn instrument_id(&self) -> InstrumentId {
         match self {
             Self::Delta(delta) => delta.instrument_id,
             Self::Deltas(deltas) => deltas.instrument_id,
@@ -346,12 +402,6 @@ impl Data {
             #[cfg(feature = "defi")]
             Self::Defi(defi) => defi.instrument_id(),
         }
-    }
-
-    /// Returns whether the data is a type of order book data.
-    #[must_use]
-    pub fn is_order_book_data(&self) -> bool {
-        matches!(self, Self::Delta(_) | Self::Deltas(_) | Self::Depth10(_))
     }
 }
 
@@ -408,6 +458,12 @@ use crate::instruments::InstrumentAny;
 impl_catalog_path_prefix!(InstrumentAny, "instruments");
 
 impl HasTsInit for Data {
+    fn ts_init(&self) -> UnixNanos {
+        DataRef::from(self).ts_init()
+    }
+}
+
+impl HasTsInit for DataRef<'_> {
     fn ts_init(&self) -> UnixNanos {
         match self {
             Self::Delta(d) => d.ts_init,
@@ -993,6 +1049,18 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    #[cfg(feature = "defi")]
+    use crate::defi::{
+        data::block::BlockPosition,
+        pool_analysis::snapshot::{PoolAnalytics, PoolSnapshot, PoolState},
+    };
+    use crate::{
+        data::stubs::{
+            stub_bar, stub_custom_data, stub_delta, stub_deltas, stub_depth10,
+            stub_instrument_close, stub_instrument_status, stub_trade_ethusdt_buy,
+        },
+        types::Price,
+    };
 
     fn params_from_json(value: serde_json::Value) -> Params {
         serde_json::from_value(value).expect("valid Params JSON")
@@ -1002,6 +1070,129 @@ mod tests {
         let mut hasher = DefaultHasher::new();
         data_type.hash(&mut hasher);
         hasher.finish()
+    }
+
+    #[rstest]
+    fn test_data_ref_maps_every_data_variant_without_copying_payloads() {
+        let instrument_id = InstrumentId::from("ETHUSDT-PERP.BINANCE");
+        let data = vec![
+            Data::Delta(stub_delta()),
+            Data::Deltas(Box::new(stub_deltas())),
+            Data::Depth10(Box::new(stub_depth10())),
+            Data::Quote(QuoteTick::default()),
+            Data::Trade(stub_trade_ethusdt_buy()),
+            Data::Bar(stub_bar()),
+            Data::MarkPrice(MarkPriceUpdate::new(
+                instrument_id,
+                Price::from("100.10"),
+                UnixNanos::from(7),
+                UnixNanos::from(8),
+            )),
+            Data::IndexPrice(IndexPriceUpdate::new(
+                instrument_id,
+                Price::from("100.20"),
+                UnixNanos::from(9),
+                UnixNanos::from(10),
+            )),
+            Data::FundingRate(FundingRateUpdate::new(
+                instrument_id,
+                "0.0001".parse().unwrap(),
+                Some(480),
+                Some(UnixNanos::from(12)),
+                UnixNanos::from(11),
+                UnixNanos::from(12),
+            )),
+            Data::OptionGreeks(OptionGreeks {
+                instrument_id,
+                ts_event: UnixNanos::from(13),
+                ts_init: UnixNanos::from(14),
+                ..OptionGreeks::default()
+            }),
+            Data::InstrumentStatus(stub_instrument_status()),
+            Data::InstrumentClose(stub_instrument_close()),
+            Data::Custom(stub_custom_data(
+                15,
+                42,
+                None,
+                Some("CUSTOM.SIM".to_string()),
+            )),
+        ];
+
+        for data in &data {
+            let data_ref = DataRef::from(data);
+
+            assert_eq!(data_ref.instrument_id(), data.instrument_id());
+            assert_eq!(data_ref.ts_init(), data.ts_init());
+
+            match (data, data_ref) {
+                (Data::Delta(expected), DataRef::Delta(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::Deltas(expected), DataRef::Deltas(actual)) => {
+                    assert!(std::ptr::eq(expected.as_ref(), actual));
+                }
+                (Data::Depth10(expected), DataRef::Depth10(actual)) => {
+                    assert!(std::ptr::eq(expected.as_ref(), actual));
+                }
+                (Data::Quote(expected), DataRef::Quote(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::Trade(expected), DataRef::Trade(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::Bar(expected), DataRef::Bar(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::MarkPrice(expected), DataRef::MarkPrice(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::IndexPrice(expected), DataRef::IndexPrice(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::FundingRate(expected), DataRef::FundingRate(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::OptionGreeks(expected), DataRef::OptionGreeks(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::InstrumentStatus(expected), DataRef::InstrumentStatus(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::InstrumentClose(expected), DataRef::InstrumentClose(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                (Data::Custom(expected), DataRef::Custom(actual)) => {
+                    assert!(std::ptr::eq(expected, actual));
+                }
+                _ => panic!("DataRef variant did not match its Data source"),
+            }
+        }
+    }
+
+    #[cfg(feature = "defi")]
+    #[rstest]
+    fn test_data_ref_maps_defi_without_copying_payload() {
+        let instrument_id = InstrumentId::from("ETH/USDC.UNISWAPV3");
+        let snapshot = PoolSnapshot::new(
+            instrument_id,
+            PoolState::default(),
+            Vec::new(),
+            Vec::new(),
+            PoolAnalytics::default(),
+            BlockPosition::new(7, "0x123".to_string(), 2, 3),
+            UnixNanos::from(16),
+            UnixNanos::from(17),
+        );
+        let data = Data::Defi(Box::new(DefiData::PoolSnapshot(snapshot)));
+        let data_ref = DataRef::from(&data);
+
+        assert_eq!(data_ref.instrument_id(), data.instrument_id());
+        assert_eq!(data_ref.ts_init(), data.ts_init());
+
+        let (Data::Defi(expected), DataRef::Defi(actual)) = (&data, data_ref) else {
+            panic!("DataRef variant did not match its Data source");
+        };
+        assert!(std::ptr::eq(expected.as_ref(), actual));
     }
 
     #[rstest]


### PR DESCRIPTION
**NautilusTrader prioritizes correctness and reliability; this change follows the established validation and testing patterns.**

- [x] I have reviewed the `CONTRIBUTING.md` and followed the established practices.

## Summary

Adds `DataRef<'a>`, a borrowed view over built-in `Data` variants, and introduces
`DataEngine::process_data_ref` for dispatching borrowed payloads. Backtest exchange routing now uses
the borrowed view while owned dispatch remains available at handler boundaries that consume data.

This is the first of three pull requests implementing the typed data transport work tracked in
[#4854](https://github.com/nautechsystems/nautilus_trader/issues/4854).

```mermaid
flowchart LR
    Data["Owned Data"] --> View["DataRef borrowed view"]
    View --> Exchange["Backtest exchange routing"]
    View --> Borrowed["DataEngine borrowed dispatch"]
    Data --> Owned["Owned consuming handlers"]
```

Dispatch flow: callers can borrow built-in data for routing while retaining ownership where a
handler consumes the payload.

## Related Issues/PRs

Related to #4854.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Design

- Mirror every built-in `Data` variant in `DataRef<'a>` and convert `&Data` without copying its
  payload.
- Delegate `instrument_id` and `ts_init` access through the borrowed representation.
- Add borrowed data-engine dispatch while preserving owned handling for `OrderBookDeltas` and DeFi
  payloads at consuming boundaries.
- Route backtest exchange data through `DataRef` before passing the owned value to the data engine.
- Cover owned and borrowed dispatch paths for market data, status, close, option Greeks, custom,
  and feature-gated DeFi variants.

## Breaking change details

None. Existing owned `Data` dispatch remains available.

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`).

No user-facing documentation changes are required for this internal dispatch foundation.

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable).

No release-note entry is included; maintainers manage `RELEASES.md`.

## Testing

- [ ] Affected code paths are already covered by the test suite.
- [x] I added/updated tests to cover new or changed logic.

The model tests verify that every `DataRef` variant borrows the original payload. Data-engine tests
exercise equivalent owned and borrowed dispatch across the affected variants.
