### PR TITLE
Upsert general table entries in the Postgres cache

### DIFF
--- a/crates/infrastructure/src/sql/queries.rs
+++ b/crates/infrastructure/src/sql/queries.rs
@@ -67,13 +67,16 @@ impl DatabaseQueries {
     ///
     /// Returns an error if the INSERT operation fails.
     pub async fn add(pool: &PgPool, key: String, value: Vec<u8>) -> anyhow::Result<()> {
-        sqlx::query("INSERT INTO general (id, value) VALUES ($1, $2)")
-            .bind(key)
-            .bind(value)
-            .execute(pool)
-            .await
-            .map(|_| ())
-            .map_err(|e| anyhow::anyhow!("Failed to insert into general table: {e}"))
+        sqlx::query(
+            "INSERT INTO general (id, value) VALUES ($1, $2) \
+             ON CONFLICT (id) DO UPDATE SET value = EXCLUDED.value",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(pool)
+        .await
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("Failed to insert into general table: {e}"))
     }
 
     /// Loads all entries from the `general` table via the provided `pool`.

--- a/crates/infrastructure/tests/integration/test_cache_database_postgres.rs
+++ b/crates/infrastructure/tests/integration/test_cache_database_postgres.rs
@@ -100,6 +100,32 @@ mod serial_tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_add_general_object_twice_updates_value() {
+        let mut pg_cache = get_test_pg_cache_database().await.unwrap();
+
+        let key = String::from("test_upsert_id");
+        let first = Bytes::from("first_value");
+        let second = Bytes::from("second_value");
+
+        pg_cache.add(key.clone(), first.clone()).unwrap();
+        wait_until(
+            || pg_cache.load().unwrap().get(&key) == Some(&first),
+            Duration::from_secs(5),
+        );
+
+        // Re-adding an existing key must update the stored value, matching the
+        // in-memory cache's insert semantics, rather than fail on the primary key
+        pg_cache.add(key.clone(), second.clone()).unwrap();
+        wait_until(
+            || pg_cache.load().unwrap().get(&key) == Some(&second),
+            Duration::from_secs(5),
+        );
+
+        pg_cache.flush().unwrap();
+        pg_cache.close().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_add_general_object_adds_to_cache() {
         let mut pg_cache = get_test_pg_cache_database().await.unwrap();
 


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed CONTRIBUTING.md and, if I used AI, AI_POLICY.md
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested this draft
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`DatabaseQueries::add` used a bare INSERT for the `general` table, so re-adding an existing key (for example the entry written from `add_position_inner` when a position is re-added) hit the primary key, and the error was logged in `drain_buffer` rather than surfacing to the caller. The query now uses `ON CONFLICT (id) DO UPDATE SET value = EXCLUDED.value`, matching the insert semantics of the in-memory `Cache::add` and the upsert pattern the other tables in `queries.rs` already use. `DO UPDATE` rather than `DO NOTHING` because a re-add with a changed value must win, as it does in memory.

## Related issues/PRs

Closes #4918

## Type of change

- [x] Bug fix (non-breaking)

## Testing

- [x] I added/updated tests to cover new or changed logic

Added `test_add_general_object_twice_updates_value`, which asserts on the loaded value rather than the return of `add()`, since the return is `Ok` before and after the change (the failure is asynchronous). The Postgres integration tests are Linux-gated; I ran them on macOS with the gate temporarily lifted against the compose Postgres from `make init-services`: the new test fails on `develop` with a 5s timeout and passes with the change, and both `general` tests pass on a truncated database. Formatting: ran `cargo +nightly fmt` on the crate; `make pre-commit` is not yet run locally (pinned tool install pending on this machine), and I will run it and update this description.
