### PR TITLE
Document installing the execution event sender at create

### DIFF
--- a/crates/common/src/live/runner.rs
+++ b/crates/common/src/live/runner.rs
@@ -21,7 +21,7 @@ use std::cell::RefCell;
 
 use crate::messages::{DataEvent, ExecutionEvent, SystemCommand, SystemEvent};
 
-/// Gets the global data event sender.
+/// Gets the thread-local data event sender.
 ///
 /// # Panics
 ///
@@ -37,7 +37,7 @@ pub fn get_data_event_sender() -> tokio::sync::mpsc::UnboundedSender<DataEvent> 
     })
 }
 
-/// Attempts to get the global data event sender without panicking.
+/// Attempts to get the thread-local data event sender without panicking.
 ///
 /// Returns `None` if the sender is not initialized (e.g., in Python/v1 bridge environments
 /// before a runner or adapter bridge has registered a sender).
@@ -46,7 +46,7 @@ pub fn try_get_data_event_sender() -> Option<tokio::sync::mpsc::UnboundedSender<
     DATA_EVENT_SENDER.with(|sender| sender.borrow().as_ref().cloned())
 }
 
-/// Sets the global data event sender.
+/// Sets the thread-local data event sender.
 ///
 /// Can only be called once per thread.
 ///
@@ -61,14 +61,14 @@ pub fn set_data_event_sender(sender: tokio::sync::mpsc::UnboundedSender<DataEven
     });
 }
 
-/// Replaces the global data event sender for the current thread.
+/// Replaces the data event sender for the current thread.
 pub fn replace_data_event_sender(sender: tokio::sync::mpsc::UnboundedSender<DataEvent>) {
     DATA_EVENT_SENDER.with(|s| {
         *s.borrow_mut() = Some(sender);
     });
 }
 
-/// Gets the global system event sender.
+/// Gets the thread-local system event sender.
 ///
 /// # Panics
 ///
@@ -84,7 +84,7 @@ pub fn get_system_event_sender() -> tokio::sync::mpsc::UnboundedSender<SystemEve
     })
 }
 
-/// Attempts to get the global system event sender without panicking.
+/// Attempts to get the thread-local system event sender without panicking.
 ///
 /// Returns `None` if the sender is not initialized (e.g., in test environments).
 #[must_use]
@@ -92,7 +92,7 @@ pub fn try_get_system_event_sender() -> Option<tokio::sync::mpsc::UnboundedSende
     SYSTEM_EVENT_SENDER.with(|sender| sender.borrow().as_ref().cloned())
 }
 
-/// Sets the global system event sender.
+/// Sets the thread-local system event sender.
 ///
 /// Can only be called once per thread.
 ///
@@ -107,14 +107,14 @@ pub fn set_system_event_sender(sender: tokio::sync::mpsc::UnboundedSender<System
     });
 }
 
-/// Replaces the global system event sender for the current thread.
+/// Replaces the system event sender for the current thread.
 pub fn replace_system_event_sender(sender: tokio::sync::mpsc::UnboundedSender<SystemEvent>) {
     SYSTEM_EVENT_SENDER.with(|s| {
         *s.borrow_mut() = Some(sender);
     });
 }
 
-/// Gets the global system command sender.
+/// Gets the thread-local system command sender.
 ///
 /// # Panics
 ///
@@ -130,7 +130,7 @@ pub fn get_system_command_sender() -> tokio::sync::mpsc::UnboundedSender<SystemC
     })
 }
 
-/// Attempts to get the global system command sender without panicking.
+/// Attempts to get the thread-local system command sender without panicking.
 ///
 /// Returns `None` if the sender is not initialized.
 #[must_use]
@@ -139,7 +139,7 @@ pub fn try_get_system_command_sender() -> Option<tokio::sync::mpsc::UnboundedSen
     SYSTEM_COMMAND_SENDER.with(|sender| sender.borrow().as_ref().cloned())
 }
 
-/// Sets the global system command sender.
+/// Sets the thread-local system command sender.
 ///
 /// Can only be called once per thread.
 ///
@@ -154,14 +154,14 @@ pub fn set_system_command_sender(sender: tokio::sync::mpsc::UnboundedSender<Syst
     });
 }
 
-/// Replaces the global system command sender for the current thread.
+/// Replaces the system command sender for the current thread.
 pub fn replace_system_command_sender(sender: tokio::sync::mpsc::UnboundedSender<SystemCommand>) {
     SYSTEM_COMMAND_SENDER.with(|s| {
         *s.borrow_mut() = Some(sender);
     });
 }
 
-/// Gets the global execution event sender.
+/// Gets the thread-local execution event sender.
 ///
 /// # Panics
 ///
@@ -177,7 +177,7 @@ pub fn get_exec_event_sender() -> tokio::sync::mpsc::UnboundedSender<ExecutionEv
     })
 }
 
-/// Attempts to get the global execution event sender without panicking.
+/// Attempts to get the thread-local execution event sender without panicking.
 ///
 /// Returns `None` if the sender is not initialized (e.g., in test environments).
 #[must_use]
@@ -185,7 +185,7 @@ pub fn try_get_exec_event_sender() -> Option<tokio::sync::mpsc::UnboundedSender<
     EXEC_EVENT_SENDER.with(|sender| sender.borrow().as_ref().cloned())
 }
 
-/// Sets the global execution event sender.
+/// Sets the thread-local execution event sender.
 ///
 /// Can only be called once per thread.
 ///
@@ -203,7 +203,7 @@ pub fn set_exec_event_sender(sender: tokio::sync::mpsc::UnboundedSender<Executio
     });
 }
 
-/// Replaces the global execution event sender for the current thread.
+/// Replaces the execution event sender for the current thread.
 pub fn replace_exec_event_sender(sender: tokio::sync::mpsc::UnboundedSender<ExecutionEvent>) {
     EXEC_EVENT_SENDER.with(|s| {
         *s.borrow_mut() = Some(sender);

--- a/crates/live/src/execution/emitter.rs
+++ b/crates/live/src/execution/emitter.rs
@@ -26,7 +26,7 @@
 //! |-- core: ExecutionClientCore    (identity + connection state)
 //! `-- emitter: ExecutionEventEmitter   (event generation + async dispatch)
 //!     |-- factory: OrderEventFactory
-//!     `-- sender: ArcSwapOption<Sender>   (set in start())
+//!     `-- sender: ArcSwapOption<Sender>   (installed in the factory's create())
 //! ```
 
 use std::sync::Arc;
@@ -58,7 +58,8 @@ use nautilus_model::{
 /// channel sender for async dispatch. It provides `emit_*` convenience methods that
 /// generate and send events in a single call.
 ///
-/// The sender is set during the adapter's `start()` phase via [`set_sender`](Self::set_sender).
+/// The sender is installed via [`set_sender`](Self::set_sender) in the execution client
+/// factory's `create`, resolved there with `try_get_exec_event_sender`.
 /// Clones share the sender slot and observe later sender installations and replacements.
 #[derive(Debug, Clone)]
 pub struct ExecutionEventEmitter {
@@ -70,7 +71,8 @@ pub struct ExecutionEventEmitter {
 impl ExecutionEventEmitter {
     /// Creates a new [`ExecutionEventEmitter`] with no sender.
     ///
-    /// Call [`set_sender`](Self::set_sender) in the adapter's `start()` method.
+    /// Call [`set_sender`](Self::set_sender) in the factory's `create`, before returning the
+    /// client.
     #[must_use]
     pub fn new(
         clock: &'static AtomicTime,
@@ -92,7 +94,11 @@ impl ExecutionEventEmitter {
 
     /// Installs or replaces the sender for this emitter and all its clones.
     ///
-    /// Call in the adapter's `start()` method.
+    /// Call in the execution client factory's `create`. `LiveNodeBuilder` binds the runner's
+    /// senders before it calls any factory, so `try_get_exec_event_sender` resolves there and
+    /// every clone taken during construction carries the result. Installing only in the client's
+    /// `start` is sufficient when `LiveNode` drives the lifecycle, and leaves the emitter
+    /// uninitialized for a client constructed where those senders are not bound.
     pub fn set_sender(&mut self, sender: tokio::sync::mpsc::UnboundedSender<ExecutionEvent>) {
         self.sender.store(Some(Arc::new(sender)));
     }

--- a/crates/live/src/execution/emitter.rs
+++ b/crates/live/src/execution/emitter.rs
@@ -26,7 +26,7 @@
 //! |-- core: ExecutionClientCore    (identity + connection state)
 //! `-- emitter: ExecutionEventEmitter   (event generation + async dispatch)
 //!     |-- factory: OrderEventFactory
-//!     `-- sender: ArcSwapOption<Sender>   (installed in the factory's create())
+//!     `-- sender: ArcSwapOption<Sender>   (shared slot, installed at create() and start())
 //! ```
 
 use std::sync::Arc;
@@ -58,8 +58,8 @@ use nautilus_model::{
 /// channel sender for async dispatch. It provides `emit_*` convenience methods that
 /// generate and send events in a single call.
 ///
-/// The sender is installed via [`set_sender`](Self::set_sender) in the execution client
-/// factory's `create`, resolved there with `try_get_exec_event_sender`.
+/// The sender is installed via [`set_sender`](Self::set_sender) in the client's `start`, and in the
+/// execution client factory's `create` when the calling thread has one.
 /// Clones share the sender slot and observe later sender installations and replacements.
 #[derive(Debug, Clone)]
 pub struct ExecutionEventEmitter {
@@ -71,8 +71,8 @@ pub struct ExecutionEventEmitter {
 impl ExecutionEventEmitter {
     /// Creates a new [`ExecutionEventEmitter`] with no sender.
     ///
-    /// Call [`set_sender`](Self::set_sender) in the factory's `create`, before returning the
-    /// client.
+    /// Call [`set_sender`](Self::set_sender) in the client's `start`, and in the factory's `create`
+    /// when `try_get_exec_event_sender` returns `Some`.
     #[must_use]
     pub fn new(
         clock: &'static AtomicTime,
@@ -94,11 +94,15 @@ impl ExecutionEventEmitter {
 
     /// Installs or replaces the sender for this emitter and all its clones.
     ///
-    /// Call in the execution client factory's `create`. `LiveNodeBuilder` binds the runner's
-    /// senders before it calls any factory, so `try_get_exec_event_sender` resolves there and
-    /// every clone taken during construction carries the result. Installing only in the client's
-    /// `start` is sufficient when `LiveNode` drives the lifecycle, and leaves the emitter
-    /// uninitialized for a client constructed where those senders are not bound.
+    /// The slot is shared, so a clone taken before this call observes the sender it installs.
+    /// Events emitted before any install are dropped with a warning.
+    ///
+    /// Call in the client's `start`, resolved from `get_exec_event_sender`: `LiveNode` rebinds the
+    /// runner's senders on the calling thread before it starts clients, so the `start` install is
+    /// the authoritative one. Call it in the execution client factory's `create` as well when
+    /// `try_get_exec_event_sender` returns `Some`; `None` there means the calling thread has no
+    /// bound senders and is not a construction failure. See the adapter guide for hosts that drive
+    /// a client outside `LiveNode`.
     pub fn set_sender(&mut self, sender: tokio::sync::mpsc::UnboundedSender<ExecutionEvent>) {
         self.sender.store(Some(Arc::new(sender)));
     }

--- a/docs/developer_guide/adapters.md
+++ b/docs/developer_guide/adapters.md
@@ -714,8 +714,16 @@ connection failure, clean up resources already started and leave state consisten
 disposal.
 
 When an execution client uses
-[`ExecutionEventEmitter`](../../crates/live/src/execution/emitter.rs), install its sender during
-`start` before any task can emit.
+[`ExecutionEventEmitter`](../../crates/live/src/execution/emitter.rs), resolve the execution event
+sender with `try_get_exec_event_sender` and install it in the factory's `create`, before the client
+is returned. `LiveNodeBuilder` binds the runner's senders to thread-local storage before it calls
+any registered factory, so `create` runs with the sender available, and the emitter shares one
+sender slot across its clones, so every clone taken during construction, including those handed to
+client-owned tasks, carries the installed sender. `start` may install the sender again; installing
+it only in `start` is sufficient when `LiveNode` drives the client's lifecycle. A host that calls a
+factory outside `LiveNodeBuilder` must bind the runner's senders on the calling thread before
+`create`, or pass the sender through its own factory or client constructor, and in either case
+install it before any event-producing work starts.
 
 #### Bootstrap ordering
 

--- a/docs/developer_guide/adapters.md
+++ b/docs/developer_guide/adapters.md
@@ -717,13 +717,20 @@ When an execution client uses
 [`ExecutionEventEmitter`](../../crates/live/src/execution/emitter.rs), resolve the execution event
 sender with `try_get_exec_event_sender` and install it in the factory's `create`, before the client
 is returned. `LiveNodeBuilder` binds the runner's senders to thread-local storage before it calls
-any registered factory, so `create` runs with the sender available, and the emitter shares one
-sender slot across its clones, so every clone taken during construction, including those handed to
-client-owned tasks, carries the installed sender. `start` may install the sender again; installing
-it only in `start` is sufficient when `LiveNode` drives the client's lifecycle. A host that calls a
-factory outside `LiveNodeBuilder` must bind the runner's senders on the calling thread before
-`create`, or pass the sender through its own factory or client constructor, and in either case
-install it before any event-producing work starts.
+any registered factory, so `create` runs with the sender available. `None` from
+`try_get_exec_event_sender` means the calling thread has no bound senders, which is expected in a
+factory unit test or in a host that binds later; it is not a construction failure. Install the
+sender in `start` as well, from `get_exec_event_sender`, and do so unconditionally: `LiveNode`
+rebinds the runner's senders on the calling thread before it starts clients, so the `start` install
+is the authoritative one, and the emitter shares one sender slot across its clones, so it reaches
+every clone taken during construction, including those handed to client-owned tasks. A host that
+calls a factory outside `LiveNodeBuilder` binds the runner's senders on the client's thread before
+`start`: the `start` install resolves through `get_exec_event_sender`, which reads only the
+thread-local slot and panics when nothing has bound it, so a sender passed through the host's own
+factory or client constructor - which reaches the emitter's shared slot via `set_sender` but not
+the thread-local slot - does not satisfy that lookup on its own. Constructor injection stands
+alone only for a client whose `start` accepts an already-installed sender instead of performing
+the unconditional lookup; the emitter-backed execution clients in this repository all perform it.
 
 #### Bootstrap ordering
 


### PR DESCRIPTION
A follow-up to the emitter sender sharing in #4874.

## The guide ties event routing to the lifecycle thread

`docs/developer_guide/adapters.md` tells an execution client using `ExecutionEventEmitter` to install its sender during `start`. The sender comes from `get_exec_event_sender`, which reads a `thread_local!` slot in `nautilus_common::live::runner`, so the instruction binds correct event routing to whichever thread runs `start`; a host arrangement where that is not the runner's thread leaves the emitter without a sender, and `send_order_event` warns and drops.

`LiveNodeBuilder::build` calls `bind_senders` on the runner before invoking any registered `ExecutionClientFactory::create`, on the same thread, so a factory can resolve the sender with `try_get_exec_event_sender` and install it before returning the client. After #4874 the emitter's clones share that slot, so every clone taken during construction carries the sender. The paragraph now says this, keeps `start`-time installation as sufficient when `LiveNode` drives the lifecycle, and states what a host calling a factory outside the builder must arrange before `create`.

## The sender accessors are not global

The `get_*`, `try_get_*`, and `set_*` doc comments on the four sender families in `crates/common/src/live/runner.rs` describe a "global" sender. The backing store is `thread_local!`, and the module's own doc says so. The comments now say thread-local.

No code changes.
