### PR TITLE
Fix risk engine account resolution for broker-routed instruments

### DIFF
--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -8338,6 +8338,37 @@ impl Cache {
             .map(|account_cell| account_cell.borrow().clone())
     }
 
+    /// Returns a borrow of the account for `instrument_id` (if found).
+    ///
+    /// A plain venue lookup is not sufficient for broker-routed instruments: the account is
+    /// registered under the broker venue (e.g. `IB`) while the instrument carries the routing
+    /// venue or exchange MIC (e.g. `SMART`, `IBIS`). Resolution order:
+    ///
+    /// 1. The explicit `account_id`, when provided.
+    /// 2. Exact venue match on the instrument's venue.
+    /// 3. The account owning an existing position for the instrument.
+    #[must_use]
+    pub fn account_for_instrument(
+        &self,
+        instrument_id: &InstrumentId,
+        account_id: Option<&AccountId>,
+    ) -> Option<AccountRef<'_>> {
+        match account_id {
+            Some(account_id) => self.account(account_id),
+            None => self
+                .account_for_venue(&instrument_id.venue)
+                .or_else(|| self.account_owning_position(instrument_id)),
+        }
+    }
+
+    /// Returns a borrow of the account owning an existing position for `instrument_id`.
+    fn account_owning_position(&self, instrument_id: &InstrumentId) -> Option<AccountRef<'_>> {
+        self.positions(None, Some(instrument_id), None, None, None)
+            .into_iter()
+            .next()
+            .and_then(|position| self.account(&position.account_id))
+    }
+
     /// Returns a borrow of the sole account in the cache, when exactly one is registered.
     ///
     /// Useful as a last-resort resolution for broker-routed instruments, where the account is

--- a/crates/common/src/cache/mod.rs
+++ b/crates/common/src/cache/mod.rs
@@ -8338,6 +8338,23 @@ impl Cache {
             .map(|account_cell| account_cell.borrow().clone())
     }
 
+    /// Returns a borrow of the sole account in the cache, when exactly one is registered.
+    ///
+    /// Useful as a last-resort resolution for broker-routed instruments, where the account is
+    /// registered under the broker venue while the instrument carries a routing venue or
+    /// exchange MIC, so a venue lookup misses. Returns `None` when zero or multiple accounts
+    /// are registered, since the choice would then be ambiguous.
+    #[must_use]
+    pub fn account_sole(&self) -> Option<AccountRef<'_>> {
+        if self.accounts.len() != 1 {
+            return None;
+        }
+        self.accounts
+            .values()
+            .next()
+            .map(|account_cell| AccountRef::new(account_cell.borrow()))
+    }
+
     /// Returns a reference to the account ID for the `venue` (if found).
     #[must_use]
     pub fn account_id(&self, venue: &Venue) -> Option<&AccountId> {

--- a/crates/common/src/cache/tests.rs
+++ b/crates/common/src/cache/tests.rs
@@ -48,6 +48,7 @@ use nautilus_model::{
         AccountState, OrderAccepted, OrderCancelRejected, OrderCanceled, OrderEmulated,
         OrderEventAny, OrderFilled, OrderPendingCancel, OrderRejected, OrderReleased,
         OrderSnapshot, OrderSubmitted, OrderUpdated,
+        account::stubs::cash_account_state_million_usd,
         order::spec::{
             OrderCanceledSpec, OrderEmulatedSpec, OrderFilledSpec, OrderReleasedSpec,
             OrderUpdatedSpec,
@@ -5134,6 +5135,75 @@ fn test_cache_account_for_venue_return_correct(mut cache: Cache) {
     let result = cache.account_for_venue(&venue);
     assert!(result.is_some());
     assert_eq!(*result.unwrap(), account);
+}
+
+#[rstest]
+fn test_cache_account_for_instrument_falls_back_from_venue_miss(mut cache: Cache) {
+    // Account issuer and instrument venue deliberately differ, as they do for broker-routed
+    // instruments (account under the broker venue, instrument under the routing venue/MIC).
+    let account = AccountAny::default();
+    let account_id = account.last_event().unwrap().account_id;
+    cache.add_account(account).unwrap();
+
+    let instrument_id = InstrumentId::from("AAPL.SMART");
+    assert!(
+        cache.account_for_venue(&instrument_id.venue).is_none(),
+        "precondition: the instrument's venue has no account"
+    );
+
+    // No position yet, so nothing to fall back to.
+    assert!(cache.account_for_instrument(&instrument_id, None).is_none());
+
+    // An explicit account_id always wins.
+    assert_eq!(
+        cache
+            .account_for_instrument(&instrument_id, Some(&account_id))
+            .map(|a| a.id()),
+        Some(account_id)
+    );
+}
+
+#[rstest]
+fn test_cache_account_for_instrument_uses_position_owning_account(mut cache: Cache) {
+    // Account registered under the broker venue `IB`, not the instrument's own venue.
+    let broker_account_id = AccountId::from("IB-DU123456");
+    let mut state = cash_account_state_million_usd("1000000 USD", "0 USD", "1000000 USD");
+    state.account_id = broker_account_id;
+    cache.add_account(AccountAny::from(state)).unwrap();
+
+    let audusd_sim = InstrumentAny::CurrencyPair(audusd_sim());
+    let order = OrderTestBuilder::new(OrderType::Market)
+        .instrument_id(audusd_sim.id())
+        .side(OrderSide::Buy)
+        .quantity(Quantity::from(100_000))
+        .build();
+    let fill = TestOrderEventStubs::filled(
+        &order,
+        &audusd_sim,
+        Some(TradeId::new("T-1")),
+        Some(PositionId::new("P-1")),
+        Some(Price::from("1.00000")),
+        None,
+        None,
+        None,
+        Some(UnixNanos::from(1_000_000_000)),
+        Some(broker_account_id),
+    );
+    let position = Position::new(&audusd_sim, fill.into());
+    let instrument_id = position.instrument_id;
+    cache.add_position(&position, OmsType::Netting).unwrap();
+
+    assert!(
+        cache.account_for_venue(&instrument_id.venue).is_none(),
+        "precondition: the instrument's venue has no account of its own"
+    );
+    assert_eq!(
+        cache
+            .account_for_instrument(&instrument_id, None)
+            .map(|a| a.id()),
+        Some(broker_account_id),
+        "resolves via the account owning a position for the instrument"
+    );
 }
 
 #[rstest]

--- a/crates/portfolio/src/portfolio.rs
+++ b/crates/portfolio/src/portfolio.rs
@@ -31,7 +31,7 @@ use nautilus_analysis::{
     snapshot::PortfolioStatistics,
 };
 use nautilus_common::{
-    cache::{AccountLookupError, AccountRef, Cache},
+    cache::{AccountLookupError, Cache},
     clock::Clock,
     enums::LogColor,
     msgbus::{self, MessagingSwitchboard, TypedHandler, TypedIntoHandler},
@@ -1666,11 +1666,7 @@ impl Portfolio {
             for (account_id, orders) in by_account {
                 let account = {
                     let cache = self.cache.borrow();
-                    match resolve_account_for_instrument(
-                        &cache,
-                        &instrument.id(),
-                        account_id.as_ref(),
-                    ) {
+                    match cache.account_for_instrument(&instrument.id(), account_id.as_ref()) {
                         Some(account) => account.cloned(),
                         None => {
                             log::error!(
@@ -1744,11 +1740,9 @@ impl Portfolio {
                     continue;
                 }
 
-                let Some(account) = resolve_account_for_instrument(
-                    &cache,
-                    &order.instrument_id(),
-                    order.account_id().as_ref(),
-                ) else {
+                let Some(account) = cache
+                    .account_for_instrument(&order.instrument_id(), order.account_id().as_ref())
+                else {
                     continue;
                 };
 
@@ -2265,7 +2259,7 @@ impl Portfolio {
         target_currency: Option<Currency>,
     ) -> Result<Money, UnrealizedPnlError> {
         let cache = self.cache.borrow();
-        let account = resolve_account_for_instrument(&cache, instrument_id, account_id);
+        let account = cache.account_for_instrument(instrument_id, account_id);
         let account = if let Some(account) = account {
             account
         } else {
@@ -2631,7 +2625,7 @@ impl Portfolio {
         self.ensure_snapshot_pnls_cached_for(instrument_id);
 
         let cache = self.cache.borrow();
-        let account = resolve_account_for_instrument(&cache, instrument_id, account_id);
+        let account = cache.account_for_instrument(instrument_id, account_id);
         let account = if let Some(account) = account {
             account
         } else {
@@ -3202,26 +3196,6 @@ fn update_bar(
     update_instrument_id(cache, clock, inner, config, &instrument_id);
 }
 
-/// Account for an instrument. For broker-routed instruments the account lives
-/// under the broker venue (e.g. `IB`) while the instrument carries the exchange
-/// MIC (e.g. `IBIS`); on venue miss, fall back to the position-owning account.
-fn resolve_account_for_instrument<'a>(
-    cache: &'a Cache,
-    instrument_id: &InstrumentId,
-    account_id: Option<&AccountId>,
-) -> Option<AccountRef<'a>> {
-    match account_id {
-        Some(id) => cache.account(id),
-        None => cache.account_for_venue(&instrument_id.venue).or_else(|| {
-            cache
-                .positions(None, Some(instrument_id), None, None, None)
-                .into_iter()
-                .next()
-                .and_then(|p| cache.account(&p.account_id))
-        }),
-    }
-}
-
 fn wallet_order_reserves_balance(order: &OrderAny) -> bool {
     order.is_open() || order.is_inflight()
 }
@@ -3303,8 +3277,9 @@ fn update_instrument_id(
         }
 
         if by_account.is_empty()
-            && let Some(account) =
-                resolve_account_for_instrument(&cache_ref, instrument_id, None).map(|a| a.cloned())
+            && let Some(account) = cache_ref
+                .account_for_instrument(instrument_id, None)
+                .map(|a| a.cloned())
         {
             by_account.entry(account.id()).or_default();
         }

--- a/crates/risk/src/engine/mod.rs
+++ b/crates/risk/src/engine/mod.rs
@@ -79,7 +79,7 @@ fn cash_or_wallet_account(account: &AccountAny) -> Option<&dyn Account> {
 /// When the lookup misses, every account-scoped check is skipped, so the resolution is
 /// attempted in the following order:
 ///
-/// 1. Exact venue match (the common case; unchanged behaviour).
+/// 1. Exact venue match (the common case; unchanged behavior).
 /// 2. The account of the execution client routing the order, when the order carries an
 ///    explicit `client_id`.
 /// 3. The account owning an existing position for the instrument.
@@ -92,7 +92,7 @@ fn cash_or_wallet_account(account: &AccountAny) -> Option<&dyn Account> {
 /// miss on the first order of a session, which is precisely when the limits should apply.
 ///
 /// Returns `None` when no account can be resolved, in which case the caller keeps the
-/// existing fail-open behaviour.
+/// existing fail-open behavior.
 fn resolve_account_for_instrument(
     cache: &Cache,
     instrument_id: &InstrumentId,

--- a/crates/risk/src/engine/mod.rs
+++ b/crates/risk/src/engine/mod.rs
@@ -82,9 +82,10 @@ fn cash_or_wallet_account(account: &AccountAny) -> Option<&dyn Account> {
 /// 1. Exact venue match (the common case; unchanged behaviour).
 /// 2. The account of the execution client routing the order, when the order carries an
 ///    explicit `client_id`.
-/// 3. The account owning an existing position for the instrument (mirrors the portfolio
-///    resolution added for broker-routed instruments).
+/// 3. The account owning an existing position for the instrument.
 /// 4. The sole registered account, when the cache holds exactly one.
+///
+/// Steps 1 and 3 are shared with the portfolio via [`Cache::account_for_instrument`].
 ///
 /// Steps 2 to 4 matter specifically for *pre-trade* checks. A new order usually has no
 /// `account_id` and no position yet, so for a broker-routed instrument steps 1 and 3 both
@@ -109,17 +110,9 @@ fn resolve_account_for_instrument(
         }
     }
 
-    if let Some(account) = cache
-        .positions(None, Some(instrument_id), None, None, None)
-        .into_iter()
-        .next()
-        .and_then(|position| cache.account(&position.account_id))
-    {
-        return Some(account.clone_without_events());
-    }
-
     cache
-        .account_sole()
+        .account_for_instrument(instrument_id, None)
+        .or_else(|| cache.account_sole())
         .map(|account| account.clone_without_events())
 }
 

--- a/crates/risk/src/engine/mod.rs
+++ b/crates/risk/src/engine/mod.rs
@@ -52,7 +52,7 @@ use nautilus_model::{
         OrderDenied, OrderDeniedReason, OrderEventAny, OrderModifyRejected, OrderPriceField,
         PositionEvent,
     },
-    identifiers::{AccountId, InstrumentId},
+    identifiers::{AccountId, InstrumentId, Venue},
     instruments::{Instrument, InstrumentAny},
     orders::{Order, OrderAny},
     types::{Currency, Money, Price, Quantity, money::MoneyRaw, quantity::QuantityRaw},
@@ -69,6 +69,58 @@ fn cash_or_wallet_account(account: &AccountAny) -> Option<&dyn Account> {
         AccountAny::Wallet(wallet) => Some(wallet),
         AccountAny::Margin(_) | AccountAny::Betting(_) => None,
     }
+}
+
+/// Resolves the account to use for account-scoped pre-trade risk checks.
+///
+/// A plain `account_for_venue` lookup on the instrument's venue is not sufficient for
+/// broker-routed instruments: the account is registered under the broker venue (e.g. `IB`)
+/// while the instrument carries the routing venue or exchange MIC (e.g. `SMART`, `IBIS`).
+/// When the lookup misses, every account-scoped check is skipped, so the resolution is
+/// attempted in the following order:
+///
+/// 1. Exact venue match (the common case; unchanged behaviour).
+/// 2. The account of the execution client routing the order, when the order carries an
+///    explicit `client_id`.
+/// 3. The account owning an existing position for the instrument (mirrors the portfolio
+///    resolution added for broker-routed instruments).
+/// 4. The sole registered account, when the cache holds exactly one.
+///
+/// Steps 2 to 4 matter specifically for *pre-trade* checks. A new order usually has no
+/// `account_id` and no position yet, so for a broker-routed instrument steps 1 and 3 both
+/// miss on the first order of a session, which is precisely when the limits should apply.
+///
+/// Returns `None` when no account can be resolved, in which case the caller keeps the
+/// existing fail-open behaviour.
+fn resolve_account_for_instrument(
+    cache: &Cache,
+    instrument_id: &InstrumentId,
+    orders: &[&OrderAny],
+) -> Option<AccountAny> {
+    if let Some(account) = cache.account_for_venue(&instrument_id.venue) {
+        return Some(account.clone_without_events());
+    }
+
+    for order in orders {
+        if let Some(client_id) = cache.client_id(&order.client_order_id())
+            && let Some(account) = cache.account_for_venue(&Venue::new(client_id.as_str()))
+        {
+            return Some(account.clone_without_events());
+        }
+    }
+
+    if let Some(account) = cache
+        .positions(None, Some(instrument_id), None, None, None)
+        .into_iter()
+        .next()
+        .and_then(|position| cache.account(&position.account_id))
+    {
+        return Some(account.clone_without_events());
+    }
+
+    cache
+        .account_sole()
+        .map(|account| account.clone_without_events())
 }
 
 fn format_rate_limit(rate_limit: &RateLimit) -> String {
@@ -1200,7 +1252,8 @@ impl RiskEngine {
             market_prices.push(price);
         }
 
-        // Get account for risk checks: use explicit account_id if provided, otherwise venue lookup
+        // Get account for risk checks: use explicit account_id if provided, otherwise resolve
+        // from the instrument (see `resolve_account_for_instrument` for the fallback order).
         let resolved_account = {
             let cache = self.cache.borrow();
 
@@ -1209,15 +1262,18 @@ impl RiskEngine {
                     .account(&account_id)
                     .map(|account| account.clone_without_events())
             } else {
-                cache
-                    .account_for_venue(&instrument.id().venue)
-                    .map(|account| account.clone_without_events())
+                resolve_account_for_instrument(&cache, &instrument.id(), orders)
             }
         };
 
         let Some(mut account) = resolved_account else {
-            log::debug!(
-                "Cannot find account for venue {} (account_id={account_id:?})",
+            // Fail-open: every account-scoped check below is skipped. Logged at WARN because
+            // the configured risk limits silently stop applying, which is not observable at
+            // the default log level otherwise.
+            log::warn!(
+                "Cannot find account for instrument {} (venue={}, account_id={account_id:?}): \
+                 skipping account-scoped risk checks",
+                instrument.id(),
                 instrument.id().venue
             );
 

--- a/crates/risk/tests/risk_engine.rs
+++ b/crates/risk/tests/risk_engine.rs
@@ -10036,7 +10036,7 @@ fn test_account_scoped_checks_still_skipped_when_no_account_registered(
 
     let mut cache = Cache::default();
     cache.add_instrument(instrument.clone()).unwrap();
-    // Deliberately no account registered: fail-open behaviour must be preserved.
+    // Deliberately no account registered: fail-open behavior must be preserved.
 
     let mut risk_engine = get_risk_engine(Some(Rc::new(RefCell::new(cache))), None, None, false);
     risk_engine.set_max_notional_per_order(instrument.id(), Decimal::from_i64(1).unwrap());

--- a/crates/risk/tests/risk_engine.rs
+++ b/crates/risk/tests/risk_engine.rs
@@ -71,7 +71,7 @@ use nautilus_model::{
         },
     },
     instruments::{
-        Commodity, CryptoPerpetual, CurrencyPair, FuturesSpread, Instrument, InstrumentAny,
+        Commodity, CryptoPerpetual, CurrencyPair, Equity, FuturesSpread, Instrument, InstrumentAny,
         OptionSpread, PerpetualContract,
         stubs::{
             audusd_sim, betting, commodity_gold, crypto_perpetual_ethusdt, currency_pair_btcusdt,
@@ -9926,4 +9926,190 @@ fn test_spot_notional_fields_ignore_metadata(
         };
         assert_eq!(command.client_order_id, order.client_order_id());
     }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Broker-routed instruments: the account is registered under the broker venue (e.g. `IB`) while
+// the instrument carries the routing venue or exchange MIC (e.g. `SMART`), so a plain
+// `account_for_venue` lookup on the instrument's venue misses and every account-scoped check
+// was previously skipped.
+// -------------------------------------------------------------------------------------------------
+
+/// Builds an equity routed via `SMART`, as an IB instrument loaded with RAW symbology is.
+fn instrument_broker_routed() -> InstrumentAny {
+    InstrumentAny::Equity(
+        Equity::builder()
+            .instrument_id(InstrumentId::from("AAPL.SMART"))
+            .raw_symbol(Symbol::from("AAPL"))
+            .currency(Currency::from("USD"))
+            .price_precision(2)
+            .price_increment(Price::from("0.01"))
+            .ts_event(UnixNanos::default())
+            .ts_init(UnixNanos::default())
+            .build()
+            .unwrap(),
+    )
+}
+
+/// Cash account whose ID issuer is the broker venue `IB`, not the instrument's venue.
+fn broker_account() -> AccountAny {
+    AccountAny::Cash(cash_account(AccountState::new(
+        AccountId::from("IB-DU123456"),
+        AccountType::Cash,
+        vec![AccountBalance::new(
+            Money::from("1000000 USD"),
+            Money::from("0 USD"),
+            Money::from("1000000 USD"),
+        )],
+        vec![],
+        true,
+        UUID4::new(),
+        0.into(),
+        0.into(),
+        Some(Currency::USD()),
+    )))
+}
+
+#[rstest]
+fn test_max_notional_denies_order_for_broker_routed_instrument(
+    strategy_id_ema_cross: StrategyId,
+    trader_id: TraderId,
+) {
+    let process_handler = register_process_handler();
+    let instrument = instrument_broker_routed();
+
+    let mut cache = Cache::default();
+    cache.add_instrument(instrument.clone()).unwrap();
+    cache.add_account(broker_account()).unwrap();
+
+    let mut risk_engine = get_risk_engine(Some(Rc::new(RefCell::new(cache))), None, None, false);
+
+    // Cap of 1 USD against a notional of ~100 USD.
+    risk_engine.set_max_notional_per_order(instrument.id(), Decimal::from_i64(1).unwrap());
+
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00"))
+        .quantity(Quantity::from("100"))
+        .build();
+
+    risk_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, None, false)
+        .unwrap();
+
+    let submit_order = SubmitOrder::new(
+        trader_id,
+        None, // no explicit client_id: routing is resolved downstream by the default route
+        strategy_id_ema_cross,
+        instrument.id(),
+        order.client_order_id(),
+        order.init_event().clone(),
+        None,
+        None,
+        None,
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let saved_events = get_process_order_event_handler_messages(&process_handler);
+    assert_eq!(saved_events.len(), 1);
+    assert!(
+        matches!(saved_events[0], OrderEventAny::Denied(_)),
+        "expected the max_notional check to deny the order, got {:?}",
+        saved_events[0]
+    );
+}
+
+#[rstest]
+fn test_account_scoped_checks_still_skipped_when_no_account_registered(
+    strategy_id_ema_cross: StrategyId,
+    trader_id: TraderId,
+) {
+    let process_handler = register_process_handler();
+    let instrument = instrument_broker_routed();
+
+    let mut cache = Cache::default();
+    cache.add_instrument(instrument.clone()).unwrap();
+    // Deliberately no account registered: fail-open behaviour must be preserved.
+
+    let mut risk_engine = get_risk_engine(Some(Rc::new(RefCell::new(cache))), None, None, false);
+    risk_engine.set_max_notional_per_order(instrument.id(), Decimal::from_i64(1).unwrap());
+
+    let order = OrderTestBuilder::new(OrderType::Limit)
+        .instrument_id(instrument.id())
+        .side(OrderSide::Buy)
+        .price(Price::from("1.00"))
+        .quantity(Quantity::from("100"))
+        .build();
+
+    risk_engine
+        .cache()
+        .borrow_mut()
+        .add_order(order.clone(), None, None, false)
+        .unwrap();
+
+    let submit_order = SubmitOrder::new(
+        trader_id,
+        None,
+        strategy_id_ema_cross,
+        instrument.id(),
+        order.client_order_id(),
+        order.init_event().clone(),
+        None,
+        None,
+        None,
+        UUID4::new(),
+        risk_engine.clock().borrow().timestamp_ns(),
+        None,
+    );
+
+    risk_engine.execute(TradingCommand::SubmitOrder(submit_order));
+
+    let saved_events = get_process_order_event_handler_messages(&process_handler);
+    assert!(
+        !saved_events
+            .iter()
+            .any(|event| matches!(event, OrderEventAny::Denied(_))),
+        "no account is resolvable, so account-scoped checks should be skipped, not denied"
+    );
+}
+
+#[rstest]
+fn test_account_sole_returns_none_when_multiple_accounts_registered() {
+    let mut cache = Cache::default();
+    assert!(cache.account_sole().is_none(), "no accounts registered");
+
+    cache.add_account(broker_account()).unwrap();
+    assert_eq!(
+        cache.account_sole().map(|account| account.id()),
+        Some(AccountId::from("IB-DU123456"))
+    );
+
+    cache
+        .add_account(AccountAny::Cash(cash_account(AccountState::new(
+            AccountId::from("SIM-000001"),
+            AccountType::Cash,
+            vec![AccountBalance::new(
+                Money::from("1000000 USD"),
+                Money::from("0 USD"),
+                Money::from("1000000 USD"),
+            )],
+            vec![],
+            true,
+            UUID4::new(),
+            0.into(),
+            0.into(),
+            Some(Currency::USD()),
+        ))))
+        .unwrap();
+    assert!(
+        cache.account_sole().is_none(),
+        "ambiguous with more than one account"
+    );
 }


### PR DESCRIPTION
**TL;DR:** The risk engine looked up the account by the instrument's venue, so for broker-routed instruments (account under `IB`, instrument under `SMART`) the lookup missed and every account-scoped pre-trade check was silently skipped while appearing configured. This adds an ordered fallback for resolving the account, hoists the shared venue and position resolution onto `Cache` so the portfolio and risk engine use one implementation, and raises the unresolved-branch log from DEBUG to WARN so a fail-open is visible. Fixes #4946.

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and, if I used AI, [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`check_orders_risk_for_account` resolved the account with `cache.account_for_venue(&instrument.id().venue)`. For broker-routed instruments the account is registered under the broker venue while the instrument carries the routing venue or exchange MIC, so the lookup missed and the method returned `true` with only a `log::debug!`, skipping `max_notional_per_order`, free-balance and cumulative-notional checks entirely.

Resolution now falls back, in order, to the routing execution client's account, the account owning an existing position, and the sole registered account. The fail-open branch is unchanged in behaviour but now logs at WARN, since risk limits silently ceasing to apply was not observable at the default log level.

The second commit hoists the portfolio's private `resolve_account_for_instrument` onto `Cache` as `account_for_instrument`, so the venue and position resolution has one implementation instead of two. The portfolio's resolution order is unchanged, and its call sites now delegate to the shared method.

The position fallback alone is not sufficient here, which is why this is not a straight reuse of #4451: a pre-trade order usually has no `account_id` and no position yet, so the first order of a session, exactly when the limits should apply, still missed.

## Related issues/PRs

Closes #4946.

Related to #4450 and #4451, which fixed the same venue-identity mismatch for the portfolio. That fix did not extend to the risk engine, and the failure mode differs: #4450 failed loudly with an ERROR per fill, whereas this fails open and silently on a safety control.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Three tests in `crates/risk/tests/risk_engine.rs`:

- `test_max_notional_denies_order_for_broker_routed_instrument` is the regression test. It builds `AAPL.SMART` with an account under `IB-DU123456` and submits an order with no explicit `client_id`, matching default routing. Verified to fail on the unpatched engine (no events emitted, the order passes risk untouched) and pass with the fix.
- `test_account_scoped_checks_still_skipped_when_no_account_registered` pins the fail-open behaviour when nothing is resolvable, so this is not a silent tightening.
- `test_account_sole_returns_none_when_multiple_accounts_registered` covers the new `Cache::account_sole` boundary at zero, one and two accounts.

Two tests in `crates/common/src/cache/tests.rs` cover the new `Cache::account_for_instrument` directly: the explicit-`account_id` and venue-miss paths, and resolution via the position-owning account when the instrument's own venue has no account.

`cargo test -p nautilus-risk -p nautilus-portfolio` passes (698 and 229), and `cargo test -p nautilus-common --lib cache::` passes (442). `cargo clippy` is clean on the three touched crates and `cargo +nightly fmt` reports no changes.

Two notes for reviewers:

The sole-account fallback is a heuristic, and it is the step that actually fixes the reported case under default routing. It only runs after the venue, client and position lookups have all missed, and it cannot cause a spurious denial: every downstream balance check is `Option`-gated on the account's currency, so an unrelated account yields the same skipped checks as today rather than a rejection. Happy to drop it if you would rather the fix stay limited to precise resolution.

The refactor commit touches the portfolio, so it is worth reviewing separately. It is intended to be behaviour-preserving there: `Cache::account_for_instrument` has the same resolution order as the helper it replaces, and the portfolio suite passes unchanged (229 tests). The two venue-scoped fallbacks elsewhere in `portfolio.rs` were deliberately left alone, since they resolve by venue rather than by instrument.
