### PR TITLE
Split reversal fills into closing and opening portions

### DIFF
--- a/crates/model/src/position.rs
+++ b/crates/model/src/position.rs
@@ -101,7 +101,9 @@ pub struct Position {
     pub realized_pnl: Option<Money>,
     #[serde(with = "nautilus_core::serialization::sorted_hashset")]
     pub trade_ids: AHashSet<TradeId>,
+    /// Total buy quantity in the current position episode.
     pub buy_qty: Quantity,
+    /// Total sell quantity in the current position episode.
     pub sell_qty: Quantity,
     pub commissions: IndexMap<Currency, Money>,
 }
@@ -554,12 +556,21 @@ impl Position {
         let last_px = fill.last_px.as_f64();
         let last_qty = fill.last_qty.as_f64();
         let last_qty_object = fill.last_qty;
+        let was_short = self.signed_qty < 0.0;
+        let is_reversal = was_short && last_qty_object > self.quantity;
+        let closing_qty_object = if is_reversal {
+            self.quantity
+        } else {
+            last_qty_object
+        };
+        let opening_qty_object = last_qty_object - closing_qty_object;
+        let closing_qty = closing_qty_object.as_f64();
 
         if self.signed_qty > 0.0 {
             self.avg_px_open = self.calculate_avg_px_open_px(last_px, last_qty);
-        } else if self.signed_qty < 0.0 {
+        } else if was_short {
             // Closing short position
-            let avg_px_close = self.calculate_avg_px_close_px(last_px, last_qty);
+            let avg_px_close = self.calculate_avg_px_close_px(last_px, closing_qty);
             self.avg_px_close = Some(avg_px_close);
             self.realized_return = self
                 .calculate_return(self.avg_px_open, avg_px_close)
@@ -568,7 +579,7 @@ impl Position {
                     0.0
                 });
             realized_pnl += self
-                .calculate_pnl_raw(self.avg_px_open, last_px, last_qty)
+                .calculate_pnl_raw(self.avg_px_open, last_px, closing_qty)
                 .unwrap_or_else(|e| {
                     log::error!("Error calculating PnL: {e}");
                     0.0
@@ -581,13 +592,16 @@ impl Position {
             self.settlement_currency,
         ));
 
-        let was_short = self.signed_qty < 0.0;
         self.signed_qty += last_qty;
         self.buy_qty = self.buy_qty + last_qty_object;
 
-        // Position reversed from short to long
-        if was_short && last_qty_object > self.quantity {
+        // Start a new accounting episode after a short-to-long reversal
+        if is_reversal {
             self.avg_px_open = last_px;
+            self.avg_px_close = None;
+            self.realized_return = 0.0;
+            self.buy_qty = opening_qty_object;
+            self.sell_qty = Quantity::zero(self.size_precision);
         }
     }
 
@@ -606,12 +620,21 @@ impl Position {
         let last_px = fill.last_px.as_f64();
         let last_qty = fill.last_qty.as_f64();
         let last_qty_object = fill.last_qty;
+        let was_long = self.signed_qty > 0.0;
+        let is_reversal = was_long && last_qty_object > self.quantity;
+        let closing_qty_object = if is_reversal {
+            self.quantity
+        } else {
+            last_qty_object
+        };
+        let opening_qty_object = last_qty_object - closing_qty_object;
+        let closing_qty = closing_qty_object.as_f64();
 
         if self.signed_qty < 0.0 {
             self.avg_px_open = self.calculate_avg_px_open_px(last_px, last_qty);
-        } else if self.signed_qty > 0.0 {
+        } else if was_long {
             // Closing long position
-            let avg_px_close = self.calculate_avg_px_close_px(last_px, last_qty);
+            let avg_px_close = self.calculate_avg_px_close_px(last_px, closing_qty);
             self.avg_px_close = Some(avg_px_close);
             self.realized_return = self
                 .calculate_return(self.avg_px_open, avg_px_close)
@@ -620,7 +643,7 @@ impl Position {
                     0.0
                 });
             realized_pnl += self
-                .calculate_pnl_raw(self.avg_px_open, last_px, last_qty)
+                .calculate_pnl_raw(self.avg_px_open, last_px, closing_qty)
                 .unwrap_or_else(|e| {
                     log::error!("Error calculating PnL: {e}");
                     0.0
@@ -633,13 +656,16 @@ impl Position {
             self.settlement_currency,
         ));
 
-        let was_long = self.signed_qty > 0.0;
         self.signed_qty -= last_qty;
         self.sell_qty = self.sell_qty + last_qty_object;
 
-        // Position reversed from long to short
-        if was_long && last_qty_object > self.quantity {
+        // Start a new accounting episode after a long-to-short reversal
+        if is_reversal {
             self.avg_px_open = last_px;
+            self.avg_px_close = None;
+            self.realized_return = 0.0;
+            self.buy_qty = Quantity::zero(self.size_precision);
+            self.sell_qty = opening_qty_object;
         }
     }
 
@@ -3354,13 +3380,68 @@ mod tests {
 
         assert_eq!(position.side, PositionSide::Long);
         assert_eq!(position.quantity, Quantity::from(593));
-        assert_eq!(position.buy_qty, Quantity::from(625));
-        assert_eq!(position.sell_qty, Quantity::from(32));
+        // The reversal starts a new episode with only the opening residual
+        assert_eq!(position.buy_qty, Quantity::from(593));
+        assert_eq!(position.sell_qty, Quantity::from(0));
         assert_eq!(position.events.len(), 4);
         assert_eq!(position.replay_events.len(), 4);
         assert_eq!(position.fill_voids.len(), 1);
         assert_eq!(position.trade_ids.len(), 3);
         assert!(position.trade_ids.contains(&TradeId::from("T-FLIP")));
+    }
+
+    #[rstest]
+    fn test_fill_void_replays_partially_voided_reversal(audusd_sim: CurrencyPair) {
+        let instrument = InstrumentAny::CurrencyPair(audusd_sim);
+        let position_id = PositionId::from("P-REVERSAL-PARTIAL-VOID");
+        let opening = OrderFilledSpec::builder()
+            .instrument_id(instrument.id())
+            .client_order_id(ClientOrderId::from("O-OPEN"))
+            .trade_id(TradeId::from("T-OPEN"))
+            .order_side(OrderSide::Sell)
+            .last_qty(Quantity::from(10))
+            .last_px(Price::from("1.00000"))
+            .currency(Currency::USD())
+            .position_id(position_id)
+            .build();
+        let partial_close = OrderFilledSpec::builder()
+            .instrument_id(instrument.id())
+            .client_order_id(ClientOrderId::from("O-CLOSE"))
+            .trade_id(TradeId::from("T-CLOSE"))
+            .order_side(OrderSide::Buy)
+            .last_qty(Quantity::from(4))
+            .last_px(Price::from("0.90000"))
+            .currency(Currency::USD())
+            .position_id(position_id)
+            .build();
+        let reversal = OrderFilledSpec::builder()
+            .instrument_id(instrument.id())
+            .client_order_id(ClientOrderId::from("O-REVERSE"))
+            .trade_id(TradeId::from("T-REVERSE"))
+            .order_side(OrderSide::Buy)
+            .last_qty(Quantity::from(11))
+            .last_px(Price::from("1.10000"))
+            .currency(Currency::USD())
+            .position_id(position_id)
+            .build();
+        let fill_voided = matching_fill_void(&reversal, Quantity::from(2), None);
+        let mut position = Position::new(&instrument, opening);
+        position.apply(&partial_close);
+        position.apply(&reversal);
+
+        position
+            .apply_fill_void(fill_voided, Quantity::from(2), None)
+            .unwrap();
+
+        assert_eq!(position.side, PositionSide::Long);
+        assert_eq!(position.quantity, Quantity::from(3));
+        assert_eq!(position.avg_px_open, 1.1);
+        assert_eq!(position.avg_px_close, None);
+        assert_eq!(position.realized_return, 0.0);
+        assert_eq!(position.buy_qty, Quantity::from(3));
+        assert_eq!(position.sell_qty, Quantity::from(0));
+        assert_eq!(position.realized_pnl, Some(Money::from("-0.20 USD")));
+        assert_eq!(position.fill_voids.len(), 1);
     }
 
     #[rstest]
@@ -5528,6 +5609,153 @@ mod tests {
         assert_eq!(position.duration_ns, DurationNanos::default());
         assert_eq!(position.event_count(), 3);
         assert!(position.is_open());
+    }
+
+    #[rstest]
+    #[case(OrderSide::Buy, OrderSide::Sell)]
+    #[case(OrderSide::Sell, OrderSide::Buy)]
+    fn test_position_reversal_starts_new_close_episode(
+        #[case] entry: OrderSide,
+        #[case] exit: OrderSide,
+    ) {
+        let (
+            open_px,
+            first_close_px,
+            reversal_px,
+            expected_side,
+            new_first_close_px,
+            new_final_close_px,
+            expected_avg_close,
+            expected_return,
+        ) = if entry == OrderSide::Buy {
+            (
+                "100.00",
+                "110.00",
+                "120.00",
+                PositionSide::Short,
+                "110.00",
+                "90.00",
+                95.0,
+                0.208_333_333_333_333_34,
+            )
+        } else {
+            (
+                "120.00",
+                "110.00",
+                "100.00",
+                PositionSide::Long,
+                "110.00",
+                "130.00",
+                125.0,
+                0.25,
+            )
+        };
+        let instrument = InstrumentAny::CurrencyPair(currency_pair_btcusdt());
+        let position_id = PositionId::new("P-REVERSAL-EPISODE");
+        let open_order = OrderTestBuilder::new(OrderType::Market)
+            .instrument_id(instrument.id())
+            .client_order_id(ClientOrderId::new("O-OPEN"))
+            .side(entry)
+            .quantity(Quantity::from("10"))
+            .build();
+        let open_fill = TestOrderEventStubs::filled(
+            &open_order,
+            &instrument,
+            Some(TradeId::new("T-OPEN")),
+            Some(position_id),
+            Some(Price::from(open_px)),
+            None,
+            None,
+            Some(Money::from("1 USDT")),
+            Some(UnixNanos::from(3_000)),
+            None,
+        );
+        let mut position = Position::new(&instrument, open_fill.into());
+
+        for (client_order_id, trade_id, quantity, price, ts_event) in [
+            ("O-CLOSE", "T-CLOSE", "4", first_close_px, 3_100),
+            ("O-REVERSE", "T-REVERSE", "8", reversal_px, 3_200),
+        ] {
+            let order = OrderTestBuilder::new(OrderType::Market)
+                .instrument_id(instrument.id())
+                .client_order_id(ClientOrderId::new(client_order_id))
+                .side(exit)
+                .quantity(Quantity::from(quantity))
+                .build();
+            let fill = TestOrderEventStubs::filled(
+                &order,
+                &instrument,
+                Some(TradeId::new(trade_id)),
+                Some(position_id),
+                Some(Price::from(price)),
+                None,
+                None,
+                Some(Money::from("1 USDT")),
+                Some(UnixNanos::from(ts_event)),
+                None,
+            );
+            position.apply(&fill.into());
+        }
+
+        assert_eq!(position.side, expected_side);
+        assert_eq!(position.quantity, Quantity::from("2"));
+        assert_eq!(position.avg_px_open, Price::from(reversal_px).as_f64());
+        assert_eq!(position.avg_px_close, None);
+        assert_eq!(position.realized_return, 0.0);
+        if expected_side == PositionSide::Long {
+            assert_eq!(position.buy_qty, Quantity::from("2"));
+            assert_eq!(position.sell_qty, Quantity::from("0"));
+        } else {
+            assert_eq!(position.buy_qty, Quantity::from("0"));
+            assert_eq!(position.sell_qty, Quantity::from("2"));
+        }
+        assert_eq!(position.realized_pnl, Some(Money::from("157 USDT")));
+
+        for (client_order_id, trade_id, quantity, price, ts_event) in [
+            (
+                "O-NEW-CLOSE-1",
+                "T-NEW-CLOSE-1",
+                "0.5",
+                new_first_close_px,
+                3_300,
+            ),
+            (
+                "O-NEW-CLOSE-2",
+                "T-NEW-CLOSE-2",
+                "1.5",
+                new_final_close_px,
+                3_400,
+            ),
+        ] {
+            let order = OrderTestBuilder::new(OrderType::Market)
+                .instrument_id(instrument.id())
+                .client_order_id(ClientOrderId::new(client_order_id))
+                .side(entry)
+                .quantity(Quantity::from(quantity))
+                .build();
+            let fill = TestOrderEventStubs::filled(
+                &order,
+                &instrument,
+                Some(TradeId::new(trade_id)),
+                Some(position_id),
+                Some(Price::from(price)),
+                None,
+                None,
+                Some(Money::from("1 USDT")),
+                Some(UnixNanos::from(ts_event)),
+                None,
+            );
+            position.apply(&fill.into());
+        }
+
+        assert_eq!(position.side, PositionSide::Flat);
+        assert_eq!(position.quantity, Quantity::zero(6));
+        assert_eq!(position.buy_qty, Quantity::from("2"));
+        assert_eq!(position.sell_qty, Quantity::from("2"));
+        assert_eq!(position.avg_px_close, Some(expected_avg_close));
+        assert_eq!(position.realized_return, expected_return);
+        assert_eq!(position.realized_pnl, Some(Money::from("205 USDT")));
+        assert_eq!(position.commissions(), vec![Money::from("5 USDT")]);
     }
 
     #[rstest]


### PR DESCRIPTION
A single fill that reverses a position through zero currently contaminates the new episode's close accounting in `Position`.

## Reversal fills carry the old episode's close state into the new one

When an opposite-side fill exceeds the open quantity, `handle_buy_order_fill` and `handle_sell_order_fill` reset only `avg_px_open`. The closing arm feeds the full `last_qty` into `calculate_avg_px_close_px`, so the close average absorbs the opening portion of the fill, and `avg_px_close`, `realized_return`, `buy_qty`, and `sell_qty` all carry across the reversal - the next episode's close averages and returns are weighted by the previous episode's volume. Realized PnL was already correct: `calculate_pnl_raw` clamps to the open quantity, so it has always used only the closing portion. The fix completes that closing-portion pattern: the fill is split with exact `Quantity` arithmetic at the pre-fill open quantity, only the closing portion reaches the close-average and PnL calculations, and the reversal establishes a fresh episode - `avg_px_open` at the fill price, `avg_px_close` cleared, `realized_return` zeroed, and the quantity accumulators re-seeded to the opening residual. `realized_pnl` stays cumulative and commissions are charged once. This departs from the legacy Python implementation, which carries the same contamination.

## Alternative shapes considered

- Applying the reversal as two synthetic fragments via `OrderFilled::split_for_position_flip`, as `flip_position` does across two objects: inside one `Position` the fragments would duplicate events, trade IDs, and commissions.
- Routing the zero crossing through `reset_cycle`, the path an exact close already takes: it resets everything including `realized_pnl`, and a single object has nowhere to archive the closed episode, so cumulative PnL from cache- and replay-derived positions would be lost.
- Clamping in `calculate_avg_px_close_px` the way `calculate_pnl_raw` already does: fixes the reversal fill's own weighting but leaves `avg_px_close`, `realized_return`, and the accumulators stale, so the second close after a reversal still misweights.
- Restructuring `Position` into per-episode records: a public-surface redesign out of proportion to the defect.

## Testing

`test_position_reversal_starts_new_close_episode` covers both directions: open, partial close, oversized reversal fill, then two differently priced closes. The two-close sequence is the load-bearing part - `calculate_avg_px_close_px` returns `last_px` when `avg_px_close` is `None`, so a single close looks correct even unfixed, and only the second close exposes stale accumulators. Assertions pin the episode reset, exact close averages and returns, and cumulative PnL with commissions counted once. `test_fill_void_replays_partially_voided_reversal` covers a reversal fill later partially voided. `test_fill_void_replays_split_fragments_in_one_corrected_cycle` is updated to the episode-scoped accumulator values; `test_position_true_reversal_uses_fill_price` is unchanged, demonstrating PnL preservation. The new assertions fail against the unfixed implementation.
