### PR TITLE
Apply hedging flip remainders to the flipped position

### DIFF
--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -3241,7 +3241,13 @@ impl ExecutionEngine {
             && let Some(fill_position_id) = fill.position_id
             && cached_position_id != fill_position_id
         {
-            if oms_type == OmsType::Hedging {
+            // A flip re-indexes the order to a newly minted virtual position ID while
+            // later fills of that order still carry the ID the order holds.
+            let flip_remainder = order.and_then(OrderAny::position_id) == Some(fill_position_id)
+                && fill_position_id.is_virtual()
+                && cached_position_id.is_virtual();
+
+            if oms_type == OmsType::Hedging && !flip_remainder {
                 log::error!(
                     "Cannot apply hedging fill {} for {}: venue position ID {fill_position_id} conflicts with cached position ID {cached_position_id}",
                     fill.trade_id,

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -3241,27 +3241,23 @@ impl ExecutionEngine {
             && let Some(fill_position_id) = fill.position_id
             && cached_position_id != fill_position_id
         {
-            // A flip re-indexes the order to a newly minted virtual position ID while
-            // later fills of that order still carry the ID the order holds.
-            let flip_remainder = order.and_then(OrderAny::position_id) == Some(fill_position_id)
-                && fill_position_id.is_virtual()
-                && cached_position_id.is_virtual();
+            if oms_type == OmsType::Hedging {
+                if !self.is_flip_remainder(fill, cached_position_id, fill_position_id) {
+                    log::error!(
+                        "Cannot apply hedging fill {} for {}: venue position ID {fill_position_id} conflicts with cached position ID {cached_position_id}",
+                        fill.trade_id,
+                        fill.client_order_id(),
+                    );
 
-            if oms_type == OmsType::Hedging && !flip_remainder {
-                log::error!(
-                    "Cannot apply hedging fill {} for {}: venue position ID {fill_position_id} conflicts with cached position ID {cached_position_id}",
-                    fill.trade_id,
-                    fill.client_order_id(),
+                    return None;
+                }
+            } else {
+                log::warn!(
+                    "Incorrect position ID assigned to fill: \
+                     cached={cached_position_id}, assigned={fill_position_id}; \
+                     re-assigning from cache",
                 );
-
-                return None;
             }
-
-            log::warn!(
-                "Incorrect position ID assigned to fill: \
-                 cached={cached_position_id}, assigned={fill_position_id}; \
-                 re-assigning from cache",
-            );
         }
 
         if let Some(position_id) = cached_position_id {
@@ -3363,6 +3359,43 @@ impl ExecutionEngine {
         }
 
         true
+    }
+
+    /// Returns whether `fill` is a later fill of an order this engine already flipped.
+    ///
+    /// Flipping under `Hedging` closes the original virtual position with the reversing order
+    /// and opens a newly minted virtual position from the same order, moving the order's cache
+    /// index onto the new ID. Every later fill of that order still carries the original ID, so
+    /// the venue ID and the cached ID disagree for the rest of the order's life.
+    ///
+    /// The split is recognized from the two positions rather than from the order, because
+    /// applying a fill writes the determined ID onto the order and would erase the evidence for
+    /// the fill after it. Both halves must still name this order: the cached position was opened
+    /// by it, and the position the fill names was closed by it.
+    fn is_flip_remainder(
+        &self,
+        fill: &OrderFilled,
+        cached_position_id: PositionId,
+        fill_position_id: PositionId,
+    ) -> bool {
+        if !cached_position_id.is_virtual() || !fill_position_id.is_virtual() {
+            return false;
+        }
+
+        let cache = self.cache.borrow();
+        let client_order_id = fill.client_order_id();
+
+        let opened_by_order = cache
+            .position_ref(&cached_position_id)
+            .is_some_and(|flipped| flipped.opening_order_id == client_order_id);
+
+        let closed_by_order = cache
+            .position_ref(&fill_position_id)
+            .is_some_and(|original| {
+                original.is_closed() && original.closing_order_id == Some(client_order_id)
+            });
+
+        opened_by_order && closed_by_order
     }
 
     fn determine_hedging_position_id(
@@ -4244,15 +4277,18 @@ impl ExecutionEngine {
                     position.id
                 );
             }
-            // Snapshot closed position if reopening (NETTING mode)
-            self.snapshot_position(position)?;
         } else {
             // HEDGING mode
             log::warn!(
-                "Received fill for closed position {} in HEDGING mode; creating new position and ignoring previous state",
+                "Received fill for closed position {} in HEDGING mode; archiving closed cycle and creating new position",
                 position.id
             );
         }
+
+        // Snapshot the closed cycle before its ID is reused: `add_position` replaces the
+        // cached position, and realized PnL totals read closed cycles from the snapshots
+        self.snapshot_position(position)?;
+
         Ok(())
     }
 

--- a/crates/execution/tests/integration/exec_engine.rs
+++ b/crates/execution/tests/integration/exec_engine.rs
@@ -13122,6 +13122,148 @@ fn test_own_book_status_integrity_during_transitions() {
     }
 }
 
+#[rstest]
+fn test_hedging_flip_applies_remainder_to_flipped_position(mut execution_engine: ExecutionEngine) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+
+    let stub_client = StubExecutionClient::new(
+        ClientId::from("STUB"),
+        AccountId::test_default(),
+        Venue::test_default(),
+        OmsType::Hedging,
+        None,
+    );
+    execution_engine
+        .register_client(Box::new(stub_client))
+        .unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_account(CashAccount::default().into())
+        .unwrap();
+
+    let position_id = PositionId::from("P-19700101-000000-000-001-1");
+    let opening_order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-1"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(
+            opening_order.clone(),
+            None,
+            Some(ClientId::from("STUB")),
+            true,
+        )
+        .unwrap();
+    execution_engine.process(&TestOrderEventStubs::submitted(
+        &opening_order,
+        AccountId::test_default(),
+    ));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &opening_order,
+        AccountId::test_default(),
+        VenueOrderId::from("V-1"),
+    ));
+    execution_engine.process(&TestOrderEventStubs::filled(
+        &opening_order,
+        &instrument.clone().into(),
+        Some(TradeId::new("T-OPEN")),
+        Some(position_id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(AccountId::test_default()),
+    ));
+
+    let reversal_order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-FLIP"))
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(200_000))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(
+            reversal_order.clone(),
+            None,
+            Some(ClientId::from("STUB")),
+            true,
+        )
+        .unwrap();
+    execution_engine.process(&TestOrderEventStubs::submitted(
+        &reversal_order,
+        AccountId::test_default(),
+    ));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &reversal_order,
+        AccountId::test_default(),
+        VenueOrderId::from("V-FLIP"),
+    ));
+    execution_engine.process(&TestOrderEventStubs::filled(
+        &reversal_order,
+        &instrument.clone().into(),
+        Some(TradeId::new("T-FLIP")),
+        Some(position_id),
+        None,
+        Some(Quantity::from(150_000)),
+        None,
+        None,
+        None,
+        Some(AccountId::test_default()),
+    ));
+
+    let partially_filled_order = cached_order_or(&execution_engine, &reversal_order);
+    let remainder_trade_id = TradeId::new("T-REMAINDER");
+    execution_engine.process(&TestOrderEventStubs::filled(
+        &partially_filled_order,
+        &instrument.into(),
+        Some(remainder_trade_id),
+        Some(position_id),
+        None,
+        Some(Quantity::from(50_000)),
+        None,
+        None,
+        None,
+        Some(AccountId::test_default()),
+    ));
+
+    let cache = execution_engine.cache().borrow();
+    let filled_order = cache.order(&reversal_order.client_order_id()).unwrap();
+    assert_eq!(filled_order.filled_qty(), Quantity::from(200_000));
+
+    let original = cache.position(&position_id).unwrap();
+    assert!(original.is_closed());
+
+    let positions = cache.positions_open(None, None, None, None, None);
+    assert_eq!(positions.len(), 1);
+    assert_ne!(positions[0].id, position_id);
+    assert_eq!(positions[0].side, PositionSide::Short);
+    assert_eq!(positions[0].quantity, Quantity::from(100_000));
+    assert!(positions[0].trade_ids.contains(&remainder_trade_id));
+}
+
 fn setup_netting_snapshot_engine(
     execution_engine: &mut ExecutionEngine,
     instrument: &CurrencyPair,

--- a/crates/execution/tests/integration/exec_engine.rs
+++ b/crates/execution/tests/integration/exec_engine.rs
@@ -13123,7 +13123,7 @@ fn test_own_book_status_integrity_during_transitions() {
 }
 
 #[rstest]
-fn test_hedging_flip_applies_remainder_to_flipped_position(mut execution_engine: ExecutionEngine) {
+fn test_hedging_flip_applies_remainders_to_flipped_position(mut execution_engine: ExecutionEngine) {
     let trader_id = TraderId::test_default();
     let strategy_id = StrategyId::test_default();
     let instrument = audusd_sim();
@@ -13185,10 +13185,10 @@ fn test_hedging_flip_applies_remainder_to_flipped_position(mut execution_engine:
         &instrument.clone().into(),
         Some(TradeId::new("T-OPEN")),
         Some(position_id),
+        Some(Price::from("1.00000")),
         None,
         None,
-        None,
-        None,
+        Some(Money::from("0 USD")),
         None,
         Some(AccountId::test_default()),
     ));
@@ -13226,28 +13226,35 @@ fn test_hedging_flip_applies_remainder_to_flipped_position(mut execution_engine:
         &instrument.clone().into(),
         Some(TradeId::new("T-FLIP")),
         Some(position_id),
-        None,
+        Some(Price::from("1.00010")),
         Some(Quantity::from(150_000)),
         None,
-        None,
+        Some(Money::from("0 USD")),
         None,
         Some(AccountId::test_default()),
     ));
 
-    let partially_filled_order = cached_order_or(&execution_engine, &reversal_order);
-    let remainder_trade_id = TradeId::new("T-REMAINDER");
-    execution_engine.process(&TestOrderEventStubs::filled(
-        &partially_filled_order,
-        &instrument.into(),
-        Some(remainder_trade_id),
-        Some(position_id),
-        None,
-        Some(Quantity::from(50_000)),
-        None,
-        None,
-        None,
-        Some(AccountId::test_default()),
-    ));
+    // Two remainders, not one: applying the first writes the cached flipped ID onto the
+    // order, so a predicate reading the order's own position ID accepts this one and
+    // rejects the next.
+    let first_remainder_trade_id = TradeId::new("T-REMAINDER-1");
+    let second_remainder_trade_id = TradeId::new("T-REMAINDER-2");
+
+    for trade_id in [first_remainder_trade_id, second_remainder_trade_id] {
+        let partially_filled_order = cached_order_or(&execution_engine, &reversal_order);
+        execution_engine.process(&TestOrderEventStubs::filled(
+            &partially_filled_order,
+            &instrument.clone().into(),
+            Some(trade_id),
+            Some(position_id),
+            None,
+            Some(Quantity::from(25_000)),
+            None,
+            None,
+            None,
+            Some(AccountId::test_default()),
+        ));
+    }
 
     let cache = execution_engine.cache().borrow();
     let filled_order = cache.order(&reversal_order.client_order_id()).unwrap();
@@ -13261,7 +13268,209 @@ fn test_hedging_flip_applies_remainder_to_flipped_position(mut execution_engine:
     assert_ne!(positions[0].id, position_id);
     assert_eq!(positions[0].side, PositionSide::Short);
     assert_eq!(positions[0].quantity, Quantity::from(100_000));
-    assert!(positions[0].trade_ids.contains(&remainder_trade_id));
+    assert!(positions[0].trade_ids.contains(&first_remainder_trade_id));
+    assert!(positions[0].trade_ids.contains(&second_remainder_trade_id));
+}
+
+#[rstest]
+fn test_hedging_flip_remainder_reopens_a_closed_flipped_position(
+    mut execution_engine: ExecutionEngine,
+) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+
+    let stub_client = StubExecutionClient::new(
+        ClientId::from("STUB"),
+        AccountId::test_default(),
+        Venue::test_default(),
+        OmsType::Hedging,
+        None,
+    );
+    execution_engine
+        .register_client(Box::new(stub_client))
+        .unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_account(CashAccount::default().into())
+        .unwrap();
+
+    let position_id = PositionId::from("P-19700101-000000-000-001-1");
+    let opening_order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-1"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(
+            opening_order.clone(),
+            None,
+            Some(ClientId::from("STUB")),
+            true,
+        )
+        .unwrap();
+    execution_engine.process(&TestOrderEventStubs::submitted(
+        &opening_order,
+        AccountId::test_default(),
+    ));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &opening_order,
+        AccountId::test_default(),
+        VenueOrderId::from("V-1"),
+    ));
+    execution_engine.process(&TestOrderEventStubs::filled(
+        &opening_order,
+        &instrument.clone().into(),
+        Some(TradeId::new("T-OPEN")),
+        Some(position_id),
+        Some(Price::from("1.00000")),
+        None,
+        None,
+        Some(Money::from("0 USD")),
+        None,
+        Some(AccountId::test_default()),
+    ));
+
+    let reversal_order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-FLIP"))
+        .side(OrderSide::Sell)
+        .quantity(Quantity::from(200_000))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(
+            reversal_order.clone(),
+            None,
+            Some(ClientId::from("STUB")),
+            true,
+        )
+        .unwrap();
+    execution_engine.process(&TestOrderEventStubs::submitted(
+        &reversal_order,
+        AccountId::test_default(),
+    ));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &reversal_order,
+        AccountId::test_default(),
+        VenueOrderId::from("V-FLIP"),
+    ));
+    execution_engine.process(&TestOrderEventStubs::filled(
+        &reversal_order,
+        &instrument.clone().into(),
+        Some(TradeId::new("T-FLIP")),
+        Some(position_id),
+        Some(Price::from("1.00010")),
+        Some(Quantity::from(150_000)),
+        None,
+        Some(Money::from("0 USD")),
+        None,
+        Some(AccountId::test_default()),
+    ));
+
+    let flipped_position_id = {
+        let cache = execution_engine.cache().borrow();
+        let open = cache.positions_open(None, None, None, None, None);
+        assert_eq!(open.len(), 1);
+        open[0].id
+    };
+
+    // Close the flipped position with a different order, so the remainder below
+    // arrives while the position its order is indexed to is already closed.
+    let closing_order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .client_order_id(ClientOrderId::from("O-CLOSE"))
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(50_000))
+        .build();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(
+            closing_order.clone(),
+            None,
+            Some(ClientId::from("STUB")),
+            true,
+        )
+        .unwrap();
+    execution_engine.process(&TestOrderEventStubs::submitted(
+        &closing_order,
+        AccountId::test_default(),
+    ));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &closing_order,
+        AccountId::test_default(),
+        VenueOrderId::from("V-CLOSE"),
+    ));
+    execution_engine.process(&TestOrderEventStubs::filled(
+        &closing_order,
+        &instrument.clone().into(),
+        Some(TradeId::new("T-CLOSE")),
+        Some(flipped_position_id),
+        Some(Price::from("1.00002")),
+        None,
+        None,
+        Some(Money::from("0 USD")),
+        None,
+        Some(AccountId::test_default()),
+    ));
+
+    let remainder_trade_id = TradeId::new("T-REMAINDER");
+    let partially_filled_order = cached_order_or(&execution_engine, &reversal_order);
+    execution_engine.process(&TestOrderEventStubs::filled(
+        &partially_filled_order,
+        &instrument.into(),
+        Some(remainder_trade_id),
+        Some(position_id),
+        Some(Price::from("1.00006")),
+        Some(Quantity::from(50_000)),
+        None,
+        Some(Money::from("0 USD")),
+        None,
+        Some(AccountId::test_default()),
+    ));
+
+    let cache = execution_engine.cache().borrow();
+    let filled_order = cache.order(&reversal_order.client_order_id()).unwrap();
+    assert_eq!(filled_order.filled_qty(), Quantity::from(200_000));
+
+    // The remainder reopens the flipped ID rather than being dropped: the engine
+    // routes a fill naming a closed position to its standard Hedging reopen.
+    let reopened = cache.position(&flipped_position_id).unwrap();
+    assert!(reopened.is_open());
+    assert_eq!(reopened.side, PositionSide::Short);
+    assert_eq!(reopened.quantity, Quantity::from(50_000));
+    assert!(reopened.trade_ids.contains(&remainder_trade_id));
+    assert!(cache.position(&position_id).unwrap().is_closed());
+
+    // The closed flipped cycle is archived before its ID is reused: short 50,000 opened at
+    // 1.00010 by the flip and closed at 1.00002, so the realized PnL totals that read
+    // closed cycles from the snapshots keep the earlier 4.00 USD after the reopen.
+    let snapshots = cache.position_snapshots(Some(&flipped_position_id), None);
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].realized_pnl, Some(Money::from("4.00 USD")));
+    assert_eq!(reopened.realized_pnl, Some(Money::from("0 USD")));
 }
 
 fn setup_netting_snapshot_engine(


### PR DESCRIPTION
A follow-up to the Hedging position ID conflict rejection introduced with the Binance Futures hedge reconciliation work.

## A partially filled reversal under Hedging drops every fill after the first

Under `OmsType::Hedging` with a virtual position ID, `flip_position` mints a fresh ID for the flipped leg and `open_position` re-indexes the order against it through `Cache::add_position`. The venue keeps stamping the ID it was given, so every later partial fill of that order arrives with the original ID, and `determine_position_id` now sees a cached ID that differs from the fill's. The Hedging arm added for venue-supplied conflicts returns `None`, so the fill is applied to neither the order nor the position: a long 2 reversed by a sell 4 that fills 3 then 1 ends short 1 with the order at `filled_qty` 3, while the venue holds short 2 and a filled order. Netting never reaches the arm because `flip_position` reuses the fill's ID there. The built-in matching engine produces the same sequence on its own: `fill_position_for_order` computes `venue_position_id` once per fill pass and `apply_fills` stamps every fill of the pass with it, so an order flipping a position and filling at two book levels in one pass reaches this in any backtest or sandbox run under Hedging.

Applying the flipping fill writes its ID onto the order, and `add_position` then moves only the cache index, so a flip remainder is a fill whose ID equals the order's own `position_id` while the cache holds a different virtual ID. When that holds and both IDs are virtual, the fill falls through to the existing warn-and-reassign-from-cache path, which lands it on the flipped position. A venue-supplied conflict never satisfies it, because the order holds the ID it was submitted or last filled under, so the rejection written for Binance hedge legs is unchanged.

## Testing

`test_hedging_flip_applies_remainder_to_flipped_position` opens a long 100,000 under a virtual ID, sells 200,000 in a 150,000 flipping partial and a 50,000 remainder, both stamped with the original ID, and asserts the order's `filled_qty` is 200,000, the original position is closed, and the single open position is a distinct ID short 100,000 carrying the remainder's trade ID. Against the unfixed engine the `filled_qty` assertion fails at 150,000. `test_conflicting_venue_position_id_rejects_hedging_fill` and the live manager's `test_reconcile_mass_status_skips_only_position_with_fill_position_id_conflict` are unchanged and still pass.
