### PR TITLE
Log unrepresentable IB tick sizes at debug instead of warn

### DIFF
--- a/crates/adapters/interactive_brokers/src/data/cache.rs
+++ b/crates/adapters/interactive_brokers/src/data/cache.rs
@@ -36,7 +36,9 @@ fn checked_quantity(size: f64, precision: u8) -> Option<Quantity> {
 
     let tolerance = 10_f64.powi(-i32::from(precision)) * 1e-9;
     if (quantity.as_f64() - size).abs() > tolerance {
-        tracing::warn!(
+        // Expected on venues which report sub-increment sizes (FINRA odd lots, fractional
+        // fills), so this is not a decode failure; see `parse::UnrepresentableSize`.
+        tracing::debug!(
             "Ignoring unrepresentable IB quote size {} with precision {}",
             size,
             precision

--- a/crates/adapters/interactive_brokers/src/data/core.rs
+++ b/crates/adapters/interactive_brokers/src/data/core.rs
@@ -1994,6 +1994,9 @@ impl DataClient for InteractiveBrokersDataClient {
                                 ts_init,
                             ) {
                                 Ok(quote_tick) => batch_quotes.push(quote_tick),
+                                Err(e) if super::parse::is_unrepresentable_size(&e) => {
+                                    tracing::debug!("Dropping quote for {}: {}", instrument_id, e);
+                                }
                                 Err(e) => {
                                     tracing::warn!("Failed to parse quote tick: {:?}", e);
                                 }
@@ -2185,6 +2188,13 @@ impl DataClient for InteractiveBrokersDataClient {
                                 trade_id,
                             ) {
                                 Ok(trade_tick) => batch_trades.push(trade_tick),
+                                Err(e) if super::parse::is_unrepresentable_size(&e) => {
+                                    tracing::debug!(
+                                        "Dropping trade print for {}: {}",
+                                        instrument_id,
+                                        e
+                                    );
+                                }
                                 Err(e) => {
                                     tracing::warn!("Failed to parse trade tick: {:?}", e);
                                 }

--- a/crates/adapters/interactive_brokers/src/data/core_streams.rs
+++ b/crates/adapters/interactive_brokers/src/data/core_streams.rs
@@ -1050,6 +1050,13 @@ pub(super) async fn handle_tick_by_tick_quote_subscription(
                                         return Ok(());
                                     }
                                 }
+                                Err(e) if crate::data::parse::is_unrepresentable_size(&e) => {
+                                    tracing::debug!(
+                                        "Dropping quote for {}: {}",
+                                        instrument_id,
+                                        e
+                                    );
+                                }
                                 Err(e) => tracing::warn!("Failed to parse quote tick: {:?}", e),
                             }
                         }
@@ -1269,6 +1276,9 @@ async fn process_trade_stream(
                                 if data_sender.send(DataEvent::Data(Data::Trade(trade_tick))).is_err() {
                                     return Ok(StreamAction::Stop);
                                 }
+                            }
+                            Err(e) if crate::data::parse::is_unrepresentable_size(&e) => {
+                                tracing::debug!("Dropping trade print for {}: {}", instrument_id, e);
                             }
                             Err(e) => tracing::warn!("Failed to parse trade tick: {:?}", e),
                         }

--- a/crates/adapters/interactive_brokers/src/data/parse.rs
+++ b/crates/adapters/interactive_brokers/src/data/parse.rs
@@ -27,16 +27,35 @@ use nautilus_model::{
     types::{Price, Quantity},
 };
 
+/// A size which cannot be represented at the instrument's size precision.
+///
+/// This is an expected condition rather than a decode failure. FINRA-reported odd lots and
+/// fractional-share fills arrive continuously in the US consolidated tape with sub-increment
+/// sizes, for instruments which only support whole units. Dropping these prints is deliberate
+/// (they carry no actionable size for a whole-unit instrument), so callers should report them
+/// separately from genuine parse errors.
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("size {size} cannot be represented at size_precision={precision}")]
+pub struct UnrepresentableSize {
+    /// The size as reported by IB.
+    pub size: f64,
+    /// The instrument's size precision.
+    pub precision: u8,
+}
+
+/// Returns whether `error` was caused by a size which cannot be represented at the
+/// instrument's size precision (see [`UnrepresentableSize`]).
+#[must_use]
+pub fn is_unrepresentable_size(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<UnrepresentableSize>().is_some()
+}
+
 fn checked_quantity(size: f64, precision: u8) -> anyhow::Result<Quantity> {
     let quantity = Quantity::new_checked(size, precision)
         .map_err(|e| anyhow::anyhow!("invalid quantity size={size}: {e}"))?;
     let tolerance = 10_f64.powi(-i32::from(precision)) * 1e-9;
     if (quantity.as_f64() - size).abs() > tolerance {
-        anyhow::bail!(
-            "quantity size={} cannot be represented with precision={}",
-            size,
-            precision
-        );
+        return Err(UnrepresentableSize { size, precision }.into());
     }
     Ok(quantity)
 }
@@ -314,6 +333,47 @@ mod tests {
     }
 
     #[rstest]
+    fn test_fractional_size_parses_when_precision_allows_it() {
+        // The same 0.5 size is valid when the instrument supports fractional units, so the
+        // drop is precision-dependent rather than a blanket rejection of fractional sizes.
+        assert!(
+            parse_trade_tick(
+                create_test_instrument_id(),
+                150.25,
+                0.5,
+                2,
+                1,
+                UnixNanos::new(0),
+                UnixNanos::new(0),
+                None,
+            )
+            .is_ok()
+        );
+    }
+
+    #[rstest]
+    fn test_invalid_size_is_not_flagged_unrepresentable() {
+        // A negative size is a genuine decode failure and must keep its WARN level,
+        // so it must NOT be classified as an expected unrepresentable-size drop.
+        let result = parse_trade_tick(
+            create_test_instrument_id(),
+            150.25,
+            -1.0,
+            2,
+            0,
+            UnixNanos::new(0),
+            UnixNanos::new(0),
+            None,
+        );
+
+        let error = result.expect_err("a negative size should not parse");
+        assert!(
+            !is_unrepresentable_size(&error),
+            "a genuine parse failure must not be treated as an expected drop: {error:?}"
+        );
+    }
+
+    #[rstest]
     fn test_parse_trade_tick_with_trade_id() {
         let instrument_id = create_test_instrument_id();
         let trade_id = TradeId::from("TRADE-001");
@@ -369,7 +429,17 @@ mod tests {
             None,
         );
 
-        assert!(result.is_err());
+        let error = result.expect_err("sub-increment size should not parse");
+        assert!(
+            is_unrepresentable_size(&error),
+            "expected an UnrepresentableSize error, got: {error:?}"
+        );
+        assert!(
+            error
+                .downcast_ref::<UnrepresentableSize>()
+                .is_some_and(|e| (e.size - 0.5).abs() < f64::EPSILON && e.precision == 0),
+            "error should carry the reported size and precision"
+        );
     }
 
     #[rstest]
@@ -387,7 +457,8 @@ mod tests {
             UnixNanos::new(0),
         );
 
-        assert!(result.is_err());
+        let error = result.expect_err("sub-increment size should not parse");
+        assert!(is_unrepresentable_size(&error));
     }
 
     #[rstest]


### PR DESCRIPTION
**TL;DR:** IB reports FINRA odd-lot and fractional-share prints with sub-increment sizes, and dropping them is deliberate, but the v2 adapter logs each drop at WARN once per tick. In one five-symbol regular session that was 1,603,188 of 1,607,952 log lines, 99.7% of the file. This adds a typed error so the expected drop can be told apart from a real decode failure, and logs it at debug. Fixes #4948.

- [x] A maintainer agreed on the problem and approach in an issue, or this is a small, self-contained fix that does not need prior discussion
- [x] I have read and followed [CONTRIBUTING.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/CONTRIBUTING.md) and, if I used AI, [AI_POLICY.md](https://github.com/nautechsystems/nautilus_trader/blob/develop/AI_POLICY.md)
- [x] I understand and can explain every submitted change and all information in this PR description
- [x] This change is complete, locally validated, and ready for review, or a maintainer requested this draft
- [x] I ran `make format`, then ran `make pre-commit` locally and confirmed it passed, or I described an agreed limitation below
- [x] I ran all relevant tests locally, no tests apply to this change, or I described an agreed limitation below
- [x] I have not modified `RELEASES.md` (maintainers keep it current to avoid merge conflicts)

## Summary

Dropping a print whose size cannot be represented at the instrument's size precision is intended behaviour, established in #4022 for #3951. That PR chose **debug** for the equivalent Python path: "invalid sizes are debug-logged and skipped". The v2 Rust adapter never adopted that level and logs the same condition at WARN, once per tick.

This is a high-frequency condition, not a rare one. FINRA-reported odd lots and fractional-share fills arrive continuously in the US consolidated tape for instruments with `size_precision=0`. Measured on `2.0.0rc4` over one regular session across AAPL, NVDA, TSLA, AMD and SNDK:

```
1,603,188 WARN lines out of 1,607,952 total   (99.7% of the log)
284 MB session log
```

Every line reads `Failed to parse trade tick: quantity size=0.63462 cannot be represented with precision=0`, which also reads like a decode failure rather than a sanctioned drop.

The problem is that one log site collapses two different things: an expected, high-frequency drop and a genuine parse error. Lowering the level indiscriminately would hide real failures. So `checked_quantity` now returns a typed `UnrepresentableSize` error, and the call sites match on it: the expected drop logs at debug with a clearer message, and anything else keeps WARN.

The four affected paths are live trades, live quotes, historical trades and historical quotes, matching the surface #4022 covered on the Python side. The duplicate size check in `data/cache.rs` is lowered to debug for the same reason, while its "invalid size" branch keeps WARN.

No ticks change: the same prints are dropped as before, only the reporting differs.

## Related issues/PRs

Closes #4948.

Follows #3951 and #4022, which established that dropping these prints is preferred over rounding them into actionable whole-unit sizes. This PR aligns the v2 Rust adapter with the log level chosen there.

Related to #4960 and its PR #4961, which makes the IB trade tick type selectable. Many of these sub-increment prints arrive through `AllLast`, so selecting `Last` would reduce their volume at the source, while this PR fixes how the remainder are reported. The two are independent and touch different lines; I verified the branches merge cleanly in either order.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [ ] Maintenance / chore

## Testing

- [ ] Affected code paths are already covered by the test suite
- [x] I added/updated tests to cover new or changed logic
- [ ] No logic changed (documentation, comments, or metadata only)

The two existing `rejects_unrepresentable_size` tests asserted only `is_err()`, so they passed either way. They now assert the classification, and the trade one asserts the error carries the reported size and precision. Verified they fail when the typed error is reverted to a plain `bail!`.

Two tests were added:

- `test_invalid_size_is_not_flagged_unrepresentable` submits a negative size and asserts it is **not** classified as an expected drop, so genuine failures keep WARN. This is the test that stops the fix from becoming a blanket silencing.
- `test_fractional_size_parses_when_precision_allows_it` shows the same 0.5 size parses at `size_precision=1`, so the drop is precision-dependent rather than a rejection of fractional sizes.

`cargo test -p nautilus-interactive-brokers` passes (420 tests). `cargo clippy --all-targets` is clean and `cargo +nightly fmt` reports no changes.

One note for reviewers: an alternative would be a periodic aggregate ("dropped N unrepresentable prints for X in the last minute"), which would keep some signal at INFO. I kept this PR to the level change since that matches the existing decision in #4022, but I am happy to add the aggregate if you would prefer the volume visible rather than at debug.
