### PR TITLE
Reject Binance Spot SBE short blocks in new-order-full decoder

### DIFF
--- a/crates/adapters/binance/src/spot/http/parse.rs
+++ b/crates/adapters/binance/src/spot/http/parse.rs
@@ -434,6 +434,13 @@ pub fn decode_new_order_full(buf: &[u8]) -> Result<BinanceNewOrderResponse, SbeD
         return Err(SbeDecodeError::UnknownTemplateId(header.template_id));
     }
 
+    if usize::from(header.block_length) < NEW_ORDER_FULL_FIELDS_END {
+        return Err(SbeDecodeError::InvalidBlockLength {
+            expected: NEW_ORDER_FULL_FIELDS_END as u16,
+            actual: header.block_length,
+        });
+    }
+
     cursor.require(header.block_length as usize)?;
 
     let price_exponent = cursor.read_i8()?;
@@ -2612,6 +2619,22 @@ mod tests {
         assert_eq!(response.fills[0].qty_mantissa, 10_000);
         assert_eq!(response.fills[0].trade_id, Some(555));
         assert_eq!(response.fills[0].commission_asset, "USDT");
+    }
+
+    #[rstest]
+    fn test_decode_new_order_full_rejects_short_block() {
+        let mut buf = build_new_order_full_buffer(ExpiryReason::NullVal);
+        resize_fixed_block(&mut buf, 116);
+
+        let error = decode_new_order_full(&buf).unwrap_err();
+
+        assert_eq!(
+            error,
+            SbeDecodeError::InvalidBlockLength {
+                expected: 117,
+                actual: 116,
+            }
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## New-order-full decoder accepts blocks shorter than its fixed fields

Follow-up from #4965. `decode_new_order_full` in `crates/adapters/binance/src/spot/http/parse.rs` had no minimum block-length check, while `decode_cancel_order` and `decode_order_block` reject a block shorter than their fixed fields with `InvalidBlockLength`. On a short block the decoder walks past the block into the fills group header and fails with `GroupSizeTooLarge` carrying a garbage count, which points away from the actual cause. Low risk in practice since the venue controls the block length, but the three decoders should behave the same.

The guard is the same shape as the cancel-order one, checked right after the template ID.

## Testing

`test_decode_new_order_full_rejects_short_block` builds the fixture from the generated encoder, shrinks the fixed block to 116 bytes and asserts `InvalidBlockLength { expected: 117, actual: 116 }`. Without the guard it fails with `GroupSizeTooLarge { count: 4160749568, max: 10000 }`.

- `cargo test -p nautilus-binance --lib spot::http::parse`: 68 passed
- `cargo clippy -p nautilus-binance --no-deps --all-targets -- -D warnings`: clean
- `prek run --files` on the changed file: `check formatting (Rust)` and `cargo fmt` pass
