### PR TITLE
Preserve cash order locks on unreported balances

### DIFF
--- a/crates/adapters/polymarket/src/execution/reports.rs
+++ b/crates/adapters/polymarket/src/execution/reports.rs
@@ -838,7 +838,9 @@ pub(super) async fn fetch_and_emit_account_state(
         "Account state updated: balance={} pUSD",
         account_balance.total
     );
-    emitter.emit_account_state(vec![account_balance], vec![], true, ts_event, None);
+    // Not a full snapshot: `GET /balance-allowance` returns no reservation figure, so
+    // reporting it as one would clear the portfolio's locks from open orders
+    emitter.emit_account_state(vec![account_balance], vec![], false, ts_event, None);
     Ok(())
 }
 

--- a/crates/model/src/accounts/cash.rs
+++ b/crates/model/src/accounts/cash.rs
@@ -260,7 +260,23 @@ impl Account for CashAccount {
             self.balances_locked.clear();
         }
 
+        let currencies: Vec<Currency> = event.balances.iter().map(|b| b.currency).collect();
+
         self.base_apply(event);
+
+        // A non-reported snapshot carries only the total, so re-derive locked and free
+        // from any reservations which survived above
+        for currency in currencies {
+            // A reported snapshot cleared the map, so its own `locked` figure stands
+            if self
+                .balances_locked
+                .keys()
+                .any(|(_, locked_currency)| *locked_currency == currency)
+            {
+                base::recalculate_balance(&mut self.base.balances, &self.balances_locked, currency);
+            }
+        }
+
         Ok(())
     }
 
@@ -363,6 +379,50 @@ mod tests {
         position::Position,
         types::{AccountBalance, Currency, Money, Price, Quantity},
     };
+
+    #[rstest]
+    fn test_unreported_snapshot_preserves_order_locks(
+        mut cash_account: CashAccount,
+        audusd_sim: CurrencyPair,
+    ) {
+        let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+        let usd = Currency::USD();
+
+        // The portfolio reserves collateral for a resting order
+        cash_account.update_balance_locked(instrument.id(), Money::from("500.00 USD"));
+        assert_eq!(
+            cash_account.balance_locked(Some(usd)).unwrap(),
+            Money::from("500.00 USD"),
+        );
+
+        // Total only, with no reservation figure and not flagged as a full snapshot
+        let refresh = AccountState::new(
+            cash_account.id,
+            AccountType::Cash,
+            vec![AccountBalance::new(
+                Money::from("1000.00 USD"),
+                Money::from("0.00 USD"),
+                Money::from("1000.00 USD"),
+            )],
+            vec![],
+            false, // is_reported
+            uuid4(),
+            1.into(),
+            1.into(),
+            Some(usd),
+        );
+        cash_account.apply(refresh).unwrap();
+
+        // The reservation must survive
+        assert_eq!(
+            cash_account.balance_locked(Some(usd)).unwrap(),
+            Money::from("500.00 USD"),
+        );
+        assert_eq!(
+            cash_account.balance_free(Some(usd)).unwrap(),
+            Money::from("500.00 USD"),
+        );
+    }
 
     #[rstest]
     fn test_display(cash_account: CashAccount) {


### PR DESCRIPTION

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
- [x] I have read and followed
  [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md)
  and, if I used AI,
  [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`AccountState::is_reported` decides whether a venue snapshot's reservation figure replaces
the portfolio's computed one. `CashAccount::apply` honours it when clearing `balances_locked`,
but `base_apply` → `update_balances` then inserts the incoming `AccountBalance` wholesale,
stamping `locked` back to the payload's value with nothing re-deriving it until the next
order event. An adapter whose venue returns a bare total has no correct option: `true` clears
the map, `false` overwrites the result.

`apply` now re-derives `locked` and `free` after `base_apply`, but only for currencies where
a local reservation survived. The guard is load-bearing — unconditional recalculation
destroys a venue-supplied `locked`, which
`test_apply_given_new_state_event_updates_correctly` catches. A reported snapshot has just
cleared the map, so nothing recalculates and its own figure stands: the path is bit-identical
for all 71 emit sites in the tree, every one of which passes `reported = true`.

Polymarket switches to `reported = false`, now correct and what makes the fix observable:
`GET /balance-allowance` returns only the collateral total, so `parse_balance_allowance`
hardcodes `Decimal::ZERO`. That zero overwrote the portfolio's reservations on every refresh
— including after every finalized trade — pinning `locked` at `0.000000` while orders rested,
so `balance_free()` reported the full total however much was committed.

Kraken spot (`http/spot/client.rs:1862`) shares the shape but is left alone: it chains a
`margin_entry` into `balances` and `spot_account_type` is configurable, so it needs separate
validation.

## Related issues/PRs

Resolves #4911

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
- [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation changes. No PyO3 bindings or wrapped Rust docs were touched, so
`make py-stubs` does not apply.

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

`test_unreported_snapshot_preserves_order_locks` (new, in `accounts::cash::tests`) stores a
`500.00 USD` reservation, applies an `is_reported = false` snapshot carrying `total = 1000.00`
and `locked = 0.00`, then asserts `locked` and `free` are both still `500.00`. It fails before
this change (`left: Money(0.00, USD)`) and passes after.

Unchanged boundary tests: `test_apply_clears_per_instrument_locks` (a reported snapshot still
clears the map) and `test_apply_given_new_state_event_updates_correctly` (a genuine
`locked = 0.5 BTC` against an empty local map survives — the one that fails without the guard).

`cargo test -p nautilus-model --lib` (3158 tests), `cargo test -p nautilus-portfolio --lib`
(64 tests) and `cargo nextest run -p nautilus-polymarket` (1902 tests) all pass.
