### PR TITLE
Fix Binance CN equity instrument parsing

### DIFF
--- a/crates/adapters/binance/src/common/parse.rs
+++ b/crates/adapters/binance/src/common/parse.rs
@@ -122,8 +122,11 @@ fn parse_tradifi_asset_class(symbol: &BinanceFuturesUsdSymbol) -> anyhow::Result
         )
     })?;
 
+    // Binance uses CN_EQUITY for some China-listed TradFi perpetuals,
+    // including UNITREEUSDT. It has the same instrument semantics as the
+    // other equity underlying types supported here.
     match underlying_type {
-        "EQUITY" | "KR_EQUITY" | "HK_EQUITY" | "PREMARKET" => Ok(AssetClass::Equity),
+        "EQUITY" | "CN_EQUITY" | "KR_EQUITY" | "HK_EQUITY" | "PREMARKET" => Ok(AssetClass::Equity),
         "COMMODITY" => Ok(AssetClass::Commodity),
         _ => anyhow::bail!(
             "Unsupported underlying type '{underlying_type}' for TRADIFI_PERPETUAL symbol '{}'",
@@ -2101,6 +2104,7 @@ mod tests {
 
     #[rstest]
     #[case::equity("SNDKUSDT", "SNDK", "EQUITY", AssetClass::Equity)]
+    #[case::chinese_equity("UNITREEUSDT", "UNITREE", "CN_EQUITY", AssetClass::Equity)]
     #[case::korean_equity("005930USDT", "005930", "KR_EQUITY", AssetClass::Equity)]
     #[case::hong_kong_equity("0700USDT", "0700", "HK_EQUITY", AssetClass::Equity)]
     #[case::premarket("SPCXUSDT", "SPCX", "PREMARKET", AssetClass::Equity)]

--- a/docs/integrations/binance.md
+++ b/docs/integrations/binance.md
@@ -129,10 +129,10 @@ listings use the same suffix, so `XAUUSDT` becomes `XAUUSDT-PERP`.
 The adapter maps `TRADIFI_PERPETUAL` listings to
 `PerpetualContract` and derives their asset class from Binance's `underlyingType`:
 
-| Binance `underlyingType`                        | Nautilus asset class |
-| ----------------------------------------------- | -------------------- |
-| `EQUITY`, `KR_EQUITY`, `HK_EQUITY`, `PREMARKET` | Equity               |
-| `COMMODITY`                                     | Commodity            |
+| Binance `underlyingType`                                     | Nautilus asset class |
+| ------------------------------------------------------------ | -------------------- |
+| `EQUITY`, `CN_EQUITY`, `KR_EQUITY`, `HK_EQUITY`, `PREMARKET` | Equity               |
+| `COMMODITY`                                                  | Commodity            |
 
 Listings with other or missing values are skipped with a warning.
 


### PR DESCRIPTION
## Summary

Binance USD-M now returns some `TRADIFI_PERPETUAL` instruments with `underlyingType=CN_EQUITY`, including `UNITREEUSDT`. The Binance Rust adapter previously rejected these instruments, causing them to be omitted from the instrument catalog and WebSocket cache; valid market-data subscriptions then silently discarded incoming frames because the symbol was absent from the cache.

This maps `CN_EQUITY` to `AssetClass::Equity`, consistent with the existing equity underlying types.

Closes #4978

## Scope

- Add `CN_EQUITY` to the existing TradFi equity mapping.
- Add a parser regression case for `UNITREEUSDT`.
- Keep `TRADIFI_PERPETUAL` represented as the existing generic non-inverse `PerpetualContract`.
- No changes to order routing, account state, Python bindings, generated stubs, or `RELEASES.md`.

## Testing

- `cargo test -p nautilus-binance --lib test_parse_usdm_tradifi_perpetual` — 8 passed.
- `cargo test -p nautilus-binance --test integration test_request_instruments_parses_tradifi_perpetual_exchange_info` — 1 passed.
- `cargo +nightly fmt --all -- --check` — passed.
- `cargo clippy -p nautilus-binance --lib --all-features -- -D warnings` — passed.
- `make format` — passed.
- `make pre-commit` — passed.

The fix was also validated against Binance Live public market data without credentials or orders: `exchangeInfo` returned `UNITREEUSDT` as `TRADIFI_PERPETUAL/CN_EQUITY/TRADING`, and the existing Rust Futures data tester connected to Live WebSocket streams and emitted `UNITREEUSDT-PERP.BINANCE` 20-level order-book updates.
