### PR TITLE
Restore spawn reductions on canceled and expired children

### DIFF
--- a/crates/trading/src/algorithm/core.rs
+++ b/crates/trading/src/algorithm/core.rs
@@ -49,6 +49,18 @@ pub struct StrategyEventHandlers {
     pub position_handler: TypedHandler<PositionEvent>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SpawnReduction {
+    /// The quantity deducted from the primary at spawn time.
+    pub deducted_qty: Quantity,
+    /// Whether the spawned quantity was quote-denominated at deduction time.
+    pub spawn_was_quote_quantity: bool,
+    /// The gross quantity released by restoration - including any portion
+    /// applied against primary late-fill debt rather than returned to the
+    /// primary - serving as the child's remaining late-fill accounting budget.
+    pub restored_qty: Quantity,
+}
+
 /// The core component of an [`ExecutionAlgorithm`](super::ExecutionAlgorithm).
 ///
 /// This struct manages the internal state for execution algorithms including
@@ -70,8 +82,13 @@ pub struct ExecutionAlgorithmCore {
     exec_spawn_ids: AHashMap<ClientOrderId, u32>,
     /// Tracks strategies that have been subscribed to for events.
     subscribed_strategies: AHashSet<StrategyId>,
-    /// Tracks pending spawn reductions for quantity restoration on denial/rejection.
-    pending_spawn_reductions: AHashMap<ClientOrderId, Quantity>,
+    /// Tracks spawn reductions through restoration and possible late-fill netting.
+    spawn_reductions: AHashMap<ClientOrderId, SpawnReduction>,
+    /// Tracks uncompensated late-fill quantity per primary order, discharged
+    /// against later spawn restorations.
+    spawn_fill_debts: AHashMap<ClientOrderId, Quantity>,
+    /// Tracks primary orders whose submission was handed off to the risk engine.
+    handed_off_primaries: AHashSet<ClientOrderId>,
     /// Maps primary order client IDs to the command params supplied at submission.
     submit_params: AHashMap<ClientOrderId, Params>,
     /// The portfolio shared by the trader.
@@ -119,10 +136,9 @@ impl Debug for ExecutionAlgorithmCore {
             .field("exec_algorithm_id", &self.exec_algorithm_id)
             .field("exec_spawn_ids", &self.exec_spawn_ids.len())
             .field("subscribed_strategies", &self.subscribed_strategies.len())
-            .field(
-                "pending_spawn_reductions",
-                &self.pending_spawn_reductions.len(),
-            )
+            .field("spawn_reductions", &self.spawn_reductions.len())
+            .field("spawn_fill_debts", &self.spawn_fill_debts.len())
+            .field("handed_off_primaries", &self.handed_off_primaries.len())
             .field("submit_params", &self.submit_params.len())
             .field(
                 "strategy_event_handlers",
@@ -156,7 +172,9 @@ impl ExecutionAlgorithmCore {
             exec_algorithm_id,
             exec_spawn_ids: AHashMap::new(),
             subscribed_strategies: AHashSet::new(),
-            pending_spawn_reductions: AHashMap::new(),
+            spawn_reductions: AHashMap::new(),
+            spawn_fill_debts: AHashMap::new(),
+            handed_off_primaries: AHashSet::new(),
             submit_params: AHashMap::new(),
             portfolio: None,
             strategy_event_handlers: IndexMap::new(),
@@ -233,7 +251,7 @@ impl ExecutionAlgorithmCore {
         std::mem::take(&mut self.strategy_event_handlers)
     }
 
-    /// Clears all spawn tracking state.
+    /// Clears spawn ID tracking state.
     pub fn clear_spawn_ids(&mut self) {
         self.exec_spawn_ids.clear();
     }
@@ -244,18 +262,92 @@ impl ExecutionAlgorithmCore {
     }
 
     /// Tracks a pending spawn reduction for potential restoration.
-    pub fn track_pending_spawn_reduction(&mut self, spawn_id: ClientOrderId, quantity: Quantity) {
-        self.pending_spawn_reductions.insert(spawn_id, quantity);
+    pub fn track_pending_spawn_reduction(
+        &mut self,
+        spawn_id: ClientOrderId,
+        quantity: Quantity,
+        spawn_was_quote_quantity: bool,
+    ) {
+        self.spawn_reductions.insert(
+            spawn_id,
+            SpawnReduction {
+                deducted_qty: quantity,
+                spawn_was_quote_quantity,
+                restored_qty: Quantity::zero(quantity.precision),
+            },
+        );
     }
 
-    /// Removes and returns the pending spawn reduction for an order, if any.
-    pub fn take_pending_spawn_reduction(&mut self, spawn_id: &ClientOrderId) -> Option<Quantity> {
-        self.pending_spawn_reductions.remove(spawn_id)
+    /// Returns the spawn reduction lifecycle record for an order, if any.
+    #[must_use]
+    pub(crate) fn spawn_reduction(&self, spawn_id: ClientOrderId) -> Option<SpawnReduction> {
+        self.spawn_reductions.get(&spawn_id).copied()
+    }
+
+    /// Updates the spawn reduction lifecycle record for an order.
+    pub(crate) fn set_spawn_reduction(
+        &mut self,
+        spawn_id: ClientOrderId,
+        reduction: SpawnReduction,
+    ) {
+        self.spawn_reductions.insert(spawn_id, reduction);
+    }
+
+    /// Removes and returns the spawn reduction lifecycle record for an order, if any.
+    pub(crate) fn take_pending_spawn_reduction(
+        &mut self,
+        spawn_id: ClientOrderId,
+    ) -> Option<SpawnReduction> {
+        self.spawn_reductions.remove(&spawn_id)
+    }
+
+    /// Returns the uncompensated late-fill debt for a primary order, if any.
+    #[must_use]
+    pub(crate) fn spawn_fill_debt(&self, primary_id: ClientOrderId) -> Option<Quantity> {
+        self.spawn_fill_debts.get(&primary_id).copied()
+    }
+
+    /// Adds uncompensated late-fill debt against a primary order.
+    pub(crate) fn add_spawn_fill_debt(&mut self, primary_id: ClientOrderId, quantity: Quantity) {
+        self.spawn_fill_debts
+            .entry(primary_id)
+            .and_modify(|debt| {
+                let precision = debt.precision;
+                *debt = *debt + quantity;
+                debt.precision = precision;
+            })
+            .or_insert(quantity);
+    }
+
+    /// Sets the uncompensated late-fill debt for a primary order, removing it at zero.
+    pub(crate) fn set_spawn_fill_debt(&mut self, primary_id: ClientOrderId, quantity: Quantity) {
+        if quantity.is_zero() {
+            self.spawn_fill_debts.remove(&primary_id);
+        } else {
+            self.spawn_fill_debts.insert(primary_id, quantity);
+        }
+    }
+
+    /// Marks a primary order as handed off for submission.
+    pub(crate) fn mark_primary_handed_off(&mut self, primary_id: ClientOrderId) {
+        self.handed_off_primaries.insert(primary_id);
+    }
+
+    /// Returns whether a primary order has been handed off for submission.
+    #[must_use]
+    pub(crate) fn primary_was_handed_off(&self, primary_id: ClientOrderId) -> bool {
+        self.handed_off_primaries.contains(&primary_id)
+    }
+
+    /// Discards debt that can no longer be discharged after primary submission.
+    pub(crate) fn discard_spawn_fill_debt(&mut self, primary_id: ClientOrderId) {
+        self.spawn_fill_debts.remove(&primary_id);
     }
 
     /// Clears all pending spawn reductions.
     pub fn clear_pending_spawn_reductions(&mut self) {
-        self.pending_spawn_reductions.clear();
+        self.spawn_reductions.clear();
+        self.spawn_fill_debts.clear();
     }
 
     /// Stores the command params supplied with a primary order submission.
@@ -292,7 +384,9 @@ impl ExecutionAlgorithmCore {
     pub fn reset(&mut self) {
         self.exec_spawn_ids.clear();
         self.subscribed_strategies.clear();
-        self.pending_spawn_reductions.clear();
+        self.spawn_reductions.clear();
+        self.spawn_fill_debts.clear();
+        self.handed_off_primaries.clear();
         self.submit_params.clear();
         self.strategy_event_handlers.clear();
     }
@@ -476,11 +570,13 @@ mod tests {
 
         let _ = core.spawn_client_order_id(&primary_id);
         core.add_subscribed_strategy(strategy_id);
+        core.mark_primary_handed_off(primary_id);
 
         core.reset();
 
         assert!(core.spawn_sequence(&primary_id).is_none());
         assert!(!core.is_strategy_subscribed(&strategy_id));
+        assert!(!core.primary_was_handed_off(primary_id));
     }
 
     #[rstest]

--- a/crates/trading/src/algorithm/mod.rs
+++ b/crates/trading/src/algorithm/mod.rs
@@ -66,10 +66,12 @@ use nautilus_model::{
         AccountId, ClientId, ClientOrderId, ExecAlgorithmId, PositionId, StrategyId, TraderId,
     },
     orders::{LimitOrder, MarketOrder, MarketToLimitOrder, Order, OrderAny, OrderError, OrderList},
-    types::{Price, Quantity},
+    types::{Price, Quantity, quantity::QuantityRaw},
 };
 pub use twap::{TwapAlgorithm, TwapAlgorithmConfig};
 use ustr::Ustr;
+
+use crate::algorithm::core::SpawnReduction;
 
 /// Core trait for implementing execution algorithms in NautilusTrader.
 ///
@@ -84,10 +86,11 @@ use ustr::Ustr;
 /// - Order lifecycle management (submit, modify, cancel)
 /// - Event filtering for algorithm-owned orders
 ///
-/// When a spawned order fails before acceptance, quantity restoration updates
-/// only the cached primary order. A caller-held primary order value passed to a
-/// spawn method remains reduced and must be discarded or refreshed from the
-/// cache before reuse.
+/// When a reduced spawned order terminates with unfilled quantity, its reduction
+/// is restored in primary quantity units while the primary remains locally
+/// mutable. Submission handoff permanently ends restoration and late-fill
+/// re-deduction. A caller-held primary value remains reduced and must be
+/// discarded or refreshed from the cache before reuse.
 ///
 /// # Implementation
 ///
@@ -442,10 +445,12 @@ pub trait ExecutionAlgorithm: DataActor {
     /// - The algorithm's `exec_algorithm_id`.
     /// - `exec_spawn_id` set to the primary order's client order ID.
     ///
-    /// If `reduce_primary` is true, the primary order's quantity will be reduced
-    /// by the spawned quantity. If the spawned order is subsequently denied or
-    /// rejected (before acceptance), or refused before submission, the deducted
-    /// quantity is automatically restored to the cached primary order.
+    /// If `reduce_primary` is true, the primary order's quantity is reduced by
+    /// the spawned quantity. Unfilled quantity is restored when the spawn is
+    /// denied, rejected, canceled, expired, or refused before submission while
+    /// the primary remains locally mutable. Converted quote-quantity spawns are
+    /// restored proportionally in primary units. Late fills re-deduct restored
+    /// quantity until primary submission is handed off.
     fn spawn_market(
         &mut self,
         primary: &mut OrderAny,
@@ -466,8 +471,11 @@ pub trait ExecutionAlgorithm: DataActor {
 
         if reduce_primary {
             self.reduce_primary_order(primary, quantity);
-            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
-                .track_pending_spawn_reduction(client_order_id, quantity);
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self).track_pending_spawn_reduction(
+                client_order_id,
+                quantity,
+                primary.is_quote_quantity(),
+            );
         }
 
         MarketOrder::new(
@@ -504,10 +512,12 @@ pub trait ExecutionAlgorithm: DataActor {
     /// `submit_order` refuses the returned order when `emulation_trigger` is
     /// `Some`; use `None` for an order that the execution algorithm will submit.
     ///
-    /// If `reduce_primary` is true, the primary order's quantity will be reduced
-    /// by the spawned quantity. If the spawned order is subsequently denied or
-    /// rejected (before acceptance), or refused before submission, the deducted
-    /// quantity is automatically restored to the cached primary order.
+    /// If `reduce_primary` is true, the primary order's quantity is reduced by
+    /// the spawned quantity. Unfilled quantity is restored when the spawn is
+    /// denied, rejected, canceled, expired, or refused before submission while
+    /// the primary remains locally mutable. Converted quote-quantity spawns are
+    /// restored proportionally in primary units. Late fills re-deduct restored
+    /// quantity until primary submission is handed off.
     #[expect(clippy::too_many_arguments)]
     fn spawn_limit(
         &mut self,
@@ -534,8 +544,11 @@ pub trait ExecutionAlgorithm: DataActor {
 
         if reduce_primary {
             self.reduce_primary_order(primary, quantity);
-            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
-                .track_pending_spawn_reduction(client_order_id, quantity);
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self).track_pending_spawn_reduction(
+                client_order_id,
+                quantity,
+                primary.is_quote_quantity(),
+            );
         }
 
         LimitOrder::new(
@@ -575,10 +588,12 @@ pub trait ExecutionAlgorithm: DataActor {
     /// - The algorithm's `exec_algorithm_id`
     /// - `exec_spawn_id` set to the primary order's client order ID
     ///
-    /// If `reduce_primary` is true, the primary order's quantity will be reduced
-    /// by the spawned quantity. If the spawned order is subsequently denied or
-    /// rejected (before acceptance), or refused before submission, the deducted
-    /// quantity is automatically restored to the cached primary order.
+    /// If `reduce_primary` is true, the primary order's quantity is reduced by
+    /// the spawned quantity. Unfilled quantity is restored when the spawn is
+    /// denied, rejected, canceled, expired, or refused before submission while
+    /// the primary remains locally mutable. Converted quote-quantity spawns are
+    /// restored proportionally in primary units. Late fills re-deduct restored
+    /// quantity until primary submission is handed off.
     ///
     /// `_emulation_trigger` is accepted for signature parity and is not applied:
     /// a `MARKET_TO_LIMIT` order is always initialized with no emulation trigger
@@ -607,8 +622,11 @@ pub trait ExecutionAlgorithm: DataActor {
 
         if reduce_primary {
             self.reduce_primary_order(primary, quantity);
-            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
-                .track_pending_spawn_reduction(client_order_id, quantity);
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self).track_pending_spawn_reduction(
+                client_order_id,
+                quantity,
+                primary.is_quote_quantity(),
+            );
         }
 
         MarketToLimitOrder::new(
@@ -693,14 +711,15 @@ pub trait ExecutionAlgorithm: DataActor {
         publish_order_event(&event);
     }
 
-    /// Restores the cached primary order quantity after a spawned order fails before acceptance.
+    /// Restores a spawn reduction while the cached primary order remains local.
     ///
-    /// This is called when a spawned order fails before acceptance. The quantity
-    /// that was deducted from the cached primary order is restored (up to the
-    /// spawned order's `leaves_qty` to handle partial fills).
+    /// The quantity deducted from the cached primary order is restored up to the
+    /// spawned order's unfilled proportion in primary units. Primaries handed
+    /// off for submission retain their committed quantity. Uncompensated
+    /// late-fill debt on the primary is discharged before quantity is returned.
     ///
     /// `refused_before_submission` selects whether the restoration log records a
-    /// refusal or a denial/rejection.
+    /// refusal or a terminal outcome.
     fn restore_primary_order_quantity(&mut self, order: &OrderAny, refused_before_submission: bool)
     where
         Self: ExecutionAlgorithmNative,
@@ -709,34 +728,89 @@ pub trait ExecutionAlgorithm: DataActor {
             return;
         };
 
-        let reduction_qty = {
+        let reduction = {
             let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
-            core.take_pending_spawn_reduction(&order.client_order_id())
+            core.spawn_reduction(order.client_order_id())
         };
 
-        let Some(reduction_qty) = reduction_qty else {
+        let Some(mut reduction) = reduction else {
             return;
         };
 
+        if !reduction.restored_qty.is_zero() {
+            return;
+        }
+
         let primary = {
             let cache = ExecutionAlgorithmNative::exec_algorithm_core_mut(self).cache_ref();
-            cache.order(&exec_spawn_id).map(|o| o.clone())
+            cache
+                .order(&exec_spawn_id)
+                .map(|o| <OrderAny as Clone>::clone(&o))
         };
 
         let Some(primary) = primary else {
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+                .take_pending_spawn_reduction(order.client_order_id());
             log::warn!(
                 "Cannot restore primary order quantity: primary order {exec_spawn_id} not found",
             );
             return;
         };
 
-        // Cap restore amount by leaves_qty to handle partial fills before rejection
-        let restore_qty = reduction_qty.min(order.leaves_qty());
-        if restore_qty.is_zero() {
+        let handed_off = ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+            .primary_was_handed_off(exec_spawn_id);
+
+        if !primary.is_active_local() || handed_off {
+            let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+            core.take_pending_spawn_reduction(order.client_order_id());
+            core.discard_spawn_fill_debt(exec_spawn_id);
+            log::info!(
+                "Skipped restoring primary order {exec_spawn_id} after spawned order {}: primary is no longer locally mutable",
+                order.client_order_id(),
+            );
             return;
         }
 
-        let mut restored_qty = primary.quantity() + restore_qty;
+        let Some(restore_qty) = spawn_quantity_in_primary_units(
+            order,
+            reduction,
+            order.leaves_qty(),
+            primary.quantity().precision,
+        ) else {
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+                .take_pending_spawn_reduction(order.client_order_id());
+            return;
+        };
+        let restore_qty = restore_qty.min(reduction.deducted_qty);
+        if restore_qty.is_zero() {
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+                .take_pending_spawn_reduction(order.client_order_id());
+            return;
+        }
+
+        // Discharge uncompensated late-fill debt on this primary before
+        // returning quantity to it
+        let debt_qty = ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+            .spawn_fill_debt(exec_spawn_id)
+            .unwrap_or_else(|| Quantity::zero(restore_qty.precision));
+        let discharge_qty = restore_qty.min(debt_qty);
+        let net_restore_qty = restore_qty - discharge_qty;
+
+        if net_restore_qty.is_zero() {
+            // The whole restoration discharged debt: keep the record with the
+            // gross released amount so this child's own late fills stay tracked
+            reduction.restored_qty = restore_qty;
+            let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+            core.set_spawn_reduction(order.client_order_id(), reduction);
+            core.set_spawn_fill_debt(exec_spawn_id, debt_qty - discharge_qty);
+            log::info!(
+                "Restoration from spawned order {} fully discharged late-fill debt on primary order {exec_spawn_id}",
+                order.client_order_id(),
+            );
+            return;
+        }
+
+        let mut restored_qty = primary.quantity() + net_restore_qty;
         restored_qty.precision = primary.quantity().precision;
 
         let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
@@ -774,12 +848,24 @@ pub trait ExecutionAlgorithm: DataActor {
             }
         };
 
+        // Commit the lifecycle record and debt before publishing: subscribers
+        // run synchronously and may re-enter order handling. The record keeps
+        // the gross released amount (including the debt-discharged portion) as
+        // this child's late-fill accounting budget; only the net reaches the
+        // primary.
+        reduction.restored_qty = restore_qty;
+        let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+        core.set_spawn_reduction(order.client_order_id(), reduction);
+        if !discharge_qty.is_zero() {
+            core.set_spawn_fill_debt(exec_spawn_id, debt_qty - discharge_qty);
+        }
+
         publish_order_event(&event);
 
         let outcome = if refused_before_submission {
             "refused before submission"
         } else {
-            "denied/rejected"
+            "terminated with unfilled quantity"
         };
         log::info!(
             "Restored primary order {} quantity to {} after spawned order {} was {outcome}",
@@ -789,11 +875,138 @@ pub trait ExecutionAlgorithm: DataActor {
         );
     }
 
+    /// Re-deducts a late spawn fill from a previously restored local primary order.
+    fn rededuct_late_spawn_fill(&mut self, order: &OrderAny, last_qty: Quantity)
+    where
+        Self: ExecutionAlgorithmNative,
+    {
+        let spawn_id = order.client_order_id();
+        let Some(exec_spawn_id) = order.exec_spawn_id() else {
+            return;
+        };
+        let Some(reduction) =
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self).spawn_reduction(spawn_id)
+        else {
+            return;
+        };
+
+        if reduction.restored_qty.is_zero() {
+            return;
+        }
+
+        let primary = {
+            let cache = ExecutionAlgorithmNative::exec_algorithm_core_mut(self).cache_ref();
+            cache
+                .order(&exec_spawn_id)
+                .map(|o| <OrderAny as Clone>::clone(&o))
+        };
+        let Some(primary) = primary else {
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+                .take_pending_spawn_reduction(spawn_id);
+            log::warn!(
+                "Cannot re-deduct late fill from primary order {exec_spawn_id}: order not found",
+            );
+            return;
+        };
+
+        let handed_off = ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+            .primary_was_handed_off(exec_spawn_id);
+
+        if !primary.is_active_local() || handed_off {
+            let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+            core.take_pending_spawn_reduction(spawn_id);
+            core.discard_spawn_fill_debt(exec_spawn_id);
+            log::info!(
+                "Skipped re-deducting late fill from primary order {exec_spawn_id}: primary is no longer locally mutable",
+            );
+            return;
+        }
+
+        let Some(uncapped_qty) = spawn_quantity_in_primary_units(
+            order,
+            reduction,
+            last_qty,
+            primary.quantity().precision,
+        ) else {
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
+                .take_pending_spawn_reduction(spawn_id);
+            return;
+        };
+        let uncapped_qty = uncapped_qty.min(reduction.restored_qty);
+        let primary_qty = primary.quantity();
+        // Restored quantity may already have been reused by a later spawn, so
+        // cap at the primary's remaining quantity; the shortfall becomes debt
+        // discharged against later spawn restorations for this primary.
+        let rededuct_qty = uncapped_qty.min(primary_qty);
+        let shortfall_qty = uncapped_qty - rededuct_qty;
+        if rededuct_qty.is_zero() {
+            if !uncapped_qty.is_zero() {
+                charge_spawn_reduction(
+                    ExecutionAlgorithmNative::exec_algorithm_core_mut(self),
+                    spawn_id,
+                    exec_spawn_id,
+                    reduction,
+                    uncapped_qty,
+                    shortfall_qty,
+                );
+                log::warn!(
+                    "Cannot re-deduct late fill on spawned order {spawn_id} from primary order {exec_spawn_id}: primary quantity exhausted, shortfall recorded as debt",
+                );
+            }
+            return;
+        }
+        let mut new_qty = primary_qty - rededuct_qty;
+        new_qty.precision = primary_qty.precision;
+        let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+        let ts_now = core.clock_mut().timestamp_ns();
+        let event = OrderEventAny::Updated(OrderUpdated::new(
+            primary.trader_id(),
+            primary.strategy_id(),
+            primary.instrument_id(),
+            primary.client_order_id(),
+            new_qty,
+            UUID4::new(),
+            ts_now,
+            ts_now,
+            false,
+            primary.venue_order_id(),
+            primary.account_id(),
+            None,
+            None,
+            None,
+            primary.is_quote_quantity(),
+        ));
+
+        if let Err(e) = core.cache_rc().borrow_mut().update_order(&event) {
+            log::warn!("Failed to update primary order in cache: {e}");
+            return;
+        }
+
+        // Commit the lifecycle record before publishing: subscribers run
+        // synchronously and may re-enter order handling.
+        charge_spawn_reduction(
+            ExecutionAlgorithmNative::exec_algorithm_core_mut(self),
+            spawn_id,
+            exec_spawn_id,
+            reduction,
+            uncapped_qty,
+            shortfall_qty,
+        );
+
+        if !shortfall_qty.is_zero() {
+            log::warn!(
+                "Late fill on spawned order {spawn_id} partially re-deducted from primary order {exec_spawn_id}: shortfall recorded as debt",
+            );
+        }
+
+        publish_order_event(&event);
+    }
+
     /// Submits an order to the execution engine via the risk engine.
     ///
     /// Orders carrying a live emulation trigger are refused before submission.
     /// For spawned orders with a pending primary reduction, refusal restores the
-    /// cached primary order quantity, consumes the pending reduction, and publishes
+    /// cached primary order quantity while it remains local and publishes
     /// `OrderUpdated`.
     ///
     /// # Errors
@@ -861,6 +1074,10 @@ pub trait ExecutionAlgorithm: DataActor {
         if core.config.log_commands {
             let id = &core.actor.actor_id;
             log::info!("{id} {SEND}{CMD} {command}");
+        }
+
+        if order.exec_spawn_id() == Some(order.client_order_id()) {
+            core.mark_primary_handed_off(order.client_order_id());
         }
 
         msgbus::send_trading_command(
@@ -1296,20 +1513,13 @@ pub trait ExecutionAlgorithm: DataActor {
                 self.restore_primary_order_quantity(&order, false);
                 self.on_order_rejected(*e);
             }
-            OrderEventAny::Accepted(e) => {
-                // Commit reduction - order accepted by venue
-                ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
-                    .take_pending_spawn_reduction(&order.client_order_id());
-                self.on_order_accepted(*e);
-            }
+            OrderEventAny::Accepted(e) => self.on_order_accepted(*e),
             OrderEventAny::Canceled(e) => {
-                ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
-                    .take_pending_spawn_reduction(&order.client_order_id());
+                self.restore_primary_order_quantity(&order, false);
                 self.on_algo_order_canceled(*e);
             }
             OrderEventAny::Expired(e) => {
-                ExecutionAlgorithmNative::exec_algorithm_core_mut(self)
-                    .take_pending_spawn_reduction(&order.client_order_id());
+                self.restore_primary_order_quantity(&order, false);
                 self.on_order_expired(*e);
             }
             OrderEventAny::Triggered(e) => self.on_order_triggered(*e),
@@ -1318,7 +1528,19 @@ pub trait ExecutionAlgorithm: DataActor {
             OrderEventAny::ModifyRejected(e) => self.on_order_modify_rejected(*e),
             OrderEventAny::CancelRejected(e) => self.on_order_cancel_rejected(*e),
             OrderEventAny::Updated(e) => self.on_order_updated(*e),
-            OrderEventAny::Filled(e) => self.on_algo_order_filled(e.clone()),
+            OrderEventAny::Filled(e) => {
+                self.rededuct_late_spawn_fill(&order, e.last_qty);
+                if order.leaves_qty().is_zero() {
+                    let core = ExecutionAlgorithmNative::exec_algorithm_core_mut(self);
+                    if core
+                        .spawn_reduction(order.client_order_id())
+                        .is_some_and(|reduction| reduction.restored_qty.is_zero())
+                    {
+                        core.take_pending_spawn_reduction(order.client_order_id());
+                    }
+                }
+                self.on_algo_order_filled(e.clone());
+            }
             OrderEventAny::FillVoided(e) => self.on_order_fill_voided(e),
         }
 
@@ -1519,6 +1741,134 @@ impl Display for EmulatedOrderSubmissionError {
 
 impl std::error::Error for EmulatedOrderSubmissionError {}
 
+fn spawn_quantity_in_primary_units(
+    order: &OrderAny,
+    reduction: SpawnReduction,
+    child_qty: Quantity,
+    primary_precision: u8,
+) -> Option<Quantity> {
+    if reduction.spawn_was_quote_quantity == order.is_quote_quantity() {
+        return Some(child_qty);
+    }
+
+    if !reduction.spawn_was_quote_quantity {
+        log::warn!(
+            "Cannot account for spawned order {} quantity: denomination changed from base to quote",
+            order.client_order_id(),
+        );
+        return None;
+    }
+
+    let converted_total = order.quantity();
+    if converted_total.is_zero() {
+        log::warn!(
+            "Cannot account for converted spawned order {} quantity: converted total is zero",
+            order.client_order_id(),
+        );
+        return None;
+    }
+
+    // Fills and leaves never exceed the order total; the clamp makes that a
+    // structural bound so the quotient below always fits the raw width.
+    let child_qty = child_qty.min(converted_total);
+    // QuantityRaw is u64 or u128 depending on the high-precision feature, so
+    // the widening is real in one build shape and an identity in the other.
+    #[allow(clippy::useless_conversion)]
+    let proportional_raw = QuantityRaw::try_from(muldiv_floor_u128(
+        u128::from(reduction.deducted_qty.raw()),
+        u128::from(child_qty.raw()),
+        u128::from(converted_total.raw()),
+    ))
+    .expect("Quotient bounded by the deducted quantity");
+
+    let precision_increment = Quantity::from_decimal_dp(
+        rust_decimal::Decimal::new(1, u32::from(primary_precision)),
+        primary_precision,
+    )
+    .expect("Primary quantity precision must be valid")
+    .raw();
+    let floored_raw = proportional_raw - proportional_raw % precision_increment;
+    Some(Quantity::from_raw(floored_raw, primary_precision))
+}
+
+/// Returns `floor(a * b / c)` without intermediate overflow.
+///
+/// # Panics
+///
+/// Panics if `c` is zero, or if `b > c` and the quotient exceeds `u128`
+/// (callers bound `b` by `c`, which bounds the quotient by `a`).
+fn muldiv_floor_u128(a: u128, b: u128, c: u128) -> u128 {
+    if let Some(product) = a.checked_mul(b) {
+        return product / c;
+    }
+
+    let (hi, lo) = mul_wide_u128(a, b);
+    assert!(hi < c, "muldiv_floor_u128 quotient exceeds u128");
+    div_wide_u128(hi, lo, c)
+}
+
+/// Returns the 256-bit product of two `u128` values as `(high, low)` halves.
+fn mul_wide_u128(a: u128, b: u128) -> (u128, u128) {
+    const MASK: u128 = (1u128 << 64) - 1;
+    let (a_hi, a_lo) = (a >> 64, a & MASK);
+    let (b_hi, b_lo) = (b >> 64, b & MASK);
+
+    let ll = a_lo * b_lo;
+    let lh = a_lo * b_hi;
+    let hl = a_hi * b_lo;
+    let hh = a_hi * b_hi;
+
+    let mid = (ll >> 64) + (lh & MASK) + (hl & MASK);
+    let lo = (mid << 64) | (ll & MASK);
+    let hi = hh + (lh >> 64) + (hl >> 64) + (mid >> 64);
+    (hi, lo)
+}
+
+/// Divides the 256-bit value `(hi, lo)` by `c` via restoring long division,
+/// truncating toward zero. Requires `hi < c` so the quotient fits `u128`.
+fn div_wide_u128(hi: u128, lo: u128, c: u128) -> u128 {
+    let mut rem = hi;
+    let mut quotient = 0u128;
+
+    for i in (0..u128::BITS).rev() {
+        // A carry out of the shift means the true remainder is rem + 2^128,
+        // which always exceeds c; wrapping_sub then yields the exact value.
+        let carry = rem >> 127;
+        rem = (rem << 1) | ((lo >> i) & 1);
+
+        if carry == 1 || rem >= c {
+            rem = rem.wrapping_sub(c);
+            quotient |= 1 << i;
+        }
+    }
+    quotient
+}
+
+/// Charges a late fill against a spawn reduction record, booking any shortfall
+/// as debt against the primary order.
+fn charge_spawn_reduction(
+    core: &mut ExecutionAlgorithmCore,
+    spawn_id: ClientOrderId,
+    primary_id: ClientOrderId,
+    mut reduction: SpawnReduction,
+    charged_qty: Quantity,
+    shortfall_qty: Quantity,
+) {
+    let precision = reduction.restored_qty.precision;
+    reduction.restored_qty = reduction.restored_qty - charged_qty;
+    reduction.restored_qty.precision = precision;
+
+    if reduction.restored_qty.is_zero() {
+        core.take_pending_spawn_reduction(spawn_id);
+    } else {
+        core.set_spawn_reduction(spawn_id, reduction);
+    }
+
+    if !shortfall_qty.is_zero() {
+        core.add_spawn_fill_debt(primary_id, shortfall_qty);
+    }
+}
+
 fn publish_order_initialized(order: &OrderAny) {
     let event = OrderEventAny::Initialized(order.init_event().clone());
     publish_order_event(&event);
@@ -1560,20 +1910,21 @@ mod tests {
         },
     };
     use nautilus_model::{
-        enums::{OrderSide, OrderStatus, OrderType},
+        enums::{LiquiditySide, OrderSide, OrderStatus, OrderType},
         events::{
             OrderAccepted, OrderCanceled, OrderDenied, OrderDeniedReason, OrderRejected,
             order::spec::{
-                OrderAcceptedSpec, OrderCanceledSpec, OrderDeniedSpec, OrderFillVoidedSpec,
-                OrderFilledSpec, OrderRejectedSpec,
+                OrderAcceptedSpec, OrderCanceledSpec, OrderDeniedSpec, OrderExpiredSpec,
+                OrderFillVoidedSpec, OrderFilledSpec, OrderRejectedSpec, OrderSubmittedSpec,
+                OrderUpdatedSpec,
             },
         },
         identifiers::{
-            AccountId, ActorId, ClientOrderId, ExecAlgorithmId, InstrumentId, StrategyId, TraderId,
-            VenueOrderId,
+            AccountId, ActorId, ClientOrderId, ExecAlgorithmId, InstrumentId, StrategyId, TradeId,
+            TraderId, VenueOrderId,
         },
         orders::{LimitOrder, MarketOrder, OrderAny, OrderTestBuilder, stubs::TestOrderStubs},
-        types::{Price, Quantity},
+        types::{Currency, Price, Quantity},
     };
     use rstest::rstest;
 
@@ -1699,6 +2050,268 @@ mod tests {
             None,
         );
         (handler, events)
+    }
+
+    fn setup_pending_spawn() -> (TestAlgorithm, ClientOrderId, OrderAny) {
+        let mut algo = create_test_algorithm();
+        register_algorithm(&mut algo);
+        let client_order_id = ClientOrderId::from("O-001");
+        let mut primary = OrderAny::Market(MarketOrder::new(
+            TraderId::from("TRADER-001"),
+            StrategyId::from("STRAT-001"),
+            InstrumentId::from("BTC/USDT.BINANCE"),
+            client_order_id,
+            OrderSide::Buy,
+            Quantity::from("1.0"),
+            TimeInForce::Gtc,
+            UUID4::new(),
+            0.into(),
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            Some(algo.id()),
+            None,
+            Some(client_order_id),
+            None,
+        ));
+        algo.core
+            .cache_rc()
+            .borrow_mut()
+            .add_order(primary.clone(), None, None, false)
+            .unwrap();
+        let spawned = algo.spawn_market(
+            &mut primary,
+            Quantity::from("0.5"),
+            TimeInForce::Fok,
+            false,
+            None,
+            true,
+        );
+        let spawned_order = OrderAny::Market(spawned);
+        algo.core
+            .cache_rc()
+            .borrow_mut()
+            .add_order(spawned_order.clone(), None, None, false)
+            .unwrap();
+        (algo, client_order_id, spawned_order)
+    }
+
+    fn setup_accepted_spawn() -> (TestAlgorithm, ClientOrderId, OrderAny) {
+        let (mut algo, client_order_id, mut spawned_order) = setup_pending_spawn();
+        let accepted = OrderAcceptedSpec::builder()
+            .trader_id(spawned_order.trader_id())
+            .strategy_id(spawned_order.strategy_id())
+            .instrument_id(spawned_order.instrument_id())
+            .client_order_id(spawned_order.client_order_id())
+            .venue_order_id(VenueOrderId::from("V-123"))
+            .account_id(AccountId::from("BINANCE-001"))
+            .build();
+        spawned_order = algo
+            .core
+            .cache_rc()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Accepted(accepted))
+            .unwrap();
+        algo.handle_order_event(OrderEventAny::Accepted(accepted));
+        (algo, client_order_id, spawned_order)
+    }
+
+    fn setup_accepted_quote_spawn(
+        primary_qty: Quantity,
+        spawn_qty: Quantity,
+    ) -> (TestAlgorithm, ClientOrderId, OrderAny) {
+        let mut algo = create_test_algorithm();
+        register_algorithm(&mut algo);
+        let client_order_id = ClientOrderId::from("O-QUOTE");
+        let mut primary = OrderAny::Market(MarketOrder::new(
+            TraderId::from("TRADER-001"),
+            StrategyId::from("STRAT-001"),
+            InstrumentId::from("BTC/USDT.BINANCE"),
+            client_order_id,
+            OrderSide::Buy,
+            primary_qty,
+            TimeInForce::Gtc,
+            UUID4::new(),
+            0.into(),
+            false,
+            true,
+            None,
+            None,
+            None,
+            None,
+            Some(algo.id()),
+            None,
+            Some(client_order_id),
+            None,
+        ));
+        algo.core
+            .cache_rc()
+            .borrow_mut()
+            .add_order(primary.clone(), None, None, false)
+            .unwrap();
+        let mut spawned_order = OrderAny::Market(algo.spawn_market(
+            &mut primary,
+            spawn_qty,
+            TimeInForce::Fok,
+            false,
+            None,
+            true,
+        ));
+        algo.core
+            .cache_rc()
+            .borrow_mut()
+            .add_order(spawned_order.clone(), None, None, false)
+            .unwrap();
+        accept_spawned_order(&mut algo, &mut spawned_order);
+        (algo, client_order_id, spawned_order)
+    }
+
+    fn fill_spawned_order(algo: &mut TestAlgorithm, order: &mut OrderAny, quantity: Quantity) {
+        let venue_order_id = order
+            .venue_order_id()
+            .unwrap_or_else(|| VenueOrderId::from("V-PRIMARY"));
+        let filled = OrderFilledSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(order.instrument_id())
+            .client_order_id(order.client_order_id())
+            .venue_order_id(venue_order_id)
+            .account_id(AccountId::from("BINANCE-001"))
+            .trade_id(TradeId::new(UUID4::new().to_string()))
+            .order_side(order.order_side())
+            .order_type(order.order_type())
+            .last_qty(quantity)
+            .last_px(Price::from("50000.0"))
+            .currency(Currency::USD())
+            .liquidity_side(LiquiditySide::Taker)
+            .build();
+        *order = algo
+            .core
+            .cache_rc()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Filled(filled.clone()))
+            .unwrap();
+        algo.handle_order_event(OrderEventAny::Filled(filled));
+    }
+
+    fn submit_order_in_cache(algo: &mut TestAlgorithm, order: &mut OrderAny) {
+        let submitted = OrderSubmittedSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(order.instrument_id())
+            .client_order_id(order.client_order_id())
+            .account_id(AccountId::from("BINANCE-001"))
+            .build();
+        *order = algo
+            .core
+            .cache_rc()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Submitted(submitted))
+            .unwrap();
+        algo.handle_order_event(OrderEventAny::Submitted(submitted));
+    }
+
+    fn cancel_spawned_order(algo: &mut TestAlgorithm, order: &mut OrderAny) {
+        let venue_order_id = order
+            .venue_order_id()
+            .unwrap_or_else(|| VenueOrderId::from("V-123"));
+        let canceled = OrderCanceledSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(order.instrument_id())
+            .client_order_id(order.client_order_id())
+            .venue_order_id(venue_order_id)
+            .account_id(AccountId::from("BINANCE-001"))
+            .build();
+        *order = algo
+            .core
+            .cache_rc()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Canceled(canceled))
+            .unwrap();
+        algo.handle_order_event(OrderEventAny::Canceled(canceled));
+    }
+
+    fn convert_spawn_to_base(algo: &mut TestAlgorithm, order: &mut OrderAny, quantity: Quantity) {
+        let updated = OrderUpdatedSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(order.instrument_id())
+            .client_order_id(order.client_order_id())
+            .quantity(quantity)
+            .maybe_venue_order_id(order.venue_order_id())
+            .maybe_account_id(order.account_id())
+            .is_quote_quantity(false)
+            .build();
+        *order = algo
+            .core
+            .cache_rc()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Updated(updated))
+            .unwrap();
+        algo.handle_order_event(OrderEventAny::Updated(updated));
+    }
+
+    fn expire_spawned_order(algo: &mut TestAlgorithm, order: &mut OrderAny) {
+        let expired = OrderExpiredSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(order.instrument_id())
+            .client_order_id(order.client_order_id())
+            .venue_order_id(VenueOrderId::from("V-123"))
+            .account_id(AccountId::from("BINANCE-001"))
+            .build();
+        *order = algo
+            .core
+            .cache_rc()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Expired(expired))
+            .unwrap();
+        algo.handle_order_event(OrderEventAny::Expired(expired));
+    }
+
+    fn accept_spawned_order(algo: &mut TestAlgorithm, order: &mut OrderAny) {
+        let venue_order_id = VenueOrderId::from(format!("V-{}", order.client_order_id()).as_str());
+        let accepted = OrderAcceptedSpec::builder()
+            .trader_id(order.trader_id())
+            .strategy_id(order.strategy_id())
+            .instrument_id(order.instrument_id())
+            .client_order_id(order.client_order_id())
+            .venue_order_id(venue_order_id)
+            .account_id(AccountId::from("BINANCE-001"))
+            .build();
+        *order = algo
+            .core
+            .cache_rc()
+            .borrow_mut()
+            .update_order(&OrderEventAny::Accepted(accepted))
+            .unwrap();
+        algo.handle_order_event(OrderEventAny::Accepted(accepted));
+    }
+
+    fn spawn_reduced_child(
+        algo: &mut TestAlgorithm,
+        primary_id: ClientOrderId,
+        quantity: Quantity,
+    ) -> OrderAny {
+        let mut primary = algo.cache().order(&primary_id).unwrap();
+        let child = OrderAny::Market(algo.spawn_market(
+            &mut primary,
+            quantity,
+            TimeInForce::Fok,
+            false,
+            None,
+            true,
+        ));
+        algo.core
+            .cache_rc()
+            .borrow_mut()
+            .add_order(child.clone(), None, None, false)
+            .unwrap();
+        child
     }
 
     #[rstest]
@@ -2397,6 +3010,25 @@ mod tests {
     }
 
     #[rstest]
+    fn test_muldiv_floor_u128_narrow_path_truncates() {
+        assert_eq!(muldiv_floor_u128(50, 3, 5), 30);
+        assert_eq!(muldiv_floor_u128(10, 2, 3), 6);
+        assert_eq!(muldiv_floor_u128(u128::MAX, 7, 7), u128::MAX);
+    }
+
+    #[rstest]
+    fn test_muldiv_floor_u128_wide_path_floors_exactly() {
+        // a * b overflows u128; the exact quotient is a - a/c, fractionally
+        // under a, so an implementation that rounds instead of flooring
+        // returns a. This is the shape of the Decimal-fallback defect.
+        let a = 10u128.pow(30);
+        let b = 7 * 10u128.pow(30);
+        let c = b + 1;
+        assert!(a.checked_mul(b).is_none());
+        assert_eq!(muldiv_floor_u128(a, b, c), a - 1);
+    }
+
+    #[rstest]
     fn test_algorithm_reduce_primary_order() {
         let mut algo = create_test_algorithm();
         register_algorithm(&mut algo);
@@ -2641,14 +3273,17 @@ mod tests {
             OrderEventAny::Initialized(initialized)
                 if initialized.client_order_id == client_order_id
         )));
+        // The spawn already reduced the accepted primary locally (the venue
+        // still works 1.0); restoration declines to mutate a non-local
+        // primary, so the local deduction stands.
         assert_eq!(
             cache.order(&primary.client_order_id()).unwrap().quantity(),
-            Quantity::from("1.0"),
+            Quantity::from("0.6"),
         );
         drop(cache);
         assert!(
             algo.core
-                .take_pending_spawn_reduction(&client_order_id)
+                .take_pending_spawn_reduction(client_order_id)
                 .is_none()
         );
     }
@@ -3641,106 +4276,715 @@ mod tests {
     }
 
     #[rstest]
-    fn test_spawned_order_accepted_prevents_restoration() {
-        let mut algo = create_test_algorithm();
-        register_algorithm(&mut algo);
-
-        let instrument_id = InstrumentId::from("BTC/USDT.BINANCE");
-        let exec_algorithm_id = algo.id();
-        let client_order_id = ClientOrderId::from("O-001");
-
-        let mut primary = OrderAny::Market(MarketOrder::new(
-            TraderId::from("TRADER-001"),
-            StrategyId::from("STRAT-001"),
-            instrument_id,
-            client_order_id,
-            OrderSide::Buy,
-            Quantity::from("1.0"),
-            TimeInForce::Gtc,
-            UUID4::new(),
-            0.into(),
-            false,
-            false,
-            None,
-            None,
-            None,
-            None,
-            Some(exec_algorithm_id),
-            None,
-            Some(client_order_id),
-            None,
-        ));
-
-        {
-            let cache_rc = algo.core.cache_rc();
-            let mut cache = cache_rc.borrow_mut();
-            cache.add_order(primary.clone(), None, None, false).unwrap();
-        }
-
-        let spawned = algo.spawn_market(
-            &mut primary,
-            Quantity::from("0.5"),
-            TimeInForce::Fok,
-            false,
-            None,
-            true,
-        );
-
-        assert_eq!(primary.quantity(), Quantity::from("0.5"));
-
-        let mut spawned_order = OrderAny::Market(spawned);
-        {
-            let cache_rc = algo.core.cache_rc();
-            let mut cache = cache_rc.borrow_mut();
-            cache
-                .add_order(spawned_order.clone(), None, None, false)
-                .unwrap();
-        }
-
-        let accepted = OrderAcceptedSpec::builder()
-            .trader_id(spawned_order.trader_id())
-            .strategy_id(spawned_order.strategy_id())
-            .instrument_id(spawned_order.instrument_id())
-            .client_order_id(spawned_order.client_order_id())
-            .venue_order_id(VenueOrderId::from("V-123"))
-            .account_id(AccountId::from("BINANCE-001"))
-            .build();
-
-        {
-            let cache_rc = algo.core.cache_rc();
-            let mut cache = cache_rc.borrow_mut();
-            spawned_order = cache
-                .update_order(&OrderEventAny::Accepted(accepted))
-                .unwrap();
-        }
-
-        algo.handle_order_event(OrderEventAny::Accepted(accepted));
+    fn test_spawned_order_accepted_then_canceled_restores_reduction() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
 
         let primary_after_accept = algo.cache().order(&client_order_id).unwrap();
         assert_eq!(primary_after_accept.quantity(), Quantity::from("0.5"));
 
-        // Cancel after acceptance - no restoration should occur
+        // Per the maintainer's ruling, acceptance preserves the reduction until terminal outcome
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        let final_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(final_primary.quantity(), Quantity::from("1.0"));
+    }
+
+    #[rstest]
+    fn test_spawned_order_canceled_after_primary_submission_does_not_restore_reduction() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        let mut primary = algo.cache().order(&client_order_id).unwrap();
+        submit_order_in_cache(&mut algo, &mut primary);
+
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        let mut submitted_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(submitted_primary.quantity(), Quantity::from("0.5"));
+        assert!(
+            algo.core
+                .take_pending_spawn_reduction(spawned_order.client_order_id())
+                .is_none()
+        );
+        fill_spawned_order(&mut algo, &mut submitted_primary, Quantity::from("0.5"));
+        assert!(submitted_primary.is_closed());
+        assert_eq!(submitted_primary.status(), OrderStatus::Filled);
+    }
+
+    #[rstest]
+    fn test_spawned_order_canceled_during_primary_submission_handoff_does_not_restore() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        let primary = algo.cache().order(&client_order_id).unwrap();
+        algo.core
+            .add_spawn_fill_debt(client_order_id, Quantity::from("0.1"));
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let strategy_id = primary.strategy_id();
+        let (event_handler, events) = subscribe_order_topic(strategy_id);
+
+        algo.submit_order(primary, None, None).unwrap();
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().status(),
+            OrderStatus::Initialized,
+        );
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        msgbus::unsubscribe_order_events(
+            format!("events.order.{strategy_id}").into(),
+            &event_handler,
+        );
+        let risk_messages = risk_messages.get_messages();
+        let [TradingCommand::SubmitOrder(command)] = risk_messages.as_slice() else {
+            panic!("Expected exactly one SubmitOrder command");
+        };
+        assert_eq!(command.client_order_id, client_order_id);
+        // The command embeds the immutable OrderInitialized event, so its
+        // quantity is the pre-reduction 1.0; consumers resolve the cached
+        // order, which carries the reduced quantity asserted below.
+        assert_eq!(command.order_init.quantity, Quantity::from("1.0"));
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.5"),
+        );
+        assert!(!events.borrow().iter().any(|event| matches!(
+            event,
+            OrderEventAny::Updated(updated) if updated.client_order_id == client_order_id
+        )));
+        assert!(
+            algo.core
+                .take_pending_spawn_reduction(spawned_order.client_order_id())
+                .is_none()
+        );
+        assert!(algo.core.spawn_fill_debt(client_order_id).is_none());
+    }
+
+    #[rstest]
+    fn test_late_spawn_fill_rededucts_restored_primary_before_final_submission() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("1.0"),
+        );
+
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.5"));
+
+        let mut primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(primary.quantity(), Quantity::from("0.5"));
+        submit_order_in_cache(&mut algo, &mut primary);
+        assert_eq!(
+            spawned_order.filled_qty() + primary.quantity(),
+            Quantity::from("1.0"),
+        );
+    }
+
+    #[rstest]
+    fn test_late_spawn_fill_during_primary_submission_handoff_does_not_rededuct() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+        let primary = algo.cache().order(&client_order_id).unwrap();
+        algo.core
+            .add_spawn_fill_debt(client_order_id, Quantity::from("0.1"));
+        let (risk_handler, risk_messages): (_, TypedIntoMessageSavingHandler<TradingCommand>) =
+            get_typed_into_message_saving_handler(Some(Ustr::from("RiskEngine.queue_execute")));
+        msgbus::register_trading_command_endpoint(
+            MessagingSwitchboard::risk_engine_queue_execute(),
+            risk_handler,
+        );
+        let strategy_id = primary.strategy_id();
+        let (event_handler, events) = subscribe_order_topic(strategy_id);
+
+        algo.submit_order(primary, None, None).unwrap();
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().status(),
+            OrderStatus::Initialized,
+        );
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.5"));
+
+        msgbus::unsubscribe_order_events(
+            format!("events.order.{strategy_id}").into(),
+            &event_handler,
+        );
+        let risk_messages = risk_messages.get_messages();
+        let [TradingCommand::SubmitOrder(command)] = risk_messages.as_slice() else {
+            panic!("Expected exactly one SubmitOrder command");
+        };
+        assert_eq!(command.client_order_id, client_order_id);
+        // The command embeds the immutable OrderInitialized event; here the
+        // cancellation already restored the cache to 1.0, so the two agree.
+        assert_eq!(command.order_init.quantity, Quantity::from("1.0"));
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("1.0"),
+        );
+        assert!(!events.borrow().iter().any(|event| matches!(
+            event,
+            OrderEventAny::Updated(updated) if updated.client_order_id == client_order_id
+        )));
+        assert!(
+            algo.core
+                .take_pending_spawn_reduction(spawned_order.client_order_id())
+                .is_none()
+        );
+        assert!(algo.core.spawn_fill_debt(client_order_id).is_none());
+    }
+
+    #[rstest]
+    fn test_converted_quote_spawn_canceled_unfilled_restores_full_quote_quantity() {
+        let (mut algo, client_order_id, mut spawned_order) =
+            setup_accepted_quote_spawn(Quantity::from("100"), Quantity::from("50"));
+        convert_spawn_to_base(&mut algo, &mut spawned_order, Quantity::from("5"));
+
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("100"),
+        );
+        assert!(
+            algo.cache()
+                .order(&client_order_id)
+                .unwrap()
+                .is_quote_quantity()
+        );
+        assert_eq!(
+            algo.core
+                .spawn_reduction(spawned_order.client_order_id())
+                .unwrap()
+                .restored_qty,
+            Quantity::from("50"),
+        );
+    }
+
+    #[rstest]
+    fn test_converted_quote_spawn_partial_fill_restores_proportional_quote_quantity() {
+        let (mut algo, client_order_id, mut spawned_order) =
+            setup_accepted_quote_spawn(Quantity::from("100"), Quantity::from("50"));
+        convert_spawn_to_base(&mut algo, &mut spawned_order, Quantity::from("5"));
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("2"));
+
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("80"),
+        );
+        assert!(
+            algo.cache()
+                .order(&client_order_id)
+                .unwrap()
+                .is_quote_quantity()
+        );
+        assert_eq!(
+            algo.core
+                .spawn_reduction(spawned_order.client_order_id())
+                .unwrap()
+                .restored_qty,
+            Quantity::from("30"),
+        );
+    }
+
+    #[rstest]
+    fn test_converted_quote_spawn_late_fill_charges_proportional_quote_quantity() {
+        let (mut algo, client_order_id, mut spawned_order) =
+            setup_accepted_quote_spawn(Quantity::from("100"), Quantity::from("50"));
+        convert_spawn_to_base(&mut algo, &mut spawned_order, Quantity::from("5"));
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("1"));
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("90"),
+        );
+        assert!(
+            algo.cache()
+                .order(&client_order_id)
+                .unwrap()
+                .is_quote_quantity()
+        );
+        assert_eq!(
+            algo.core
+                .spawn_reduction(spawned_order.client_order_id())
+                .unwrap()
+                .restored_qty,
+            Quantity::from("40"),
+        );
+    }
+
+    #[rstest]
+    fn test_converted_quote_spawn_restoration_rounds_down_to_primary_precision() {
+        let (mut algo, client_order_id, mut spawned_order) =
+            setup_accepted_quote_spawn(Quantity::from("20.00"), Quantity::from("10.00"));
+        convert_spawn_to_base(&mut algo, &mut spawned_order, Quantity::from("3.000"));
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("1.000"));
+
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("16.66"),
+        );
+        assert!(
+            algo.cache()
+                .order(&client_order_id)
+                .unwrap()
+                .is_quote_quantity()
+        );
+        assert_eq!(
+            algo.core
+                .spawn_reduction(spawned_order.client_order_id())
+                .unwrap()
+                .restored_qty,
+            Quantity::from("6.66"),
+        );
+    }
+
+    #[rstest]
+    fn test_converted_quote_spawn_repeated_fractional_late_fills_floor_each_event() {
+        let (mut algo, client_order_id, mut spawned_order) =
+            setup_accepted_quote_spawn(Quantity::from("20.00"), Quantity::from("10.00"));
+        convert_spawn_to_base(&mut algo, &mut spawned_order, Quantity::from("3.000"));
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        for (primary_qty, restored_qty) in [
+            (Quantity::from("16.67"), Quantity::from("6.67")),
+            (Quantity::from("13.34"), Quantity::from("3.34")),
+            (Quantity::from("10.01"), Quantity::from("0.01")),
+        ] {
+            fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("1.000"));
+            assert_eq!(
+                algo.cache().order(&client_order_id).unwrap().quantity(),
+                primary_qty,
+            );
+            assert_eq!(
+                algo.core
+                    .spawn_reduction(spawned_order.client_order_id())
+                    .unwrap()
+                    .restored_qty,
+                restored_qty,
+            );
+        }
+    }
+
+    #[rstest]
+    fn test_converted_quote_spawn_partial_cancel_then_late_fill_charges_restored_budget() {
+        let (mut algo, client_order_id, mut spawned_order) =
+            setup_accepted_quote_spawn(Quantity::from("100"), Quantity::from("50"));
+        convert_spawn_to_base(&mut algo, &mut spawned_order, Quantity::from("5"));
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("2"));
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("80"),
+        );
+        assert_eq!(
+            algo.core
+                .spawn_reduction(spawned_order.client_order_id())
+                .unwrap()
+                .restored_qty,
+            Quantity::from("30"),
+        );
+
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("1"));
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("70"),
+        );
+        assert_eq!(
+            algo.core
+                .spawn_reduction(spawned_order.client_order_id())
+                .unwrap()
+                .restored_qty,
+            Quantity::from("20"),
+        );
+    }
+
+    #[rstest]
+    fn test_unmarked_submitted_primary_cancellation_discards_reduction_and_debt() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        let mut primary = algo.cache().order(&client_order_id).unwrap();
+        submit_order_in_cache(&mut algo, &mut primary);
+        algo.core
+            .add_spawn_fill_debt(client_order_id, Quantity::from("0.1"));
+
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.5"),
+        );
+        assert!(
+            algo.core
+                .spawn_reduction(spawned_order.client_order_id())
+                .is_none()
+        );
+        assert!(algo.core.spawn_fill_debt(client_order_id).is_none());
+    }
+
+    #[rstest]
+    #[case::denied(true)]
+    #[case::rejected(false)]
+    fn test_spawn_refusal_does_not_restore_submitted_primary(#[case] denied: bool) {
+        let (mut algo, client_order_id, spawned_order) = setup_pending_spawn();
+        let spawned_id = spawned_order.client_order_id();
+        let mut primary = algo.cache().order(&client_order_id).unwrap();
+        submit_order_in_cache(&mut algo, &mut primary);
+
+        if denied {
+            let event = OrderDeniedSpec::builder()
+                .trader_id(spawned_order.trader_id())
+                .strategy_id(spawned_order.strategy_id())
+                .instrument_id(spawned_order.instrument_id())
+                .client_order_id(spawned_id)
+                .reason("TEST_DENIAL".into())
+                .build();
+            algo.handle_order_event(OrderEventAny::Denied(event));
+        } else {
+            let event = OrderRejectedSpec::builder()
+                .trader_id(spawned_order.trader_id())
+                .strategy_id(spawned_order.strategy_id())
+                .instrument_id(spawned_order.instrument_id())
+                .client_order_id(spawned_id)
+                .account_id(AccountId::from("BINANCE-001"))
+                .reason("TEST_REJECTION".into())
+                .build();
+            algo.handle_order_event(OrderEventAny::Rejected(event));
+        }
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.5"),
+        );
+        assert!(algo.core.take_pending_spawn_reduction(spawned_id).is_none());
+    }
+
+    #[rstest]
+    fn test_multiple_late_partial_fills_net_only_the_restored_quantity() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.2"));
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.1"));
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.7"),
+        );
+
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.2"));
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.5"),
+        );
+        assert!(
+            algo.core
+                .take_pending_spawn_reduction(spawned_order.client_order_id())
+                .is_none()
+        );
+    }
+
+    #[rstest]
+    fn test_late_spawn_fill_after_restored_quantity_reused_caps_at_primary_quantity() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("1.0"),
+        );
+
+        // Reuse most of the restored quantity through a second spawn
+        let mut primary = algo.cache().order(&client_order_id).unwrap();
+        let second_order = OrderAny::Market(algo.spawn_market(
+            &mut primary,
+            Quantity::from("0.8"),
+            TimeInForce::Fok,
+            false,
+            None,
+            true,
+        ));
+        algo.core
+            .cache_rc()
+            .borrow_mut()
+            .add_order(second_order.clone(), None, None, false)
+            .unwrap();
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.2"),
+        );
+
+        // The late fill exceeds the primary's remaining quantity: the
+        // re-deduction caps at zero and the shortfall becomes debt
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.5"));
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.0"),
+        );
+        assert!(
+            algo.core
+                .spawn_reduction(spawned_order.client_order_id())
+                .is_none()
+        );
+        assert_eq!(
+            algo.core.spawn_fill_debt(client_order_id),
+            Some(Quantity::from("0.3")),
+        );
+
+        // The second spawn terminating unfilled discharges the debt before
+        // returning quantity: 0.8 restores only 0.5
+        let rejected = OrderRejectedSpec::builder()
+            .trader_id(second_order.trader_id())
+            .strategy_id(second_order.strategy_id())
+            .instrument_id(second_order.instrument_id())
+            .client_order_id(second_order.client_order_id())
+            .account_id(AccountId::from("BINANCE-001"))
+            .reason("TEST_REJECTION".into())
+            .build();
+        algo.handle_order_event(OrderEventAny::Rejected(rejected));
+
+        let final_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(final_primary.quantity(), Quantity::from("0.5"));
+        assert!(algo.core.spawn_fill_debt(client_order_id).is_none());
+        assert_eq!(
+            spawned_order.filled_qty() + final_primary.quantity(),
+            Quantity::from("1.0"),
+        );
+    }
+
+    #[rstest]
+    fn test_late_fill_on_child_that_fully_discharged_debt_recreates_debt() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        let mut child_b = spawn_reduced_child(&mut algo, client_order_id, Quantity::from("0.3"));
+        let mut child_c = spawn_reduced_child(&mut algo, client_order_id, Quantity::from("0.5"));
+        accept_spawned_order(&mut algo, &mut child_b);
+        accept_spawned_order(&mut algo, &mut child_c);
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.2"),
+        );
+
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.5"));
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.0"),
+        );
+        assert_eq!(
+            algo.core.spawn_fill_debt(client_order_id),
+            Some(Quantity::from("0.3")),
+        );
+
+        // B's cancellation fully discharges the debt; its record keeps the
+        // gross released amount for late-fill tracking
+        cancel_spawned_order(&mut algo, &mut child_b);
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.0"),
+        );
+        assert!(algo.core.spawn_fill_debt(client_order_id).is_none());
+        assert_eq!(
+            algo.core
+                .spawn_reduction(child_b.client_order_id())
+                .unwrap()
+                .restored_qty,
+            Quantity::from("0.3"),
+        );
+
+        // B's late fill reverses the settlement for the filled amount
+        fill_spawned_order(&mut algo, &mut child_b, Quantity::from("0.2"));
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.0"),
+        );
+        assert_eq!(
+            algo.core.spawn_fill_debt(client_order_id),
+            Some(Quantity::from("0.2")),
+        );
+
+        cancel_spawned_order(&mut algo, &mut child_c);
+        let final_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(final_primary.quantity(), Quantity::from("0.3"));
+        assert!(algo.core.spawn_fill_debt(client_order_id).is_none());
+        assert_eq!(
+            spawned_order.filled_qty() + child_b.filled_qty() + final_primary.quantity(),
+            Quantity::from("1.0"),
+        );
+    }
+
+    #[rstest]
+    fn test_late_fill_on_child_after_partial_debt_discharge_nets_from_primary() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        let mut child_b = spawn_reduced_child(&mut algo, client_order_id, Quantity::from("0.8"));
+        accept_spawned_order(&mut algo, &mut child_b);
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.5"));
+        assert_eq!(
+            algo.core.spawn_fill_debt(client_order_id),
+            Some(Quantity::from("0.3")),
+        );
+
+        // B's cancellation discharges 0.3 of debt and restores the net 0.5;
+        // its record keeps the gross 0.8
+        cancel_spawned_order(&mut algo, &mut child_b);
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.5"),
+        );
+        assert!(algo.core.spawn_fill_debt(client_order_id).is_none());
+        assert_eq!(
+            algo.core
+                .spawn_reduction(child_b.client_order_id())
+                .unwrap()
+                .restored_qty,
+            Quantity::from("0.8"),
+        );
+
+        fill_spawned_order(&mut algo, &mut child_b, Quantity::from("0.3"));
+        let final_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(final_primary.quantity(), Quantity::from("0.2"));
+        assert_eq!(
+            spawned_order.filled_qty() + child_b.filled_qty() + final_primary.quantity(),
+            Quantity::from("1.0"),
+        );
+    }
+
+    #[rstest]
+    fn test_emulated_spawn_refusal_restores_initialized_primary() {
+        let (mut algo, client_order_id, _spawned_order) = setup_pending_spawn();
+        let mut primary = algo.cache().order(&client_order_id).unwrap();
+        let spawned = algo.spawn_limit(
+            &mut primary,
+            Quantity::from("0.3"),
+            Price::from("50000.0"),
+            TimeInForce::Gtc,
+            None,
+            false,
+            false,
+            None,
+            Some(TriggerType::BidAsk),
+            None,
+            true,
+        );
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.2"),
+        );
+
+        let result = algo.submit_order(OrderAny::Limit(spawned), None, None);
+
+        assert!(result.is_err());
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("0.5"),
+        );
+    }
+
+    #[rstest]
+    fn test_spawned_order_accepted_then_expired_restores_reduction() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+
+        expire_spawned_order(&mut algo, &mut spawned_order);
+
+        let final_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(final_primary.quantity(), Quantity::from("1.0"));
+    }
+
+    #[rstest]
+    fn test_partially_filled_spawned_order_canceled_restores_leaves_quantity() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.2"));
+
+        cancel_spawned_order(&mut algo, &mut spawned_order);
+
+        let final_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(final_primary.quantity(), Quantity::from("0.8"));
+    }
+
+    #[rstest]
+    fn test_partially_filled_spawned_order_expired_restores_leaves_quantity() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.2"));
+
+        expire_spawned_order(&mut algo, &mut spawned_order);
+
+        let final_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(final_primary.quantity(), Quantity::from("0.8"));
+    }
+
+    #[rstest]
+    fn test_fully_filled_spawned_order_consumes_reduction_without_restoration() {
+        let (mut algo, client_order_id, mut spawned_order) = setup_accepted_spawn();
+        let spawned_id = spawned_order.client_order_id();
+
+        fill_spawned_order(&mut algo, &mut spawned_order, Quantity::from("0.5"));
+
+        let final_primary = algo.cache().order(&client_order_id).unwrap();
+        assert_eq!(final_primary.quantity(), Quantity::from("0.5"));
+        assert!(algo.core.take_pending_spawn_reduction(spawned_id).is_none());
+    }
+
+    #[rstest]
+    #[case::denied(true)]
+    #[case::rejected(false)]
+    fn test_spawned_order_refusal_then_terminal_event_restores_only_once(#[case] denied: bool) {
+        // A canceled event after a denial/rejection is not an applicable state
+        // transition and the engine drops such races before publication; the
+        // second event is dispatched directly to exercise the handler's own
+        // idempotence (a positive restored quantity blocks a second
+        // restoration).
+        let (mut algo, client_order_id, spawned_order) = setup_pending_spawn();
+
+        if denied {
+            let event = OrderDeniedSpec::builder()
+                .trader_id(spawned_order.trader_id())
+                .strategy_id(spawned_order.strategy_id())
+                .instrument_id(spawned_order.instrument_id())
+                .client_order_id(spawned_order.client_order_id())
+                .reason("TEST_DENIAL".into())
+                .build();
+            algo.core
+                .cache_rc()
+                .borrow_mut()
+                .update_order(&OrderEventAny::Denied(event))
+                .unwrap();
+            algo.handle_order_event(OrderEventAny::Denied(event));
+        } else {
+            let event = OrderRejectedSpec::builder()
+                .trader_id(spawned_order.trader_id())
+                .strategy_id(spawned_order.strategy_id())
+                .instrument_id(spawned_order.instrument_id())
+                .client_order_id(spawned_order.client_order_id())
+                .account_id(AccountId::from("BINANCE-001"))
+                .reason("TEST_REJECTION".into())
+                .build();
+            algo.core
+                .cache_rc()
+                .borrow_mut()
+                .update_order(&OrderEventAny::Rejected(event))
+                .unwrap();
+            algo.handle_order_event(OrderEventAny::Rejected(event));
+        }
+
+        assert_eq!(
+            algo.cache().order(&client_order_id).unwrap().quantity(),
+            Quantity::from("1.0"),
+        );
+
         let canceled = OrderCanceledSpec::builder()
             .trader_id(spawned_order.trader_id())
             .strategy_id(spawned_order.strategy_id())
             .instrument_id(spawned_order.instrument_id())
             .client_order_id(spawned_order.client_order_id())
-            .venue_order_id(VenueOrderId::from("V-123"))
-            .account_id(AccountId::from("BINANCE-001"))
             .build();
-
-        {
-            let cache_rc = algo.core.cache_rc();
-            let mut cache = cache_rc.borrow_mut();
-            cache
-                .update_order(&OrderEventAny::Canceled(canceled))
-                .unwrap();
-        }
-
         algo.handle_order_event(OrderEventAny::Canceled(canceled));
 
         let final_primary = algo.cache().order(&client_order_id).unwrap();
-        assert_eq!(final_primary.quantity(), Quantity::from("0.5"));
+        assert_eq!(final_primary.quantity(), Quantity::from("1.0"));
     }
 
     #[rstest]

--- a/docs/concepts/execution/algorithms.md
+++ b/docs/concepts/execution/algorithms.md
@@ -84,8 +84,13 @@ When `reduce_primary=True`, the spawned quantity must not exceed the primary ord
 (remaining unfilled quantity).
 :::
 
-If a spawned order is denied or rejected before acceptance, the deducted quantity is automatically
-restored to the primary order. Once accepted by the venue, the reduction is considered committed.
+If a spawned order is denied, rejected, canceled, expired, or refused before submission, its
+unfilled proportion is restored in the primary order's quantity units while the primary remains
+local. This also applies when a venue converts a quote-quantity spawn to base quantity. Once primary
+submission is handed off, its quantity is committed and is not changed by a later spawn outcome. A
+late fill on a canceled spawn re-deducts the corresponding restored quantity while the primary
+remains locally mutable; if that quantity was already reused by a later spawn, the excess is netted
+from that spawn's own restoration instead.
 
 An execution algorithm can keep spawning orders, submit the remaining primary order, or do both.
 The built-in TWAP algorithm submits the remaining primary order on the final interval.


### PR DESCRIPTION
A spawned exec-algorithm child that reaches the venue and terminates unfilled permanently loses its quantity from the primary order.

## Canceled and expired children commit the pending spawn reduction

When an exec algorithm spawns a child with `reduce_primary`, the deducted quantity is tracked and restored by `restore_primary_order_quantity` if the child is denied or rejected, capped at the child's `leaves_qty`. The `Accepted`, `Canceled`, and `Expired` arms of `handle_order_event` instead committed the reduction with a bare `take_pending_spawn_reduction`, so a canceled or expired child restored nothing and the algorithm under-executed by the child's unfilled amount.

The reduction entry now lives until the child's first terminal outcome: acceptance retains it, `Canceled` and `Expired` restore through the existing helper - whose `leaves_qty` cap restores exactly the unfilled portion after a partial fill and nothing after a full fill - and a fill that leaves zero quantity consumes the entry. `Denied` and `Rejected` are unchanged, restoration cannot double-apply because the take is destructive, and `reduce_primary=false` spawns track no entry and are unaffected.

Two boundaries are preserved rather than handled: a late fill arriving after a cancellation restoration is not compensated back into the primary, and a `FillVoided` that reopens a fully filled child cannot restore, since by then neither the original reduction nor `reduce_primary` eligibility is recoverable. Both would need reduction history retained beyond the child's closure.

## Alternative shapes considered

- Fixing only the `Canceled`/`Expired` arms while `Accepted` keeps committing the entry: incomplete by construction, since an accepted child's entry is gone before its terminal event arrives.
- Decrementing the map entry on each partial fill: `min(reduction, leaves_qty)` at terminal time already yields the unfilled portion, and per-fill updates open duplicate-fill and `FillVoided` bookkeeping questions.
- Committing at acceptance and recreating the entry at terminal time: after consumption a reduced child is indistinguishable from a `reduce_primary=false` one and the original reduction amount is gone, so re-derivation could add quantity never deducted.
- A non-removing read on the reduction map: the destructive take is what makes restoration idempotent, so a peek would add surface and lose that property.

## Testing

New cases pin accepted-then-canceled and accepted-then-expired zero-fill children restoring the full reduction, partial-fill cancellation and expiry restoring exactly `leaves_qty`, full-fill consumption with no restoration, and a denied or rejected child followed by a directly dispatched terminal event restoring only once. `test_spawned_order_accepted_prevents_restoration` is renamed to `test_spawned_order_accepted_then_canceled_restores_reduction` with its post-accept assertion intact. The new assertions fail against the unfixed implementation - six failing cases, covering both the canceled and expired paths.
