### PR TITLE
Restore backtest request warnings

### DIFF
--- a/crates/backtest/src/data_client.rs
+++ b/crates/backtest/src/data_client.rs
@@ -28,15 +28,13 @@ use nautilus_common::{
     cache::Cache,
     clients::DataClient,
     messages::data::{
-        RequestBars, RequestBookSnapshot, RequestCustomData, RequestInstrument, RequestInstruments,
-        RequestOptionChainReferencePrice, RequestQuotes, RequestTrades, SubscribeBars,
-        SubscribeBookDeltas, SubscribeBookDepth10, SubscribeCustomData, SubscribeIndexPrices,
-        SubscribeInstrument, SubscribeInstrumentClose, SubscribeInstrumentStatus,
-        SubscribeInstruments, SubscribeMarkPrices, SubscribeQuotes, SubscribeTrades,
-        UnsubscribeBars, UnsubscribeBookDeltas, UnsubscribeBookDepth10, UnsubscribeCustomData,
-        UnsubscribeIndexPrices, UnsubscribeInstrument, UnsubscribeInstrumentClose,
-        UnsubscribeInstrumentStatus, UnsubscribeInstruments, UnsubscribeMarkPrices,
-        UnsubscribeQuotes, UnsubscribeTrades,
+        RequestOptionChainReferencePrice, SubscribeBars, SubscribeBookDeltas, SubscribeBookDepth10,
+        SubscribeCustomData, SubscribeIndexPrices, SubscribeInstrument, SubscribeInstrumentClose,
+        SubscribeInstrumentStatus, SubscribeInstruments, SubscribeMarkPrices, SubscribeQuotes,
+        SubscribeTrades, UnsubscribeBars, UnsubscribeBookDeltas, UnsubscribeBookDepth10,
+        UnsubscribeCustomData, UnsubscribeIndexPrices, UnsubscribeInstrument,
+        UnsubscribeInstrumentClose, UnsubscribeInstrumentStatus, UnsubscribeInstruments,
+        UnsubscribeMarkPrices, UnsubscribeQuotes, UnsubscribeTrades,
     },
 };
 use nautilus_model::identifiers::{ClientId, Venue};
@@ -285,41 +283,6 @@ impl DataClient for BacktestDataClient {
         Ok(())
     }
 
-    fn request_data(&self, _request: RequestCustomData) -> anyhow::Result<()> {
-        // No-op in backtest: data is replayed by the engine
-        Ok(())
-    }
-
-    fn request_instruments(&self, _request: RequestInstruments) -> anyhow::Result<()> {
-        // No-op in backtest: instruments are pre-loaded
-        Ok(())
-    }
-
-    fn request_instrument(&self, _request: RequestInstrument) -> anyhow::Result<()> {
-        // No-op in backtest: instruments are pre-loaded
-        Ok(())
-    }
-
-    fn request_book_snapshot(&self, _request: RequestBookSnapshot) -> anyhow::Result<()> {
-        // No-op in backtest
-        Ok(())
-    }
-
-    fn request_quotes(&self, _request: RequestQuotes) -> anyhow::Result<()> {
-        // No-op in backtest: quotes are replayed by the engine
-        Ok(())
-    }
-
-    fn request_trades(&self, _request: RequestTrades) -> anyhow::Result<()> {
-        // No-op in backtest: trades are replayed by the engine
-        Ok(())
-    }
-
-    fn request_bars(&self, _request: RequestBars) -> anyhow::Result<()> {
-        // No-op in backtest: bars are replayed by the engine
-        Ok(())
-    }
-
     fn request_option_chain_reference_price(
         &self,
         _request: RequestOptionChainReferencePrice,
@@ -335,6 +298,10 @@ impl DataClient for BacktestDataClient {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Mutex, MutexGuard};
+
+    use log::{Level, LevelFilter, Log, Metadata, Record};
+    use nautilus_common::messages::data::RequestInstruments;
     use nautilus_core::{UUID4, UnixNanos};
     use nautilus_model::identifiers::{InstrumentId, OptionSeriesId};
     use rstest::rstest;
@@ -342,6 +309,80 @@ mod tests {
 
     use super::*;
 
+    struct RequestWarnCapture {
+        messages: Mutex<Vec<String>>,
+    }
+
+    impl RequestWarnCapture {
+        fn clear(&self) {
+            self.messages.lock().unwrap().clear();
+        }
+
+        fn messages(&self) -> Vec<String> {
+            self.messages.lock().unwrap().clone()
+        }
+    }
+
+    impl Log for RequestWarnCapture {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            metadata.level() == Level::Warn
+        }
+
+        fn log(&self, record: &Record<'_>) {
+            if self.enabled(record.metadata()) {
+                self.messages
+                    .lock()
+                    .unwrap()
+                    .push(record.args().to_string());
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    static REQUEST_WARN_CAPTURE: RequestWarnCapture = RequestWarnCapture {
+        messages: Mutex::new(Vec::new()),
+    };
+    static REQUEST_WARN_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn start_request_warn_capture() -> MutexGuard<'static, ()> {
+        let guard = REQUEST_WARN_TEST_LOCK.lock().unwrap();
+        let _ = log::set_logger(&REQUEST_WARN_CAPTURE);
+        log::set_max_level(LevelFilter::Warn);
+        REQUEST_WARN_CAPTURE.clear();
+        guard
+    }
+
+    #[rstest]
+    fn test_request_instruments_logs_not_implemented_warning() {
+        let _guard = start_request_warn_capture();
+
+        let client_id = ClientId::new("BACKTEST");
+        let venue = Venue::new("BACKTEST");
+        let cache = Rc::new(RefCell::new(Cache::default()));
+        let client = BacktestDataClient::new(client_id, venue, cache);
+
+        let request = RequestInstruments::new(
+            None,
+            None,
+            Some(client_id),
+            Some(venue),
+            UUID4::new(),
+            UnixNanos::default(),
+            None,
+        );
+
+        let result = client.request_instruments(request);
+
+        assert!(result.is_ok());
+        assert!(
+            REQUEST_WARN_CAPTURE
+                .messages()
+                .iter()
+                .any(|message| message.contains("RequestInstruments")
+                    && message.contains("handler not implemented")),
+        );
+    }
     #[rstest]
     fn test_option_chain_reference_price_is_unsupported() {
         let client_id = ClientId::new("BACKTEST");


### PR DESCRIPTION
# Pull Request

* [x] A maintainer agreed on the problem and approach in an issue, or this is a small,
  self-contained fix that does not need prior discussion
* [x] I have read and followed
  https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md
  and, if I used AI,
  https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md
* [x] I understand and can explain every submitted change and all information in this PR description
* [x] This change is complete, locally validated, and ready for review, or a maintainer requested
  this draft
* [ ] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I
  described an agreed limitation below
* [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed
  limitation below
* [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Restore warnings for unsupported on-demand requests in `BacktestDataClient` by removing silent `request_*` overrides and allowing the existing `DataClient` defaults to handle them.

The inherited defaults already log that the handler is not implemented while preserving the existing `Ok(())` behavior. The explicit option-chain reference-price error and subscription behavior remain unchanged.

## Related issues/PRs

Closes #4933

## Type of change

* [x] Bug fix (non-breaking)
* [ ] New feature (non-breaking)
* [ ] Improvement (non-breaking)
* [ ] Breaking change (impacts existing behavior)
* [ ] Documentation update
* [ ] Maintenance / chore

## Breaking change details (if applicable)

Not applicable.

## Documentation

* [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)
* [ ] For PyO3 binding or wrapped Rust doc changes, I ran `make py-stubs` and committed the generated output

No documentation changes.

## Testing

**New or changed logic must be covered by tests.**

* [ ] Affected code paths are already covered by the test suite
* [x] I added/updated tests to cover new or changed logic
* [ ] No logic changed (documentation, comments, or metadata only)

Added a regression test verifying that an unsupported backtest instrument request still returns `Ok(())` while emitting the inherited `handler not implemented` warning.

Local validation:

* `cargo nextest run -p nautilus-backtest --lib` — 166 passed, 0 skipped
* `cargo check -p nautilus-backtest --features defi` — passed
* `cargo clippy -p nautilus-backtest --lib --no-deps -- -D warnings` — passed
* `cargo +nightly fmt --all -- --check` — passed
* `git diff --check` — passed

Native Windows does not provide `make` in this environment. I ran the Rust formatting and relevant validation commands directly. The file-scoped pre-commit run passed the applicable code, formatting, convention, logging, copyright, link, secret, and related repository checks; several infrastructure hooks could not execute because their Unix shell environment could not resolve the Windows Cargo installation or required separate Python/tooling dependencies.

Broader workspace Clippy and rustdoc runs are also currently blocked by unrelated existing failures outside this change: a documentation lint in `crates/persistence/src/parquet.rs` and a broken intra-doc link in `crates/backtest/src/engine.rs`.
