### PR TITLE
Fix AroonOscillator lowest low scan and tie handling

### DIFF
--- a/crates/indicators/src/momentum/aroon.rs
+++ b/crates/indicators/src/momentum/aroon.rs
@@ -162,29 +162,28 @@ impl AroonOscillator {
     }
 
     fn calculate_aroon(&mut self) {
-        let len = self.high_inputs.len();
-        debug_assert_eq!(len, self.period + 1);
+        debug_assert_eq!(self.high_inputs.len(), self.period + 1);
 
-        let mut max_idx = 0_usize;
+        // Scan the full window from newest to oldest so the enumeration index
+        // is the periods-since count directly and ties resolve to the most
+        // recent occurrence of the extreme.
+        let mut periods_since_high = 0_usize;
         let mut max_val = f64::MIN;
-        for (idx, &hi) in self.high_inputs.iter().enumerate() {
+        for (periods_back, &hi) in self.high_inputs.iter().rev().enumerate() {
             if hi > max_val {
                 max_val = hi;
-                max_idx = idx;
+                periods_since_high = periods_back;
             }
         }
 
-        let mut min_idx_rel = 0_usize;
+        let mut periods_since_low = 0_usize;
         let mut min_val = f64::MAX;
-        for (idx, &lo) in self.low_inputs.iter().skip(1).enumerate() {
+        for (periods_back, &lo) in self.low_inputs.iter().rev().enumerate() {
             if lo < min_val {
                 min_val = lo;
-                min_idx_rel = idx;
+                periods_since_low = periods_back;
             }
         }
-
-        let periods_since_high = len - 1 - max_idx;
-        let periods_since_low = self.period - 1 - min_idx_rel;
 
         self.aroon_up =
             Self::round(100.0 * (self.period - periods_since_high) as f64 / self.period as f64);
@@ -244,8 +243,8 @@ mod tests {
         aroon.update_raw(110.10, 109.70);
         assert!(aroon.initialized());
         assert_eq!(aroon.aroon_up, 100.0);
-        assert_eq!(aroon.aroon_down, 100.0);
-        assert_eq!(aroon.value, 0.0);
+        assert_eq!(aroon.aroon_down, 0.0);
+        assert_eq!(aroon.value, 100.0);
     }
 
     #[rstest]
@@ -280,7 +279,8 @@ mod tests {
         }
         assert!(aroon.initialized());
         assert_eq!(aroon.aroon_up, 30.0);
-        assert_eq!(aroon.value, -25.0);
+        assert_eq!(aroon.aroon_down, 0.0);
+        assert_eq!(aroon.value, 30.0);
     }
 
     #[rstest]
@@ -337,7 +337,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_ignore_oldest_low() {
+    fn test_lowest_low_at_oldest_bar() {
         let mut aroon = AroonOscillator::new(5);
         aroon.update_raw(10.0, 0.0);
         let inputs = [
@@ -353,7 +353,29 @@ mod tests {
         }
         assert!(aroon.initialized());
         assert_eq!(aroon.aroon_up, 100.0);
-        assert_eq!(aroon.aroon_down, 20.0);
-        assert_eq!(aroon.value, 80.0);
+        assert_eq!(aroon.aroon_down, 0.0);
+        assert_eq!(aroon.value, 100.0);
+    }
+
+    #[rstest]
+    fn test_tie_favors_most_recent_occurrence() {
+        let mut aroon = AroonOscillator::new(4);
+        let inputs = [
+            (110.0, 100.0),
+            (110.0, 100.0),
+            (105.0, 101.0),
+            (105.0, 101.0),
+            (105.0, 101.0),
+        ];
+
+        for &(h, l) in &inputs {
+            aroon.update_raw(h, l);
+        }
+        assert!(aroon.initialized());
+        // Highest high and lowest low both occur twice; the most recent
+        // occurrence (index 1, three periods back) determines the counts
+        assert_eq!(aroon.aroon_up, 25.0);
+        assert_eq!(aroon.aroon_down, 25.0);
+        assert_eq!(aroon.value, 0.0);
     }
 }

--- a/python/tests/unit/indicators/test_aroon.py
+++ b/python/tests/unit/indicators/test_aroon.py
@@ -103,8 +103,8 @@ def test_handle_bar_uses_bar_high_and_low() -> None:
     # Assert
     assert indicator.initialized
     assert indicator.aroon_up == 0.0
-    assert indicator.aroon_down == 100.0
-    assert indicator.value == -100.0
+    assert indicator.aroon_down == 0.0
+    assert indicator.value == 0.0
 
 
 def test_handle_quote_tick_updates_indicator() -> None:
@@ -155,8 +155,8 @@ def test_value_with_two_inputs() -> None:
     # Assert
     assert aroon.initialized
     assert aroon.aroon_up == 100.0
-    assert aroon.aroon_down == 100.0
-    assert aroon.value == 0
+    assert aroon.aroon_down == 0.0
+    assert aroon.value == 100.0
 
 
 def test_value_with_twenty_inputs(aroon: AroonOscillator) -> None:
@@ -186,9 +186,9 @@ def test_value_with_twenty_inputs(aroon: AroonOscillator) -> None:
     aroon.update_raw(110.04, 109.96)
 
     # Assert
-    assert aroon.aroon_up == 0.0
+    assert aroon.aroon_up == 10.0
     assert aroon.aroon_down == 20.0
-    assert aroon.value == -20.0
+    assert aroon.value == -10.0
 
 
 def test_reset_successfully_returns_indicator_to_fresh_state(aroon: AroonOscillator) -> None:


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`AroonOscillator::calculate_aroon` scanned the highs over the full `period + 1` bar window but scanned the lows with `.iter().skip(1)`, excluding the oldest bar, so Aroon Down was overstated whenever the lowest low of the window was the oldest bar; once initialized, Aroon Down had a floor of `100 / period` and could never reach 0 while Aroon Up could. On the fixture in `test_value_twenty_inputs` the oscillator produced `-25` where the correct value is `+30`, a sign flip on a trend signal. Tie handling was also inverted relative to the v1 Cython implementation, which used `np.argmax` / `np.argmin` over a newest-first deque (most recent occurrence of the extreme wins); the current code kept the oldest occurrence. The fix rewrites both scans to iterate the window from newest to oldest with strict comparisons, so the enumeration index is directly the periods-since count and ties resolve to the most recent occurrence, restoring the v1 window-scan and tie-break semantics for a full window and keeping the two scans symmetric.

Note this corrects the emitted values: any consumer of `aroon_down` (and of `aroon_up` in tie cases) will see different numbers after this change, which is the point of the fix but worth flagging for anyone comparing output across versions. No in-repo strategies, examples, or docs consume the affected values.

Unrelated issue noted, not fixed here: `AroonOscillator::new(MAX_PERIOD)` is accepted, but the window needs `period + 1` elements while the backing `ArrayDeque` capacity is `MAX_PERIOD`, so at `period = 1024` the window silently caps at 1024 elements (and the `debug_assert_eq!` fires in debug builds). This predates this change.

## Related issues/PRs

Closes #4913

## Type of change

- [x] Bug fix (non-breaking)

## Breaking change details (if applicable)

n/a (output values change because they were incorrect; no API or behavioral contract changes)

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

## Testing

- [x] I added/updated tests to cover new or changed logic

Test changes:

- Corrected the fixtures that had pinned the defective behavior: `test_value_one_input` and `test_value_twenty_inputs` in Rust, and `test_handle_bar_uses_bar_high_and_low`, `test_value_with_two_inputs`, and `test_value_with_twenty_inputs` in Python. The corrected Python expectations for the 20-input, period-10 fixture (`up == 10.0`, `down == 20.0`, `value == -10.0`) match what the legacy Cython-era test asserted for the identical inputs and period (`tests/unit_tests/indicators/test_aroon.py` at v1.231.0: `9.999999999999998` / `19.999999999999996` / `-9.999999999999998`; the float noise there comes from v1's `100.0 * (1.0 - n / period)` formulation, while the Rust computation is exact for these values).
- Renamed `test_ignore_oldest_low` to `test_lowest_low_at_oldest_bar` with the corrected expectation (`down == 0`), since the previous name and assertion described the defect.
- Added `test_tie_favors_most_recent_occurrence` covering the tie-break behavior for both sides.

Validation: `cargo test -p nautilus-indicators --lib` (568 passed), `pytest python/tests/unit/indicators/` (148 passed), `cargo clippy -p nautilus-indicators` clean, `cargo +nightly fmt` no changes. I also ran a differential test of the built module against a reference implementation of the v1 semantics (pure-Python argmax/argmin over a newest-first `deque(maxlen=period + 1)`, first occurrence wins) across 500 random walks with mixed periods: 0 mismatches over 8,156 full-window evaluations; script available on request.
