### PR TITLE
Add runtime external order claim command for live nodes

### DIFF
--- a/crates/common/src/actor/tests.rs
+++ b/crates/common/src/actor/tests.rs
@@ -5485,7 +5485,10 @@ fn test_reconnect_socket_enqueues_typed_command(
     drop(actor);
 
     let SystemCommand::ReconnectSocket(command) =
-        system_rx.try_recv().expect("reconnect command queued");
+        system_rx.try_recv().expect("reconnect command queued")
+    else {
+        panic!("expected reconnect socket command");
+    };
 
     assert_eq!(command.trader_id, trader_id);
     assert_eq!(command.client_id, ClientId::from("POLYMARKET"));

--- a/crates/common/src/messages/mod.rs
+++ b/crates/common/src/messages/mod.rs
@@ -59,9 +59,11 @@ pub enum DataEvent {
 }
 
 /// System command variants routed to a live node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum SystemCommand {
     ReconnectSocket(system::ReconnectSocket),
+    #[cfg(feature = "live")]
+    SetExternalOrderClaims(system::SetExternalOrderClaims),
 }
 
 /// System event variants routed to a live node.

--- a/crates/common/src/messages/system/claims.rs
+++ b/crates/common/src/messages/system/claims.rs
@@ -1,0 +1,70 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::fmt::Display;
+
+use nautilus_core::UnixNanos;
+use nautilus_model::identifiers::{InstrumentId, StrategyId, TraderId};
+
+/// Command replacing the external order claims owned by a strategy.
+///
+/// The instrument IDs are the complete desired claim set, not an additive update. A stale partial
+/// set releases claims omitted from the command, and an empty set releases every claim owned by the
+/// strategy. Conflicts and repeated instruments reject the entire update atomically, while claims
+/// owned by other strategies remain unchanged.
+///
+/// Sending this command only confirms that it was queued, not that it was applied. The caller must
+/// not infer that routing changed from a successful send.
+///
+/// This command is intended for low-rate control operations. Its unbounded channel provides no
+/// backpressure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetExternalOrderClaims {
+    pub trader_id: TraderId,
+    pub strategy_id: StrategyId,
+    pub instrument_ids: Vec<InstrumentId>,
+    pub ts_init: UnixNanos,
+}
+
+impl SetExternalOrderClaims {
+    /// Creates a new [`SetExternalOrderClaims`] instance.
+    #[must_use]
+    pub const fn new(
+        trader_id: TraderId,
+        strategy_id: StrategyId,
+        instrument_ids: Vec<InstrumentId>,
+        ts_init: UnixNanos,
+    ) -> Self {
+        Self {
+            trader_id,
+            strategy_id,
+            instrument_ids,
+            ts_init,
+        }
+    }
+}
+
+impl Display for SetExternalOrderClaims {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}(trader_id={}, strategy_id={}, instrument_ids={:?})",
+            stringify!(SetExternalOrderClaims),
+            self.trader_id,
+            self.strategy_id,
+            self.instrument_ids,
+        )
+    }
+}

--- a/crates/common/src/messages/system/mod.rs
+++ b/crates/common/src/messages/system/mod.rs
@@ -19,7 +19,12 @@ pub mod shutdown;
 pub mod socket;
 pub mod trading;
 
+#[cfg(feature = "live")]
+pub mod claims;
+
 // Re-exports
+#[cfg(feature = "live")]
+pub use claims::SetExternalOrderClaims;
 pub use component::ComponentStateChanged;
 pub use queue::{QueueCondition, QueueState, QueueStateChanged};
 pub use shutdown::ShutdownSystem;

--- a/crates/common/src/python/actor.rs
+++ b/crates/common/src/python/actor.rs
@@ -3942,7 +3942,9 @@ class CapturingActor:
         let command = system_rx
             .try_recv()
             .expect("reconnect command should be queued");
-        let SystemCommand::ReconnectSocket(command) = command;
+        let SystemCommand::ReconnectSocket(command) = command else {
+            panic!("expected reconnect socket command");
+        };
 
         assert_eq!(command.trader_id, trader_id);
         assert_eq!(command.client_id, ClientId::from("POLYMARKET"));

--- a/crates/live/src/node/mod.rs
+++ b/crates/live/src/node/mod.rs
@@ -96,7 +96,10 @@ use nautilus_common::{
             GenerateFillReports, GenerateOrderStatusReports, GeneratePositionStatusReports,
             TradingCommand,
         },
-        system::{QueueStateChanged, ReconnectSocket, SocketStateChange, SocketStateChanged},
+        system::{
+            QueueStateChanged, ReconnectSocket, SetExternalOrderClaims, SocketStateChange,
+            SocketStateChanged,
+        },
     },
     msgbus::{self, BusMessage, MessagingSwitchboard},
     runner::{SystemChannel, TimeEventMessage, TradingCommandMessage},
@@ -597,6 +600,40 @@ impl LiveNode {
         match command {
             SystemCommand::ReconnectSocket(command) => {
                 self.process_socket_reconnect(command);
+            }
+            SystemCommand::SetExternalOrderClaims(command) => {
+                self.process_set_external_order_claims(command);
+            }
+        }
+    }
+
+    fn process_set_external_order_claims(&self, command: SetExternalOrderClaims) {
+        let SetExternalOrderClaims {
+            trader_id,
+            strategy_id,
+            instrument_ids,
+            ..
+        } = command;
+
+        if trader_id != self.config.trader_id {
+            log::warn!(
+                "Rejected external order claims for {strategy_id}: trader {trader_id} does not match node trader {}",
+                self.config.trader_id
+            );
+            return;
+        }
+
+        match self.kernel.cache.try_borrow_mut() {
+            Ok(mut cache) => match cache.set_external_order_claims(strategy_id, &instrument_ids) {
+                Ok(()) => {
+                    log::info!("Set external order claims for {strategy_id}: {instrument_ids:?}");
+                }
+                Err(e) => {
+                    log::error!("Failed to set external order claims for {strategy_id}: {e}");
+                }
+            },
+            Err(e) => {
+                log::error!("Failed to set external order claims for {strategy_id}: {e}");
             }
         }
     }
@@ -3919,11 +3956,15 @@ mod tests {
         cache::Cache,
         clock::{Clock, TestClock},
         enums::SerializationEncoding,
-        live::runner::{get_data_event_sender, get_exec_event_sender, get_system_event_sender},
+        live::runner::{
+            get_data_event_sender, get_exec_event_sender, get_system_command_sender,
+            get_system_event_sender,
+        },
         messages::{
             execution::{QueryAccount, SubmitOrder, TradingCommand},
             system::{
-                QueueCondition, QueueState, ReconnectSocket, SocketState, SocketStateChanged,
+                QueueCondition, QueueState, ReconnectSocket, SetExternalOrderClaims, SocketState,
+                SocketStateChanged,
             },
         },
         msgbus::{
@@ -5789,6 +5830,26 @@ mod tests {
         builder.build().unwrap()
     }
 
+    fn live_node_for_run_loop() -> LiveNode {
+        let config = LiveNodeConfig {
+            trader_id: TraderId::from("CLAIMS-RUN-001"),
+            environment: Environment::Sandbox,
+            exec_engine: crate::config::LiveExecutionEngineConfig {
+                reconciliation: false,
+                ..Default::default()
+            },
+            timeout_connection: Duration::ZERO,
+            timeout_reconciliation: Duration::ZERO,
+            timeout_portfolio: Duration::ZERO,
+            timeout_disconnection: Duration::ZERO,
+            delay_post_stop: Duration::ZERO,
+            timeout_shutdown: Duration::ZERO,
+            ..Default::default()
+        };
+
+        LiveNode::build("ExternalClaimsRunNode".to_string(), Some(config)).unwrap()
+    }
+
     #[rstest]
     fn test_add_strategy_registers_external_order_claims_with_manager_and_engine() {
         let mut node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
@@ -5871,6 +5932,239 @@ mod tests {
                 .borrow()
                 .get_external_order_claim(&instrument_id),
             Some(strategy_id)
+        );
+    }
+
+    #[rstest]
+    fn test_set_external_order_claims_rejects_mismatched_trader() {
+        let node = LiveNode::builder(TraderId::from("TESTER-001"), Environment::Sandbox)
+            .unwrap()
+            .build()
+            .unwrap();
+        let strategy_id = StrategyId::from("CLAIMS-TRADER-001");
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+
+        node.process_system_command(SystemCommand::SetExternalOrderClaims(
+            SetExternalOrderClaims::new(
+                TraderId::from("OTHER-001"),
+                strategy_id,
+                vec![instrument_id],
+                UnixNanos::default(),
+            ),
+        ));
+        assert_eq!(
+            node.kernel
+                .cache
+                .borrow()
+                .external_order_claim(&instrument_id),
+            None
+        );
+
+        node.process_system_command(SystemCommand::SetExternalOrderClaims(
+            SetExternalOrderClaims::new(
+                node.trader_id(),
+                strategy_id,
+                vec![instrument_id],
+                UnixNanos::default(),
+            ),
+        ));
+        assert_eq!(
+            node.kernel
+                .cache
+                .borrow()
+                .external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_set_external_order_claims_from_another_thread_while_run_owns_node() {
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let cache = node.kernel.cache();
+        node.runner.as_ref().unwrap().bind_senders();
+        let sender = get_system_command_sender();
+        let trader_id = node.trader_id();
+        let strategy_id = StrategyId::from("CLAIMS-THREAD-001");
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+
+        {
+            let run = node.run();
+            tokio::pin!(run);
+            let drive = async {
+                wait_until_async(|| async { handle.is_running() }, Duration::from_secs(10)).await;
+
+                std::thread::spawn(move || {
+                    sender
+                        .send(SystemCommand::SetExternalOrderClaims(
+                            SetExternalOrderClaims::new(
+                                trader_id,
+                                strategy_id,
+                                vec![instrument_id],
+                                UnixNanos::default(),
+                            ),
+                        ))
+                        .expect("system command channel should be open");
+                })
+                .join()
+                .expect("claim sender thread should finish");
+
+                wait_until_async(
+                    || async {
+                        cache.borrow().external_order_claim(&instrument_id) == Some(strategy_id)
+                    },
+                    Duration::from_secs(10),
+                )
+                .await;
+                handle.stop();
+            };
+
+            let (run_result, ()) = tokio::join!(run, drive);
+            run_result.expect("node should stop cleanly");
+        }
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&instrument_id),
+            Some(strategy_id)
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_set_external_order_claims_conflict_is_atomic_while_run_owns_node() {
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let cache = node.kernel.cache();
+        let trader_id = node.trader_id();
+        let existing_strategy_id = StrategyId::from("CLAIMS-CONFLICT-001");
+        let new_strategy_id = StrategyId::from("CLAIMS-CONFLICT-002");
+        let conflicting_instrument = InstrumentId::from("AUDUSD.SIM");
+        let retained_instrument = InstrumentId::from("GBPUSD.SIM");
+        let requested_instrument = InstrumentId::from("EURUSD.SIM");
+        let marker_strategy_id = StrategyId::from("CLAIMS-CONFLICT-003");
+        let marker_instrument = InstrumentId::from("USDJPY.SIM");
+        node.register_external_order_claims(existing_strategy_id, &[conflicting_instrument])
+            .unwrap();
+        node.register_external_order_claims(new_strategy_id, &[retained_instrument])
+            .unwrap();
+        node.runner.as_ref().unwrap().bind_senders();
+        let sender = get_system_command_sender();
+
+        {
+            let run = node.run();
+            tokio::pin!(run);
+            let drive = async {
+                wait_until_async(|| async { handle.is_running() }, Duration::from_secs(10)).await;
+                sender
+                    .send(SystemCommand::SetExternalOrderClaims(
+                        SetExternalOrderClaims::new(
+                            trader_id,
+                            new_strategy_id,
+                            vec![requested_instrument, conflicting_instrument],
+                            UnixNanos::default(),
+                        ),
+                    ))
+                    .expect("system command channel should be open");
+                sender
+                    .send(SystemCommand::SetExternalOrderClaims(
+                        SetExternalOrderClaims::new(
+                            trader_id,
+                            marker_strategy_id,
+                            vec![marker_instrument],
+                            UnixNanos::default(),
+                        ),
+                    ))
+                    .expect("system command channel should be open");
+
+                wait_until_async(
+                    || async {
+                        cache.borrow().external_order_claim(&marker_instrument)
+                            == Some(marker_strategy_id)
+                    },
+                    Duration::from_secs(10),
+                )
+                .await;
+                handle.stop();
+            };
+
+            let (run_result, ()) = tokio::join!(run, drive);
+            run_result.expect("node should stop cleanly");
+        }
+        let cache = node.kernel.cache.borrow();
+        assert_eq!(
+            cache.external_order_claim(&conflicting_instrument),
+            Some(existing_strategy_id)
+        );
+        assert_eq!(
+            cache.external_order_claim(&retained_instrument),
+            Some(new_strategy_id)
+        );
+        assert_eq!(cache.external_order_claim(&requested_instrument), None);
+    }
+
+    #[rstest]
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_set_external_order_claims_empty_set_releases_while_run_owns_node() {
+        let mut node = live_node_for_run_loop();
+        let handle = node.handle();
+        let cache = node.kernel.cache();
+        let trader_id = node.trader_id();
+        let strategy_id = StrategyId::from("CLAIMS-RELEASE-001");
+        let instrument_id = InstrumentId::from("AUDUSD.SIM");
+        node.register_external_order_claims(strategy_id, &[instrument_id])
+            .unwrap();
+        node.runner.as_ref().unwrap().bind_senders();
+        let sender = get_system_command_sender();
+
+        {
+            let run = node.run();
+            tokio::pin!(run);
+            let drive = async {
+                wait_until_async(|| async { handle.is_running() }, Duration::from_secs(10)).await;
+                sender
+                    .send(SystemCommand::SetExternalOrderClaims(
+                        SetExternalOrderClaims::new(
+                            trader_id,
+                            strategy_id,
+                            Vec::new(),
+                            UnixNanos::default(),
+                        ),
+                    ))
+                    .expect("system command channel should be open");
+
+                wait_until_async(
+                    || async {
+                        cache
+                            .borrow()
+                            .external_order_claim(&instrument_id)
+                            .is_none()
+                    },
+                    Duration::from_secs(10),
+                )
+                .await;
+                handle.stop();
+            };
+
+            let (run_result, ()) = tokio::join!(run, drive);
+            run_result.expect("node should stop cleanly");
+        }
+        assert_eq!(
+            node.exec_manager.get_external_order_claim(&instrument_id),
+            None
+        );
+        assert_eq!(
+            node.kernel
+                .exec_engine
+                .borrow()
+                .get_external_order_claim(&instrument_id),
+            None
         );
     }
 
@@ -7859,7 +8153,7 @@ mod tests {
         let mut pending = PendingEvents::default();
         let command = stub_system_command();
 
-        pending.system_commands.push(command);
+        pending.system_commands.push(command.clone());
         let system_commands = pending.take_system_commands();
 
         assert_eq!(system_commands, vec![command]);

--- a/crates/live/src/runner.rs
+++ b/crates/live/src/runner.rs
@@ -1986,7 +1986,9 @@ mod tests {
             runner.bind_senders();
             let system_command = test_system_command();
 
-            get_system_command_sender().send(system_command).unwrap();
+            get_system_command_sender()
+                .send(system_command.clone())
+                .unwrap();
             get_system_event_sender().send(test_system_event()).unwrap();
 
             let system_commands = runner.drain_pending_system_commands();

--- a/crates/trading/src/python/strategy.rs
+++ b/crates/trading/src/python/strategy.rs
@@ -4969,7 +4969,9 @@ class IndicatorEventStrategy:
             let command = system_rx
                 .try_recv()
                 .expect("reconnect command should be queued");
-            let SystemCommand::ReconnectSocket(command) = command;
+            let SystemCommand::ReconnectSocket(command) = command else {
+                panic!("expected reconnect socket command");
+            };
 
             assert_eq!(command.trader_id, TraderId::from("TRADER-001"));
             assert_eq!(command.client_id, ClientId::from("POLYMARKET"));


### PR DESCRIPTION
A follow-up to the cache-backed external order claim routing in 681607428c, extending runtime claim updates to threads the node does not run on.

## A worker on another thread cannot update claims while `run()` owns the node

`LiveNode::register_external_order_claims` needs the node object, `run()` consumes it, and the cache is thread-bound - so our supervisor worker, which drives the node through `LiveNodeHandle` and decides claim ownership at runtime, has no route to claim registration for the whole run. `Strategy::set_external_order_instrument_ids` covers a strategy updating its own claims; nothing covers a non-strategy component.

The fix adds `SystemCommand::SetExternalOrderClaims`, a responder-free replace-set command riding the existing system command channel, dispatched by `process_system_command` into `Cache::set_external_order_claims`. Semantics mirror the cache method exactly: the vector is the strategy's complete desired set, empty releases all claims, conflicts and repeated instruments reject atomically. A command whose `trader_id` does not match the node is rejected with a warning, the same check `ReconnectSocket` dispatch performs. The message, its module, and the variant are gated on the `live` feature, so the default `nautilus-common` graph is unchanged.

A successful send confirms the command was queued, not applied; failures surface through the node's log rather than an acknowledgement channel, and the unbounded channel makes this a low-rate control operation.

If a confirmed-before-action guarantee is wanted, that is an outcome channel whose shape is yours to choose; this PR does not build one.

`SystemCommand` loses `Copy` for the `Vec<InstrumentId>` payload; the two tests that reused a sent command now clone it, and the three irrefutable `ReconnectSocket` bindings become `let ... else`.

## Testing

`test_set_external_order_claims_from_another_thread_while_run_owns_node` sends from a spawned OS thread while the run loop services the node and asserts the claim through the engine and manager lookups. The conflict test follows a conflicting set with a marker command (FIFO within the channel) and asserts the prior owner and the requester's existing claim are intact with no part of the rejected set applied. The empty-set test pins release; the mismatched-trader test pins the guard with a matching-trader positive control. With the dispatch handler disarmed, the cross-thread, conflict, and release tests fail by timeout while every existing claims test passes.
