### PR TITLE
Make the IB tick-by-tick trade type selectable

### DIFF
--- a/crates/adapters/interactive_brokers/src/config.rs
+++ b/crates/adapters/interactive_brokers/src/config.rs
@@ -116,6 +116,14 @@ pub struct InteractiveBrokersDataClientConfig {
     /// Whether to use batch quotes (reqMktData) by default instead of tick-by-tick.
     #[builder(default = true)]
     pub batch_quotes: bool,
+    /// Whether to subscribe tick-by-tick trades as `AllLast` rather than `Last`.
+    ///
+    /// `AllLast` includes trade types which are not part of the price-forming tape, such as
+    /// combos, derivatively-priced and average-price prints. `Last` returns regular trades
+    /// only, which is usually what should be recorded for replay. Defaults to `true` to
+    /// preserve existing behaviour.
+    #[builder(default = true)]
+    pub all_last_trades: bool,
     /// Instrument provider configuration.
     #[builder(default)]
     pub instrument_provider: InteractiveBrokersInstrumentProviderConfig,
@@ -402,5 +410,42 @@ mod tests {
         assert!(formatted.contains("password: Some(<redacted>)"));
         assert!(!formatted.contains("test-user"));
         assert!(!formatted.contains("test-password"));
+    }
+
+    #[rstest]
+    fn data_client_config_defaults_to_all_last_trades() {
+        // Defaults must preserve the previous behaviour for existing users.
+        let config = InteractiveBrokersDataClientConfig::default();
+        assert!(config.all_last_trades);
+    }
+
+    #[rstest]
+    fn data_client_config_can_select_last_trades() {
+        let config = InteractiveBrokersDataClientConfig::builder()
+            .all_last_trades(false)
+            .build();
+        assert!(!config.all_last_trades);
+    }
+
+    #[rstest]
+    fn data_client_config_all_last_trades_round_trips_through_serde() {
+        let config = InteractiveBrokersDataClientConfig::builder()
+            .all_last_trades(false)
+            .build();
+
+        let json = serde_json::to_string(&config).unwrap();
+        let decoded: InteractiveBrokersDataClientConfig = serde_json::from_str(&json).unwrap();
+
+        assert!(!decoded.all_last_trades);
+    }
+
+    #[rstest]
+    fn data_client_config_omitted_all_last_trades_deserializes_to_default() {
+        // `#[serde(default)]` on the struct means an existing config file without the new
+        // field must still deserialize, and keep the previous behaviour.
+        let decoded: InteractiveBrokersDataClientConfig =
+            serde_json::from_str(r#"{"host":"127.0.0.1","port":7497}"#).unwrap();
+
+        assert!(decoded.all_last_trades);
     }
 }

--- a/crates/adapters/interactive_brokers/src/config.rs
+++ b/crates/adapters/interactive_brokers/src/config.rs
@@ -121,7 +121,7 @@ pub struct InteractiveBrokersDataClientConfig {
     /// `AllLast` includes trade types which are not part of the price-forming tape, such as
     /// combos, derivatively-priced and average-price prints. `Last` returns regular trades
     /// only, which is usually what should be recorded for replay. Defaults to `true` to
-    /// preserve existing behaviour.
+    /// preserve existing behavior.
     #[builder(default = true)]
     pub all_last_trades: bool,
     /// Instrument provider configuration.
@@ -414,7 +414,7 @@ mod tests {
 
     #[rstest]
     fn data_client_config_defaults_to_all_last_trades() {
-        // Defaults must preserve the previous behaviour for existing users.
+        // Defaults must preserve the previous behavior for existing users.
         let config = InteractiveBrokersDataClientConfig::default();
         assert!(config.all_last_trades);
     }
@@ -442,7 +442,7 @@ mod tests {
     #[rstest]
     fn data_client_config_omitted_all_last_trades_deserializes_to_default() {
         // `#[serde(default)]` on the struct means an existing config file without the new
-        // field must still deserialize, and keep the previous behaviour.
+        // field must still deserialize, and keep the previous behavior.
         let decoded: InteractiveBrokersDataClientConfig =
             serde_json::from_str(r#"{"host":"127.0.0.1","port":7497}"#).unwrap();
 

--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -1257,6 +1257,7 @@ impl DataClient for InteractiveBrokersDataClient {
         let client_clone = client.as_arc().clone();
         let subscription_token_clone = subscription_token.clone();
         let data_farm_state = Arc::clone(&self.data_farm_state);
+        let all_last_trades = self.config.all_last_trades;
 
         let task = async move {
             if let Err(e) = handle_trade_subscription(
@@ -1269,6 +1270,7 @@ impl DataClient for InteractiveBrokersDataClient {
                 clock,
                 subscription_token_clone,
                 data_farm_state,
+                all_last_trades,
             )
             .await
             {

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -1108,8 +1108,13 @@ pub(super) async fn handle_trade_subscription(
     clock: &'static AtomicTime,
     cancellation_token: CancellationToken,
     data_farm_state: Arc<DataFarmConnectionState>,
+    all_last: bool,
 ) -> anyhow::Result<()> {
-    tracing::debug!("Starting trade subscription for {}", instrument_id);
+    tracing::debug!(
+        "Starting trade subscription for {} ({})",
+        instrument_id,
+        if all_last { "AllLast" } else { "Last" }
+    );
 
     let mut farm_generation = data_farm_state.recovery_generation();
 
@@ -1118,11 +1123,20 @@ pub(super) async fn handle_trade_subscription(
             break;
         }
 
-        let mut subscription = client
-            .tick_by_tick(&contract, 0)
-            .all_last()
-            .await
-            .context("Failed to create tick-by-tick trade subscription")?;
+        // `AllLast` includes trade types which are not part of the price-forming tape
+        // (combos, derivatively-priced and average-price prints); `Last` excludes them.
+        let builder = client.tick_by_tick(&contract, 0);
+        let mut subscription = if all_last {
+            builder
+                .all_last()
+                .await
+                .context("Failed to create tick-by-tick AllLast trade subscription")?
+        } else {
+            builder
+                .last()
+                .await
+                .context("Failed to create tick-by-tick Last trade subscription")?
+        };
 
         let action = process_trade_stream(
             &mut subscription,

--- a/crates/adapters/interactive_brokers/src/python/config.rs
+++ b/crates/adapters/interactive_brokers/src/python/config.rs
@@ -40,7 +40,7 @@ fn validate_order_id_client_slot(client_id: i32) -> PyResult<()> {
 impl InteractiveBrokersDataClientConfig {
     /// Creates a new `InteractiveBrokersDataClientConfig` instance.
     #[new]
-    #[pyo3(signature = (host=None, port=None, client_id=None, use_regular_trading_hours=None, market_data_type=None, ignore_quote_tick_size_updates=None, connection_timeout=None, request_timeout=None, handle_revised_bars=None, batch_quotes=None, instrument_provider=None, dockerized_gateway=None))]
+    #[pyo3(signature = (host=None, port=None, client_id=None, use_regular_trading_hours=None, market_data_type=None, ignore_quote_tick_size_updates=None, connection_timeout=None, request_timeout=None, handle_revised_bars=None, batch_quotes=None, all_last_trades=None, instrument_provider=None, dockerized_gateway=None))]
     #[allow(clippy::too_many_arguments)]
     fn py_new(
         host: Option<String>,
@@ -53,6 +53,7 @@ impl InteractiveBrokersDataClientConfig {
         request_timeout: Option<u64>,
         handle_revised_bars: Option<bool>,
         batch_quotes: Option<bool>,
+        all_last_trades: Option<bool>,
         instrument_provider: Option<InteractiveBrokersInstrumentProviderConfig>,
         dockerized_gateway: Option<&DockerizedIBGatewayConfig>,
     ) -> PyResult<Self> {
@@ -78,6 +79,7 @@ impl InteractiveBrokersDataClientConfig {
             request_timeout,
             handle_revised_bars: handle_revised_bars.unwrap_or(false),
             batch_quotes: batch_quotes.unwrap_or(true),
+            all_last_trades: all_last_trades.unwrap_or(true),
             instrument_provider: instrument_provider.unwrap_or_default(),
         })
     }
@@ -140,6 +142,12 @@ impl InteractiveBrokersDataClientConfig {
     #[getter]
     fn batch_quotes(&self) -> bool {
         self.batch_quotes
+    }
+
+    /// Returns whether tick-by-tick trades are subscribed as `AllLast` rather than `Last`.
+    #[getter]
+    fn all_last_trades(&self) -> bool {
+        self.all_last_trades
     }
 
     /// Returns the instrument provider configuration.

--- a/docs/integrations/interactive_brokers.md
+++ b/docs/integrations/interactive_brokers.md
@@ -290,6 +290,7 @@ for the supported order attributes.
 | `request_timeout`                | `60` seconds  | Set the IB API request timeout.                       |
 | `handle_revised_bars`            | `False`       | Process revised real-time bars.                       |
 | `batch_quotes`                   | `True`        | Use `reqMktData` instead of tick-by-tick quotes.      |
+| `all_last_trades`                | `True`        | Use `AllLast` instead of `Last` for trades.           |
 | `instrument_provider`            | Default       | Configure contract and instrument loading.            |
 
 ### Execution client

--- a/python/nautilus_trader/adapters/interactive_brokers/__init__.pyi
+++ b/python/nautilus_trader/adapters/interactive_brokers/__init__.pyi
@@ -110,6 +110,7 @@ class InteractiveBrokersDataClientConfig:
         request_timeout: int | None = None,
         handle_revised_bars: bool | None = None,
         batch_quotes: bool | None = None,
+        all_last_trades: bool | None = None,
         instrument_provider: InteractiveBrokersInstrumentProviderConfig | None = None,
         dockerized_gateway: DockerizedIBGatewayConfig | None = None,
     ) -> None: ...
@@ -133,6 +134,8 @@ class InteractiveBrokersDataClientConfig:
     def handle_revised_bars(self) -> bool: ...
     @property
     def batch_quotes(self) -> bool: ...
+    @property
+    def all_last_trades(self) -> bool: ...
     @property
     def instrument_provider(self) -> InteractiveBrokersInstrumentProviderConfig: ...
     @instrument_provider.setter


### PR DESCRIPTION
**TL;DR:** The IB data client hardcoded tick-by-tick trades to `AllLast`, which includes prints that are not part of the price-forming tape and cannot be identified downstream. This adds an `all_last_trades` config field so `Last` can be selected instead, defaulting to the current behaviour. Fixes #4960.

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and, if I used AI, [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

`handle_trade_subscription` called `.all_last()` unconditionally. `AllLast` includes trade types which are not price-forming, such as combos, derivatively-priced and average-price prints, and those cannot be filtered downstream because the trade conditions are dropped when a `TradeTick` is constructed. The practical consequence is that a recorded tape cannot reproduce the live session it came from.

Replaying one recorded IB session through the same strategy code reproduced every data-derived decision exactly: opening range 229.82/232.58, entry trigger 232.70, size 17, entry fill 17 @ 232.70, protective stop at 229.82, exit reason `protective_stop_hit`. Only the stop's fill price diverged, live 229.69 against replay 224.93, turning a realised -51.17 into -132.09. The tape contained prints far below the trigger which were never executable prices.

`InteractiveBrokersDataClientConfig` now carries `all_last_trades`, following the existing `batch_quotes` convention in the same struct, which already lets the caller choose which IB mechanism supplies quotes. `ibapi` exposes `last()` alongside `all_last()` on the same builder, so this only surfaces a choice which already existed.

The default is `true`, so behaviour is unchanged unless a user opts in. The data client option table in `docs/integrations/interactive_brokers.md` gains a row for the new field.

## Related issues/PRs

Closes #4960.

Related to #4948: odd-lot and irregular prints arrive through `AllLast`, so selecting `Last` may reduce the volume of unrepresentable sizes at the source rather than only lowering how loudly they are logged. The two changes are independent.

Related to #2194 (fill simulation), though the cause here is upstream of the fill model.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

Four tests in `crates/adapters/interactive_brokers/src/config.rs`:

- the default is `AllLast`, pinning that existing users are unaffected;
- the builder can select `Last`;
- the field survives a serde round trip;
- a config document written before this field exists still deserializes, and keeps the previous behaviour.

`cargo test -p nautilus-interactive-brokers` passes (422 tests). `cargo clippy --all-targets` is clean and `cargo +nightly fmt` reports no changes.

`make py-stubs` runs and reproduces the committed stubs with no diff. My earlier failure to build with `--features python` was a local environment problem (PyO3 picked up the system Python 3.9 because the checkout had no `python/.venv`), not a build issue.

The subscription branch itself needs a live IB connection, so it is covered by the config tests plus the `AllLast`/`Last` marker now included in the subscription's debug log, rather than by a unit test.

### One judgement call

I placed `all_last_trades` next to `batch_quotes` in the Python signature rather than appending it, since that matches the struct field order and reads better. That does shift the positions of `instrument_provider` and `dockerized_gateway` for anyone passing them positionally. Happy to move it to the end if you would rather not change positional order at all.
