### PR TITLE
Fix Binance Spot cancel report client order ID matching

### DIFF
--- a/crates/adapters/binance/src/common/dispatch.rs
+++ b/crates/adapters/binance/src/common/dispatch.rs
@@ -88,6 +88,7 @@ pub struct WsDispatchState {
     replacements: DashMap<ClientOrderId, PendingReplacement>,
     emitted_accepted: Mutex<FifoCache<ClientOrderId, 10_000>>,
     filled_orders: Mutex<FifoCache<ClientOrderId, 10_000>>,
+    cancel_replace_cancel_ids: Mutex<FifoCache<String, 10_000>>,
 }
 
 impl Default for WsDispatchState {
@@ -100,6 +101,7 @@ impl Default for WsDispatchState {
             replacements: DashMap::new(),
             emitted_accepted: Mutex::new(FifoCache::new()),
             filled_orders: Mutex::new(FifoCache::new()),
+            cancel_replace_cancel_ids: Mutex::new(FifoCache::new()),
         }
     }
 }
@@ -121,6 +123,17 @@ impl WsDispatchState {
     /// Marks an order as having received a fill.
     pub fn insert_filled(&self, cid: ClientOrderId) {
         self.filled_orders.lock().add(cid);
+    }
+
+    pub fn is_cancel_replace_cancel_id(&self, id: &str) -> bool {
+        self.cancel_replace_cancel_ids
+            .lock()
+            .contains(&id.to_string())
+    }
+
+    /// Records the `cancelNewClientOrderId` sent with a cancel-replace request.
+    pub fn insert_cancel_replace_cancel_id(&self, id: String) {
+        self.cancel_replace_cancel_ids.lock().add(id);
     }
 
     pub fn insert_algo_order_id(&self, cid: ClientOrderId, venue_order_id: VenueOrderId) {

--- a/crates/adapters/binance/src/common/dispatch.rs
+++ b/crates/adapters/binance/src/common/dispatch.rs
@@ -29,6 +29,7 @@ use nautilus_model::{
     enums::{OrderSide, OrderType},
     events::{OrderAccepted, OrderCanceled, OrderEventAny},
     identifiers::{AccountId, ClientOrderId, InstrumentId, PositionId, StrategyId, VenueOrderId},
+    reports::OrderStatusReport,
     types::{Price, Quantity},
 };
 use parking_lot::Mutex;
@@ -61,10 +62,10 @@ pub struct PendingRequest {
 enum CancelReplaceOutcome {
     Pending,
     /// The cancel report arrived; withheld while the replacement is pending or succeeded.
-    Canceled {
-        venue_order_id: VenueOrderId,
-        ts_event: UnixNanos,
-    },
+    ///
+    /// Parsed at that point so it can be replayed even for an order without a
+    /// dispatch identity, such as one recovered after restart.
+    Canceled(Box<OrderStatusReport>),
     /// The venue rejected the request before any cancel report arrived.
     Rejected,
 }
@@ -151,18 +152,20 @@ impl WsDispatchState {
             .insert(cancel_id, CancelReplaceOutcome::Pending);
     }
 
+    /// Returns `true` when `cancel_id` belongs to a cancel-replace this client issued.
+    pub fn has_cancel_replace(&self, cancel_id: &str) -> bool {
+        self.cancel_replace_outcomes
+            .lock()
+            .contains_key(&cancel_id.to_string())
+    }
+
     /// Records the cancel half's `CANCELED` report for a cancel-replace request.
     ///
     /// Returns `true` when the report must be withheld because the replacement is
     /// pending or succeeded, and `false` when it should dispatch as a standalone
     /// cancel because the venue already rejected the replacement or the ID is not
     /// one this client issued.
-    pub fn on_cancel_replace_canceled(
-        &self,
-        cancel_id: &str,
-        venue_order_id: VenueOrderId,
-        ts_event: UnixNanos,
-    ) -> bool {
+    pub fn on_cancel_replace_canceled(&self, cancel_id: &str, report: OrderStatusReport) -> bool {
         let mut outcomes = self.cancel_replace_outcomes.lock();
         let Some(outcome) = outcomes.get_mut(&cancel_id.to_string()) else {
             return false;
@@ -170,22 +173,19 @@ impl WsDispatchState {
 
         match outcome {
             CancelReplaceOutcome::Pending => {
-                *outcome = CancelReplaceOutcome::Canceled {
-                    venue_order_id,
-                    ts_event,
-                };
+                *outcome = CancelReplaceOutcome::Canceled(Box::new(report));
                 true
             }
-            CancelReplaceOutcome::Canceled { .. } => true,
+            CancelReplaceOutcome::Canceled(_) => true,
             CancelReplaceOutcome::Rejected => false,
         }
     }
 
     /// Records a rejected cancel-replace request.
     ///
-    /// Returns the confirmed cancellation when its report already arrived, so the
-    /// caller can emit `OrderCanceled` for the original order.
-    pub fn on_cancel_replace_rejected(&self, cancel_id: &str) -> Option<(VenueOrderId, UnixNanos)> {
+    /// Returns the withheld cancel report when it already arrived, so the caller
+    /// can emit the confirmed cancellation for the original order.
+    pub fn on_cancel_replace_rejected(&self, cancel_id: &str) -> Option<OrderStatusReport> {
         let mut outcomes = self.cancel_replace_outcomes.lock();
         let outcome = outcomes.get_mut(&cancel_id.to_string())?;
 
@@ -194,10 +194,7 @@ impl WsDispatchState {
                 *outcome = CancelReplaceOutcome::Rejected;
                 None
             }
-            CancelReplaceOutcome::Canceled {
-                venue_order_id,
-                ts_event,
-            } => Some((*venue_order_id, *ts_event)),
+            CancelReplaceOutcome::Canceled(report) => Some((**report).clone()),
             CancelReplaceOutcome::Rejected => None,
         }
     }

--- a/crates/adapters/binance/src/common/dispatch.rs
+++ b/crates/adapters/binance/src/common/dispatch.rs
@@ -22,7 +22,7 @@
 //! - Untracked orders fall back to execution reports for reconciliation.
 
 use dashmap::DashMap;
-use nautilus_common::cache::fifo::FifoCache;
+use nautilus_common::cache::fifo::{FifoCache, FifoCacheMap};
 use nautilus_core::{UUID4, UnixNanos};
 use nautilus_live::ExecutionEventEmitter;
 use nautilus_model::{
@@ -51,6 +51,22 @@ pub struct PendingRequest {
     pub client_order_id: ClientOrderId,
     pub venue_order_id: Option<VenueOrderId>,
     pub operation: PendingOperation,
+}
+
+/// Outcome of a cancel-replace request, tracked by its `cancelNewClientOrderId`.
+///
+/// The cancel half's `CANCELED` report and the venue's response arrive in either
+/// order, so whichever comes second completes the picture.
+#[derive(Debug, Clone)]
+enum CancelReplaceOutcome {
+    Pending,
+    /// The cancel report arrived; withheld while the replacement is pending or succeeded.
+    Canceled {
+        venue_order_id: VenueOrderId,
+        ts_event: UnixNanos,
+    },
+    /// The venue rejected the request before any cancel report arrived.
+    Rejected,
 }
 
 /// Order identity context stored at submission time.
@@ -88,7 +104,9 @@ pub struct WsDispatchState {
     replacements: DashMap<ClientOrderId, PendingReplacement>,
     emitted_accepted: Mutex<FifoCache<ClientOrderId, 10_000>>,
     filled_orders: Mutex<FifoCache<ClientOrderId, 10_000>>,
-    cancel_replace_cancel_ids: Mutex<FifoCache<String, 10_000>>,
+    /// Cancel-replace request IDs mapped to their `cancelNewClientOrderId`.
+    pub cancel_replace_request_ids: DashMap<String, String>,
+    cancel_replace_outcomes: Mutex<FifoCacheMap<String, CancelReplaceOutcome, 10_000>>,
 }
 
 impl Default for WsDispatchState {
@@ -101,7 +119,8 @@ impl Default for WsDispatchState {
             replacements: DashMap::new(),
             emitted_accepted: Mutex::new(FifoCache::new()),
             filled_orders: Mutex::new(FifoCache::new()),
-            cancel_replace_cancel_ids: Mutex::new(FifoCache::new()),
+            cancel_replace_request_ids: DashMap::new(),
+            cancel_replace_outcomes: Mutex::new(FifoCacheMap::new()),
         }
     }
 }
@@ -125,15 +144,62 @@ impl WsDispatchState {
         self.filled_orders.lock().add(cid);
     }
 
-    pub fn is_cancel_replace_cancel_id(&self, id: &str) -> bool {
-        self.cancel_replace_cancel_ids
+    /// Records the `cancelNewClientOrderId` sent with a cancel-replace request.
+    pub fn insert_cancel_replace(&self, cancel_id: String) {
+        self.cancel_replace_outcomes
             .lock()
-            .contains(&id.to_string())
+            .insert(cancel_id, CancelReplaceOutcome::Pending);
     }
 
-    /// Records the `cancelNewClientOrderId` sent with a cancel-replace request.
-    pub fn insert_cancel_replace_cancel_id(&self, id: String) {
-        self.cancel_replace_cancel_ids.lock().add(id);
+    /// Records the cancel half's `CANCELED` report for a cancel-replace request.
+    ///
+    /// Returns `true` when the report must be withheld because the replacement is
+    /// pending or succeeded, and `false` when it should dispatch as a standalone
+    /// cancel because the venue already rejected the replacement or the ID is not
+    /// one this client issued.
+    pub fn on_cancel_replace_canceled(
+        &self,
+        cancel_id: &str,
+        venue_order_id: VenueOrderId,
+        ts_event: UnixNanos,
+    ) -> bool {
+        let mut outcomes = self.cancel_replace_outcomes.lock();
+        let Some(outcome) = outcomes.get_mut(&cancel_id.to_string()) else {
+            return false;
+        };
+
+        match outcome {
+            CancelReplaceOutcome::Pending => {
+                *outcome = CancelReplaceOutcome::Canceled {
+                    venue_order_id,
+                    ts_event,
+                };
+                true
+            }
+            CancelReplaceOutcome::Canceled { .. } => true,
+            CancelReplaceOutcome::Rejected => false,
+        }
+    }
+
+    /// Records a rejected cancel-replace request.
+    ///
+    /// Returns the confirmed cancellation when its report already arrived, so the
+    /// caller can emit `OrderCanceled` for the original order.
+    pub fn on_cancel_replace_rejected(&self, cancel_id: &str) -> Option<(VenueOrderId, UnixNanos)> {
+        let mut outcomes = self.cancel_replace_outcomes.lock();
+        let outcome = outcomes.get_mut(&cancel_id.to_string())?;
+
+        match outcome {
+            CancelReplaceOutcome::Pending => {
+                *outcome = CancelReplaceOutcome::Rejected;
+                None
+            }
+            CancelReplaceOutcome::Canceled {
+                venue_order_id,
+                ts_event,
+            } => Some((*venue_order_id, *ts_event)),
+            CancelReplaceOutcome::Rejected => None,
+        }
     }
 
     pub fn insert_algo_order_id(&self, cid: ClientOrderId, venue_order_id: VenueOrderId) {

--- a/crates/adapters/binance/src/spot/execution.rs
+++ b/crates/adapters/binance/src/spot/execution.rs
@@ -110,8 +110,9 @@ use crate::{
                 BinanceCancelOrderResponse,
             },
             query::{
-                BatchCancelItem, CancelOrderParams, CancelReplaceOrderParams,
-                NewOcoOrderListParams, NewOrderParams,
+                BatchCancelItem, CANCEL_REPLACE_CANCEL_ID_PREFIX, CancelOrderParams,
+                CancelReplaceOrderParams, NewOcoOrderListParams, NewOrderParams,
+                cancel_replace_cancel_id,
             },
         },
         sbe::spot::{
@@ -3248,6 +3249,7 @@ fn build_cancel_replace_params(
         } else {
             None
         },
+        cancel_new_client_order_id: Some(cancel_replace_cancel_id(cancel_order_id)),
         new_client_order_id: Some(client_id_str),
         stop_price: None,
         trailing_delta: None,
@@ -3283,23 +3285,30 @@ fn dispatch_execution_report(
     let (price_precision, size_precision) =
         (instrument.price_precision(), instrument.size_precision());
 
-    let report_client_id = if report.execution_type == BinanceSpotExecutionType::Canceled {
-        report
-            .original_client_order_id
-            .as_deref()
-            .filter(|id| !id.is_empty())
-            .unwrap_or(&report.client_order_id)
-    } else {
-        &report.client_order_id
+    if report.execution_type == BinanceSpotExecutionType::Canceled
+        && report
+            .client_order_id
+            .starts_with(CANCEL_REPLACE_CANCEL_ID_PREFIX)
+    {
+        // Cancel half of a cancel-replace: the replacement `NEW` drives `OrderUpdated`
+        log::debug!(
+            "Skipping cancel-replace cancel report: client_order_id={}, venue_order_id={}",
+            report.order_client_order_id(),
+            report.order_id
+        );
+        return;
+    }
+
+    let client_order_id = match decode_client_order_id(
+        report.order_client_order_id(),
+        BINANCE_NAUTILUS_SPOT_BROKER_ID,
+    ) {
+        Ok(client_order_id) => client_order_id,
+        Err(e) => {
+            log::warn!("Skipping Spot execution report with invalid client order ID: {e}");
+            return;
+        }
     };
-    let client_order_id =
-        match decode_client_order_id(report_client_id, BINANCE_NAUTILUS_SPOT_BROKER_ID) {
-            Ok(client_order_id) => client_order_id,
-            Err(e) => {
-                log::warn!("Skipping Spot execution report with invalid client order ID: {e}");
-                return;
-            }
-        };
 
     let identity = dispatch_state
         .order_identities
@@ -4700,6 +4709,135 @@ mod tests {
 
         assert!(rx.try_recv().is_err());
         assert!(dispatch_state.order_identities.is_empty());
+    }
+
+    #[rstest]
+    fn test_dispatch_execution_report_canceled_resolves_order_by_orig_client_order_id() {
+        let clock = get_atomic_clock_realtime();
+        let (emitter, mut rx) = create_test_emitter(clock);
+        let http_client = create_test_http_client(clock);
+        let client_order_id = ClientOrderId::from("O-20200101-000000-000-000-0");
+        let instrument_id = InstrumentId::from("ETHUSDT.BINANCE");
+        let dispatch_state = WsDispatchState::default();
+        dispatch_state.insert_accepted(client_order_id);
+        dispatch_state.order_identities.insert(
+            client_order_id,
+            OrderIdentity {
+                instrument_id,
+                strategy_id: StrategyId::from("TEST-STRATEGY"),
+                order_side: OrderSide::Buy,
+                order_type: OrderType::Limit,
+                price: None,
+                quantity: Quantity::from("1"),
+                venue_position_id: None,
+            },
+        );
+        let seen_trade_ids = Arc::new(Mutex::new(FifoCache::new()));
+        let json = crate::common::testing::load_fixture_string(
+            "spot/user_data_json/execution_report_canceled.json",
+        );
+        let mut report: BinanceSpotExecutionReport = serde_json::from_str(&json).unwrap();
+        report.original_client_order_id = Some(report.client_order_id.clone());
+        report.client_order_id = "web_9f8e7d6c5b4a".to_string();
+
+        dispatch_execution_report(
+            &report,
+            &emitter,
+            &http_client,
+            AccountId::from("BINANCE-001"),
+            false,
+            &dispatch_state,
+            &seen_trade_ids,
+            clock.get_time_ns(),
+        );
+
+        match rx.try_recv().expect("OrderCanceled expected") {
+            ExecutionEvent::Order(OrderEventAny::Canceled(event)) => {
+                assert_eq!(event.client_order_id, client_order_id);
+            }
+            other => panic!("Expected OrderCanceled, was {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
+        assert!(dispatch_state.order_identities.is_empty());
+    }
+
+    #[rstest]
+    fn test_dispatch_execution_report_cancel_replace_skips_cancel_then_updates_on_new() {
+        let clock = get_atomic_clock_realtime();
+        let (emitter, mut rx) = create_test_emitter(clock);
+        let http_client = create_test_http_client(clock);
+        let client_order_id = ClientOrderId::from("O-20200101-000000-000-000-0");
+        let instrument_id = InstrumentId::from("ETHUSDT.BINANCE");
+        let dispatch_state = WsDispatchState::default();
+        dispatch_state.insert_accepted(client_order_id);
+        dispatch_state.order_identities.insert(
+            client_order_id,
+            OrderIdentity {
+                instrument_id,
+                strategy_id: StrategyId::from("TEST-STRATEGY"),
+                order_side: OrderSide::Buy,
+                order_type: OrderType::Limit,
+                price: None,
+                quantity: Quantity::from("1"),
+                venue_position_id: None,
+            },
+        );
+        let seen_trade_ids = Arc::new(Mutex::new(FifoCache::new()));
+        let account_id = AccountId::from("BINANCE-001");
+
+        let json = crate::common::testing::load_fixture_string(
+            "spot/user_data_json/execution_report_canceled.json",
+        );
+        let mut canceled: BinanceSpotExecutionReport = serde_json::from_str(&json).unwrap();
+        canceled.original_client_order_id = Some(canceled.client_order_id.clone());
+        canceled.client_order_id = cancel_replace_cancel_id(Some(canceled.order_id));
+
+        dispatch_execution_report(
+            &canceled,
+            &emitter,
+            &http_client,
+            account_id,
+            false,
+            &dispatch_state,
+            &seen_trade_ids,
+            clock.get_time_ns(),
+        );
+
+        assert!(rx.try_recv().is_err(), "cancel half must not emit");
+        assert!(
+            dispatch_state
+                .order_identities
+                .contains_key(&client_order_id)
+        );
+
+        let json = crate::common::testing::load_fixture_string(
+            "spot/user_data_json/execution_report_new.json",
+        );
+        let mut new: BinanceSpotExecutionReport = serde_json::from_str(&json).unwrap();
+        new.order_id = canceled.order_id + 1;
+
+        dispatch_execution_report(
+            &new,
+            &emitter,
+            &http_client,
+            account_id,
+            false,
+            &dispatch_state,
+            &seen_trade_ids,
+            clock.get_time_ns(),
+        );
+
+        match rx.try_recv().expect("OrderUpdated expected") {
+            ExecutionEvent::Order(OrderEventAny::Updated(event)) => {
+                assert_eq!(event.client_order_id, client_order_id);
+                assert_eq!(
+                    event.venue_order_id,
+                    Some(VenueOrderId::new(new.order_id.to_string()))
+                );
+            }
+            other => panic!("Expected OrderUpdated, was {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
     }
 
     #[rstest]

--- a/crates/adapters/binance/src/spot/execution.rs
+++ b/crates/adapters/binance/src/spot/execution.rs
@@ -1903,9 +1903,15 @@ impl ExecutionClient for BinanceSpotExecutionClient {
             let command = cmd;
             let ws_client = self.ws_trading_client.as_ref().unwrap().clone();
             let cancel_id = cancel_replace_cancel_id();
-            dispatch_state.insert_cancel_replace_cancel_id(cancel_id.clone());
-            let params =
-                build_cancel_replace_params(&command, &order, quantity, use_gtd, cancel_id)?;
+            dispatch_state.insert_cancel_replace(cancel_id.clone());
+            let params = build_cancel_replace_params(
+                &command,
+                &order,
+                quantity,
+                use_gtd,
+                cancel_id.clone(),
+            )?;
+
             if let Some(venue_order_id) = command.venue_order_id {
                 dispatch_state.begin_replace(command.client_order_id, venue_order_id);
             }
@@ -1920,6 +1926,9 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                     operation: PendingOperation::Modify,
                 },
             );
+            dispatch_state
+                .cancel_replace_request_ids
+                .insert(request_id.clone(), cancel_id);
 
             self.spawn_task("modify_order_ws", async move {
                 if let Err(e) = ws_client
@@ -1927,6 +1936,9 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                     .await
                 {
                     dispatch_state.pending_requests.remove(&request_id);
+                    dispatch_state
+                        .cancel_replace_request_ids
+                        .remove(&request_id);
                     log::warn!(
                         "WS modify request failed for {}, awaiting reconciliation: {e}",
                         command.client_order_id
@@ -1939,9 +1951,9 @@ impl ExecutionClient for BinanceSpotExecutionClient {
             let command = cmd;
             let http_client = self.http_client.clone();
             log::debug!("WS trading not active, falling back to HTTP for modify_order");
+            let dispatch_state = self.dispatch_state.clone();
             let cancel_id = cancel_replace_cancel_id();
-            self.dispatch_state
-                .insert_cancel_replace_cancel_id(cancel_id.clone());
+            dispatch_state.insert_cancel_replace(cancel_id.clone());
 
             if let Some(venue_order_id) = command.venue_order_id {
                 dispatch_state.begin_replace(command.client_order_id, venue_order_id);
@@ -2037,6 +2049,20 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                                 );
                                 event_emitter
                                     .send_order_event(OrderEventAny::ModifyRejected(rejected_event));
+
+                                if let Some((venue_order_id, ts_event)) =
+                                    dispatch_state.on_cancel_replace_rejected(&cancel_id)
+                                {
+                                    emit_canceled_after_rejected_replace(
+                                        &event_emitter,
+                                        &dispatch_state,
+                                        account_id,
+                                        command.client_order_id,
+                                        venue_order_id,
+                                        ts_event,
+                                        ts_now,
+                                    );
+                                }
                             }
                         }
                         return Err(e);
@@ -2529,6 +2555,9 @@ fn dispatch_ws_trading_message(
             new_order_response,
         } => {
             dispatch_state.pending_requests.remove(&request_id);
+            dispatch_state
+                .cancel_replace_request_ids
+                .remove(&request_id);
             log::debug!(
                 "WS cancel-replace accepted: request_id={request_id}, \
                  canceled_id={}, new_id={}",
@@ -2547,20 +2576,27 @@ fn dispatch_ws_trading_message(
                 "WS cancel-replace rejected: request_id={request_id}, status={status}, code={code}, msg={msg}"
             );
 
-            if let Some((_, pending)) = dispatch_state.pending_requests.remove(&request_id) {
-                let reason = format!("code={code}: {msg}");
+            let reason = format!("code={code}: {msg}");
+            let is_ambiguous = matches!(
+                classify_venue_failure(Some(i64::from(code)), Some(status), &reason),
+                CommandFailure::Ambiguous(_)
+            );
+            let confirmed_cancel = dispatch_state
+                .cancel_replace_request_ids
+                .remove(&request_id)
+                .filter(|_| !is_ambiguous)
+                .and_then(|(_, cancel_id)| dispatch_state.on_cancel_replace_rejected(&cancel_id));
+            let pending = dispatch_state
+                .pending_requests
+                .remove(&request_id)
+                .map(|(_, pending)| pending);
 
-                match classify_venue_failure(Some(i64::from(code)), Some(status), &reason) {
-                    CommandFailure::Ambiguous(_) => {
-                        log::warn!(
-                            "Ambiguous WS modify failure for {}, awaiting reconciliation: {reason}",
-                            pending.client_order_id,
-                        );
-                        return;
-                    }
-                    CommandFailure::NotSent(_) | CommandFailure::VenueRejected(_) => {}
-                }
+            if is_ambiguous {
+                log::warn!("Ambiguous WS modify failure, awaiting reconciliation: {reason}");
+                return;
+            }
 
+            if let Some(pending) = &pending {
                 if let Some(canceled) = dispatch_state.reject_replace(pending.client_order_id) {
                     dispatch_state.cleanup_terminal(pending.client_order_id);
                     emitter.send_order_event(OrderEventAny::Canceled(canceled));
@@ -2588,9 +2624,24 @@ fn dispatch_ws_trading_message(
                     emitter.send_order_event(OrderEventAny::ModifyRejected(rejected));
                 }
             }
+
+            if let (Some(pending), Some((venue_order_id, ts_event))) = (pending, confirmed_cancel) {
+                emit_canceled_after_rejected_replace(
+                    emitter,
+                    dispatch_state,
+                    account_id,
+                    pending.client_order_id,
+                    venue_order_id,
+                    ts_event,
+                    clock.get_time_ns(),
+                );
+            }
         }
         BinanceSpotWsTradingMessage::RequestFailed { request_id, msg } => {
             dispatch_state.pending_requests.remove(&request_id);
+            dispatch_state
+                .cancel_replace_request_ids
+                .remove(&request_id);
             log::error!(
                 "WS trading request failed without structured venue response: request_id={request_id}, {msg}"
             );
@@ -3227,6 +3278,42 @@ fn cancel_replace_cancel_id() -> String {
     format!("CR-{}", UUID4::new().as_str().replace('-', ""))
 }
 
+/// Emits `OrderCanceled` for the original order of a cancel-replace whose cancel
+/// half the venue confirmed before rejecting the replacement.
+fn emit_canceled_after_rejected_replace(
+    emitter: &ExecutionEventEmitter,
+    state: &WsDispatchState,
+    account_id: AccountId,
+    client_order_id: ClientOrderId,
+    venue_order_id: VenueOrderId,
+    ts_event: UnixNanos,
+    ts_init: UnixNanos,
+) {
+    let Some(identity) = state
+        .order_identities
+        .get(&client_order_id)
+        .map(|r| r.clone())
+    else {
+        return;
+    };
+
+    let canceled = OrderCanceled::new(
+        emitter.trader_id(),
+        identity.strategy_id,
+        identity.instrument_id,
+        client_order_id,
+        UUID4::new(),
+        ts_event,
+        ts_init,
+        false,
+        Some(venue_order_id),
+        Some(account_id),
+        None,
+    );
+    state.cleanup_terminal(client_order_id);
+    emitter.send_order_event(OrderEventAny::Canceled(canceled));
+}
+
 fn build_cancel_replace_params(
     cmd: &ModifyOrder,
     order: &impl Order,
@@ -3300,16 +3387,24 @@ fn dispatch_execution_report(
     let (price_precision, size_precision) =
         (instrument.price_precision(), instrument.size_precision());
 
-    if report.execution_type == BinanceSpotExecutionType::Canceled
-        && dispatch_state.is_cancel_replace_cancel_id(&report.client_order_id)
-    {
-        // Cancel half of a cancel-replace: the replacement `NEW` drives `OrderUpdated`
-        log::debug!(
-            "Skipping cancel-replace cancel report: client_order_id={}, venue_order_id={}",
-            report.order_client_order_id(),
-            report.order_id
-        );
-        return;
+    if report.execution_type == BinanceSpotExecutionType::Canceled {
+        let venue_order_id = VenueOrderId::new(report.order_id.to_string());
+        let ts_event =
+            parse_millis_or_init(report.event_time, "Spot execution event time", ts_init);
+
+        if dispatch_state.on_cancel_replace_canceled(
+            &report.client_order_id,
+            venue_order_id,
+            ts_event,
+        ) {
+            // Cancel half of a cancel-replace: the replacement `NEW` drives `OrderUpdated`
+            log::debug!(
+                "Withholding cancel-replace cancel report: client_order_id={}, venue_order_id={}",
+                report.order_client_order_id(),
+                report.order_id
+            );
+            return;
+        }
     }
 
     let client_order_id = match decode_client_order_id(
@@ -4852,7 +4947,7 @@ mod tests {
         let mut canceled: BinanceSpotExecutionReport = serde_json::from_str(&json).unwrap();
         canceled.original_client_order_id = Some(canceled.client_order_id.clone());
         let cancel_id = cancel_replace_cancel_id();
-        dispatch_state.insert_cancel_replace_cancel_id(cancel_id.clone());
+        dispatch_state.insert_cancel_replace(cancel_id.clone());
         canceled.client_order_id = cancel_id;
 
         dispatch_execution_report(
@@ -4873,6 +4968,235 @@ mod tests {
                 .contains_key(&client_order_id)
         );
 
+        let json = crate::common::testing::load_fixture_string(
+            "spot/user_data_json/execution_report_new.json",
+        );
+        let mut new: BinanceSpotExecutionReport = serde_json::from_str(&json).unwrap();
+        new.order_id = canceled.order_id + 1;
+
+        dispatch_execution_report(
+            &new,
+            &emitter,
+            &http_client,
+            account_id,
+            false,
+            &dispatch_state,
+            &seen_trade_ids,
+            clock.get_time_ns(),
+        );
+
+        match rx.try_recv().expect("OrderUpdated expected") {
+            ExecutionEvent::Order(OrderEventAny::Updated(event)) => {
+                assert_eq!(event.client_order_id, client_order_id);
+                assert_eq!(
+                    event.venue_order_id,
+                    Some(VenueOrderId::new(new.order_id.to_string()))
+                );
+            }
+            other => panic!("Expected OrderUpdated, was {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    fn cancel_replace_cancel_report(cancel_id: &str) -> BinanceSpotExecutionReport {
+        let json = crate::common::testing::load_fixture_string(
+            "spot/user_data_json/execution_report_canceled.json",
+        );
+        let mut report: BinanceSpotExecutionReport = serde_json::from_str(&json).unwrap();
+        report.original_client_order_id = Some(report.client_order_id.clone());
+        report.client_order_id = cancel_id.to_string();
+        report
+    }
+
+    fn reject_cancel_replace(
+        request_id: &str,
+        code: i32,
+        emitter: &ExecutionEventEmitter,
+        http_client: &BinanceSpotHttpClient,
+        dispatch_state: &WsDispatchState,
+        task_spawner: &TaskSpawner,
+        clock: &'static AtomicTime,
+    ) {
+        let seen_trade_ids = Arc::new(Mutex::new(FifoCache::new()));
+        let ws_authenticated = tokio::sync::Notify::new();
+        let ws_user_data_subscribed = tokio::sync::Notify::new();
+        let (ws_setup_error_tx, _ws_setup_error_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        dispatch_ws_trading_message(
+            BinanceSpotWsTradingMessage::CancelReplaceRejected {
+                request_id: request_id.to_string(),
+                status: 400,
+                code,
+                msg: "Order cancel-replace partially failed".to_string(),
+            },
+            emitter,
+            http_client,
+            AccountId::from("BINANCE-001"),
+            false,
+            clock,
+            dispatch_state,
+            &ws_authenticated,
+            &ws_user_data_subscribed,
+            &ws_setup_error_tx,
+            &seen_trade_ids,
+            task_spawner,
+        );
+    }
+
+    #[rstest]
+    #[case::cancel_report_first(true)]
+    #[case::rejection_first(false)]
+    fn test_cancel_replace_rejected_after_confirmed_cancel_emits_canceled(
+        #[case] cancel_report_first: bool,
+    ) {
+        let tasks = TaskGroup::new();
+        let task_spawner = tasks.spawner().expect("task spawner");
+        let clock = get_atomic_clock_realtime();
+        let (emitter, mut rx) = create_test_emitter(clock);
+        let http_client = create_test_http_client(clock);
+        let client_order_id = ClientOrderId::from("O-20200101-000000-000-000-0");
+        let instrument_id = InstrumentId::from("ETHUSDT.BINANCE");
+        let dispatch_state = create_tracked_dispatch_state(client_order_id, instrument_id);
+        dispatch_state.insert_accepted(client_order_id);
+        let seen_trade_ids = Arc::new(Mutex::new(FifoCache::new()));
+        let account_id = AccountId::from("BINANCE-001");
+
+        let cancel_id = cancel_replace_cancel_id();
+        dispatch_state.insert_cancel_replace(cancel_id.clone());
+        dispatch_state.pending_requests.insert(
+            "req-modify".to_string(),
+            PendingRequest {
+                client_order_id,
+                venue_order_id: Some(VenueOrderId::from("12345678")),
+                operation: PendingOperation::Modify,
+            },
+        );
+        dispatch_state
+            .cancel_replace_request_ids
+            .insert("req-modify".to_string(), cancel_id.clone());
+        dispatch_state.begin_replace(client_order_id, VenueOrderId::from("12345678"));
+        let canceled = cancel_replace_cancel_report(&cancel_id);
+
+        if cancel_report_first {
+            dispatch_execution_report(
+                &canceled,
+                &emitter,
+                &http_client,
+                account_id,
+                false,
+                &dispatch_state,
+                &seen_trade_ids,
+                clock.get_time_ns(),
+            );
+            assert!(rx.try_recv().is_err(), "cancel report must be withheld");
+        }
+
+        reject_cancel_replace(
+            "req-modify",
+            -2021,
+            &emitter,
+            &http_client,
+            &dispatch_state,
+            &task_spawner,
+            clock,
+        );
+
+        match rx.try_recv().expect("OrderModifyRejected expected") {
+            ExecutionEvent::Order(OrderEventAny::ModifyRejected(event)) => {
+                assert_eq!(event.client_order_id, client_order_id);
+            }
+            other => panic!("Expected OrderModifyRejected, was {other:?}"),
+        }
+
+        if !cancel_report_first {
+            assert!(rx.try_recv().is_err(), "no cancel confirmed yet");
+            dispatch_execution_report(
+                &canceled,
+                &emitter,
+                &http_client,
+                account_id,
+                false,
+                &dispatch_state,
+                &seen_trade_ids,
+                clock.get_time_ns(),
+            );
+        }
+
+        match rx.try_recv().expect("OrderCanceled expected") {
+            ExecutionEvent::Order(OrderEventAny::Canceled(event)) => {
+                assert_eq!(event.client_order_id, client_order_id);
+                assert_eq!(event.venue_order_id, Some(VenueOrderId::from("12345678")));
+                assert_eq!(
+                    event.ts_event,
+                    UnixNanos::from(1_709_654_402_000_000_000u64)
+                );
+            }
+            other => panic!("Expected OrderCanceled, was {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
+        assert!(dispatch_state.order_identities.is_empty());
+        assert!(dispatch_state.pending_requests.is_empty());
+        assert!(dispatch_state.cancel_replace_request_ids.is_empty());
+    }
+
+    #[rstest]
+    #[case::unexpected_response(BINANCE_UNEXPECTED_RESPONSE_CODE)]
+    #[case::status_unknown(BINANCE_STATUS_UNKNOWN_CODE)]
+    fn test_cancel_replace_ambiguous_rejection_keeps_withholding_cancel(#[case] code: i64) {
+        let tasks = TaskGroup::new();
+        let task_spawner = tasks.spawner().expect("task spawner");
+        let clock = get_atomic_clock_realtime();
+        let (emitter, mut rx) = create_test_emitter(clock);
+        let http_client = create_test_http_client(clock);
+        let client_order_id = ClientOrderId::from("O-20200101-000000-000-000-0");
+        let instrument_id = InstrumentId::from("ETHUSDT.BINANCE");
+        let dispatch_state = create_tracked_dispatch_state(client_order_id, instrument_id);
+        dispatch_state.insert_accepted(client_order_id);
+        let seen_trade_ids = Arc::new(Mutex::new(FifoCache::new()));
+        let account_id = AccountId::from("BINANCE-001");
+
+        let cancel_id = cancel_replace_cancel_id();
+        dispatch_state.insert_cancel_replace(cancel_id.clone());
+        dispatch_state.pending_requests.insert(
+            "req-modify".to_string(),
+            PendingRequest {
+                client_order_id,
+                venue_order_id: Some(VenueOrderId::from("12345678")),
+                operation: PendingOperation::Modify,
+            },
+        );
+        dispatch_state
+            .cancel_replace_request_ids
+            .insert("req-modify".to_string(), cancel_id.clone());
+        dispatch_state.begin_replace(client_order_id, VenueOrderId::from("12345678"));
+        let canceled = cancel_replace_cancel_report(&cancel_id);
+
+        dispatch_execution_report(
+            &canceled,
+            &emitter,
+            &http_client,
+            account_id,
+            false,
+            &dispatch_state,
+            &seen_trade_ids,
+            clock.get_time_ns(),
+        );
+        reject_cancel_replace(
+            "req-modify",
+            i32::try_from(code).unwrap(),
+            &emitter,
+            &http_client,
+            &dispatch_state,
+            &task_spawner,
+            clock,
+        );
+
+        assert!(
+            rx.try_recv().is_err(),
+            "ambiguous outcome must remain pending"
+        );
+
+        // The replacement did go through: its NEW still drives OrderUpdated
         let json = crate::common::testing::load_fixture_string(
             "spot/user_data_json/execution_report_new.json",
         );

--- a/crates/adapters/binance/src/spot/execution.rs
+++ b/crates/adapters/binance/src/spot/execution.rs
@@ -110,9 +110,8 @@ use crate::{
                 BinanceCancelOrderResponse,
             },
             query::{
-                BatchCancelItem, CANCEL_REPLACE_CANCEL_ID_PREFIX, CancelOrderParams,
-                CancelReplaceOrderParams, NewOcoOrderListParams, NewOrderParams,
-                cancel_replace_cancel_id,
+                BatchCancelItem, CancelOrderParams, CancelReplaceOrderParams,
+                NewOcoOrderListParams, NewOrderParams,
             },
         },
         sbe::spot::{
@@ -1903,7 +1902,10 @@ impl ExecutionClient for BinanceSpotExecutionClient {
         if self.ws_order_transport_active() {
             let command = cmd;
             let ws_client = self.ws_trading_client.as_ref().unwrap().clone();
-            let params = build_cancel_replace_params(&command, &order, quantity, use_gtd)?;
+            let cancel_id = cancel_replace_cancel_id();
+            dispatch_state.insert_cancel_replace_cancel_id(cancel_id.clone());
+            let params =
+                build_cancel_replace_params(&command, &order, quantity, use_gtd, cancel_id)?;
             if let Some(venue_order_id) = command.venue_order_id {
                 dispatch_state.begin_replace(command.client_order_id, venue_order_id);
             }
@@ -1937,6 +1939,9 @@ impl ExecutionClient for BinanceSpotExecutionClient {
             let command = cmd;
             let http_client = self.http_client.clone();
             log::debug!("WS trading not active, falling back to HTTP for modify_order");
+            let cancel_id = cancel_replace_cancel_id();
+            self.dispatch_state
+                .insert_cancel_replace_cancel_id(cancel_id.clone());
 
             if let Some(venue_order_id) = command.venue_order_id {
                 dispatch_state.begin_replace(command.client_order_id, venue_order_id);
@@ -1957,6 +1962,7 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                                 time_in_force,
                                 command.price,
                                 use_gtd,
+                                &cancel_id,
                             )
                             .await
                     }
@@ -3213,11 +3219,20 @@ fn build_cancel_order_params(cmd: &CancelOrder, prefer_client_order_id: bool) ->
     }
 }
 
+/// Returns a unique `cancelNewClientOrderId` for a cancel-replace request.
+///
+/// Registered in [`WsDispatchState`] so the cancel half's `CANCELED` report can
+/// be matched to the request that produced it.
+fn cancel_replace_cancel_id() -> String {
+    format!("CR-{}", UUID4::new().as_str().replace('-', ""))
+}
+
 fn build_cancel_replace_params(
     cmd: &ModifyOrder,
     order: &impl Order,
     quantity: Quantity,
     use_gtd: bool,
+    cancel_new_client_order_id: String,
 ) -> anyhow::Result<CancelReplaceOrderParams> {
     let binance_side = BinanceSide::try_from(order.order_side())?;
     let binance_order_type = order_type_to_binance_spot(order.order_type(), false)?;
@@ -3249,7 +3264,7 @@ fn build_cancel_replace_params(
         } else {
             None
         },
-        cancel_new_client_order_id: Some(cancel_replace_cancel_id(cancel_order_id)),
+        cancel_new_client_order_id: Some(cancel_new_client_order_id),
         new_client_order_id: Some(client_id_str),
         stop_price: None,
         trailing_delta: None,
@@ -3286,9 +3301,7 @@ fn dispatch_execution_report(
         (instrument.price_precision(), instrument.size_precision());
 
     if report.execution_type == BinanceSpotExecutionType::Canceled
-        && report
-            .client_order_id
-            .starts_with(CANCEL_REPLACE_CANCEL_ID_PREFIX)
+        && dispatch_state.is_cancel_replace_cancel_id(&report.client_order_id)
     {
         // Cancel half of a cancel-replace: the replacement `NEW` drives `OrderUpdated`
         log::debug!(
@@ -4762,6 +4775,54 @@ mod tests {
     }
 
     #[rstest]
+    fn test_build_cancel_replace_params_sends_cancel_new_client_order_id() {
+        let client_order_id = ClientOrderId::from("O-20200101-000000-000-000-0");
+        let instrument_id = InstrumentId::from("ETHUSDT.BINANCE");
+        let mut builder = OrderTestBuilder::new(OrderType::Limit);
+        let order = builder
+            .instrument_id(instrument_id)
+            .client_order_id(client_order_id)
+            .side(OrderSide::Buy)
+            .quantity(Quantity::from("1"))
+            .price(Price::from("2500.00"))
+            .build();
+        let cmd = ModifyOrder::new(
+            TraderId::from("TESTER-001"),
+            None,
+            StrategyId::from("TEST-STRATEGY"),
+            instrument_id,
+            client_order_id,
+            Some(VenueOrderId::from("12345678")),
+            Some(Quantity::from("2")),
+            Some(Price::from("2400.00")),
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        );
+        let cancel_id = cancel_replace_cancel_id();
+
+        let params = build_cancel_replace_params(
+            &cmd,
+            &order,
+            Quantity::from("2"),
+            false,
+            cancel_id.clone(),
+        )
+        .unwrap();
+
+        assert!(cancel_id.len() <= 36);
+        assert_eq!(params.cancel_order_id, Some(12345678));
+        assert_eq!(
+            params.cancel_new_client_order_id.as_deref(),
+            Some(cancel_id.as_str())
+        );
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["cancelNewClientOrderId"], cancel_id);
+    }
+
+    #[rstest]
     fn test_dispatch_execution_report_cancel_replace_skips_cancel_then_updates_on_new() {
         let clock = get_atomic_clock_realtime();
         let (emitter, mut rx) = create_test_emitter(clock);
@@ -4790,7 +4851,9 @@ mod tests {
         );
         let mut canceled: BinanceSpotExecutionReport = serde_json::from_str(&json).unwrap();
         canceled.original_client_order_id = Some(canceled.client_order_id.clone());
-        canceled.client_order_id = cancel_replace_cancel_id(Some(canceled.order_id));
+        let cancel_id = cancel_replace_cancel_id();
+        dispatch_state.insert_cancel_replace_cancel_id(cancel_id.clone());
+        canceled.client_order_id = cancel_id;
 
         dispatch_execution_report(
             &canceled,

--- a/crates/adapters/binance/src/spot/execution.rs
+++ b/crates/adapters/binance/src/spot/execution.rs
@@ -1989,7 +1989,13 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                             anyhow::bail!("Spot replacement response has no price");
                         };
 
-                        if !dispatch_state.record_order_update(command.client_order_id, report.venue_order_id, report.quantity, price, report.trigger_price) {
+                        if !dispatch_state.record_order_update(
+                            command.client_order_id,
+                            report.venue_order_id,
+                            report.quantity,
+                            price,
+                            report.trigger_price,
+                        ) {
                             return Ok(());
                         }
                         let ts_now = clock.get_time_ns();
@@ -2013,58 +2019,15 @@ impl ExecutionClient for BinanceSpotExecutionClient {
                         event_emitter.send_order_event(OrderEventAny::Updated(updated_event));
                     }
                     Err(e) => {
-                        let failure = e.downcast_ref::<BinanceSpotHttpError>().map_or_else(
-                            || CommandFailure::Ambiguous(e.to_string()),
-                            classify_spot_http_failure,
+                        handle_http_modify_failure(
+                            &e,
+                            &command,
+                            &cancel_id,
+                            &event_emitter,
+                            &dispatch_state,
+                            account_id,
+                            clock.get_time_ns(),
                         );
-
-                        match failure {
-                            CommandFailure::Ambiguous(reason) => {
-                                log::warn!(
-                                    "Ambiguous modify failure for {}, awaiting reconciliation: {reason}",
-                                    command.client_order_id
-                                );
-                            }
-                            CommandFailure::NotSent(reason)
-                            | CommandFailure::VenueRejected(reason) => {
-                                if let Some(canceled) = dispatch_state.reject_replace(command.client_order_id) {
-                                    dispatch_state.cleanup_terminal(command.client_order_id);
-                                    event_emitter.send_order_event(OrderEventAny::Canceled(canceled));
-                                    return Err(e);
-                                }
-                                let ts_now = clock.get_time_ns();
-                                let rejected_event = OrderModifyRejected::new(
-                                    trader_id,
-                                    command.strategy_id,
-                                    command.instrument_id,
-                                    command.client_order_id,
-                                    format!("modify-order-error: {}", sanitize_reason(&reason))
-                                        .into(),
-                                    UUID4::new(),
-                                    ts_now,
-                                    ts_now,
-                                    false,
-                                    command.venue_order_id,
-                                    Some(account_id),
-                                );
-                                event_emitter
-                                    .send_order_event(OrderEventAny::ModifyRejected(rejected_event));
-
-                                if let Some((venue_order_id, ts_event)) =
-                                    dispatch_state.on_cancel_replace_rejected(&cancel_id)
-                                {
-                                    emit_canceled_after_rejected_replace(
-                                        &event_emitter,
-                                        &dispatch_state,
-                                        account_id,
-                                        command.client_order_id,
-                                        venue_order_id,
-                                        ts_event,
-                                        ts_now,
-                                    );
-                                }
-                            }
-                        }
                         return Err(e);
                     }
                 }
@@ -2625,14 +2588,12 @@ fn dispatch_ws_trading_message(
                 }
             }
 
-            if let (Some(pending), Some((venue_order_id, ts_event))) = (pending, confirmed_cancel) {
+            if let Some(report) = confirmed_cancel {
                 emit_canceled_after_rejected_replace(
                     emitter,
                     dispatch_state,
                     account_id,
-                    pending.client_order_id,
-                    venue_order_id,
-                    ts_event,
+                    report,
                     clock.get_time_ns(),
                 );
             }
@@ -3278,22 +3239,25 @@ fn cancel_replace_cancel_id() -> String {
     format!("CR-{}", UUID4::new().as_str().replace('-', ""))
 }
 
-/// Emits `OrderCanceled` for the original order of a cancel-replace whose cancel
-/// half the venue confirmed before rejecting the replacement.
+/// Emits the confirmed cancellation of a cancel-replace whose replacement the
+/// venue rejected: `OrderCanceled` for a tracked order, or the withheld status
+/// report for an order without a dispatch identity (recovered after restart or
+/// claimed through reconciliation) so reconciliation applies it.
 fn emit_canceled_after_rejected_replace(
     emitter: &ExecutionEventEmitter,
     state: &WsDispatchState,
     account_id: AccountId,
-    client_order_id: ClientOrderId,
-    venue_order_id: VenueOrderId,
-    ts_event: UnixNanos,
+    report: OrderStatusReport,
     ts_init: UnixNanos,
 ) {
-    let Some(identity) = state
-        .order_identities
-        .get(&client_order_id)
-        .map(|r| r.clone())
-    else {
+    let identity = report
+        .client_order_id
+        .and_then(|cid| state.order_identities.get(&cid).map(|r| r.clone()));
+    if let Some(client_order_id) = report.client_order_id {
+        state.cleanup_terminal(client_order_id);
+    }
+    let (Some(client_order_id), Some(identity)) = (report.client_order_id, identity) else {
+        emitter.send_order_status_report(report);
         return;
     };
 
@@ -3303,15 +3267,67 @@ fn emit_canceled_after_rejected_replace(
         identity.instrument_id,
         client_order_id,
         UUID4::new(),
-        ts_event,
+        report.ts_last,
         ts_init,
         false,
-        Some(venue_order_id),
+        Some(report.venue_order_id),
         Some(account_id),
         None,
     );
-    state.cleanup_terminal(client_order_id);
     emitter.send_order_event(OrderEventAny::Canceled(canceled));
+}
+
+/// Handles a failed HTTP cancel-replace: emits `OrderModifyRejected` for a
+/// definitive rejection and replays the withheld cancel report if it already
+/// arrived.
+fn handle_http_modify_failure(
+    error: &anyhow::Error,
+    command: &ModifyOrder,
+    cancel_id: &str,
+    emitter: &ExecutionEventEmitter,
+    state: &WsDispatchState,
+    account_id: AccountId,
+    ts_now: UnixNanos,
+) {
+    let failure = error.downcast_ref::<BinanceSpotHttpError>().map_or_else(
+        || CommandFailure::Ambiguous(error.to_string()),
+        classify_spot_http_failure,
+    );
+
+    match failure {
+        CommandFailure::Ambiguous(reason) => {
+            log::warn!(
+                "Ambiguous modify failure for {}, awaiting reconciliation: {reason}",
+                command.client_order_id
+            );
+        }
+        CommandFailure::NotSent(reason) | CommandFailure::VenueRejected(reason) => {
+            if let Some(canceled) = state.reject_replace(command.client_order_id) {
+                state.cleanup_terminal(command.client_order_id);
+                emitter.send_order_event(OrderEventAny::Canceled(canceled));
+                return;
+            }
+
+            let rejected_event = OrderModifyRejected::new(
+                emitter.trader_id(),
+                command.strategy_id,
+                command.instrument_id,
+                command.client_order_id,
+                format!("modify-order-error: {}", sanitize_reason(&reason)).into(),
+                UUID4::new(),
+                ts_now,
+                ts_now,
+                false,
+                command.venue_order_id,
+                Some(account_id),
+            );
+            emitter.send_order_event(OrderEventAny::ModifyRejected(rejected_event));
+
+            if let Some(report) = state.on_cancel_replace_rejected(cancel_id) {
+                emit_canceled_after_rejected_replace(emitter, state, account_id, report, ts_now);
+            }
+        }
+    }
 }
 
 fn build_cancel_replace_params(
@@ -3387,23 +3403,32 @@ fn dispatch_execution_report(
     let (price_precision, size_precision) =
         (instrument.price_precision(), instrument.size_precision());
 
-    if report.execution_type == BinanceSpotExecutionType::Canceled {
-        let venue_order_id = VenueOrderId::new(report.order_id.to_string());
-        let ts_event =
-            parse_millis_or_init(report.event_time, "Spot execution event time", ts_init);
-
-        if dispatch_state.on_cancel_replace_canceled(
-            &report.client_order_id,
-            venue_order_id,
-            ts_event,
+    if report.execution_type == BinanceSpotExecutionType::Canceled
+        && dispatch_state.has_cancel_replace(&report.client_order_id)
+    {
+        match parse_spot_exec_report_to_order_status(
+            report,
+            instrument_id,
+            price_precision,
+            size_precision,
+            account_id,
+            treat_expired_as_canceled,
+            ts_init,
         ) {
-            // Cancel half of a cancel-replace: the replacement `NEW` drives `OrderUpdated`
-            log::debug!(
-                "Withholding cancel-replace cancel report: client_order_id={}, venue_order_id={}",
-                report.order_client_order_id(),
-                report.order_id
-            );
-            return;
+            Ok(status) => {
+                if dispatch_state.on_cancel_replace_canceled(&report.client_order_id, status) {
+                    // Cancel half of a cancel-replace: the replacement `NEW` drives `OrderUpdated`
+                    log::debug!(
+                        "Withholding cancel-replace cancel report: client_order_id={}, venue_order_id={}",
+                        report.order_client_order_id(),
+                        report.order_id
+                    );
+                    return;
+                }
+            }
+            Err(e) => log::warn!(
+                "Cannot withhold cancel-replace cancel report, dispatching normally: {e}"
+            ),
         }
     }
 
@@ -3929,7 +3954,7 @@ fn is_spot_post_only_rejection(error: &BinanceSpotHttpError) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use nautilus_common::messages::ExecutionEvent;
+    use nautilus_common::messages::{ExecutionEvent, execution::ExecutionReport};
     use nautilus_core::time::get_atomic_clock_realtime;
     use nautilus_model::{
         enums::{AccountType, LiquiditySide, OrderSide, TimeInForce},
@@ -5137,6 +5162,101 @@ mod tests {
         assert!(dispatch_state.order_identities.is_empty());
         assert!(dispatch_state.pending_requests.is_empty());
         assert!(dispatch_state.cancel_replace_request_ids.is_empty());
+    }
+
+    #[rstest]
+    #[case::partial_failure(-2021, 409, true)]
+    #[case::ambiguous(BINANCE_STATUS_UNKNOWN_CODE, 500, false)]
+    fn test_http_modify_failure_replays_withheld_cancel_without_identity(
+        #[case] code: i64,
+        #[case] status: u16,
+        #[case] definitive: bool,
+    ) {
+        let clock = get_atomic_clock_realtime();
+        let (emitter, mut rx) = create_test_emitter(clock);
+        let http_client = create_test_http_client(clock);
+        let dispatch_state = WsDispatchState::default();
+        let seen_trade_ids = Arc::new(Mutex::new(FifoCache::new()));
+        let account_id = AccountId::from("BINANCE-001");
+        let client_order_id = ClientOrderId::from("O-20200101-000000-000-000-0");
+        let instrument_id = InstrumentId::from("ETHUSDT.BINANCE");
+
+        let cancel_id = cancel_replace_cancel_id();
+        dispatch_state.insert_cancel_replace(cancel_id.clone());
+        let canceled = cancel_replace_cancel_report(&cancel_id);
+
+        dispatch_execution_report(
+            &canceled,
+            &emitter,
+            &http_client,
+            account_id,
+            false,
+            &dispatch_state,
+            &seen_trade_ids,
+            clock.get_time_ns(),
+        );
+        assert!(rx.try_recv().is_err(), "cancel report must be withheld");
+
+        let command = ModifyOrder::new(
+            TraderId::from("TESTER-001"),
+            None,
+            StrategyId::from("TEST-STRATEGY"),
+            instrument_id,
+            client_order_id,
+            Some(VenueOrderId::from("12345678")),
+            Some(Quantity::from("2")),
+            Some(Price::from("2400.00")),
+            None,
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+            None,
+        );
+        let error = anyhow::anyhow!(BinanceSpotHttpError::BinanceError {
+            code,
+            message: "Order cancel-replace partially failed.".to_string(),
+            status,
+            retry_after: None,
+        });
+
+        handle_http_modify_failure(
+            &error,
+            &command,
+            &cancel_id,
+            &emitter,
+            &dispatch_state,
+            account_id,
+            clock.get_time_ns(),
+        );
+
+        if !definitive {
+            assert!(
+                rx.try_recv().is_err(),
+                "ambiguous outcome must remain pending"
+            );
+            return;
+        }
+
+        match rx.try_recv().expect("OrderModifyRejected expected") {
+            ExecutionEvent::Order(OrderEventAny::ModifyRejected(event)) => {
+                assert_eq!(event.client_order_id, client_order_id);
+            }
+            other => panic!("Expected OrderModifyRejected, was {other:?}"),
+        }
+
+        match rx.try_recv().expect("cancel status report expected") {
+            ExecutionEvent::Report(ExecutionReport::Order(report)) => {
+                assert_eq!(report.client_order_id, Some(client_order_id));
+                assert_eq!(report.venue_order_id, VenueOrderId::from("12345678"));
+                assert_eq!(report.order_status, OrderStatus::Canceled);
+                assert_eq!(
+                    report.ts_last,
+                    UnixNanos::from(1_709_654_402_000_000_000u64)
+                );
+            }
+            other => panic!("Expected order status report, was {other:?}"),
+        }
+        assert!(rx.try_recv().is_err());
     }
 
     #[rstest]

--- a/crates/adapters/binance/src/spot/http/client.rs
+++ b/crates/adapters/binance/src/spot/http/client.rs
@@ -81,7 +81,7 @@ use super::{
         AllOrdersParams, AvgPriceParams, BatchCancelItem, BatchOrderItem, CancelOpenOrdersParams,
         CancelOrderParams, CancelReplaceOrderParams, DepthParams, KlinesParams, ListenKeyParams,
         NewOcoOrderListParams, NewOrderParams, OpenOrdersParams, QueryOrderParams, TickerParams,
-        TradeFeeParams, TradesParams,
+        TradeFeeParams, TradesParams, cancel_replace_cancel_id,
     },
 };
 use crate::{
@@ -1700,6 +1700,7 @@ impl BinanceRawSpotHttpClient {
             price: price.map(|s| s.to_string()),
             cancel_order_id,
             cancel_orig_client_order_id: cancel_client_order_id.map(|s| s.to_string()),
+            cancel_new_client_order_id: Some(cancel_replace_cancel_id(cancel_order_id)),
             new_client_order_id: new_client_order_id.map(|s| s.to_string()),
             stop_price: None,
             trailing_delta: None,

--- a/crates/adapters/binance/src/spot/http/client.rs
+++ b/crates/adapters/binance/src/spot/http/client.rs
@@ -81,7 +81,7 @@ use super::{
         AllOrdersParams, AvgPriceParams, BatchCancelItem, BatchOrderItem, CancelOpenOrdersParams,
         CancelOrderParams, CancelReplaceOrderParams, DepthParams, KlinesParams, ListenKeyParams,
         NewOcoOrderListParams, NewOrderParams, OpenOrdersParams, QueryOrderParams, TickerParams,
-        TradeFeeParams, TradesParams, cancel_replace_cancel_id,
+        TradeFeeParams, TradesParams,
     },
 };
 use crate::{
@@ -1687,6 +1687,7 @@ impl BinanceRawSpotHttpClient {
         price: Option<&str>,
         cancel_order_id: Option<i64>,
         cancel_client_order_id: Option<&str>,
+        cancel_new_client_order_id: Option<&str>,
         new_client_order_id: Option<&str>,
     ) -> BinanceSpotHttpResult<BinanceNewOrderResponse> {
         let params = CancelReplaceOrderParams {
@@ -1700,7 +1701,7 @@ impl BinanceRawSpotHttpClient {
             price: price.map(|s| s.to_string()),
             cancel_order_id,
             cancel_orig_client_order_id: cancel_client_order_id.map(|s| s.to_string()),
-            cancel_new_client_order_id: Some(cancel_replace_cancel_id(cancel_order_id)),
+            cancel_new_client_order_id: cancel_new_client_order_id.map(|s| s.to_string()),
             new_client_order_id: new_client_order_id.map(|s| s.to_string()),
             stop_price: None,
             trailing_delta: None,
@@ -3533,6 +3534,7 @@ impl BinanceSpotHttpClient {
         time_in_force: TimeInForce,
         price: Option<Price>,
         use_gtd: bool,
+        cancel_new_client_order_id: &str,
     ) -> anyhow::Result<OrderStatusReport> {
         let symbol = instrument_id.symbol.inner();
         let instrument = self
@@ -3566,6 +3568,7 @@ impl BinanceSpotHttpClient {
                 price_str.as_deref(),
                 Some(cancel_order_id),
                 None,
+                Some(cancel_new_client_order_id),
                 Some(&client_id_str),
             )
             .await

--- a/crates/adapters/binance/src/spot/http/query.rs
+++ b/crates/adapters/binance/src/spot/http/query.rs
@@ -320,6 +320,21 @@ impl CancelOpenOrdersParams {
     }
 }
 
+/// Prefix of the `cancelNewClientOrderId` sent with cancel-replace requests.
+///
+/// Binance echoes it in `c` on the cancel half's `CANCELED` report, which
+/// tells that report apart from a standalone cancel.
+pub const CANCEL_REPLACE_CANCEL_ID_PREFIX: &str = "CR-";
+
+/// Returns the `cancelNewClientOrderId` for a cancel-replace of `cancel_order_id`.
+#[must_use]
+pub fn cancel_replace_cancel_id(cancel_order_id: Option<i64>) -> String {
+    match cancel_order_id {
+        Some(id) => format!("{CANCEL_REPLACE_CANCEL_ID_PREFIX}{id}"),
+        None => CANCEL_REPLACE_CANCEL_ID_PREFIX.to_string(),
+    }
+}
+
 /// Query parameters for cancel and replace order.
 #[derive(Debug, Clone, Serialize)]
 pub struct CancelReplaceOrderParams {
@@ -354,6 +369,12 @@ pub struct CancelReplaceOrderParams {
         rename = "cancelOrigClientOrderId"
     )]
     pub cancel_orig_client_order_id: Option<String>,
+    /// Client order ID for the cancel half of the request.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "cancelNewClientOrderId"
+    )]
+    pub cancel_new_client_order_id: Option<String>,
     /// New client order ID.
     #[serde(skip_serializing_if = "Option::is_none", rename = "newClientOrderId")]
     pub new_client_order_id: Option<String>,

--- a/crates/adapters/binance/src/spot/http/query.rs
+++ b/crates/adapters/binance/src/spot/http/query.rs
@@ -320,21 +320,6 @@ impl CancelOpenOrdersParams {
     }
 }
 
-/// Prefix of the `cancelNewClientOrderId` sent with cancel-replace requests.
-///
-/// Binance echoes it in `c` on the cancel half's `CANCELED` report, which
-/// tells that report apart from a standalone cancel.
-pub const CANCEL_REPLACE_CANCEL_ID_PREFIX: &str = "CR-";
-
-/// Returns the `cancelNewClientOrderId` for a cancel-replace of `cancel_order_id`.
-#[must_use]
-pub fn cancel_replace_cancel_id(cancel_order_id: Option<i64>) -> String {
-    match cancel_order_id {
-        Some(id) => format!("{CANCEL_REPLACE_CANCEL_ID_PREFIX}{id}"),
-        None => CANCEL_REPLACE_CANCEL_ID_PREFIX.to_string(),
-    }
-}
-
 /// Query parameters for cancel and replace order.
 #[derive(Debug, Clone, Serialize)]
 pub struct CancelReplaceOrderParams {

--- a/crates/adapters/binance/src/spot/websocket/trading/parse.rs
+++ b/crates/adapters/binance/src/spot/websocket/trading/parse.rs
@@ -54,7 +54,7 @@ pub fn parse_spot_exec_report_to_order_status(
     ts_init: UnixNanos,
 ) -> anyhow::Result<OrderStatusReport> {
     let client_order_id =
-        decode_client_order_id(&msg.client_order_id, BINANCE_NAUTILUS_SPOT_BROKER_ID)?;
+        decode_client_order_id(msg.order_client_order_id(), BINANCE_NAUTILUS_SPOT_BROKER_ID)?;
     let venue_order_id = VenueOrderId::new(msg.order_id.to_string());
     let ts_event = parse_millis_or_init(msg.event_time, "Spot execution event time", ts_init);
 
@@ -142,7 +142,7 @@ pub fn parse_spot_exec_report_to_fill(
     ts_init: UnixNanos,
 ) -> anyhow::Result<FillReport> {
     let client_order_id =
-        decode_client_order_id(&msg.client_order_id, BINANCE_NAUTILUS_SPOT_BROKER_ID)?;
+        decode_client_order_id(msg.order_client_order_id(), BINANCE_NAUTILUS_SPOT_BROKER_ID)?;
     let venue_order_id = VenueOrderId::new(msg.order_id.to_string());
     let trade_id = TradeId::new(msg.trade_id.to_string());
     let ts_event = parse_millis_or_init(msg.event_time, "Spot execution event time", ts_init);
@@ -441,6 +441,33 @@ mod tests {
         );
 
         assert_eq!(result.unwrap_err().to_string(), expected);
+    }
+
+    #[rstest]
+    #[case::orig_set(Some("x-TD67BGP9-T0000000000000"), "O-20200101-000000-000-000-0")]
+    #[case::orig_empty(Some(""), "web_9f8e7d6c5b4a")]
+    #[case::orig_missing(None, "web_9f8e7d6c5b4a")]
+    fn test_parse_execution_report_to_order_status_canceled_prefers_orig_client_order_id(
+        #[case] original_client_order_id: Option<&str>,
+        #[case] expected: &str,
+    ) {
+        let json = load_fixture_string("spot/user_data_json/execution_report_canceled.json");
+        let mut msg: BinanceSpotExecutionReport = serde_json::from_str(&json).unwrap();
+        msg.client_order_id = "web_9f8e7d6c5b4a".to_string();
+        msg.original_client_order_id = original_client_order_id.map(str::to_string);
+
+        let report = parse_spot_exec_report_to_order_status(
+            &msg,
+            instrument_id(),
+            PRICE_PRECISION,
+            SIZE_PRECISION,
+            AccountId::from("BINANCE-001"),
+            false,
+            UnixNanos::from(1_000_000_000u64),
+        )
+        .unwrap();
+
+        assert_eq!(report.client_order_id, Some(ClientOrderId::from(expected)));
     }
 
     #[rstest]

--- a/crates/adapters/binance/src/spot/websocket/trading/user_data.rs
+++ b/crates/adapters/binance/src/spot/websocket/trading/user_data.rs
@@ -140,6 +140,21 @@ pub struct BinanceSpotExecutionReport {
     pub expiry_reason: Option<String>,
 }
 
+impl BinanceSpotExecutionReport {
+    /// Returns the client order ID of the order this report belongs to.
+    ///
+    /// When a report results from a cancel request, Binance carries the request's
+    /// ID in `c` and the ID of the order being canceled in `C`, which is empty
+    /// otherwise.
+    #[must_use]
+    pub fn order_client_order_id(&self) -> &str {
+        match self.original_client_order_id.as_deref() {
+            Some(id) if !id.is_empty() => id,
+            _ => &self.client_order_id,
+        }
+    }
+}
+
 /// Account position update event (`outboundAccountPosition`).
 ///
 /// Sent whenever there is a balance change (not associated with an order).

--- a/crates/adapters/binance/tests/integration/spot/http.rs
+++ b/crates/adapters/binance/tests/integration/spot/http.rs
@@ -662,6 +662,7 @@ fn build_mixed_cancel_open_orders_response(
 struct TestServerState {
     request_count: Arc<parking_lot::Mutex<usize>>,
     rate_limit_after: usize,
+    cancel_replace_params: Arc<parking_lot::Mutex<Option<HashMap<String, String>>>>,
 }
 
 impl TestServerState {
@@ -669,6 +670,7 @@ impl TestServerState {
         Self {
             request_count: Arc::new(parking_lot::Mutex::new(0)),
             rate_limit_after: limit,
+            cancel_replace_params: Arc::default(),
         }
     }
 
@@ -744,6 +746,7 @@ fn create_router(state: Arc<TestServerState>) -> Router {
     let my_trades_state = state.clone();
     let new_order_state = state.clone();
     let cancel_order_state = state.clone();
+    let cancel_replace_state = state.clone();
     let cancel_all_orders_state = state;
 
     Router::new()
@@ -1048,6 +1051,39 @@ fn create_router(state: Arc<TestServerState>) -> Router {
                             ),
                         ];
                         sbe_response(build_orders_response(&orders)).into_response()
+                    }
+                },
+            ),
+        )
+        .route(
+            "/api/v3/order/cancelReplace",
+            post(
+                move |headers: HeaderMap, Query(params): Query<HashMap<String, String>>| {
+                    let state = cancel_replace_state.clone();
+                    async move {
+                        if !has_auth_headers(&headers) {
+                            return unauthorized_response().into_response();
+                        }
+
+                        let symbol = params
+                            .get("symbol")
+                            .cloned()
+                            .unwrap_or_else(|| "BTCUSDT".to_string());
+                        let client_order_id = params
+                            .get("newClientOrderId")
+                            .cloned()
+                            .unwrap_or_else(|| "replace-order".to_string());
+                        *state.cancel_replace_params.lock() = Some(params);
+                        sbe_response(build_new_order_response(
+                            99998,
+                            &symbol,
+                            &client_order_id,
+                            100_000_000_000,
+                            10_000_000,
+                            0,
+                            1,
+                        ))
+                        .into_response()
                     }
                 },
             ),
@@ -2068,6 +2104,56 @@ async fn test_domain_cancel_order() {
         .unwrap();
 
     assert_eq!(venue_order_id, VenueOrderId::from("12345"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_cancel_replace_order_sends_cancel_new_client_order_id() {
+    let state = Arc::new(TestServerState::default());
+    let addr = start_test_server(state.clone()).await;
+    let base_url = format!("http://{addr}");
+
+    let client = BinanceRawSpotHttpClient::new(
+        BinanceEnvironment::Live,
+        Some("test_api_key".to_string()),
+        Some("test_api_secret".to_string()),
+        Some(base_url),
+        None,
+        Some(60),
+        None,
+    )
+    .unwrap();
+
+    let response = client
+        .cancel_replace_order(
+            "BTCUSDT",
+            BinanceSide::Buy,
+            BinanceSpotOrderType::Limit,
+            Some(BinanceTimeInForce::Gtc),
+            Some("0.1"),
+            Some("1000.00"),
+            Some(12345),
+            None,
+            Some("CR-test"),
+            Some("replace-1"),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.client_order_id, "replace-1");
+    let params = state.cancel_replace_params.lock().clone().unwrap();
+    assert_eq!(
+        params.get("cancelOrderId").map(String::as_str),
+        Some("12345")
+    );
+    assert_eq!(
+        params.get("cancelNewClientOrderId").map(String::as_str),
+        Some("CR-test")
+    );
+    assert_eq!(
+        params.get("newClientOrderId").map(String::as_str),
+        Some("replace-1")
+    );
 }
 
 #[rstest]

--- a/crates/adapters/binance/tests/integration/spot/http.rs
+++ b/crates/adapters/binance/tests/integration/spot/http.rs
@@ -63,6 +63,7 @@ const ORDER_TEMPLATE_ID: u16 = 304;
 const CANCEL_ORDER_TEMPLATE_ID: u16 = 305;
 const CANCEL_OPEN_ORDERS_TEMPLATE_ID: u16 = 306;
 const CANCEL_ORDER_LIST_TEMPLATE_ID: u16 = 312;
+const CANCEL_REPLACE_TEMPLATE_ID: u16 = 307;
 const ACCOUNT_TEMPLATE_ID: u16 = 400;
 const ORDERS_TEMPLATE_ID: u16 = 308;
 const ACCOUNT_TRADES_TEMPLATE_ID: u16 = 401;
@@ -1074,7 +1075,16 @@ fn create_router(state: Arc<TestServerState>) -> Router {
                             .cloned()
                             .unwrap_or_else(|| "replace-order".to_string());
                         *state.cancel_replace_params.lock() = Some(params);
-                        sbe_response(build_new_order_response(
+                        let canceled = build_cancel_order_response(
+                            12345,
+                            &symbol,
+                            "CR-test",
+                            "original-order",
+                            100_000_000_000,
+                            10_000_000,
+                            0,
+                        );
+                        let replacement = build_new_order_response(
                             99998,
                             &symbol,
                             &client_order_id,
@@ -1082,8 +1092,19 @@ fn create_router(state: Arc<TestServerState>) -> Router {
                             10_000_000,
                             0,
                             1,
-                        ))
-                        .into_response()
+                        );
+                        let mut response =
+                            create_sbe_header(2, CANCEL_REPLACE_TEMPLATE_ID).to_vec();
+                        response.extend_from_slice(&[0, 0]);
+                        response.extend_from_slice(
+                            &u16::try_from(canceled.len()).unwrap().to_le_bytes(),
+                        );
+                        response.extend_from_slice(&canceled);
+                        response.extend_from_slice(
+                            &u32::try_from(replacement.len()).unwrap().to_le_bytes(),
+                        );
+                        response.extend_from_slice(&replacement);
+                        sbe_response(response).into_response()
                     }
                 },
             ),

--- a/crates/adapters/binance/tests/integration/spot/websocket_trading.rs
+++ b/crates/adapters/binance/tests/integration/spot/websocket_trading.rs
@@ -847,6 +847,7 @@ async fn test_command_send_failure_emits_request_failed_not_rejection(
                 price: Some("51000.00".to_string()),
                 cancel_order_id: Some(12345),
                 cancel_orig_client_order_id: None,
+                cancel_new_client_order_id: None,
                 new_client_order_id: Some("test-replace-send-fail".to_string()),
                 stop_price: None,
                 trailing_delta: None,


### PR DESCRIPTION
## A Spot cancel report is matched on the cancel request's ID

On a `CANCELED` `executionReport` Binance puts the cancel request's client ID in `c` and the
order's own ID in `C`. The Spot client cancels by `orderId` with no `newClientOrderId`, so `c` is
a Binance-generated string, and `dispatch_execution_report` only ever read `c`. The lookup in
`order_identities` missed, the report went down the untracked path, and the emitted
`OrderStatusReport` carried the cancel request's ID. The engine still recovered the order through
the `venue_order_id` fallback, so order state ended up right, but nothing cleared the in-flight
`CancelOrder` entry and `check_inflight_orders` polled it with four `QueryOrder`s per cancel.

`BinanceSpotExecutionReport::order_client_order_id` returns `C` when non-empty and `c` otherwise,
and the dispatch lookup and the two parsers in `websocket/trading/parse.rs` use it. `C` is empty
on every other execution type, so `NEW`, `TRADE` and `REJECTED` reports are unchanged, and cancels
not initiated by Nautilus resolve the same way, which setting `newClientOrderId` on our own cancel
requests would not give us.

Preferring `C` on its own regresses cancel-replace. The cancel half of a `cancelReplace` produces
a `CANCELED` report with the same shape, so it would now reach the tracked path, emit an
authoritative `OrderCanceled` for the order being modified and drop its identity before the
replacement `NEW` arrives. The HTTP modify fallback relies on that report staying untracked so the
engine's superseded-cancel check can discard it. Each cancel-replace now sends a unique
`cancelNewClientOrderId` (`CR-` plus a UUID, 35 characters) that the execution client records in
`WsDispatchState` before the request goes out, on both the WS and HTTP paths.
`dispatch_execution_report` skips a `CANCELED` report only when its `c` is an id this client
issued, so a standalone cancel from another client cannot be mistaken for one. The replacement
`NEW` then drives `OrderUpdated` through the already-accepted branch that exists for it. The id
is a parameter through `build_cancel_replace_params`, `BinanceSpotHttpClient::modify_order` and
`BinanceRawSpotHttpClient::cancel_replace_order`.

Withholding that report has one failure mode: Binance can cancel the original order and then reject
the replacement (`-2021`), and `OrderModifyRejected` restores the order to accepted and clears its
in-flight entry, so with periodic reconciliation off nothing would ever cancel it locally. Each
cancel-replace outcome is therefore tracked by its cancel ID: pending on send, canceled once the
report arrives, rejected once the venue answers. If the report came first, the rejection handler
on both the WS and HTTP paths emits `OrderModifyRejected` and then `OrderCanceled` carrying the
original venue order ID and the report's timestamp. If the rejection came first, the later report
is no longer withheld and dispatches as a standalone cancel. Ambiguous codes (`-1006`, `-1007`)
leave the outcome pending, since the replacement may have gone through and its `NEW` still drives
`OrderUpdated`.
The withheld report is kept as its parsed `OrderStatusReport`, so an order without a dispatch
identity (recovered after restart or claimed through reconciliation) is closed too: the replay emits
`OrderCanceled` when an identity exists and otherwise sends the status report for reconciliation to
apply, as an untracked cancel report does today.

Closes #4923

## Testing

`test_dispatch_execution_report_canceled_resolves_order_by_orig_client_order_id` feeds a
`CANCELED` report with a generated `c` and the tracked order's ID in `C`, and asserts
`OrderCanceled` for that order with its identity cleared. On `develop` it fails with an
`OrderStatusReport` instead. `test_dispatch_execution_report_cancel_replace_skips_cancel_then_updates_on_new`
registers an issued cancel id, feeds the cancel report carrying it and asserts nothing is emitted and the identity survives, then feeds
the replacement `NEW` and asserts `OrderUpdated` with the new `venue_order_id`. `test_build_cancel_replace_params_sends_cancel_new_client_order_id` builds the params from a
`ModifyOrder` and asserts the field is set and serializes as `cancelNewClientOrderId`, which is the
form the WS handler sends. `test_cancel_replace_order_sends_cancel_new_client_order_id` in the
HTTP integration suite drives `BinanceRawSpotHttpClient::cancel_replace_order` against the mock
server and asserts the query carried `cancelOrderId`, `cancelNewClientOrderId` and
`newClientOrderId`. `test_cancel_replace_rejected_after_confirmed_cancel_emits_canceled` runs both arrival orders
against the same fixture and asserts `OrderModifyRejected` then `OrderCanceled` with the old venue
order ID and the report's `ts_event`, then empty identity and pending maps.
`test_cancel_replace_ambiguous_rejection_keeps_withholding_cancel` covers `-1006` and `-1007`
followed by the replacement `NEW`.
`test_http_modify_failure_replays_withheld_cancel_without_identity` withholds a cancel report with
an empty dispatch state and drives `handle_http_modify_failure`, the function the HTTP modify task
calls on failure, asserting `OrderModifyRejected` then a canceled status report with the order's
client ID, original venue order ID and event time; the exec test server has no user-data push, so
the report cannot be landed between request and rejection end to end without new harness plumbing.
The parse test
covers `C` set, `C` empty as the JSON feed sends it, and `C` absent. The SBE decoder already maps
an empty `origClientOrderId` to `None`, so it is untouched.

`cargo test -p nautilus-binance` passes (1111 lib, 170 spot integration), as do
`cargo clippy -p nautilus-binance --no-deps --all-targets -- -D warnings` and the
`check-formatting-rs` and `fmt` pre-commit hooks on the changed files.

One adjacent observation, not addressed here: the `decode_order` cursor issue also noted in #4923 is
a separate change.
