### PR TITLE
Preload all cached instruments before IB reconciliation

### DIFF
--- a/crates/adapters/interactive_brokers/src/execution/core.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core.rs
@@ -673,7 +673,7 @@ impl ExecutionClient for InteractiveBrokersExecutionClient {
         let session_result = async {
 
         log::debug!("Preloading cached spread instruments for execution client");
-        self.preload_cached_spread_instruments(client.as_ref())
+        self.preload_cached_instruments(client.as_ref())
             .await?;
 
         // Get initial next order ID (uses self.ib_client internally)

--- a/crates/adapters/interactive_brokers/src/execution/core_tests.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tests.rs
@@ -1594,7 +1594,7 @@ async fn test_get_leg_instrument_id_and_ratio_with_sell_action() {
 }
 
 #[rstest]
-fn test_cached_spread_instrument_ids_for_preload_deduplicates_spread_orders() {
+fn test_cached_instrument_ids_for_preload_deduplicates_spread_orders() {
     let instrument_provider = create_test_instrument_provider();
     let mut cache = Cache::default();
     let spread_instrument_id = create_test_spread_instrument();
@@ -1616,7 +1616,7 @@ fn test_cached_spread_instrument_ids_for_preload_deduplicates_spread_orders() {
     cache.add_order(order_one, None, None, false).unwrap();
     cache.add_order(order_two, None, None, false).unwrap();
 
-    let spread_ids = InteractiveBrokersExecutionClient::cached_spread_instrument_ids_for_preload(
+    let spread_ids = InteractiveBrokersExecutionClient::cached_instrument_ids_for_preload(
         &cache,
         &instrument_provider,
     );
@@ -1625,7 +1625,7 @@ fn test_cached_spread_instrument_ids_for_preload_deduplicates_spread_orders() {
 }
 
 #[rstest]
-fn test_cached_spread_instrument_ids_for_preload_ignores_non_spread_orders() {
+fn test_cached_instrument_ids_for_preload_includes_single_leg_orders() {
     let instrument_provider = create_test_instrument_provider();
     let mut cache = Cache::default();
     let instrument_id = InstrumentId::new(Symbol::from("AAPL"), Venue::from("SMART"));
@@ -1639,12 +1639,39 @@ fn test_cached_spread_instrument_ids_for_preload_ignores_non_spread_orders() {
 
     cache.add_order(order, None, None, false).unwrap();
 
-    let spread_ids = InteractiveBrokersExecutionClient::cached_spread_instrument_ids_for_preload(
+    let instrument_ids = InteractiveBrokersExecutionClient::cached_instrument_ids_for_preload(
         &cache,
         &instrument_provider,
     );
 
-    assert!(spread_ids.is_empty());
+    // A single-leg instrument referenced by a cached order must be preloaded too,
+    // otherwise replayed executions on it are dropped after a restart
+    assert_eq!(instrument_ids, vec![instrument_id]);
+}
+
+#[rstest]
+fn test_cached_instrument_ids_for_preload_skips_instruments_already_loaded() {
+    let instrument_provider = create_test_instrument_provider();
+    let equity = equity_aapl();
+    let instrument_id = equity.id();
+    instrument_provider.insert_test_instrument(InstrumentAny::from(equity), 265598, 1);
+
+    let mut cache = Cache::default();
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument_id)
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00"))
+        .quantity(Quantity::from(1))
+        .build();
+
+    cache.add_order(order, None, None, false).unwrap();
+
+    let instrument_ids = InteractiveBrokersExecutionClient::cached_instrument_ids_for_preload(
+        &cache,
+        &instrument_provider,
+    );
+
+    assert!(instrument_ids.is_empty());
 }
 
 #[rstest]

--- a/crates/adapters/interactive_brokers/src/execution/core_tracking.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_tracking.rs
@@ -10,45 +10,44 @@
 use super::*;
 
 impl InteractiveBrokersExecutionClient {
-    pub(super) fn cached_spread_instrument_ids_for_preload(
+    pub(super) fn cached_instrument_ids_for_preload(
         cache: &Cache,
         instrument_provider: &InteractiveBrokersInstrumentProvider,
     ) -> Vec<InstrumentId> {
-        let mut spread_ids = ahash::AHashSet::new();
+        let mut instrument_ids = ahash::AHashSet::new();
 
         for client_order_id in cache.iter_client_order_ids(None, None, None, None) {
             if let Some(order) = cache.order(&client_order_id) {
                 let instrument_id = order.instrument_id();
-                if is_spread_instrument_id(&instrument_id)
-                    && instrument_provider.find(&instrument_id).is_none()
-                {
-                    spread_ids.insert(instrument_id);
+                if instrument_provider.find(&instrument_id).is_none() {
+                    instrument_ids.insert(instrument_id);
                 }
             }
         }
 
-        let mut spread_ids: Vec<InstrumentId> = spread_ids.into_iter().collect();
-        spread_ids.sort_by_key(|a| a.to_string());
-        spread_ids
+        let mut instrument_ids: Vec<InstrumentId> = instrument_ids.into_iter().collect();
+        instrument_ids.sort_by_key(|a| a.to_string());
+        instrument_ids
     }
 
-    pub(super) async fn preload_cached_spread_instruments(
-        &self,
-        client: &Client,
-    ) -> anyhow::Result<()> {
-        let spread_ids = {
+    pub(super) async fn preload_cached_instruments(&self, client: &Client) -> anyhow::Result<()> {
+        let instrument_ids = {
             let cache = self.core.cache();
-            Self::cached_spread_instrument_ids_for_preload(&cache, &self.instrument_provider)
+            Self::cached_instrument_ids_for_preload(&cache, &self.instrument_provider)
         };
 
-        if spread_ids.is_empty() {
+        if instrument_ids.is_empty() {
             return Ok(());
         }
 
         tracing::debug!(
-            "Preloading {} cached Interactive Brokers spread instrument(s) before reconciliation",
-            spread_ids.len()
+            "Preloading {} cached Interactive Brokers instrument(s) before reconciliation",
+            instrument_ids.len()
         );
+
+        let (spread_ids, single_leg_ids): (Vec<InstrumentId>, Vec<InstrumentId>) = instrument_ids
+            .into_iter()
+            .partition(is_spread_instrument_id);
 
         for instrument_id in spread_ids {
             match self
@@ -69,6 +68,31 @@ impl InteractiveBrokersExecutionClient {
                     tracing::warn!(
                         "Failed to preload cached spread instrument {}: {}",
                         instrument_id,
+                        e
+                    );
+                }
+            }
+        }
+
+        if !single_leg_ids.is_empty() {
+            match self
+                .instrument_provider
+                .load_ids_with_return_async(client, single_leg_ids.clone(), None)
+                .await
+            {
+                Ok(loaded_ids) => {
+                    for instrument_id in &single_leg_ids {
+                        if loaded_ids.contains(instrument_id) {
+                            tracing::debug!("Preloaded cached instrument {}", instrument_id);
+                        } else {
+                            tracing::warn!("Failed to preload cached instrument {}", instrument_id);
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to preload cached instruments {:?}: {}",
+                        single_leg_ids,
                         e
                     );
                 }

--- a/crates/adapters/interactive_brokers/src/execution/core_updates.rs
+++ b/crates/adapters/interactive_brokers/src/execution/core_updates.rs
@@ -385,6 +385,10 @@ impl InteractiveBrokersExecutionClient {
         account_id: AccountId,
     ) -> anyhow::Result<()> {
         let Some(instrument) = instrument_provider.find(&instrument_id) else {
+            tracing::warn!(
+                "Instrument {} not found in provider, dropping OrderUpdated",
+                instrument_id
+            );
             return Ok(());
         };
 
@@ -919,6 +923,10 @@ impl InteractiveBrokersExecutionClient {
         }
 
         let Some(instrument) = instrument_provider.find(instrument_id) else {
+            tracing::warn!(
+                "Instrument {} not found in provider, cannot update average fill price",
+                instrument_id
+            );
             return Ok(());
         };
 


### PR DESCRIPTION
- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed CONTRIBUTING.md and, if I used AI, AI_POLICY.md
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested this draft
- [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

On restart, IB replays the session's `execDetails` and the execution client resolves each one through the process-local instrument provider, which starts empty, so fills on instruments the Cache already holds were dropped (the issue measured ten dropped executions and three phantom EXTERNAL positions across three restarts). The pre-reconciliation preload already closed this race for spread instruments but was gated on `is_spread_instrument_id`; this widens it to every instrument referenced by a cached order, with single-leg ids loaded through the provider's existing batch loader in one call. This is option 2 from the issue rather than a Cache fallback, because the provider path resolves contract details (including the price magnifier) that a Cache fallback would have to guess. The two provider-miss paths in `core_updates.rs` that returned `Ok(())` silently now log a warning.

## Related issues/PRs

Closes #4932

## Type of change

- [x] Bug fix (non-breaking)

## Testing

- [x] I added/updated tests to cover new or changed logic

The existing `..._ignores_non_spread_orders` test asserted the bug; it is now `test_cached_instrument_ids_for_preload_includes_single_leg_orders`, which fails on `develop` and passes with the change. Added `..._skips_instruments_already_loaded` to pin the provider-miss filter; the spread dedup test is unchanged apart from the rename. `cargo test -p nautilus-interactive-brokers preload` and `cargo clippy --all-targets -- -D warnings` are green. Not validated against a live Gateway. Formatting: `cargo +nightly fmt` on the crate; `make pre-commit` is not yet run locally (pinned tool install pending on this machine), and I will run it and update this description.
