### PR TITLE
Remove stale config param from doc comment

### DIFF
--- a/crates/model/src/defi/pool_analysis/size_estimator.rs
+++ b/crates/model/src/defi/pool_analysis/size_estimator.rs
@@ -139,7 +139,6 @@ struct BinarySearchState {
 /// - `profiler` - Reference to the pool profiler
 /// - `impact_bps` - Target impact in basis points
 /// - `zero_for_one` - Swap direction
-/// - `config` - Estimation configuration (only uses `safety_multiplier`)
 ///
 /// # Returns
 /// Estimated maximum size as U256


### PR DESCRIPTION
## What
Removed a stale `config` parameter bullet from the doc comment on `estimate_max_size_for_impact` in crates/model/src/defi/pool_analysis/size_estimator.rs; the function only takes profiler, impact_bps, and zero_for_one.

## Why
A small, objectively-verifiable improvement (docs) found during a
daily open-source maintenance pass (2026-09-02).

## How verified
Read the function signature (3 params) and its sole call site (3 args passed), confirming the doc's 4th documented parameter `config` does not exist.
Automated gates: 1 changed lines across 1 files (within limits); cargo check: passed (nautilus-model).

---
Prepared with Claude Code assistance and reviewed by Aarush's
automation gates (diff-size, file-scope, deletion, and build checks)
before opening.