### PR TITLE
Guard SortinoRatio against single-observation samples

### DIFF
--- a/crates/analysis/src/statistics/sortino_ratio.rs
+++ b/crates/analysis/src/statistics/sortino_ratio.rs
@@ -79,6 +79,12 @@ impl PortfolioStatistic for SortinoRatio {
         }
 
         let returns = self.downsample_to_daily_bins(raw_returns);
+
+        // Match `calculate_std`: a single observation cannot estimate dispersion
+        if returns.len() < 2 {
+            return Some(f64::NAN);
+        }
+
         let total_n = returns.len() as f64;
         let mean = returns.values().sum::<f64>() / total_n;
 
@@ -142,6 +148,17 @@ mod tests {
     fn test_zero_downside_deviation() {
         let ratio = SortinoRatio::new(None);
         let returns = create_returns(&[0.02, 0.03, 0.01]);
+        let result = ratio.calculate_from_returns(&returns);
+        assert!(result.is_some());
+        assert!(result.unwrap().is_nan());
+    }
+
+    #[rstest]
+    #[case(-0.02)]
+    #[case(0.02)]
+    fn test_single_observation_returns_nan(#[case] value: f64) {
+        let ratio = SortinoRatio::new(None);
+        let returns = create_returns(&[value]);
         let result = ratio.calculate_from_returns(&returns);
         assert!(result.is_some());
         assert!(result.unwrap().is_nan());


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed CONTRIBUTING.md and, if I used AI, AI_POLICY.md
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested this draft
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`SortinoRatio::calculate_from_returns` computed a downside deviation from a single daily observation and returned a finite but meaningless value (about -15.87 for one -2% return), while `SharpeRatio` returns NaN through the `n < 2` rule in `calculate_std`. This adds the same guard after daily downsampling, so a single-observation sample yields NaN regardless of sign and the two statistics agree on when dispersion is undefined.

## Related issues/PRs

Closes #4915

## Type of change

- [x] Bug fix (non-breaking)

## Testing

- [x] I added/updated tests to cover new or changed logic

Added `test_single_observation_returns_nan` (rstest cases -0.02 and 0.02). The negative case fails on `develop` and passes with the guard; `cargo test -p nautilus-analysis sortino` is green. Formatting: ran `cargo +nightly fmt` on the crate; `make pre-commit` is not yet run locally (pinned tool install pending on this machine), and I will run it and update this description. The issue notes that OmegaRatio, ValueAtRisk and ExpectedShortfall lack the same guard; kept this PR to Sortino and happy to follow up with a shared minimum-observation check if wanted.
