### PR TITLE
Publish an event when the execution engine declines a fill

### DIFF
--- a/crates/common/src/msgbus/switchboard.rs
+++ b/crates/common/src/msgbus/switchboard.rs
@@ -477,6 +477,10 @@ define_switchboard! {
     get_event_order_topic(strategy_id: StrategyId) -> strategy_id,
     "events.order.{}", strategy_id;
 
+    order_fill_declined_topics: StrategyId,
+    get_order_fill_declined_topic(strategy_id: StrategyId) -> strategy_id,
+    "events.order_fill_declined.{}", strategy_id;
+
     event_position_topics: StrategyId,
     get_event_position_topic(strategy_id: StrategyId) -> strategy_id,
     "events.position.{}", strategy_id;
@@ -691,6 +695,7 @@ define_wrappers! {
     get_snapshot_order_topic(client_order_id: ClientOrderId) -> MStr<Topic>,
     get_snapshot_position_topic(position_id: PositionId) -> MStr<Topic>,
     get_event_order_topic(strategy_id: StrategyId) -> MStr<Topic>,
+    get_order_fill_declined_topic(strategy_id: StrategyId) -> MStr<Topic>,
     get_event_position_topic(strategy_id: StrategyId) -> MStr<Topic>,
 }
 

--- a/crates/execution/src/engine/mod.rs
+++ b/crates/execution/src/engine/mod.rs
@@ -68,12 +68,13 @@ use nautilus_core::{
 use nautilus_model::{
     accounts::Account,
     enums::{
-        AccountType, ContingencyType, OmsType, OrderStatus, OrderType, PositionSide, TimeInForce,
+        AccountType, ContingencyType, FillDeclinedReason, OmsType, OrderStatus, OrderType,
+        PositionSide, TimeInForce,
     },
     events::{
-        OrderAccepted, OrderDenied, OrderDeniedReason, OrderEvent, OrderEventAny, OrderFillVoided,
-        OrderFilled, OrderInitialized, PositionChanged, PositionClosed, PositionEvent,
-        PositionOpened,
+        OrderAccepted, OrderDenied, OrderDeniedReason, OrderEvent, OrderEventAny,
+        OrderFillDeclined, OrderFillVoided, OrderFilled, OrderInitialized, PositionChanged,
+        PositionClosed, PositionEvent, PositionOpened,
     },
     identifiers::{
         AccountId, ClientId, ClientOrderId, ExecAlgorithmId, InstrumentId, PositionId, StrategyId,
@@ -2876,10 +2877,20 @@ impl ExecutionEngine {
                     return;
                 };
                 let configured_oms_type = self.determine_oms_type(fill);
-                let Some(position_id) =
-                    self.determine_position_id(fill, configured_oms_type, Some(&order_before_fill))
-                else {
-                    return;
+                let position_id = match self.determine_position_id(
+                    fill,
+                    configured_oms_type,
+                    Some(&order_before_fill),
+                ) {
+                    PositionIdOutcome::Assigned(position_id) => position_id,
+                    PositionIdOutcome::Declined {
+                        reason,
+                        details,
+                        position_id,
+                    } => {
+                        self.decline_fill(fill, position_id, reason, details);
+                        return;
+                    }
                 };
                 let oms_type = self
                     .cache
@@ -2896,21 +2907,46 @@ impl ExecutionEngine {
                     self.validate_fill_for_order_projection(&order_before_fill, &fill)
                 };
 
-                if validation.is_ok() {
-                    let event = OrderEventAny::Filled(fill.clone());
-                    let Some(order) =
-                        self.update_cached_order(client_order_id, &event, apply_position)
-                    else {
-                        return;
-                    };
+                match validation {
+                    Ok(()) => {
+                        let event = OrderEventAny::Filled(fill.clone());
+                        let order =
+                            match self.update_cached_order(client_order_id, &event, apply_position)
+                            {
+                                Ok(order) => order,
+                                Err(CachedOrderSkip::InvalidState) => {
+                                    let details = format!(
+                                        "Invalid order state: status={}",
+                                        order_before_fill.status()
+                                    );
+                                    self.decline_fill(
+                                        &fill,
+                                        fill.position_id,
+                                        FillDeclinedReason::InvalidOrderState,
+                                        details,
+                                    );
+                                    return;
+                                }
+                                Err(CachedOrderSkip::Silent) => return,
+                            };
 
-                    let position_events = if apply_position {
-                        self.handle_order_fill(&order, fill, oms_type)
-                    } else {
-                        Vec::new()
-                    };
-                    self.publish_order_event(&event);
-                    self.publish_position_events(position_events);
+                        let position_events = if apply_position {
+                            self.handle_order_fill(&order, fill, oms_type)
+                        } else {
+                            Vec::new()
+                        };
+                        self.publish_order_event(&event);
+                        self.publish_position_events(position_events);
+                    }
+                    Err(
+                        FillValidationError::Duplicate | FillValidationError::DuplicatePosition,
+                    ) => {}
+                    Err(FillValidationError::Overfill { details }) => self.decline_fill(
+                        &fill,
+                        fill.position_id,
+                        FillDeclinedReason::Overfill,
+                        details,
+                    ),
                 }
             }
             OrderEventAny::FillVoided(voided) => {
@@ -3009,7 +3045,7 @@ impl ExecutionEngine {
 
                 if self
                     .update_cached_order(client_order_id, &event, true)
-                    .is_none()
+                    .is_err()
                 {
                     return;
                 }
@@ -3024,7 +3060,7 @@ impl ExecutionEngine {
             _ => {
                 if self
                     .update_cached_order(client_order_id, &event, true)
-                    .is_some()
+                    .is_ok()
                 {
                     self.publish_order_event(&event);
                 }
@@ -3053,7 +3089,8 @@ impl ExecutionEngine {
         let position_id = self.determine_leg_fill_position_id(&fill, oms_type);
         fill.position_id = Some(position_id);
 
-        if !self.validate_fill_for_position(position_id, &fill) {
+        if let Err((_, details)) = self.validate_fill_for_position(position_id, &fill) {
+            log::error!("{details}");
             return;
         }
 
@@ -3228,7 +3265,7 @@ impl ExecutionEngine {
         fill: &OrderFilled,
         oms_type: OmsType,
         order: Option<&OrderAny>,
-    ) -> Option<PositionId> {
+    ) -> PositionIdOutcome {
         let cache = self.cache.borrow();
         let cached_position_id = cache.position_id(&fill.client_order_id()).copied();
         drop(cache);
@@ -3247,13 +3284,17 @@ impl ExecutionEngine {
         {
             if oms_type == OmsType::Hedging {
                 if !self.is_flip_remainder(fill, cached_position_id, fill_position_id) {
-                    log::error!(
+                    let details = format!(
                         "Cannot apply hedging fill {} for {}: venue position ID {fill_position_id} conflicts with cached position ID {cached_position_id}",
                         fill.trade_id,
                         fill.client_order_id(),
                     );
 
-                    return None;
+                    return PositionIdOutcome::Declined {
+                        reason: FillDeclinedReason::PositionIdConflict,
+                        details,
+                        position_id: Some(fill_position_id),
+                    };
                 }
             } else {
                 log::warn!(
@@ -3269,11 +3310,15 @@ impl ExecutionEngine {
                 log::debug!("Assigned {position_id} to {}", fill.client_order_id());
             }
 
-            if !self.validate_fill_for_position(position_id, fill) {
-                return None;
+            if let Err((reason, details)) = self.validate_fill_for_position(position_id, fill) {
+                return PositionIdOutcome::Declined {
+                    reason,
+                    details,
+                    position_id: Some(position_id),
+                };
             }
 
-            return Some(position_id);
+            return PositionIdOutcome::Assigned(position_id);
         }
 
         let position_id = match (oms_type, fill.position_id) {
@@ -3283,8 +3328,12 @@ impl ExecutionEngine {
             _ => self.determine_netting_position_id(fill),
         };
 
-        if !self.validate_fill_for_position(position_id, fill) {
-            return None;
+        if let Err((reason, details)) = self.validate_fill_for_position(position_id, fill) {
+            return PositionIdOutcome::Declined {
+                reason,
+                details,
+                position_id: Some(position_id),
+            };
         }
 
         let order = if let Some(o) = order {
@@ -3313,7 +3362,7 @@ impl ExecutionEngine {
                     "Primary exec spawn order {exec_spawn_id} not found, \
                      skipping position ID propagation"
                 );
-                return Some(position_id);
+                return PositionIdOutcome::Assigned(position_id);
             };
             let primary_already_indexed = cache.position_id(&primary.client_order_id()).is_some();
             drop(cache);
@@ -3332,7 +3381,7 @@ impl ExecutionEngine {
             }
         }
 
-        Some(position_id)
+        PositionIdOutcome::Assigned(position_id)
     }
 
     /// Returns whether `fill` may be applied to the position assigned to `position_id`.
@@ -3346,23 +3395,25 @@ impl ExecutionEngine {
     /// so two accounts trading one instrument under one strategy share a position ID.
     /// External order claims can be handed to a successor strategy while the predecessor's
     /// positions stay cached, so a later venue fill can carry the new strategy against them.
-    fn validate_fill_for_position(&self, position_id: PositionId, fill: &OrderFilled) -> bool {
+    fn validate_fill_for_position(
+        &self,
+        position_id: PositionId,
+        fill: &OrderFilled,
+    ) -> Result<(), (FillDeclinedReason, String)> {
         let cache = self.cache.borrow();
         let Some(position) = cache.position_ref(&position_id) else {
-            return true;
+            return Ok(());
         };
 
         if position.instrument_id != fill.instrument_id {
-            log::error!(
+            let details = format!(
                 "Cannot apply fill {} to position {position_id}: instrument_id mismatch, expected={}, received={}",
-                fill.trade_id,
-                position.instrument_id,
-                fill.instrument_id
+                fill.trade_id, position.instrument_id, fill.instrument_id
             );
-            return false;
+            return Err((FillDeclinedReason::PositionInstrumentMismatch, details));
         }
 
-        true
+        Ok(())
     }
 
     /// Returns whether `fill` is a later fill of an order this engine already flipped.
@@ -3476,14 +3527,18 @@ impl ExecutionEngine {
         PositionId::new(format!("{}-{}", fill.instrument_id, fill.strategy_id))
     }
 
-    fn validate_fill_for_order(&self, order: &OrderAny, fill: &OrderFilled) -> anyhow::Result<()> {
+    fn validate_fill_for_order(
+        &self,
+        order: &OrderAny,
+        fill: &OrderFilled,
+    ) -> Result<(), FillValidationError> {
         if order.is_duplicate_fill(fill) {
             log::warn!(
                 "Duplicate fill: {} trade_id={} already applied, skipping",
                 order.client_order_id(),
                 fill.trade_id
             );
-            anyhow::bail!("Duplicate fill");
+            return Err(FillValidationError::Duplicate);
         }
 
         if let Some(position_id) = fill.position_id
@@ -3495,7 +3550,7 @@ impl ExecutionEngine {
                 fill.trade_id,
                 position_id
             );
-            anyhow::bail!("Duplicate position fill");
+            return Err(FillValidationError::DuplicatePosition);
         }
 
         self.check_overfill(order, fill)
@@ -3505,9 +3560,9 @@ impl ExecutionEngine {
         &self,
         order: &OrderAny,
         fill: &OrderFilled,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), FillValidationError> {
         if order.is_duplicate_fill(fill) {
-            anyhow::bail!("Duplicate fill");
+            return Err(FillValidationError::Duplicate);
         }
 
         self.check_overfill(order, fill)
@@ -3525,7 +3580,7 @@ impl ExecutionEngine {
         client_order_id: ClientOrderId,
         event: &OrderEventAny,
         send_portfolio_update: bool,
-    ) -> Option<OrderAny> {
+    ) -> Result<OrderAny, CachedOrderSkip> {
         let result = { self.cache.borrow_mut().update_order(event) };
 
         let order = match result {
@@ -3535,29 +3590,34 @@ impl ExecutionEngine {
                     e.downcast_ref::<OrderError>(),
                     Some(OrderError::InvalidStateTransition)
                 ) {
+                    // A dropped fill represents real, possibly lost, execution: the caller
+                    // logs and publishes it through `decline_fill`.
+                    if matches!(event, OrderEventAny::Filled(_)) {
+                        return Err(CachedOrderSkip::InvalidState);
+                    }
+
                     // A non-fill event that fails to apply to an already-closed order is an
                     // expected venue race (e.g. a place reject then a stream cancel for the same
-                    // order), not an anomaly. A dropped fill stays at warn even on a closed order,
-                    // since it represents real, possibly lost, execution.
+                    // order), not an anomaly.
                     let already_closed = self
                         .cache
                         .borrow()
                         .order(&client_order_id)
                         .is_some_and(|o| o.is_closed());
 
-                    if already_closed && !matches!(event, OrderEventAny::Filled(_)) {
+                    if already_closed {
                         log::debug!("InvalidStateTrigger: {e}, did not apply {event}");
                     } else {
                         log::warn!("InvalidStateTrigger: {e}, did not apply {event}");
                     }
-                    return None;
+                    return Err(CachedOrderSkip::InvalidState);
                 }
 
                 if let Some(OrderError::DuplicateFill(trade_id)) = e.downcast_ref::<OrderError>() {
                     log::warn!(
                         "Duplicate fill rejected at order level: trade_id={trade_id}, did not apply {event}"
                     );
-                    return None;
+                    return Err(CachedOrderSkip::Silent);
                 }
 
                 if let Some(OrderError::DuplicateFillVoid(trade_id)) =
@@ -3566,7 +3626,7 @@ impl ExecutionEngine {
                     log::warn!(
                         "Duplicate fill void rejected at order level: trade_id={trade_id}, did not apply {event}"
                     );
-                    return None;
+                    return Err(CachedOrderSkip::Silent);
                 }
 
                 log::error!("Error applying event: {e}, did not apply {event}");
@@ -3604,7 +3664,7 @@ impl ExecutionEngine {
                         }
                     }
                 }
-                return None;
+                return Err(CachedOrderSkip::Silent);
             }
         };
 
@@ -3633,7 +3693,7 @@ impl ExecutionEngine {
             self.send_order_update_to_portfolio(event);
         }
 
-        Some(order)
+        Ok(order)
     }
 
     fn send_order_update_to_portfolio(&self, event: &OrderEventAny) {
@@ -3720,7 +3780,11 @@ impl ExecutionEngine {
         }
     }
 
-    fn check_overfill(&self, order: &OrderAny, fill: &OrderFilled) -> anyhow::Result<()> {
+    fn check_overfill(
+        &self,
+        order: &OrderAny,
+        fill: &OrderFilled,
+    ) -> Result<(), FillValidationError> {
         let potential_overfill = order.calculate_overfill(fill.last_qty);
 
         if potential_overfill.is_positive() {
@@ -3743,11 +3807,42 @@ impl ExecutionEngine {
                     fill.last_qty,
                     order.quantity()
                 );
-                anyhow::bail!("{msg}");
+                return Err(FillValidationError::Overfill { details: msg });
             }
         }
 
         Ok(())
+    }
+
+    fn decline_fill(
+        &self,
+        fill: &OrderFilled,
+        position_id: Option<PositionId>,
+        reason: FillDeclinedReason,
+        details: String,
+    ) {
+        log::error!("{details}");
+        let event = OrderFillDeclined {
+            trader_id: fill.trader_id,
+            strategy_id: fill.strategy_id,
+            instrument_id: fill.instrument_id,
+            client_order_id: fill.client_order_id,
+            venue_order_id: fill.venue_order_id,
+            account_id: fill.account_id,
+            trade_id: fill.trade_id,
+            position_id: position_id.or(fill.position_id),
+            order_side: fill.order_side,
+            last_qty: fill.last_qty,
+            last_px: fill.last_px,
+            reason,
+            details: details.into(),
+            event_id: UUID4::new(),
+            causation_id: fill.event_id,
+            ts_event: fill.ts_event,
+            ts_init: self.clock.borrow().timestamp_ns(),
+        };
+        let topic = switchboard::get_order_fill_declined_topic(fill.strategy_id);
+        msgbus::publish_any(topic, &event);
     }
 
     fn handle_order_fill(
@@ -4544,6 +4639,26 @@ enum SubmissionValidationResult {
         status: OrderStatus,
     },
     Deny(OrderDeniedReason),
+}
+
+enum FillValidationError {
+    Duplicate,
+    DuplicatePosition,
+    Overfill { details: String },
+}
+
+enum PositionIdOutcome {
+    Assigned(PositionId),
+    Declined {
+        reason: FillDeclinedReason,
+        details: String,
+        position_id: Option<PositionId>,
+    },
+}
+
+enum CachedOrderSkip {
+    InvalidState,
+    Silent,
 }
 
 #[cfg(test)]

--- a/crates/execution/tests/integration/exec_engine.rs
+++ b/crates/execution/tests/integration/exec_engine.rs
@@ -61,13 +61,13 @@ use nautilus_model::{
     accounts::{AccountAny, CashAccount},
     data::QuoteTick,
     enums::{
-        AccountType, AssetClass, ContingencyType, LiquiditySide, OmsType, OrderSide, OrderStatus,
-        OrderType, PositionSide, TimeInForce, TriggerType,
+        AccountType, AssetClass, ContingencyType, FillDeclinedReason, LiquiditySide, OmsType,
+        OrderSide, OrderStatus, OrderType, PositionSide, TimeInForce, TriggerType,
     },
     events::{
         AccountState, OrderCancelRejected, OrderCanceled, OrderDenied, OrderEventAny, OrderExpired,
-        OrderFilled, OrderModifyRejected, OrderPendingCancel, OrderPendingUpdate, OrderRejected,
-        OrderUpdated, PositionEvent,
+        OrderFillDeclined, OrderFilled, OrderModifyRejected, OrderPendingCancel,
+        OrderPendingUpdate, OrderRejected, OrderUpdated, PositionEvent,
         order::spec::{
             OrderCancelRejectedSpec, OrderCanceledSpec, OrderExpiredSpec, OrderFillVoidedSpec,
             OrderFilledSpec, OrderModifyRejectedSpec, OrderPendingCancelSpec,
@@ -99,6 +99,13 @@ use serde_json::Value;
 use ustr::Ustr;
 
 use crate::cache_database::{FailNthAddOrderDatabase, FailNthAddOrderDatabaseControl};
+
+fn as_order_filled(event: &OrderEventAny) -> &OrderFilled {
+    let OrderEventAny::Filled(fill) = event else {
+        panic!("Expected OrderFilled event");
+    };
+    fill
+}
 
 #[fixture]
 fn test_clock() -> Rc<RefCell<dyn clock::Clock>> {
@@ -2507,6 +2514,217 @@ fn test_terminal_fill_void_rejects_late_fill_without_opening_position(
             .iter()
             .all(|event| !matches!(event, OrderEventAny::Filled(_)))
     );
+}
+
+#[rstest]
+fn test_invalid_order_state_publishes_fill_declined(mut execution_engine: ExecutionEngine) {
+    let (instrument, order) = prepare_accepted_order(&mut execution_engine);
+    let venue_order_id = VenueOrderId::from("V-001");
+    let account_id = AccountId::test_default();
+    let trade_id = TradeId::new("T-VOID-TERMINAL");
+    let voided = OrderEventAny::FillVoided(
+        OrderFillVoidedSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(instrument.id())
+            .client_order_id(order.client_order_id())
+            .venue_order_id(venue_order_id)
+            .account_id(account_id)
+            .trade_id(trade_id)
+            .voided_qty(order.quantity())
+            .order_side(order.order_side())
+            .order_type(order.order_type())
+            .last_px(Price::from("1.00000"))
+            .currency(instrument.quote_currency())
+            .liquidity_side(LiquiditySide::NoLiquiditySide)
+            .build(),
+    );
+    let late_fill = OrderEventAny::Filled(build_order_filled(
+        order.trader_id(),
+        order.strategy_id(),
+        instrument.id(),
+        order.client_order_id(),
+        venue_order_id,
+        account_id,
+        trade_id,
+        order.order_side(),
+        order.order_type(),
+        order.quantity(),
+        Price::from("1.00000"),
+        instrument.quote_currency(),
+        LiquiditySide::Maker,
+        None,
+        None,
+    ));
+    execution_engine.process(&voided);
+
+    let topic = switchboard::get_order_fill_declined_topic(order.strategy_id());
+    let pattern: msgbus::MStr<msgbus::Pattern> = topic.as_ref().into();
+    let (handler, saver) = get_any_saving_handler::<OrderFillDeclined>(None);
+    msgbus::subscribe_any(pattern, handler.clone(), None);
+
+    execution_engine.process(&late_fill);
+    msgbus::unsubscribe_any(pattern, &handler);
+
+    let declined = saver.get_messages();
+    assert_eq!(declined.len(), 1);
+    assert_eq!(declined[0].reason, FillDeclinedReason::InvalidOrderState);
+    assert_eq!(declined[0].trade_id, trade_id);
+    assert_eq!(
+        declined[0].causation_id,
+        as_order_filled(&late_fill).event_id
+    );
+    assert!(declined[0].details.contains("VOIDED"));
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
+    assert_eq!(cached_order.status(), OrderStatus::Voided);
+    assert_eq!(cached_order.filled_qty(), Quantity::from(0));
+    assert!(cache.positions(None, None, None, None, None).is_empty());
+}
+
+#[rstest]
+fn test_overfill_refusal_publishes_fill_declined(mut execution_engine: ExecutionEngine) {
+    let (instrument, order) = prepare_accepted_order(&mut execution_engine);
+    let fill = OrderEventAny::Filled(build_order_filled(
+        order.trader_id(),
+        order.strategy_id(),
+        instrument.id(),
+        order.client_order_id(),
+        VenueOrderId::from("V-001"),
+        AccountId::test_default(),
+        TradeId::new("T-OVERFILL"),
+        order.order_side(),
+        order.order_type(),
+        order.quantity() + order.quantity(),
+        Price::from("1.00000"),
+        instrument.quote_currency(),
+        LiquiditySide::Maker,
+        None,
+        None,
+    ));
+    let topic = switchboard::get_order_fill_declined_topic(order.strategy_id());
+    let pattern: msgbus::MStr<msgbus::Pattern> = topic.as_ref().into();
+    let (handler, saver) = get_any_saving_handler::<OrderFillDeclined>(None);
+    msgbus::subscribe_any(pattern, handler.clone(), None);
+
+    execution_engine.process(&fill);
+    msgbus::unsubscribe_any(pattern, &handler);
+
+    let declined = saver.get_messages();
+    assert_eq!(declined.len(), 1);
+    assert_eq!(declined[0].reason, FillDeclinedReason::Overfill);
+    assert_eq!(declined[0].causation_id, as_order_filled(&fill).event_id);
+    assert!(declined[0].details.contains("potential_overfill"));
+    let cached = execution_engine.cache().borrow();
+    assert_eq!(
+        cached.order(&order.client_order_id()).unwrap().filled_qty(),
+        Quantity::from(0)
+    );
+    assert!(cached.positions(None, None, None, None, None).is_empty());
+}
+
+#[rstest]
+fn test_duplicate_fill_does_not_publish_fill_declined(mut execution_engine: ExecutionEngine) {
+    let (instrument, order) = prepare_accepted_order(&mut execution_engine);
+    let fill = OrderEventAny::Filled(build_order_filled(
+        order.trader_id(),
+        order.strategy_id(),
+        instrument.id(),
+        order.client_order_id(),
+        VenueOrderId::from("V-001"),
+        AccountId::test_default(),
+        TradeId::new("T-DUPLICATE"),
+        order.order_side(),
+        order.order_type(),
+        order.quantity(),
+        Price::from("1.00000"),
+        instrument.quote_currency(),
+        LiquiditySide::Maker,
+        None,
+        None,
+    ));
+    execution_engine.process(&fill);
+
+    let topic = switchboard::get_order_fill_declined_topic(order.strategy_id());
+    let pattern: msgbus::MStr<msgbus::Pattern> = topic.as_ref().into();
+    let (handler, saver) = get_any_saving_handler::<OrderFillDeclined>(None);
+    msgbus::subscribe_any(pattern, handler.clone(), None);
+    execution_engine.process(&fill);
+    msgbus::unsubscribe_any(pattern, &handler);
+
+    assert!(saver.get_messages().is_empty());
+}
+
+#[rstest]
+fn test_position_instrument_mismatch_publishes_fill_declined(
+    mut execution_engine: ExecutionEngine,
+) {
+    let (instrument, order) = prepare_accepted_order(&mut execution_engine);
+    let other_instrument = gbpusd_sim();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(other_instrument.clone().into())
+        .unwrap();
+    let position_id = PositionId::new(format!("{}-{}", instrument.id(), order.strategy_id()));
+    let position_fill = build_order_filled(
+        order.trader_id(),
+        order.strategy_id(),
+        other_instrument.id(),
+        order.client_order_id(),
+        VenueOrderId::from("V-OTHER"),
+        AccountId::test_default(),
+        TradeId::new("T-OTHER"),
+        order.order_side(),
+        order.order_type(),
+        order.quantity(),
+        Price::from("1.00000"),
+        other_instrument.quote_currency(),
+        LiquiditySide::Maker,
+        Some(position_id),
+        None,
+    );
+    let position = Position::new(&other_instrument.into(), position_fill);
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_position(&position, OmsType::Netting)
+        .unwrap();
+    let fill = OrderEventAny::Filled(build_order_filled(
+        order.trader_id(),
+        order.strategy_id(),
+        instrument.id(),
+        order.client_order_id(),
+        VenueOrderId::from("V-001"),
+        AccountId::test_default(),
+        TradeId::new("T-MISMATCH"),
+        order.order_side(),
+        order.order_type(),
+        order.quantity(),
+        Price::from("1.00000"),
+        instrument.quote_currency(),
+        LiquiditySide::Maker,
+        None,
+        None,
+    ));
+    let topic = switchboard::get_order_fill_declined_topic(order.strategy_id());
+    let pattern: msgbus::MStr<msgbus::Pattern> = topic.as_ref().into();
+    let (handler, saver) = get_any_saving_handler::<OrderFillDeclined>(None);
+    msgbus::subscribe_any(pattern, handler.clone(), None);
+
+    execution_engine.process(&fill);
+    msgbus::unsubscribe_any(pattern, &handler);
+
+    let declined = saver.get_messages();
+    assert_eq!(declined.len(), 1);
+    assert_eq!(
+        declined[0].reason,
+        FillDeclinedReason::PositionInstrumentMismatch
+    );
+    assert_eq!(declined[0].position_id, Some(position_id));
+    assert!(declined[0].details.contains("expected="));
+    assert!(declined[0].details.contains("received="));
 }
 
 #[rstest]
@@ -8391,6 +8609,110 @@ fn test_conflicting_venue_position_id_rejects_hedging_fill(mut execution_engine:
     let cached_order = cache.order(&order.client_order_id()).unwrap();
 
     assert_eq!(cached_order.status(), OrderStatus::Accepted);
+    assert_eq!(cached_order.filled_qty(), Quantity::from(0));
+    assert!(!cache.position_exists(&cached_position_id));
+    assert!(!cache.position_exists(&venue_position_id));
+}
+
+#[rstest]
+fn test_position_id_conflict_publishes_fill_declined(mut execution_engine: ExecutionEngine) {
+    let trader_id = TraderId::test_default();
+    let strategy_id = StrategyId::test_default();
+    let instrument = audusd_sim();
+
+    let stub_client = StubExecutionClient::new(
+        ClientId::from("STUB"),
+        AccountId::test_default(),
+        Venue::test_default(),
+        OmsType::Hedging,
+        None,
+    );
+    execution_engine
+        .register_client(Box::new(stub_client))
+        .unwrap();
+
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_instrument(instrument.clone().into())
+        .unwrap();
+
+    let account = CashAccount::default();
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_account(account.into())
+        .unwrap();
+
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .trader_id(trader_id)
+        .strategy_id(strategy_id)
+        .instrument_id(instrument.id)
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+
+    let cached_position_id = PositionId::from("CACHED-POS");
+    execution_engine
+        .cache()
+        .borrow_mut()
+        .add_order(
+            order.clone(),
+            Some(cached_position_id),
+            Some(ClientId::from("STUB")),
+            true,
+        )
+        .unwrap();
+
+    execution_engine.process(&TestOrderEventStubs::submitted(
+        &order,
+        AccountId::test_default(),
+    ));
+    execution_engine.process(&TestOrderEventStubs::accepted(
+        &order,
+        AccountId::test_default(),
+        VenueOrderId::from("V-001"),
+    ));
+
+    let venue_position_id = PositionId::from("VENUE-POS");
+    let order_filled_event = TestOrderEventStubs::filled(
+        &cached_order_or(&execution_engine, &order),
+        &instrument.into(),
+        Some(TradeId::new("E-19700101-000000-001-001-1")),
+        Some(venue_position_id),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(AccountId::test_default()),
+    );
+
+    let topic = switchboard::get_order_fill_declined_topic(strategy_id);
+    let pattern: msgbus::MStr<msgbus::Pattern> = topic.as_ref().into();
+    let (handler, saver) = get_any_saving_handler::<OrderFillDeclined>(None);
+    msgbus::subscribe_any(pattern, handler.clone(), None);
+
+    execution_engine.process(&order_filled_event);
+    msgbus::unsubscribe_any(pattern, &handler);
+
+    let declined = saver.get_messages();
+    assert_eq!(declined.len(), 1);
+    assert_eq!(declined[0].reason, FillDeclinedReason::PositionIdConflict);
+    assert_eq!(
+        declined[0].trade_id,
+        as_order_filled(&order_filled_event).trade_id
+    );
+    assert_eq!(declined[0].position_id, Some(venue_position_id));
+    assert_eq!(
+        declined[0].causation_id,
+        as_order_filled(&order_filled_event).event_id
+    );
+    assert!(declined[0].details.contains("VENUE-POS"));
+    assert!(declined[0].details.contains("CACHED-POS"));
+
+    let cache = execution_engine.cache().borrow();
+    let cached_order = cache.order(&order.client_order_id()).unwrap();
     assert_eq!(cached_order.filled_qty(), Quantity::from(0));
     assert!(!cache.position_exists(&cached_position_id));
     assert!(!cache.position_exists(&venue_position_id));

--- a/crates/model/src/enums.rs
+++ b/crates/model/src/enums.rs
@@ -1247,6 +1247,47 @@ impl OrderSide {
     }
 }
 
+/// The reason the execution engine declined to apply a fill.
+#[repr(C)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Display,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    AsRefStr,
+    FromRepr,
+    EnumIter,
+    EnumString,
+)]
+#[strum(ascii_case_insensitive)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(
+        frozen,
+        eq,
+        eq_int,
+        module = "nautilus_trader.model",
+        from_py_object,
+        rename_all = "SCREAMING_SNAKE_CASE",
+    )
+)]
+pub enum FillDeclinedReason {
+    /// The fill's venue position ID conflicts with the position ID cached for the order.
+    PositionIdConflict = 1,
+    /// The fill's instrument differs from the cached position's instrument.
+    PositionInstrumentMismatch = 2,
+    /// The fill would take the order past its quantity and overfills are not allowed.
+    Overfill = 3,
+    /// The order's state cannot accept a fill.
+    InvalidOrderState = 4,
+}
+
 /// The status for a specific order.
 ///
 /// An order is considered _open_ for the following status:
@@ -2108,6 +2149,7 @@ enum_strum_serde!(BookType);
 enum_strum_serde!(ContingencyType);
 enum_strum_serde!(ContinuousFutureAdjustmentType);
 enum_strum_serde!(CurrencyType);
+enum_strum_serde!(FillDeclinedReason);
 enum_strum_serde!(GreeksConvention);
 enum_strum_serde!(InstrumentClass);
 enum_strum_serde!(InstrumentCloseType);

--- a/crates/model/src/events/mod.rs
+++ b/crates/model/src/events/mod.rs
@@ -40,6 +40,7 @@ pub use crate::events::{
         denied_reason::{OrderDeniedCode, OrderDeniedReason, OrderPriceField},
         emulated::OrderEmulated,
         expired::OrderExpired,
+        fill_declined::OrderFillDeclined,
         fill_voided::OrderFillVoided,
         filled::OrderFilled,
         initialized::OrderInitialized,

--- a/crates/model/src/events/order/fill_declined.rs
+++ b/crates/model/src/events/order/fill_declined.rs
@@ -1,0 +1,76 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::fmt::Display;
+
+use nautilus_core::{UUID4, UnixNanos};
+use serde::{Deserialize, Serialize};
+use ustr::Ustr;
+
+use crate::{
+    enums::{FillDeclinedReason, OrderSide},
+    identifiers::{
+        AccountId, ClientOrderId, InstrumentId, PositionId, StrategyId, TradeId, TraderId,
+        VenueOrderId,
+    },
+    types::{Price, Quantity},
+};
+
+/// Represents an order fill the execution engine declined to apply.
+///
+/// The fill was received from the venue but was applied to neither the order nor a position,
+/// so local state has diverged from the venue's. This is not an order lifecycle event and
+/// changes no order state; it is published on the `events.order_fill_declined.{strategy_id}`
+/// topic so a Rust subscriber can fail closed.
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader.model", from_py_object)
+)]
+pub struct OrderFillDeclined {
+    pub trader_id: TraderId,
+    pub strategy_id: StrategyId,
+    pub instrument_id: InstrumentId,
+    pub client_order_id: ClientOrderId,
+    pub venue_order_id: VenueOrderId,
+    pub account_id: AccountId,
+    pub trade_id: TradeId,
+    pub position_id: Option<PositionId>,
+    pub order_side: OrderSide,
+    pub last_qty: Quantity,
+    pub last_px: Price,
+    pub reason: FillDeclinedReason,
+    pub details: Ustr,
+    pub event_id: UUID4,
+    pub causation_id: UUID4,
+    pub ts_event: UnixNanos,
+    pub ts_init: UnixNanos,
+}
+
+impl Display for OrderFillDeclined {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}(client_order_id={}, trade_id={}, reason={}, details={})",
+            stringify!(OrderFillDeclined),
+            self.client_order_id,
+            self.trade_id,
+            self.reason,
+            self.details,
+        )
+    }
+}

--- a/crates/model/src/events/order/mod.rs
+++ b/crates/model/src/events/order/mod.rs
@@ -40,6 +40,7 @@ pub mod denied;
 pub mod denied_reason;
 pub mod emulated;
 pub mod expired;
+pub mod fill_declined;
 pub mod fill_voided;
 pub mod filled;
 pub mod initialized;


### PR DESCRIPTION
A follow-up to the hedging flip remainder fix in #4908. This branch is stacked on that one and includes its commit, so #4908 needs to land first; the diff to review here is the second commit only.

## A fill the execution engine declines to apply leaves no trace a subscriber can see

When `ExecutionEngine::handle_order_event` declines an `OrderFilled`, it returns before `update_cached_order` and before `publish_order_event`: the order is not updated, no event is published, and one log line is the only record. The cached order and position are wrong from then on with nothing a strategy, operator or reconciler can act on. Four decline classes are substantive: a venue-supplied position ID conflicting with the cached one under Hedging (the rejection from the Binance hedge reconciliation work, which #4908 narrows to exclude the engine's own flip), a fill whose instrument differs from the cached position's, an overfill with `allow_overfills` off, and a fill on an order whose state cannot accept one. The overfill case had no log line either: `check_overfill` bailed through `anyhow` and the caller discarded the error.

`process` is bus-driven and returns nothing, so the signal is a message. `OrderFillDeclined` is a standalone type published with `msgbus::publish_any` on `events.order_fill_declined.{strategy_id}`, in the shape `TradingStateChanged` already uses. It is not an `OrderEventAny` variant: it changes no order state, and a variant would enter every order's `apply`, the serialization schemas and the persistence paths for an event none of them should ever see. It carries the fill's identity and exposure fields (`client_order_id`, `venue_order_id`, `trade_id`, `position_id`, `order_side`, `last_qty`, `last_px`), a unit-variant `FillDeclinedReason` a strategy can match on, a `details` string with the diagnostic the log line carries, and `causation_id` set to the declined fill's `event_id`. Duplicate fills stay at warn and publish nothing. One private `decline_fill` logs and publishes at the final decision point; the validators now return typed errors so the caller can classify rather than parse a string.

Rust subscribers only. `PyCallableHandler` forwards `PyMessage` and nothing else, so a Rust-published message cannot reach a Python callable, and this adds no Python wrapper or stub entry, the same position `TradingStateChanged` is in. Bridging that is a separate change to the Python message bus.

## Testing

`test_position_id_conflict_publishes_fill_declined`, `test_position_instrument_mismatch_publishes_fill_declined`, `test_overfill_refusal_publishes_fill_declined` and `test_invalid_order_state_publishes_fill_declined` each subscribe to the topic and assert exactly one message with the expected reason, the fill's trade ID and `causation_id`, and that the order and positions are unchanged. `test_duplicate_fill_does_not_publish_fill_declined` asserts none. With the publish removed from `decline_fill`, all four positive assertions fail on a message count of 0.
