### PR TITLE
Expose OKX account configuration in the raw HTTP client

### DIFF
--- a/crates/adapters/okx/src/common/enums.rs
+++ b/crates/adapters/okx/src/common/enums.rs
@@ -736,6 +736,47 @@ pub enum OKXPositionMode {
     LongShortMode,
 }
 
+/// Represents the account mode reported by OKX account configuration.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OKXAccountLevel {
+    /// Spot mode.
+    #[serde(rename = "1")]
+    Spot,
+    /// Futures mode.
+    #[serde(rename = "2")]
+    Futures,
+    /// Multi-currency margin mode.
+    #[serde(rename = "3")]
+    MultiCurrencyMargin,
+    /// Portfolio margin mode.
+    #[serde(rename = "4")]
+    PortfolioMargin,
+}
+
+/// Represents the fee-charging currency configured for an OKX account.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OKXFeeType {
+    /// Fees are charged in the currency received from the trade.
+    #[serde(rename = "0")]
+    ReceivedCurrency,
+    /// Fees are always charged in the trading pair's quote currency.
+    #[serde(rename = "1")]
+    QuoteCurrency,
+}
+
+/// Represents a permission of the requesting OKX API key or access token.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, AsRefStr, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum OKXApiKeyPermission {
+    /// Read permission.
+    ReadOnly,
+    /// Trading permission.
+    Trade,
+    /// Withdrawal permission.
+    Withdraw,
+}
+
 #[derive(
     Copy,
     Clone,

--- a/crates/adapters/okx/src/http/client.rs
+++ b/crates/adapters/okx/src/http/client.rs
@@ -84,13 +84,13 @@ use ustr::Ustr;
 use super::{
     error::OKXHttpError,
     models::{
-        OKXAccount, OKXAmendAlgoOrderRequest, OKXAmendAlgoOrderResponse, OKXAmendOrderRequest,
-        OKXAttachAlgoOrdRequest, OKXCancelAlgoOrderRequest, OKXCancelAlgoOrderResponse,
-        OKXCancelAllSpreadOrdersRequest, OKXCancelOrderRequest, OKXCancelOrderResponse,
-        OKXCancelSpreadOrderRequest, OKXEventContractEvent, OKXEventContractMarket,
-        OKXEventContractSeries, OKXFeeRate, OKXFundingRateHistory, OKXIndexTicker, OKXMarkPrice,
-        OKXOptionSummary, OKXOrderAlgo, OKXOrderBookSnapshot, OKXOrderHistory,
-        OKXPlaceAlgoOrderRequest, OKXPlaceAlgoOrderResponse, OKXPlaceOrderRequest,
+        OKXAccount, OKXAccountConfiguration, OKXAmendAlgoOrderRequest, OKXAmendAlgoOrderResponse,
+        OKXAmendOrderRequest, OKXAttachAlgoOrdRequest, OKXCancelAlgoOrderRequest,
+        OKXCancelAlgoOrderResponse, OKXCancelAllSpreadOrdersRequest, OKXCancelOrderRequest,
+        OKXCancelOrderResponse, OKXCancelSpreadOrderRequest, OKXEventContractEvent,
+        OKXEventContractMarket, OKXEventContractSeries, OKXFeeRate, OKXFundingRateHistory,
+        OKXIndexTicker, OKXMarkPrice, OKXOptionSummary, OKXOrderAlgo, OKXOrderBookSnapshot,
+        OKXOrderHistory, OKXPlaceAlgoOrderRequest, OKXPlaceAlgoOrderResponse, OKXPlaceOrderRequest,
         OKXPlaceOrderResponse, OKXPlaceSpreadOrderRequest, OKXPosition, OKXPositionHistory,
         OKXPositionTier, OKXPriceLimit, OKXRpiOrderBookSnapshot, OKXServerTime, OKXSpread,
         OKXSpreadOrder, OKXSpreadTrade, OKXTransactionDetail,
@@ -594,6 +594,10 @@ impl OKXRawHttpClient {
     fn rate_limiter_quotas() -> Vec<(String, Quota)> {
         vec![
             (OKX_GLOBAL_RATE_KEY.to_string(), *OKX_REST_QUOTA),
+            (
+                "okx:/api/v5/account/config".to_string(),
+                Quota::per_second(NonZeroU32::new(2).expect("non-zero")).expect("valid constant"),
+            ),
             (
                 "okx:/api/v5/account/set-position-mode".to_string(),
                 Quota::per_second(NonZeroU32::new(2).expect("non-zero")).expect("valid constant"),
@@ -1747,6 +1751,27 @@ impl OKXRawHttpClient {
             false,
         )
         .await
+    }
+
+    /// Requests the authenticated account's configuration.
+    ///
+    /// Returns the response data array, which is empty if OKX returns no configuration.
+    /// This query exposes exchange configuration without applying account or permission policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if credentials are missing, the request fails, OKX returns an error,
+    /// or required configuration fields are missing or invalid.
+    ///
+    /// # References
+    ///
+    /// <https://www.okx.com/docs-v5/en/#trading-account-rest-api-get-account-configuration>
+    pub async fn get_account_configuration(
+        &self,
+    ) -> Result<Vec<OKXAccountConfiguration>, OKXHttpError> {
+        let path = "/api/v5/account/config";
+        self.send_request::<_, ()>(Method::GET, path, None, None, true)
+            .await
     }
 
     /// Requests a list of assets (with non-zero balance), remaining balance, and available amount

--- a/crates/adapters/okx/src/http/models.rs
+++ b/crates/adapters/okx/src/http/models.rs
@@ -17,7 +17,7 @@
 
 use nautilus_core::serialization::deserialize_optional_decimal;
 use rust_decimal::Decimal;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de::IntoDeserializer};
 use ustr::Ustr;
 
 use crate::common::{
@@ -76,9 +76,10 @@ pub struct OKXCandlestick(
 
 use crate::common::{
     enums::{
-        OKXAlgoOrderStatus, OKXAlgoOrderType, OKXExecType, OKXInstrumentType, OKXMarginMode,
-        OKXOrderCategory, OKXOrderStatus, OKXOrderType, OKXPositionSide, OKXSide, OKXSpreadState,
-        OKXSpreadType, OKXTargetCurrency, OKXTradeMode, OKXTriggerType, OKXVipLevel,
+        OKXAccountLevel, OKXAlgoOrderStatus, OKXAlgoOrderType, OKXApiKeyPermission, OKXExecType,
+        OKXFeeType, OKXInstrumentType, OKXMarginMode, OKXOrderCategory, OKXOrderStatus,
+        OKXOrderType, OKXPositionMode, OKXPositionSide, OKXSide, OKXSpreadState, OKXSpreadType,
+        OKXTargetCurrency, OKXTradeMode, OKXTriggerType, OKXVipLevel,
     },
     parse::deserialize_string_to_u64,
 };
@@ -520,6 +521,32 @@ pub struct OKXPositionTier {
     pub quote_max_loan: String,
     /// Base currency borrowing amount.
     pub base_max_loan: String,
+}
+
+/// Represents configuration evidence from `GET /api/v5/account/config`.
+///
+/// The configuration fields are required and unknown enum values are rejected.
+/// Account-mode and API-key-permission policy remains the caller's responsibility.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OKXAccountConfiguration {
+    /// Account mode.
+    #[serde(rename = "acctLv", deserialize_with = "deserialize_configuration_enum")]
+    pub account_level: OKXAccountLevel,
+    /// Position mode.
+    #[serde(
+        rename = "posMode",
+        deserialize_with = "deserialize_configuration_enum"
+    )]
+    pub position_mode: OKXPositionMode,
+    /// Whether automatic borrowing is enabled.
+    pub auto_loan: bool,
+    /// Configured fee-charging currency.
+    #[serde(deserialize_with = "deserialize_configuration_enum")]
+    pub fee_type: OKXFeeType,
+    /// Permissions of the requesting API key or access token, in response order.
+    #[serde(rename = "perm", with = "account_permissions")]
+    pub permissions: Vec<OKXApiKeyPermission>,
 }
 
 /// Represents an account balance snapshot from `GET /api/v5/account/balance`.
@@ -1593,6 +1620,47 @@ pub struct OKXFeeRate {
     /// Data return timestamp (Unix timestamp in milliseconds).
     #[serde(deserialize_with = "deserialize_string_to_u64")]
     pub ts: u64,
+}
+
+fn deserialize_configuration_enum<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    T::deserialize(value.into_deserializer())
+}
+
+mod account_permissions {
+    use serde::{Deserialize, Deserializer, Serializer, de::IntoDeserializer};
+
+    use crate::common::enums::OKXApiKeyPermission;
+
+    pub(super) fn serialize<S>(
+        permissions: &[OKXApiKeyPermission],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = permissions
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<Vec<_>>()
+            .join(",");
+        serializer.serialize_str(&value)
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Vec<OKXApiKeyPermission>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value
+            .split(',')
+            .map(|permission| OKXApiKeyPermission::deserialize(permission.into_deserializer()))
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/crates/adapters/okx/test_data/README.md
+++ b/crates/adapters/okx/test_data/README.md
@@ -1,0 +1,6 @@
+# OKX HTTP fixtures
+
+`http_get_account_configuration.json` follows the response example in the
+[official account-configuration documentation](https://www.okx.com/docs-v5/en/#trading-account-rest-api-get-account-configuration),
+retrieved on 2026-09-08. The account IDs are synthetic. The HTTP tests vary the
+five configuration fields to exercise documented values and malformed inputs.

--- a/crates/adapters/okx/test_data/http_get_account_configuration.json
+++ b/crates/adapters/okx/test_data/http_get_account_configuration.json
@@ -1,0 +1,41 @@
+{
+  "code": "0",
+  "data": [
+    {
+      "acctLv": "2",
+      "acctStpMode": "cancel_maker",
+      "autoLoan": false,
+      "ctIsoMode": "automatic",
+      "enableSpotBorrow": false,
+      "greeksType": "PA",
+      "feeType": "0",
+      "ip": "",
+      "type": "0",
+      "kycLv": "3",
+      "label": "v5 test",
+      "level": "Lv1",
+      "levelTmp": "",
+      "liquidationGear": "-1",
+      "mainUid": "10000000000000001",
+      "mgnIsoMode": "automatic",
+      "opAuth": "1",
+      "perm": "read_only,withdraw,trade",
+      "posMode": "long_short_mode",
+      "roleType": "0",
+      "spotBorrowAutoRepay": false,
+      "spotOffsetType": "",
+      "spotRoleType": "0",
+      "spotTraderInsts": [],
+      "stgyType": "0",
+      "traderInsts": [],
+      "uid": "10000000000000001",
+      "settleCcy": "USDC",
+      "settleCcyList": [
+        "USD",
+        "USDC",
+        "USDG"
+      ]
+    }
+  ],
+  "msg": ""
+}

--- a/crates/adapters/okx/tests/integration/http.rs
+++ b/crates/adapters/okx/tests/integration/http.rs
@@ -28,6 +28,7 @@ use std::{
 
 use axum::{
     Router,
+    body::Bytes,
     extract::Query,
     http::{HeaderMap, HeaderValue, StatusCode, Uri, header::RETRY_AFTER},
     response::{IntoResponse, Json},
@@ -50,10 +51,11 @@ use nautilus_network::http::{HttpClient, HttpClientError};
 use nautilus_okx::{
     common::{
         consts::OKX_NAUTILUS_BROKER_ID,
+        credential::Credential,
         enums::{
-            OKXAlgoOrderStatus, OKXEnvironment, OKXInstrumentType, OKXOrderStatus, OKXOrderType,
-            OKXPositionMode, OKXPositionSide, OKXRpiPermission, OKXSide, OKXTradeMode,
-            OKXTriggerType,
+            OKXAccountLevel, OKXAlgoOrderStatus, OKXApiKeyPermission, OKXEnvironment, OKXFeeType,
+            OKXInstrumentType, OKXOrderStatus, OKXOrderType, OKXPositionMode, OKXPositionSide,
+            OKXRpiPermission, OKXSide, OKXTradeMode, OKXTriggerType,
         },
         failure::classify_okx_http_failure,
         models::OKXInstrument,
@@ -84,6 +86,8 @@ use ustr::Ustr;
 
 #[derive(Clone, Default)]
 struct TestServerState {
+    account_configuration_request: Arc<tokio::sync::Mutex<Option<(HeaderMap, Uri, Bytes)>>>,
+    account_configuration_response: Arc<tokio::sync::Mutex<Option<(StatusCode, String)>>>,
     request_count: Arc<tokio::sync::Mutex<usize>>,
     last_history_trades_query: Arc<tokio::sync::Mutex<Option<HashMap<String, String>>>>,
     last_pending_orders_query: Arc<tokio::sync::Mutex<Option<HashMap<String, String>>>>,
@@ -362,6 +366,7 @@ fn event_contract_markets_response(params: &HashMap<String, String>) -> Value {
 }
 
 fn create_router(state: Arc<TestServerState>) -> Router {
+    let account_configuration_state = state.clone();
     let instruments_state = state.clone();
     let spreads_state = state.clone();
     let spread_order_query_state = state.clone();
@@ -734,6 +739,26 @@ fn create_router(state: Arc<TestServerState>) -> Router {
                         "msg": "",
                         "data": [],
                     }))
+                }
+            }),
+        )
+        .route(
+            "/api/v5/account/config",
+            get(move |headers: HeaderMap, uri: Uri, body: Bytes| {
+                let state = account_configuration_state.clone();
+                async move {
+                    *state.account_configuration_request.lock().await = Some((headers, uri, body));
+                    state
+                        .account_configuration_response
+                        .lock()
+                        .await
+                        .clone()
+                        .unwrap_or_else(|| {
+                            (
+                                StatusCode::OK,
+                                load_test_data("http_get_account_configuration.json").to_string(),
+                            )
+                        })
                 }
             }),
         )
@@ -2344,6 +2369,325 @@ async fn test_http_request_event_contract_markets_preserves_settlement_boundarie
     assert_eq!(between_markets[0].cap_strike, "INF");
     assert_eq!(between_markets[0].hit_dir, "");
     assert_eq!(state.event_market_queries.lock().await.len(), 2);
+}
+
+async fn account_configuration_client(
+    state: Arc<TestServerState>,
+    environment: OKXEnvironment,
+) -> OKXRawHttpClient {
+    let addr = start_test_server(state).await;
+    OKXRawHttpClient::with_credentials(
+        "test_key".to_string(),
+        "test_secret".to_string(),
+        "passphrase".to_string(),
+        format!("http://{addr}"),
+        5,
+        0,
+        1,
+        1,
+        environment,
+        None,
+    )
+    .unwrap()
+}
+
+#[rstest]
+#[case(OKXEnvironment::Live)]
+#[case(OKXEnvironment::Demo)]
+#[tokio::test]
+async fn test_http_account_configuration_authenticated_request(
+    #[case] environment: OKXEnvironment,
+) {
+    let state = Arc::new(TestServerState::default());
+    let client = account_configuration_client(state.clone(), environment).await;
+
+    let accounts = client.get_account_configuration().await.unwrap();
+
+    assert_eq!(accounts.len(), 1);
+    let account = &accounts[0];
+    assert_eq!(account.account_level, OKXAccountLevel::Futures);
+    assert_eq!(account.position_mode, OKXPositionMode::LongShortMode);
+    assert!(!account.auto_loan);
+    assert_eq!(account.fee_type, OKXFeeType::ReceivedCurrency);
+    assert_eq!(
+        account.permissions,
+        vec![
+            OKXApiKeyPermission::ReadOnly,
+            OKXApiKeyPermission::Withdraw,
+            OKXApiKeyPermission::Trade
+        ]
+    );
+
+    let (headers, uri, body) = state
+        .account_configuration_request
+        .lock()
+        .await
+        .clone()
+        .unwrap();
+    assert_eq!(uri.path(), "/api/v5/account/config");
+    assert_eq!(uri.query(), None);
+    assert!(body.is_empty());
+    assert!(has_auth_headers(&headers));
+    assert_eq!(headers["ok-access-key"], "test_key");
+    assert_eq!(headers["ok-access-passphrase"], "passphrase");
+    assert_eq!(
+        headers
+            .get("x-simulated-trading")
+            .map(|value| value.to_str().unwrap()),
+        (environment == OKXEnvironment::Demo).then_some("1")
+    );
+    let timestamp = headers["ok-access-timestamp"].to_str().unwrap();
+    assert_eq!(
+        timestamp,
+        format!("{:.3}", timestamp.parse::<Timestamp>().unwrap())
+    );
+    let credential = Credential::new(
+        "test_key".to_string(),
+        "test_secret".to_string(),
+        "passphrase".to_string(),
+    );
+    assert_eq!(
+        headers["ok-access-sign"],
+        credential.sign_bytes(timestamp, "GET", "/api/v5/account/config", None)
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_account_configuration_requires_credentials() {
+    let state = Arc::new(TestServerState::default());
+    let addr = start_test_server(state.clone()).await;
+    let client = OKXRawHttpClient::new(
+        Some(format!("http://{addr}")),
+        5,
+        0,
+        1,
+        1,
+        OKXEnvironment::Demo,
+        None,
+    )
+    .unwrap();
+
+    assert!(matches!(
+        client.get_account_configuration().await,
+        Err(OKXHttpError::MissingCredentials)
+    ));
+    assert!(state.account_configuration_request.lock().await.is_none());
+}
+
+#[rstest]
+#[case("1", OKXAccountLevel::Spot)]
+#[case("2", OKXAccountLevel::Futures)]
+#[case("3", OKXAccountLevel::MultiCurrencyMargin)]
+#[case("4", OKXAccountLevel::PortfolioMargin)]
+#[tokio::test]
+async fn test_http_account_configuration_documented_values(
+    #[case] account_level: &str,
+    #[case] expected_level: OKXAccountLevel,
+    #[values(("net_mode", OKXPositionMode::NetMode), ("long_short_mode", OKXPositionMode::LongShortMode))]
+    position: (&str, OKXPositionMode),
+    #[values(("0", OKXFeeType::ReceivedCurrency), ("1", OKXFeeType::QuoteCurrency))] fee: (
+        &str,
+        OKXFeeType,
+    ),
+    #[values(false, true)] auto_loan: bool,
+) {
+    let state = Arc::new(TestServerState::default());
+    let mut response = load_test_data("http_get_account_configuration.json");
+    let account = &mut response["data"][0];
+    account["acctLv"] = json!(account_level);
+    account["posMode"] = json!(position.0);
+    account["feeType"] = json!(fee.0);
+    account["autoLoan"] = json!(auto_loan);
+    *state.account_configuration_response.lock().await =
+        Some((StatusCode::OK, response.to_string()));
+    let client = account_configuration_client(state, OKXEnvironment::Demo).await;
+
+    let accounts = client.get_account_configuration().await.unwrap();
+
+    assert_eq!(accounts.len(), 1);
+    assert_eq!(accounts[0].account_level, expected_level);
+    assert_eq!(accounts[0].position_mode, position.1);
+    assert_eq!(accounts[0].auto_loan, auto_loan);
+    assert_eq!(accounts[0].fee_type, fee.1);
+    let serialized = serde_json::to_value(&accounts[0]).unwrap();
+    for field in ["acctLv", "posMode", "autoLoan", "feeType", "perm"] {
+        assert_eq!(serialized[field], response["data"][0][field]);
+    }
+}
+
+#[rstest]
+#[case("read_only", vec![OKXApiKeyPermission::ReadOnly])]
+#[case("trade", vec![OKXApiKeyPermission::Trade])]
+#[case("withdraw", vec![OKXApiKeyPermission::Withdraw])]
+#[case("read_only,trade", vec![OKXApiKeyPermission::ReadOnly, OKXApiKeyPermission::Trade])]
+#[case("read_only,withdraw", vec![OKXApiKeyPermission::ReadOnly, OKXApiKeyPermission::Withdraw])]
+#[case("trade,withdraw", vec![OKXApiKeyPermission::Trade, OKXApiKeyPermission::Withdraw])]
+#[case("read_only,withdraw,trade", vec![OKXApiKeyPermission::ReadOnly, OKXApiKeyPermission::Withdraw, OKXApiKeyPermission::Trade])]
+#[case("trade,read_only", vec![OKXApiKeyPermission::Trade, OKXApiKeyPermission::ReadOnly])]
+#[case("read_only,read_only", vec![OKXApiKeyPermission::ReadOnly, OKXApiKeyPermission::ReadOnly])]
+#[tokio::test]
+async fn test_http_account_configuration_permissions(
+    #[case] permissions: &str,
+    #[case] expected: Vec<OKXApiKeyPermission>,
+) {
+    let state = Arc::new(TestServerState::default());
+    let mut response = load_test_data("http_get_account_configuration.json");
+    response["data"][0]["perm"] = json!(permissions);
+    *state.account_configuration_response.lock().await =
+        Some((StatusCode::OK, response.to_string()));
+    let client = account_configuration_client(state, OKXEnvironment::Demo).await;
+
+    let accounts = client.get_account_configuration().await.unwrap();
+
+    assert_eq!(accounts[0].permissions, expected);
+    assert_eq!(
+        serde_json::to_value(&accounts[0]).unwrap()["perm"],
+        permissions
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_account_configuration_missing_fields(
+    #[values("acctLv", "posMode", "autoLoan", "feeType", "perm")] field: &str,
+) {
+    let state = Arc::new(TestServerState::default());
+    let mut response = load_test_data("http_get_account_configuration.json");
+    response["data"][0].as_object_mut().unwrap().remove(field);
+    *state.account_configuration_response.lock().await =
+        Some((StatusCode::OK, response.to_string()));
+    let client = account_configuration_client(state, OKXEnvironment::Demo).await;
+
+    assert!(matches!(
+        client.get_account_configuration().await,
+        Err(OKXHttpError::ResponseDecoding(_))
+    ));
+}
+
+#[rstest]
+#[case("acctLv", json!("5"))]
+#[case("acctLv", json!(1))]
+#[case("acctLv", json!({"1": null}))]
+#[case("posMode", json!("hedge_mode"))]
+#[case("posMode", json!({"net_mode": null}))]
+#[case("feeType", json!("2"))]
+#[case("feeType", json!(0))]
+#[case("feeType", json!({"0": null}))]
+#[case("autoLoan", json!("true"))]
+#[case("autoLoan", json!("false"))]
+#[case("autoLoan", json!(1))]
+#[case("perm", json!("read_only,admin"))]
+#[case("perm", json!("read_only,,trade"))]
+#[case("perm", json!("read_only,"))]
+#[case("perm", json!(",trade"))]
+#[case("perm", json!("read_only, trade"))]
+#[case("perm", json!("READ_ONLY"))]
+#[case("perm", json!(["read_only", "trade"]))]
+#[tokio::test]
+async fn test_http_account_configuration_invalid_values(#[case] field: &str, #[case] value: Value) {
+    let state = Arc::new(TestServerState::default());
+    let mut response = load_test_data("http_get_account_configuration.json");
+    response["data"][0][field] = value;
+    *state.account_configuration_response.lock().await =
+        Some((StatusCode::OK, response.to_string()));
+    let client = account_configuration_client(state, OKXEnvironment::Demo).await;
+
+    assert!(matches!(
+        client.get_account_configuration().await,
+        Err(OKXHttpError::ResponseDecoding(_))
+    ));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_account_configuration_empty_or_wrong_types(
+    #[values("acctLv", "posMode", "autoLoan", "feeType", "perm")] field: &str,
+    #[values(json!(null), json!(""), json!([]), json!({}))] value: Value,
+) {
+    let state = Arc::new(TestServerState::default());
+    let mut response = load_test_data("http_get_account_configuration.json");
+    response["data"][0][field] = value;
+    *state.account_configuration_response.lock().await =
+        Some((StatusCode::OK, response.to_string()));
+    let client = account_configuration_client(state, OKXEnvironment::Demo).await;
+
+    assert!(matches!(
+        client.get_account_configuration().await,
+        Err(OKXHttpError::ResponseDecoding(_))
+    ));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_account_configuration_malformed_response(
+    #[values("not JSON", "{", r#"{"code":"0","msg":"","data":["#)] body: &str,
+) {
+    let state = Arc::new(TestServerState::default());
+    *state.account_configuration_response.lock().await = Some((StatusCode::OK, body.to_string()));
+    let client = account_configuration_client(state, OKXEnvironment::Demo).await;
+
+    assert!(matches!(
+        client.get_account_configuration().await,
+        Err(OKXHttpError::MalformedResponse(_))
+    ));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_account_configuration_invalid_envelope(
+    #[values(json!({}), json!({"code":"0","msg":""}), json!({"code":"0","msg":"","data":null}), json!({"code":"0","msg":"","data":[{}]}))]
+    response: Value,
+) {
+    let state = Arc::new(TestServerState::default());
+    *state.account_configuration_response.lock().await =
+        Some((StatusCode::OK, response.to_string()));
+    let client = account_configuration_client(state, OKXEnvironment::Demo).await;
+
+    assert!(matches!(
+        client.get_account_configuration().await,
+        Err(OKXHttpError::ResponseDecoding(_))
+    ));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_account_configuration_empty_response() {
+    let state = Arc::new(TestServerState::default());
+    *state.account_configuration_response.lock().await =
+        Some((StatusCode::OK, okx_response(&[]).to_string()));
+    let client = account_configuration_client(state.clone(), OKXEnvironment::Demo).await;
+
+    assert!(client.get_account_configuration().await.unwrap().is_empty());
+
+    *state.account_configuration_response.lock().await = Some((StatusCode::OK, String::new()));
+
+    assert!(matches!(
+        client.get_account_configuration().await,
+        Err(OKXHttpError::EmptyResponse)
+    ));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_http_account_configuration_structured_error(
+    #[values(StatusCode::OK, StatusCode::UNAUTHORIZED)] status: StatusCode,
+) {
+    let state = Arc::new(TestServerState::default());
+    let response = json!({"code":"50113", "msg":"Invalid signature", "data":[]});
+    *state.account_configuration_response.lock().await = Some((status, response.to_string()));
+    let client = account_configuration_client(state, OKXEnvironment::Demo).await;
+
+    match client.get_account_configuration().await {
+        Err(OKXHttpError::OkxError {
+            error_code,
+            message,
+        }) => {
+            assert_eq!(error_code, "50113");
+            assert_eq!(message, "Invalid signature");
+        }
+        other => panic!("expected OkxError: {other:?}"),
+    }
 }
 
 #[rstest]


### PR DESCRIPTION
# Pull Request

- [x] A maintainer agreed on the problem and approach in an issue
- [x] I have read and followed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed
- [x] I ran all relevant tests locally
- [x] I have not modified `RELEASES.md`

## Summary

Adds `OKXRawHttpClient::get_account_configuration()` for authenticated `GET /api/v5/account/config`, returning `Vec<OKXAccountConfiguration>` through the existing request and response handling. The model exposes typed account levels, position modes, fee types, API-key permissions, and the automatic-borrowing flag; it reuses `OKXPositionMode` and leaves application policy to callers.

Missing required fields, malformed values, and unknown configuration values return decoding errors. Empty response data retains the raw client's empty-vector convention. The method reuses authentication, signing, base-URL routing, Demo headers, retries, and error propagation, with an endpoint quota in the existing limiter.

## Related issues/PRs

Closes #4894.

[Maintainer approval and API direction](https://github.com/nautechsystems/nautilus_trader/issues/4894#issuecomment-5580806531).

## Type of change

- [x] New feature (non-breaking)

## Documentation

- [x] Documentation changes follow the style guide

Rustdoc describes the query and response contract. The fixture README records the official endpoint example and synthetic account identifiers. No Python bindings or generated stubs changed.

## Testing

- [x] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic

- Focused account-configuration tests: 97 passed.
- OKX unit and integration suite: 1,237 passed, 0 skipped.
- `make format`: passed.
- `make pre-commit`: passed, including Clippy and Rustdoc checks.
- Independent static review: no actionable findings.

Tests use synthetic fixtures and local mock servers. They establish client behavior, not live account or trading readiness.
