### PR TITLE
Add Binance RPI order support

### DIFF
--- a/crates/adapters/binance/src/common/enums.rs
+++ b/crates/adapters/binance/src/common/enums.rs
@@ -383,7 +383,7 @@ pub enum BinanceTimeInForce {
     Gtx,
     /// Good till date.
     Gtd,
-    /// Request-for-quote interactive (USD-M Futures).
+    /// Retail Price Improvement (USD-M Futures).
     Rpi,
     /// Unknown or undocumented value.
     #[serde(other)]

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -3183,6 +3183,7 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
             .as_ref()
             .and_then(|params| params.get_bool("rpi"))
             .unwrap_or(false);
+
         if rpi {
             let reason = "rpi is only supported for individual Binance Futures order submission";
             for order in &orders {
@@ -3789,15 +3790,23 @@ fn validate_order(
         .unwrap_or(false);
 
     if rpi {
-        anyhow::ensure!(
-            client.product_type == BinanceProductType::UsdM,
-            "rpi is only supported for Binance USD-M Futures"
-        );
-        anyhow::ensure!(
-            order.order_type() == OrderType::Limit,
-            "rpi is only supported for LIMIT orders"
-        );
-        anyhow::ensure!(order.is_post_only(), "rpi requires post_only=true");
+        if client.product_type != BinanceProductType::UsdM {
+            return Err(OrderDeniedReason::ValidationFailed {
+                detail: "rpi is only supported for Binance USD-M Futures".to_string(),
+            });
+        }
+
+        if order.order_type() != OrderType::Limit {
+            return Err(OrderDeniedReason::ValidationFailed {
+                detail: "rpi is only supported for LIMIT orders".to_string(),
+            });
+        }
+
+        if !order.is_post_only() {
+            return Err(OrderDeniedReason::ValidationFailed {
+                detail: "rpi requires post_only=true".to_string(),
+            });
+        }
     }
 
     if close_position {

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -3178,6 +3178,19 @@ impl ExecutionClient for BinanceFuturesExecutionClient {
             return Ok(());
         }
 
+        let rpi = cmd
+            .params
+            .as_ref()
+            .and_then(|params| params.get_bool("rpi"))
+            .unwrap_or(false);
+        if rpi {
+            let reason = "rpi is only supported for individual Binance Futures order submission";
+            for order in &orders {
+                self.emitter.emit_order_denied(order, reason);
+            }
+            return Ok(());
+        }
+
         let close_position = cmd
             .params
             .as_ref()

--- a/crates/adapters/binance/src/futures/execution.rs
+++ b/crates/adapters/binance/src/futures/execution.rs
@@ -536,6 +536,11 @@ impl BinanceFuturesExecutionClient {
             .as_ref()
             .and_then(|p| p.get_bool(PARAMS_CLOSE_POSITION))
             .unwrap_or(false);
+        let rpi = cmd
+            .params
+            .as_ref()
+            .and_then(|p| p.get_bool("rpi"))
+            .unwrap_or(false);
 
         let use_algo_api = is_algo_order_type(order_type);
         let use_ws = self.ws_trading_active() && !use_algo_api;
@@ -593,7 +598,9 @@ impl BinanceFuturesExecutionClient {
             let symbol = format_binance_symbol(&instrument_id);
             let binance_side = BinanceSide::try_from(order_side)?;
             let binance_order_type = order_type_to_binance_futures(order_type)?;
-            let binance_tif = if post_only {
+            let binance_tif = if rpi {
+                BinanceTimeInForce::Rpi
+            } else if post_only {
                 BinanceTimeInForce::Gtx
             } else {
                 BinanceTimeInForce::try_from(time_in_force)?
@@ -707,6 +714,7 @@ impl BinanceFuturesExecutionClient {
                         trigger_price,
                         reduce_only,
                         post_only,
+                        rpi,
                         position_side,
                         price_match,
                         good_till_date,
@@ -3760,6 +3768,24 @@ fn validate_order(
         .as_ref()
         .and_then(|params| params.get_bool(PARAMS_CLOSE_POSITION))
         .unwrap_or(false);
+
+    let rpi = cmd
+        .params
+        .as_ref()
+        .and_then(|params| params.get_bool("rpi"))
+        .unwrap_or(false);
+
+    if rpi {
+        anyhow::ensure!(
+            client.product_type == BinanceProductType::UsdM,
+            "rpi is only supported for Binance USD-M Futures"
+        );
+        anyhow::ensure!(
+            order.order_type() == OrderType::Limit,
+            "rpi is only supported for LIMIT orders"
+        );
+        anyhow::ensure!(order.is_post_only(), "rpi requires post_only=true");
+    }
 
     if close_position {
         let order_type = order.order_type();

--- a/crates/adapters/binance/src/futures/http/client.rs
+++ b/crates/adapters/binance/src/futures/http/client.rs
@@ -2212,6 +2212,7 @@ impl BinanceFuturesHttpClient {
         trigger_price: Option<Price>,
         reduce_only: bool,
         post_only: bool,
+        rpi: bool,
         position_side: Option<BinancePositionSide>,
         price_match: Option<BinancePriceMatch>,
         good_till_date: Option<i64>,
@@ -2221,7 +2222,9 @@ impl BinanceFuturesHttpClient {
 
         let binance_side = BinanceSide::try_from(order_side)?;
         let binance_order_type = order_type_to_binance_futures(order_type)?;
-        let binance_tif = if post_only {
+        let binance_tif = if rpi {
+            BinanceTimeInForce::Rpi
+        } else if post_only {
             BinanceTimeInForce::Gtx
         } else {
             BinanceTimeInForce::try_from(time_in_force)?

--- a/crates/adapters/binance/src/futures/http/models.rs
+++ b/crates/adapters/binance/src/futures/http/models.rs
@@ -1187,6 +1187,12 @@ impl BinanceFuturesOrder {
             Some(UUID4::new()),
         );
 
+        report.post_only = self.order_type == BinanceFuturesOrderType::Limit
+            && matches!(
+                self.time_in_force,
+                BinanceTimeInForce::Gtx | BinanceTimeInForce::Rpi
+            );
+
         if let Some(price) = price {
             report = report.with_price(price);
         }
@@ -1231,7 +1237,7 @@ impl BinanceTimeInForce {
             Self::Fok => TimeInForce::Fok,
             Self::Gtx => TimeInForce::Gtc, // GTX is GTC with post-only
             Self::Gtd => TimeInForce::Gtd,
-            Self::Rpi => TimeInForce::Ioc, // RPI behaves as immediate
+            Self::Rpi => TimeInForce::Gtc,
             Self::Unknown => anyhow::bail!("unknown Binance time in force"),
         })
     }
@@ -2109,6 +2115,27 @@ mod tests {
             order.self_trade_prevention_mode,
             Some(BinanceSelfTradePreventionMode::None)
         );
+    }
+
+    #[rstest]
+    fn test_order_to_report_maps_rpi_to_gtc_post_only() {
+        let mut order = order_with_price("50000.00");
+        order.order_type = BinanceFuturesOrderType::Limit;
+        order.time_in_force = BinanceTimeInForce::Rpi;
+
+        let report = order
+            .to_order_status_report(
+                AccountId::from("BINANCE-FUTURES-001"),
+                InstrumentId::from("BTCUSDT-PERP.BINANCE"),
+                2,
+                3,
+                false,
+                UnixNanos::from(1_000_000_000u64),
+            )
+            .unwrap();
+
+        assert_eq!(report.time_in_force, TimeInForce::Gtc);
+        assert!(report.post_only);
     }
 
     #[rstest]

--- a/crates/adapters/binance/src/futures/websocket/streams/parse_exec.rs
+++ b/crates/adapters/binance/src/futures/websocket/streams/parse_exec.rs
@@ -111,7 +111,10 @@ pub fn parse_futures_order_update_to_order_status(
 
     report.price = Some(price);
     report.post_only = order.order_type == BinanceFuturesOrderType::Limit
-        && order.time_in_force == BinanceTimeInForce::Gtx;
+        && matches!(
+            order.time_in_force,
+            BinanceTimeInForce::Gtx | BinanceTimeInForce::Rpi
+        );
 
     match parse_good_till_date(order.good_till_date) {
         Ok(expire_time) => report.expire_time = expire_time,
@@ -592,6 +595,28 @@ mod tests {
         assert_eq!(report.order_type, OrderType::TrailingStopMarket);
         assert_eq!(report.venue_order_id, VenueOrderId::new("8886774"));
         assert_eq!(report.client_order_id, Some(ClientOrderId::from("TEST")));
+    }
+
+    #[rstest]
+    fn test_parse_order_update_to_order_status_maps_rpi_to_gtc_post_only() {
+        let mut msg: BinanceFuturesOrderUpdateMsg = load_user_data_fixture("order_update_new.json");
+        msg.order.order_type = BinanceFuturesOrderType::Limit;
+        msg.order.time_in_force = BinanceTimeInForce::Rpi;
+        msg.order.original_price = "50000.00".to_string();
+
+        let report = parse_futures_order_update_to_order_status(
+            &msg,
+            instrument_id(),
+            PRICE_PRECISION,
+            SIZE_PRECISION,
+            account_id(),
+            false,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .unwrap();
+
+        assert_eq!(report.time_in_force, TimeInForce::Gtc);
+        assert!(report.post_only);
     }
 
     #[rstest]

--- a/crates/adapters/binance/tests/integration/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/integration/futures/exec_client.rs
@@ -1876,6 +1876,90 @@ async fn test_submit_usdm_gtd_order_encodes_expiry_over_http() {
 }
 
 #[rstest]
+#[case::rpi(true, true, "RPI")]
+#[case::post_only(false, true, "GTX")]
+#[case::regular(false, false, "GTC")]
+#[tokio::test]
+async fn test_submit_order_maps_time_in_force_over_http(
+    #[case] rpi: bool,
+    #[case] post_only: bool,
+    #[case] expected_time_in_force: &str,
+) {
+    let (addr, captured_query) = start_exec_test_server_with_order_capture().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+    let (mut client, _rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let order = add_limit_order_with_post_only_to_cache(
+        &cache,
+        ClientOrderId::new("time-in-force-http-test-001"),
+        post_only,
+    );
+    let params = rpi.then(rpi_params);
+    client
+        .submit_order(submit_order_command_with_params(&order, params))
+        .unwrap();
+
+    wait_until_async(
+        || {
+            let captured_query = captured_query.clone();
+            async move { captured_query.lock().is_some() }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let query = captured_query.lock().clone().unwrap();
+    assert_eq!(
+        query.get("timeInForce").map(String::as_str),
+        Some(expected_time_in_force),
+    );
+}
+
+#[rstest]
+#[case::coin_m(
+    BinanceProductType::CoinM,
+    true,
+    true,
+    "rpi is only supported for Binance USD-M Futures"
+)]
+#[case::non_limit(
+    BinanceProductType::UsdM,
+    false,
+    true,
+    "rpi is only supported for LIMIT orders"
+)]
+#[case::missing_post_only(BinanceProductType::UsdM, true, false, "rpi requires post_only=true")]
+#[tokio::test]
+async fn test_submit_rpi_rejects_invalid_order_combinations(
+    #[case] product_type: BinanceProductType,
+    #[case] limit_order: bool,
+    #[case] post_only: bool,
+    #[case] expected_error: &str,
+) {
+    let (client, _rx, cache) = create_test_execution_client_for_product(
+        "http://127.0.0.1:1".to_string(),
+        "ws://127.0.0.1:1/ws".to_string(),
+        product_type,
+    );
+
+    let client_order_id = ClientOrderId::new("rpi-invalid-order-test-001");
+    let order = if limit_order {
+        add_limit_order_with_post_only_to_cache(&cache, client_order_id, post_only)
+    } else {
+        add_stop_market_order_to_cache(&cache, client_order_id, OrderSide::Buy, false)
+    };
+    let error = client
+        .submit_order(submit_order_command_with_params(&order, Some(rpi_params())))
+        .unwrap_err();
+
+    assert_eq!(error.to_string(), expected_error);
+}
+
+#[rstest]
 #[tokio::test]
 async fn test_submit_order_list_posts_batch_orders_for_independent_limits() {
     let (addr, captured_queries) = start_exec_test_server_with_query_capture().await;
@@ -5849,13 +5933,40 @@ fn add_limit_order_to_cache(
     cache: &Rc<RefCell<Cache>>,
     client_order_id: ClientOrderId,
 ) -> OrderAny {
-    add_limit_order_for_instrument_to_cache(cache, test_instrument_id(), client_order_id)
+    add_limit_order_with_post_only_to_cache(cache, client_order_id, true)
+}
+
+fn add_limit_order_with_post_only_to_cache(
+    cache: &Rc<RefCell<Cache>>,
+    client_order_id: ClientOrderId,
+    post_only: bool,
+) -> OrderAny {
+    add_limit_order_for_instrument_with_post_only_to_cache(
+        cache,
+        test_instrument_id(),
+        client_order_id,
+        post_only,
+    )
 }
 
 fn add_limit_order_for_instrument_to_cache(
     cache: &Rc<RefCell<Cache>>,
     instrument_id: InstrumentId,
     client_order_id: ClientOrderId,
+) -> OrderAny {
+    add_limit_order_for_instrument_with_post_only_to_cache(
+        cache,
+        instrument_id,
+        client_order_id,
+        true,
+    )
+}
+
+fn add_limit_order_for_instrument_with_post_only_to_cache(
+    cache: &Rc<RefCell<Cache>>,
+    instrument_id: InstrumentId,
+    client_order_id: ClientOrderId,
+    post_only: bool,
 ) -> OrderAny {
     let order = LimitOrder::new(
         test_trader_id(),
@@ -5867,7 +5978,7 @@ fn add_limit_order_for_instrument_to_cache(
         Price::from("50000.00"),
         TimeInForce::Gtc,
         None,
-        true,
+        post_only,
         false,
         false,
         None,
@@ -6100,6 +6211,12 @@ fn add_stop_market_order_to_cache(
 fn close_position_params() -> Params {
     let mut params = Params::new();
     params.insert("close_position".to_string(), json!(true));
+    params
+}
+
+fn rpi_params() -> Params {
+    let mut params = Params::new();
+    params.insert("rpi".to_string(), json!(true));
     params
 }
 
@@ -6650,6 +6767,37 @@ async fn test_submit_order_ws_reduce_only_respects_position_mode(
     assert_eq!(
         params.get("reduceOnly").and_then(|value| value.as_bool()),
         expected_reduce_only
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_submit_order_with_rpi_uses_rpi_time_in_force_over_ws() {
+    let (addr, captured_ws_trading_messages) =
+        start_exec_test_server_with_ws_trading_capture().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+    let base_url_ws_trading = format!("ws://{addr}/ws-fapi/v1");
+
+    let (mut client, _rx, cache) = create_test_execution_client_with_ws_trading(
+        base_url_http,
+        base_url_ws,
+        base_url_ws_trading,
+    );
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let order = add_limit_order_to_cache(&cache, ClientOrderId::new("rpi-ws-test-001"));
+    client
+        .submit_order(submit_order_command_with_params(&order, Some(rpi_params())))
+        .unwrap();
+
+    let message = wait_for_ws_trading_method(&captured_ws_trading_messages, "order.place").await;
+    let params = message.get("params").unwrap();
+    assert_eq!(
+        params.get("timeInForce").and_then(|value| value.as_str()),
+        Some("RPI"),
     );
 }
 

--- a/crates/adapters/binance/tests/integration/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/integration/futures/exec_client.rs
@@ -1940,11 +1940,12 @@ async fn test_submit_rpi_rejects_invalid_order_combinations(
     #[case] post_only: bool,
     #[case] expected_error: &str,
 ) {
-    let (client, _rx, cache) = create_test_execution_client_for_product(
+    let (mut client, mut rx, cache) = create_test_execution_client_for_product(
         "http://127.0.0.1:1".to_string(),
         "ws://127.0.0.1:1/ws".to_string(),
         product_type,
     );
+    client.start().unwrap();
 
     let client_order_id = ClientOrderId::new("rpi-invalid-order-test-001");
     let order = if limit_order {
@@ -1952,11 +1953,23 @@ async fn test_submit_rpi_rejects_invalid_order_combinations(
     } else {
         add_stop_market_order_to_cache(&cache, client_order_id, OrderSide::Buy, false)
     };
-    let error = client
+    client
         .submit_order(submit_order_command_with_params(&order, Some(rpi_params())))
-        .unwrap_err();
+        .unwrap();
 
-    assert_eq!(error.to_string(), expected_error);
+    let event = rx.try_recv().expect("OrderDenied expected");
+    let ExecutionEvent::Order(OrderEventAny::Denied(denied)) = event else {
+        panic!("Expected OrderDenied, was {event:?}");
+    };
+    assert_eq!(denied.client_order_id, client_order_id);
+    assert_eq!(denied.instrument_id, order.instrument_id());
+    assert_eq!(denied.strategy_id, order.strategy_id());
+    assert_eq!(denied.trader_id, order.trader_id());
+    assert_eq!(
+        denied.reason.as_str(),
+        format!("VALIDATION_FAILED: {expected_error}")
+    );
+    assert!(rx.try_recv().is_err());
 }
 
 #[rstest]

--- a/crates/adapters/binance/tests/integration/futures/exec_client.rs
+++ b/crates/adapters/binance/tests/integration/futures/exec_client.rs
@@ -2002,6 +2002,53 @@ async fn test_submit_order_list_posts_batch_orders_for_independent_limits() {
 
 #[rstest]
 #[tokio::test]
+async fn test_submit_order_list_denies_rpi_without_batch_submit() {
+    let (addr, captured_queries) = start_exec_test_server_with_query_capture().await;
+    let base_url_http = format!("http://{addr}");
+    let base_url_ws = format!("ws://{addr}/ws");
+
+    let (mut client, mut rx, cache) = create_test_execution_client(base_url_http, base_url_ws);
+    add_test_account_to_cache(&cache, AccountId::from("BINANCE-001"));
+
+    client.start().unwrap();
+    client.connect().await.unwrap();
+
+    let orders = vec![
+        add_limit_order_to_cache(&cache, ClientOrderId::new("list-rpi-001")),
+        add_limit_order_to_cache(&cache, ClientOrderId::new("list-rpi-002")),
+    ];
+    let mut command = submit_order_list_command(&orders);
+    command.params = Some(rpi_params());
+
+    client.submit_order_list(command).unwrap();
+
+    let expected_reason = "rpi is only supported for individual Binance Futures order submission";
+    let mut denied_count = 0;
+    wait_until_async(
+        || {
+            while let Ok(event) = rx.try_recv() {
+                if let ExecutionEvent::Order(OrderEventAny::Denied(denied)) = event {
+                    assert_eq!(denied.reason.as_str(), expected_reason);
+                    denied_count += 1;
+                }
+            }
+            let done = denied_count == orders.len();
+            async move { done }
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    assert!(
+        captured_queries
+            .lock()
+            .iter()
+            .all(|query| query.path != "batchOrders")
+    );
+}
+
+#[rstest]
+#[tokio::test]
 async fn test_submit_hedge_order_rejects_custom_position_id_before_request() {
     let (addr, captured_query) =
         start_exec_test_server_with_order_capture_and_hedge_mode(true).await;

--- a/docs/integrations/binance.md
+++ b/docs/integrations/binance.md
@@ -439,7 +439,7 @@ command (Rust). The Binance execution clients recognize:
 | ---------------- | ------ | ----------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
 | `price_match`    | `str`  | USDT/COIN Futures | Delegate price selection to Binance.             | `LIMIT` only; not with `post_only`.                                                       |
 | `close_position` | `bool` | USDT/COIN Futures | Close the whole position when the trigger fires. | `StopMarket` and `MarketIfTouched` only; requires `reduce_only=true`; not in order lists. |
-| `rpi`            | `bool` | USDT Futures      | Submit a Retail Price Improvement order.         | `LIMIT` only; requires `post_only=true`; individual orders only.                           |
+| `rpi`            | `bool` | USDT Futures      | Submit a Retail Price Improvement order.         | `LIMIT` only; requires `post_only=true`; individual orders only.                          |
 
 See [Price match](#price-match), [RPI](#rpi), and [Close position](#close-position) for the full
 behavior.

--- a/docs/integrations/binance.md
+++ b/docs/integrations/binance.md
@@ -439,8 +439,10 @@ command (Rust). The Binance execution clients recognize:
 | ---------------- | ------ | ----------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
 | `price_match`    | `str`  | USDT/COIN Futures | Delegate price selection to Binance.             | `LIMIT` only; not with `post_only`.                                                       |
 | `close_position` | `bool` | USDT/COIN Futures | Close the whole position when the trigger fires. | `StopMarket` and `MarketIfTouched` only; requires `reduce_only=true`; not in order lists. |
+| `rpi`            | `bool` | USDT Futures      | Submit a Retail Price Improvement order.         | `LIMIT` only; requires `post_only=true`.                                                  |
 
-See [Price match](#price-match) and [Close position](#close-position) for the full behavior.
+See [Price match](#price-match), [RPI](#rpi), and [Close position](#close-position) for the full
+behavior.
 
 ### Price match
 
@@ -503,6 +505,31 @@ If Binance accepts the order at a different price (e.g. 64,995.50), you
 receive an `OrderAccepted` event followed by an `OrderUpdated` event with
 the new price.
 :::
+
+### RPI
+
+Binance RPI (Retail Price Improvement) uses `timeInForce=RPI`. It is post-only and only matches
+eligible retail orders from the Binance App or Web. Nautilus exposes it through the Binance-specific
+`rpi` parameter; use it only with a USD-M LIMIT order whose `post_only=true`. Without `rpi`, regular
+post-only orders continue to use `GTX`. See Binance's [USD-M Futures API definitions](https://developers.binance.com/zh-CN/docs/products/derivatives-trading-usds-futures/common-definition)
+for venue details.
+
+```rust tab="Rust"
+let params = Params::from([("rpi", true.into())]);
+self.submit_order(order, None, None, Some(params))?;
+```
+
+```python tab="Python"
+order = strategy.order_factory.limit(
+    instrument_id=InstrumentId.from_str("BTCUSDT-PERP.BINANCE"),
+    order_side=OrderSide.BUY,
+    quantity=Quantity.from_int(1),
+    price=Price.from_str("65000"),
+    post_only=True,
+)
+
+strategy.submit_order(order, params={"rpi": True})
+```
 
 ### Close position
 

--- a/docs/integrations/binance.md
+++ b/docs/integrations/binance.md
@@ -439,7 +439,7 @@ command (Rust). The Binance execution clients recognize:
 | ---------------- | ------ | ----------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------- |
 | `price_match`    | `str`  | USDT/COIN Futures | Delegate price selection to Binance.             | `LIMIT` only; not with `post_only`.                                                       |
 | `close_position` | `bool` | USDT/COIN Futures | Close the whole position when the trigger fires. | `StopMarket` and `MarketIfTouched` only; requires `reduce_only=true`; not in order lists. |
-| `rpi`            | `bool` | USDT Futures      | Submit a Retail Price Improvement order.         | `LIMIT` only; requires `post_only=true`.                                                  |
+| `rpi`            | `bool` | USDT Futures      | Submit a Retail Price Improvement order.         | `LIMIT` only; requires `post_only=true`; individual orders only.                           |
 
 See [Price match](#price-match), [RPI](#rpi), and [Close position](#close-position) for the full
 behavior.
@@ -510,8 +510,9 @@ the new price.
 
 Binance RPI (Retail Price Improvement) uses `timeInForce=RPI`. It is post-only and only matches
 eligible retail orders from the Binance App or Web. Nautilus exposes it through the Binance-specific
-`rpi` parameter; use it only with a USD-M LIMIT order whose `post_only=true`. Without `rpi`, regular
-post-only orders continue to use `GTX`. See Binance's [USD-M Futures API definitions](https://developers.binance.com/zh-CN/docs/products/derivatives-trading-usds-futures/common-definition)
+`rpi` parameter; use it only with a USD-M LIMIT order whose `post_only=true`. It is supported only
+for individual `SubmitOrder` commands; `SubmitOrderList` is denied. Without `rpi`, regular post-only
+orders continue to use `GTX`. See Binance's [USD-M Futures API definitions](https://developers.binance.com/zh-CN/docs/products/derivatives-trading-usds-futures/common-definition)
 for venue details.
 
 ```rust tab="Rust"


### PR DESCRIPTION
# Pull Request

**Suggested PR title:** `Add Binance RPI order submission support`

**NautilusTrader can execute live trades involving real capital. Pull requests are held to a very
high standard for correctness, reliability, testing, clarity, and maintainability.**

> External contributions must not modify files under `.github/workflows` or `.github/actions`;
> workflow changes are maintainer-only.

* [ ] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
* [x] I have read and followed
  https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md
  and, if I used AI,
  https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md
* [x] I understand and can explain every submitted change and all information in this PR description
* [ ] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
* [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
* [ ] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
* [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Adds Binance USD-M Futures Retail Price Improvement (RPI) order submission support through the existing venue-specific `SubmitOrder.params` mechanism for both Python and Rust strategies.

When a LIMIT order is submitted with `post_only=true` and `rpi=true`, the Binance adapter now sends `timeInForce=RPI` instead of the standard post-only `GTX`, while preserving existing behavior for all non-RPI orders. The change includes local validation, HTTP and WebSocket submission support, tests, and documentation.

## Related issues/PRs

Closes #REPLACE_WITH_ISSUE_NUMBER

## Type of change

* [ ] Bug fix (non-breaking)
* [x] New feature (non-breaking)
* [x] Improvement (non-breaking)
* [ ] Breaking change (impacts existing behavior)
* [x] Documentation update
* [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable. Existing Binance order submission behavior is unchanged unless the venue-specific `rpi` parameter is explicitly enabled.

Regular post-only LIMIT orders continue to use `timeInForce=GTX`.

## Documentation

* [x] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
* [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No PyO3 binding or wrapped Rust API changes are required for this feature because it uses the existing `SubmitOrder.params` interface.

## Testing

**New or changed logic must be covered by tests.** Select all that apply:

* [ ] Affected code paths are already covered by the test suite
* [x] I added/updated tests to cover new or changed logic
* [ ] No logic changed (documentation, comments, or metadata only)

Added coverage for:

* USD-M LIMIT orders with `post_only=true` and `rpi=true` mapping to `timeInForce=RPI`.
* Existing post-only orders without RPI continuing to map to `timeInForce=GTX`.
* Existing non-post-only time-in-force behavior remaining unchanged.
* RPI rejection for unsupported Binance product types.
* RPI rejection for incompatible order types.
* RPI rejection when `post_only=true` is not set.
* RPI mapping through both HTTP and WebSocket order submission paths.

Local validation:

* `cargo nextest run -p nautilus-binance` — REPLACE_WITH_RESULT
* `make format` — REPLACE_WITH_RESULT
* `make pre-commit` — REPLACE_WITH_RESULT
